### PR TITLE
Add warning for horizon timeout

### DIFF
--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -90,7 +90,8 @@ class HorizonService < PacemakerServiceObject
 
     # keystone_timeout is in seconds and horizon_timeout is in minutes
     if horizon_timeout * 60 > keystone_timeout
-      validation_error("Horizon timeout is bigger than keystone token expiration and these may cause problems.")
+      validation_error("Setting the Horizon timeout (#{horizon_timeout * 60} minutes) longer than the Keystone token expiration timeout" \ 
+        "(#{keystone_timeout} minutes) is not supported. Please lower the Horizon token timeout.")
     end
 
     super

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -84,14 +84,19 @@ class HorizonService < PacemakerServiceObject
         validation_error("Multi domain support requires enabling Keystone V3 API in the keystone proposal first.")
       end
 
-    horizon_timeout = proposal["attributes"]["nova_dashboard"]["session_timeout"]
-    keystone_proposal = Proposal.where(barclamp: "keystone", name: "default").first
-    keystone_timeout = keystone_proposal["attributes"]["keystone"]["token_expiration"]
+      horizon_timeout = proposal["attributes"]["nova_dashboard"]["session_timeout"]
+      keystone_proposal = Proposal.where(barclamp: "keystone", name: "default").first
+      keystone_timeout = keystone_proposal["attributes"]["keystone"]["token_expiration"]
 
-    # keystone_timeout is in seconds and horizon_timeout is in minutes
-    if horizon_timeout * 60 > keystone_timeout
-      validation_error("Setting the Horizon timeout (#{horizon_timeout * 60} minutes) longer than the Keystone token expiration timeout" \ 
-        "(#{keystone_timeout} minutes) is not supported. Please lower the Horizon token timeout.")
+      timeout_warning = <<-EOF
+Setting the Horizon timeout (#{horizon_timeout} minutes) longer than the Keystone token expiration timeout (#{keystone_timeout * 60} minutes) is not supported.
+Please lower the Horizon token timeout.
+EOF
+
+      # keystone_timeout is in seconds and horizon_timeout is in minutes
+      if horizon_timeout * 60 > keystone_timeout
+        validation_error(timeout_warning)
+      end
     end
 
     super

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -83,6 +83,14 @@ class HorizonService < PacemakerServiceObject
       if keystone["attributes"][ks_svc.bc_name]["api"]["version"].to_f < 3.0
         validation_error("Multi domain support requires enabling Keystone V3 API in the keystone proposal first.")
       end
+
+    horizon_timeout = proposal["attributes"]["nova_dashboard"]["session_timeout"]
+    keystone_proposal = Proposal.where(barclamp: "keystone", name: "default").first
+    keystone_timeout = keystone_proposal["attributes"]["keystone"]["token_expiration"]
+
+    # keystone_timeout is in seconds and horizon_timeout is in minutes
+    if horizon_timeout * 60 > keystone_timeout
+      validation_error("Horizon timeout is bigger than keystone token expiration and these may cause problems.")
     end
 
     super

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -83,6 +83,15 @@ class KeystoneService < PacemakerServiceObject
       validation_error("API version 3 or newer is required when enabling domain specific drivers.")
     end
 
+    keystone_timeout = proposal["attributes"]["keystone"]["token_expiration"]
+    horizon_proposal = Proposal.where(barclamp: "nova_dashboard", name: "default").first
+    horizon_timeout = horizon_proposal["attributes"]["nova_dashboard"]["session_timeout"]
+
+    # keystone_timeout is in seconds and horizon_timeout is in minutes
+    if horizon_timeout * 60 > keystone_timeout
+      validation_error("Horizon timeout is bigger than keystone token expiration and these may cause problems.")
+    end
+
     super
   end
 

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -85,11 +85,14 @@ class KeystoneService < PacemakerServiceObject
 
     keystone_timeout = proposal["attributes"]["keystone"]["token_expiration"]
     horizon_proposal = Proposal.where(barclamp: "nova_dashboard", name: "default").first
-    horizon_timeout = horizon_proposal["attributes"]["nova_dashboard"]["session_timeout"]
+    unless horizon_proposal.nil?
+      horizon_timeout = horizon_proposal["attributes"]["nova_dashboard"]["session_timeout"]
 
-    # keystone_timeout is in seconds and horizon_timeout is in minutes
-    if horizon_timeout * 60 > keystone_timeout
-      validation_error("Horizon timeout is bigger than keystone token expiration and these may cause problems.")
+      # keystone_timeout is in seconds and horizon_timeout is in minutes
+      if horizon_timeout * 60 > keystone_timeout
+        validation_error("Setting the Horizon timeout (#{horizon_timeout * 60} minutes) longer than the Keystone token expiration timeout" \ 
+          "(#{keystone_timeout} minutes) is not supported. Please lower the Horizon token timeout.")
+      end
     end
 
     super

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -88,10 +88,13 @@ class KeystoneService < PacemakerServiceObject
     unless horizon_proposal.nil?
       horizon_timeout = horizon_proposal["attributes"]["nova_dashboard"]["session_timeout"]
 
+    timeout_warning = <<-EOF
+Setting the Horizon timeout (#{horizon_timeout} minutes) longer than the Keystone token expiration timeout (#{keystone_timeout * 60} minutes) is not supported.
+Please lower the Horizon token timeout.
+EOF
       # keystone_timeout is in seconds and horizon_timeout is in minutes
       if horizon_timeout * 60 > keystone_timeout
-        validation_error("Setting the Horizon timeout (#{horizon_timeout * 60} minutes) longer than the Keystone token expiration timeout" \ 
-          "(#{keystone_timeout} minutes) is not supported. Please lower the Horizon token timeout.")
+        validation_error(timeout_warning)
       end
     end
 


### PR DESCRIPTION
Horizon timeout is impacted by keystone token timeout since when the
token gets outdated, then the user is automatically unable to use
horizon. This patch includes a check for the timeout of horizon and
keystone barclamps.