### PR TITLE
Add option to enforce use of config drive (bsc#943166)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -300,6 +300,7 @@ template "/etc/nova/nova.conf" do
             libvirt_migration: node[:nova]["use_migration"],
             libvirt_enable_multipath: node[:nova][:libvirt_use_multipath],
             shared_instances: node[:nova]["use_shared_instance_storage"],
+            force_config_drive: node[:nova]["force_config_drive"],
             glance_server_protocol: glance_server_protocol,
             glance_server_host: glance_server_host,
             glance_server_port: glance_server_port,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1373,6 +1373,9 @@ linuxnet_interface_driver=""
 # Whether to attempt to inject network setup into guest
 # (boolean value)
 #flat_injected=false
+<% if @force_config_drive %>
+flat_injected=true
+<% end -%>
 
 # FlatDhcp will bridge into this interface if set (string
 # value)
@@ -1881,6 +1884,10 @@ ram_allocation_ratio=<%= node[:nova][:scheduler][:ram_allocation_ratio] %>
 # Config drive format. One of iso9660 (default) or vfat
 # (string value)
 #config_drive_format=iso9660
+<% if @force_config_drive %>
+# We need to set it to vfat then, see https://review.openstack.org/#/c/168646/
+config_drive_format=vfat
+<% end -%>
 
 # DEPRECATED (not needed any more):  Where to put temporary
 # files associated with config drive creation (string value)
@@ -1888,7 +1895,9 @@ ram_allocation_ratio=<%= node[:nova][:scheduler][:ram_allocation_ratio] %>
 
 # Set to force injection to take place on a config drive (if
 # set, valid options are: always) (string value)
-#force_config_drive=<None>
+<% if @force_config_drive %>
+force_config_drive=always
+<% end -%>
 
 # Name and optionally path of the tool used for ISO image
 # creation (string value)

--- a/chef/data_bags/crowbar/bc-template-nova.json
+++ b/chef/data_bags/crowbar/bc-template-nova.json
@@ -21,6 +21,7 @@
       "use_migration": false,
       "use_syslog": false,
       "neutron_url_timeout": 30,
+      "force_config_drive": false,
       "vnc_keymap": "en-us",
       "scheduler": {
         "ram_allocation_ratio": 1.0,
@@ -79,7 +80,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 32,
+      "schema-revision": 33,
       "element_states": {
         "nova-multi-controller": [ "readying", "ready", "applying" ],
         "nova-multi-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-nova.schema
+++ b/chef/data_bags/crowbar/bc-template-nova.schema
@@ -32,6 +32,7 @@
             "itxt_instance": { "type": "str", "required": true },
             "neutron_metadata_proxy_shared_secret": { "type": "str" },
             "neutron_url_timeout": {"type": "int"},
+            "force_config_drive": { "type": "bool", "required": true },
             "vnc_keymap": { "type": "str" , "required": true },
             "scheduler": {
               "type": "map",

--- a/chef/data_bags/crowbar/migrate/nova/033_add_configdrive.rb
+++ b/chef/data_bags/crowbar/migrate/nova/033_add_configdrive.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.has_key? "force_config_drive"
+    a["force_config_drive"] = ta["force_config_drive"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.has_key? "force_config_drive"
+    a.delete("force_config_drive")
+  end
+  return a, d
+end


### PR DESCRIPTION
This is useful in environments where the dhcp-agent is
disabled, which means there is no neutron/nova metadata proxy
available.