### PR TITLE
Bump schema revision to match the added migration

### DIFF
--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -138,7 +138,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 31,
+      "schema-revision": 32,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
https://github.com/crowbar/barclamp-keystone/pull/285
added a migration but didn't raise schema, so it wasn't
executed.