### PR TITLE
If tempest is deployed, load docker image at docker compute node

### DIFF
--- a/chef/cookbooks/nova/recipes/docker.rb
+++ b/chef/cookbooks/nova/recipes/docker.rb
@@ -19,3 +19,23 @@
 #
 
 node.set[:nova][:libvirt_type] = "docker"
+
+# if tempest is deployed, load packaged docker image at docker compute node
+tempest_node = search(:node, "roles:tempest").first
+unless tempest_node.nil?
+  docker_image = tempest_node[:tempest][:tempest_test_docker_image] || ""
+
+  bash "load docker image" do
+    code <<-EOH
+      TEMP=$(mktemp -d)
+      IMG_FILE=$(basename #{docker_image})
+
+      wget --no-verbose #{docker_image} --directory-prefix=$TEMP 2>&1 || exit $?
+      docker load --input=$TEMP/$IMG_FILE
+      mkdir -p /var/lib/crowbar
+      touch /var/lib/crowbar/docker_for_tempest_loaded
+      rm -rf $TEMP
+EOH
+    not_if { docker_image.empty? || ::File.exists?("/var/lib/crowbar/docker_for_tempest_loaded") }
+  end
+end


### PR DESCRIPTION
so that tempest could run tests with docker based image.

The image is packaged in tempest barclamp. We can't do this from
tempest recipe because tempest might be deployed on another node
which does not have access to the docker comput node.

Tex version is here https://github.com/crowbar/barclamp-nova/pull/481

This should work together with https://github.com/crowbar/crowbar-openstack/pull/18
