### PR TITLE
Set dhcp_client to empty value will skip test_subnet_details

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -480,7 +480,8 @@ template "/etc/tempest/tempest.conf" do
     cinder_backend1_name: cinder_backend1_name,
     cinder_backend2_name: cinder_backend2_name,
     storage_protocol: storage_protocol,
-    vendor_name: vendor_name
+    vendor_name: vendor_name,
+    use_docker: use_docker
   )
 end
 

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -944,6 +944,13 @@ img_file = cirros-<%= @cirros_version %>-x86_64-disk.img
 # ssh username for the image file (string value)
 ssh_user = cirros
 
+# DHCP client used by images to renew DCHP lease. If left empty,
+# update operation will be skipped. Supported clients: "udhcpc",
+# "dhclient" (string value)
+# Allowed values: udhcpc, dhclient
+<% if @use_docker %>
+dhcp_client =
+<% end %>
 
 [service_available]
 


### PR DESCRIPTION
test that is not supported by docker instances.

Requires https://review.openstack.org/#/c/221874/