### PR TITLE
postgresql: Fix version of postgresql for SLE12 SP1

### DIFF
--- a/chef/cookbooks/postgresql/attributes/default.rb
+++ b/chef/cookbooks/postgresql/attributes/default.rb
@@ -134,12 +134,18 @@ when "suse"
       "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-pg"]
     default["postgresql"]["server"]["packages"] = ["postgresql91-server"]
     default["postgresql"]["contrib"]["packages"] = ["postgresql91-contrib"]
-  else
+  when node["platform_version"].to_f == 12.0
     default["postgresql"]["version"] = "9.3"
     default["postgresql"]["client"]["packages"] = ["postgresql93",
       "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-pg"]
     default["postgresql"]["server"]["packages"] = ["postgresql93-server"]
     default["postgresql"]["contrib"]["packages"] = ["postgresql93-contrib"]
+  else
+    default["postgresql"]["version"] = "9.4"
+    default["postgresql"]["client"]["packages"] = ["postgresql94",
+      "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-pg"]
+    default["postgresql"]["server"]["packages"] = ["postgresql94-server"]
+    default["postgresql"]["contrib"]["packages"] = ["postgresql94-contrib"]
   end
 
   default["postgresql"]["dir"] = "/var/lib/pgsql/data"


### PR DESCRIPTION
It's 9.4, not 9.3 like in SLE12.