### PR TITLE
Set the right physical_network for the floating network

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -78,9 +78,9 @@ when "ml2"
   when "vlan"
     fixed_network_type = "--provider:network_type vlan --provider:segmentation_id #{fixed_net["vlan"]} --provider:physical_network physnet1"
     if node[:network][:networks][:nova_floating][:use_vlan]
-      floating_network_type = "--provider:network_type vlan --provider:segmentation_id #{floating_net["vlan"]} --provider:physical_network physnet1"
+      floating_network_type = "--provider:network_type vlan --provider:segmentation_id #{floating_net["vlan"]} --provider:physical_network floating"
     else
-      floating_network_type = "--provider:network_type flat --provider:physical_network physnet1"
+      floating_network_type = "--provider:network_type flat --provider:physical_network floating"
     end
   when "gre"
     fixed_network_type = "--provider:network_type gre --provider:segmentation_id 1"


### PR DESCRIPTION
It needs to be on "floating" not "physnet1". It seems this didn't matter much as
long as we still had the "external_network_bridge" setting in the config. But
that needed to go for mulitple external network support.