### PR TITLE
manila: Allow manual backend setup

### DIFF
--- a/chef/cookbooks/manila/recipes/share.rb
+++ b/chef/cookbooks/manila/recipes/share.rb
@@ -29,6 +29,8 @@ node[:manila][:shares].each_with_index do |share, share_idx|
     # nothing special needs to be done for the generic driver
   when share[:backend_driver] == "netapp"
     # FIXME (toabctl): Do some NetApp config magic.
+  when share[:backend_driver] == "manual"
+    # nothing special needs to be done for the generic driver
   end
 end
 

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -1855,7 +1855,6 @@ neutron_net_id=<%= share['generic']['neutron_net_id'] %>
 neutron_subnet_id=<%= share['generic']['neutron_subnet_id'] %>
 <% end -%>
 <% end -%> <%# generic driver %>
-
 <% if share['backend_driver'] == 'netapp' -%>
 share_driver=manila.share.drivers.netapp.common.NetAppDriver
 share_backend_name=<%= share['backend_name'] %>
@@ -1873,8 +1872,11 @@ netapp_transport_type=<%= share['netapp']['netapp_transport_type'] %>
 netapp_aggregate_name_search_pattern=<%= share['netapp']['netapp_aggregate_name_search_pattern'] %>
 <% end -%>
 <% end -%> <%# netapp driver %>
-
-
+<% if share['backend_driver'] == 'manual' -%>
+share_backend_name=<%= share['backend_name'] %>
+share_driver=<%= share['manual']['driver'] %>
+<%= share['manual']['config'] %>
+<% end -%> <%# manual driver %>
 <% end -%> <%# shares loop %>
 #############################################################################
 #############################################################################

--- a/chef/data_bags/crowbar/bc-template-manila.json
+++ b/chef/data_bags/crowbar/bc-template-manila.json
@@ -44,6 +44,10 @@
           "netapp_password": "",
           "netapp_vserver": "",
           "netapp_transport_type": "https"
+        },
+        "manual": {
+          "driver": "",
+          "config": ""
         }
       },
       "shares": [
@@ -64,7 +68,7 @@
     "manila": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 0,
+      "schema-revision": 10,
       "element_states": {
         "manila-server": [ "readying", "ready", "applying" ],
         "manila-share": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-manila.schema
+++ b/chef/data_bags/crowbar/bc-template-manila.schema
@@ -64,6 +64,12 @@
                     "netapp_transport_type": { "type": "str", "required": true },
                     "netapp_aggregate_name_search_pattern": { "type": "str", "required": false }
                   }
+                },
+                "manual": {
+                "type": "map", "mapping": {
+                    "driver": { "type": "str", "required": true },
+                    "config": { "type": "str", "required": true }
+                  }
                 }
               }
             },
@@ -95,6 +101,12 @@
                       "netapp_transport_type": { "type": "str", "required": true },
                       "netapp_aggregate_name_search_pattern": { "type": "str", "required": false }
                      }
+                  },
+                  "manual": {
+                    "type": "map", "mapping": {
+                      "driver": { "type": "str", "required": true },
+                      "config": { "type": "str", "required": true }
+                    }
                   }
                 }
               } ]

--- a/chef/data_bags/crowbar/migrate/manila/010_add_manual_backend.rb
+++ b/chef/data_bags/crowbar/migrate/manila/010_add_manual_backend.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a["share_defaults"].has_key? "manual"
+    a["share_defaults"]["manual"] = ta["share_defaults"]["manual"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["share_defaults"].has_key? "manual"
+    a["share_defaults"].delete("manual")
+  end
+  return a, d
+end

--- a/crowbar_framework/app/helpers/manila_barclamp_helper.rb
+++ b/crowbar_framework/app/helpers/manila_barclamp_helper.rb
@@ -29,7 +29,8 @@ module ManilaBarclampHelper
     options_for_select(
       [
         [t(".shares.generic_share_driver"), "generic"],
-        [t(".shares.netapp_share_driver"), "netapp"]
+        [t(".shares.netapp_share_driver"), "netapp"],
+        [t(".shares.manual_share_driver"), "manual"]
       ],
       selected.to_s
     )

--- a/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
@@ -44,6 +44,23 @@
               = password_field %w(shares {{@index}} netapp netapp_password)
               = select_field %w(shares {{@index}} netapp netapp_transport_type), :collection => :netapp_transports_for_manila
           {{/if_eq}}
+          {{#if_eq backend_driver 'manual'}}
+          %li.list-group-item
+            %fieldset
+            %legend
+              = t(".shares.manual_parameters")
+
+            .alert.alert-warning
+              = t(".shares.manual.not_supported")
+
+            = string_field %w(shares {{@index}} manual driver)
+            %span.help-block
+              = t(".shares.manual.driver_hint")
+
+            = text_field %w(shares {{@index}} manual config), :size => "80x5"
+            %span.help-block
+              = t(".shares.manual.config_hint")
+          {{/if_eq}}
         {{/each}}
 
     %fieldset

--- a/crowbar_framework/config/locales/manila.en.yml
+++ b/crowbar_framework/config/locales/manila.en.yml
@@ -33,8 +33,14 @@ en:
           loading_text: 'Loading Backends...'
           generic_parameters: 'Generic backend parameters'
           netapp_parameters: "NetApp parameters"
+          manual_parameters: 'Other driver parameters'
           generic_share_driver: 'Generic driver'
           netapp_share_driver: 'NetApp driver'
+          manual_share_driver: 'Other driver'
+          manual:
+            config_hint: 'Each line will be added to manila.conf. If the driver needs an external file, this file must be manually uploaded.'
+            driver_hint: 'For instance, manila.share.drivers.generic.GenericShareDriver'
+            not_supported: 'Manually picking a driver can be used to specify a Manila driver not available in the list of drivers above. This is however not supported.'
           index:
             generic:
               service_instance_user: 'Service instance user'
@@ -48,3 +54,6 @@ en:
               netapp_server_hostname: 'Server host name'
               netapp_server_port: 'Server port'
               netapp_transport_type: 'Transport Type'
+            manual:
+              config: 'Options'
+              driver: 'Driver'


### PR DESCRIPTION
A manual backend can be used when the crowbar ui and raw view
don't support a driver or a specific feature of a driver.
Something similar in Cinder already exists and was used as blueprint.