### PR TITLE
add sample input files for `crowbar batch build`

### DIFF
--- a/crowbar_framework/examples/HA-cloud.yaml
+++ b/crowbar_framework/examples/HA-cloud.yaml
@@ -1,0 +1,122 @@
+# Example input file for 'crowbar batch build' command which sets up a
+# cloud with a single 2-node HA cluster using DRBD and SBD for
+# STONITH, and a single KVM compute node.
+#
+# Assumes that the two controller nodes are aliased 'controller1' and
+# 'controller2', and the compute node is aliased 'compute1'.
+#
+# If you are short of physical or virtual hardware and only want to
+# test the controller cluster, you can skip the compute node via:
+#
+#   crowbar batch build -e cinder -e nova
+#
+---
+global_options:
+- action_for_existing_proposals: skip   # could also be e.g. 'recreate' or 'overwrite'
+proposals:
+- barclamp: provisioner
+  attributes:
+    shell_prompt: USER@ALIAS:CWD SUFFIX
+- barclamp: pacemaker
+  name: cluster1
+  action_if_exists: overwrite
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          "@@controller1@@":
+            devices:
+            - /dev/sdc
+          "@@controller2@@":
+            devices:
+            - /dev/sdc
+    drbd:
+      enabled: true
+  deployment:
+    elements:
+      hawk-server:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      pacemaker-cluster-member:
+      - "@@controller1@@"
+      - "@@controller2@@"
+- barclamp: database
+  # Proposal name defaults to 'default'.
+  # Default attributes are good enough, so we just need to assign
+  # nodes to roles:
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 10
+  deployment:
+    elements:
+      database-server:
+        - cluster:cluster1
+- barclamp: rabbitmq
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 10
+  deployment:
+    elements:
+      rabbitmq-server:
+        - cluster:cluster1
+- barclamp: keystone
+  deployment:
+    elements:
+      keystone-server:
+        - cluster:cluster1
+- barclamp: glance
+  deployment:
+    elements:
+      glance-server:
+        - cluster:cluster1
+- barclamp: cinder
+  wipe_attributes:
+    - volumes
+  attributes:
+    volumes:
+      - backend_name: local
+        backend_driver: local
+        local:
+          file_size: 2000
+          volume_name: cinder-volumes
+          file_name: /var/lib/cinder/volume.raw
+  deployment:
+    elements:
+      cinder-controller:
+        - cluster:cluster1
+      cinder-volume:
+        - "@@compute1@@"
+- barclamp: neutron
+  deployment:
+    elements:
+      neutron-server:
+        - cluster:cluster1
+      neutron-network:
+        - cluster:cluster1
+- barclamp: nova
+  attributes:
+    kvm:
+      ksm_enabled: true
+  deployment:
+    elements:
+      nova-multi-controller:
+        - cluster:cluster1
+      nova-multi-compute-qemu:
+        - "@@compute1@@"
+- barclamp: nova_dashboard
+  deployment:
+    elements:
+      nova_dashboard-server:
+        - cluster:cluster1
+- barclamp: heat
+  deployment:
+    elements:
+      heat-server:
+        - cluster:cluster1

--- a/crowbar_framework/examples/simple-cloud.yaml
+++ b/crowbar_framework/examples/simple-cloud.yaml
@@ -1,0 +1,79 @@
+# Example input file for 'crowbar batch build' command which sets up a
+# cloud with a single controller and a single KVM compute node.
+#
+# Assumes that the controller node is aliased 'controller1', and the
+# compute node is aliased 'compute1'.
+---
+global_options:
+- action_for_existing_proposals: skip   # could also be e.g. 'recreate' or 'overwrite'
+proposals:
+- barclamp: provisioner
+  attributes:
+    shell_prompt: USER@ALIAS:CWD SUFFIX
+- barclamp: database
+  # Proposal name defaults to 'default'.
+  # Default attributes are good enough, so we just need to assign
+  # nodes to roles:
+  deployment:
+    elements:
+      database-server:
+        - "@@controller1@@"
+- barclamp: rabbitmq
+  deployment:
+    elements:
+      rabbitmq-server:
+        - "@@controller1@@"
+- barclamp: keystone
+  deployment:
+    elements:
+      keystone-server:
+        - "@@controller1@@"
+- barclamp: glance
+  deployment:
+    elements:
+      glance-server:
+        - "@@controller1@@"
+- barclamp: cinder
+  wipe_attributes:
+    - volumes
+  attributes:
+    volumes:
+      - backend_name: local
+        backend_driver: local
+        local:
+          file_size: 2000
+          volume_name: cinder-volumes
+          file_name: /var/lib/cinder/volume.raw
+  deployment:
+    elements:
+      cinder-controller:
+        - "@@controller1@@"
+      cinder-volume:
+        - "@@compute1@@"
+- barclamp: neutron
+  deployment:
+    elements:
+      neutron-server:
+        - "@@controller1@@"
+      neutron-network:
+        - "@@controller1@@"
+- barclamp: nova
+  attributes:
+    kvm:
+      ksm_enabled: true
+  deployment:
+    elements:
+      nova-multi-controller:
+        - "@@controller1@@"
+      nova-multi-compute-qemu:
+        - "@@compute1@@"
+- barclamp: nova_dashboard
+  deployment:
+    elements:
+      nova_dashboard-server:
+        - "@@controller1@@"
+- barclamp: heat
+  deployment:
+    elements:
+      heat-server:
+        - "@@controller1@@"


### PR DESCRIPTION
This should allow people to "kick the tyres" even quicker.  They originate from https://github.com/SUSE-Cloud/suse-cloud-vagrant/tree/master/vagrant/provisioning/admin and @dirkmueller suggested that some of the tweaks in the appliances / Vagrant boxes should be ported into the product.  So this is the first step towards that.