### PR TITLE
[UNTESTED] ensure mongodb is installed/configured before clustering (bsc#944417)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/mongodb.rb
+++ b/chef/cookbooks/ceilometer/recipes/mongodb.rb
@@ -46,6 +46,11 @@ service mongo_service do
 end
 
 if ha_enabled
+  # Wait for all nodes to reach this point so we know that all nodes
+  # will have all the required packages installed and configured before
+  # we create the pacemaker resources.
+  crowbar_pacemaker_sync_mark "sync-mongodb_before_ha"
+
   crowbar_pacemaker_sync_mark "wait-mongodb_service"
 
   pacemaker_primitive "mongodb" do


### PR DESCRIPTION
Just like with all other HA OpenStack resources, we need to prevent the resources being configured in Pacemaker before we know that all nodes have the necessary packages installed and correctly configured.

This was one of the lessons learnt during analysis of:

  https://bugzilla.suse.com/show_bug.cgi?id=944417
