### PR TITLE
Fixup migration for tex backport

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/032_add_domain_specific_drivers.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/032_add_domain_specific_drivers.rb
@@ -1,11 +1,15 @@
 def upgrade ta, td, a, d
-  a["domain_specific_drivers"] = ta["domain_specific_drivers"]
-  a["domain_config_dir"] = ta["domain_config_dir"]
+  unless a.has_key? "multi_domain_support"
+    a["domain_specific_drivers"] = ta["domain_specific_drivers"]
+    a["domain_config_dir"] = ta["domain_config_dir"]
+  end
   return a, d
 end
 
 def downgrade ta, td, a, d
-  a.delete("domain_specific_drivers")
-  a.delete("domain_config_dir")
+  unless ta.has_key? "multi_domain_support"
+    a.delete("domain_specific_drivers")
+    a.delete("domain_config_dir")
+  end
   return a, d
 end

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -80,7 +80,7 @@ class KeystoneService < PacemakerServiceObject
     # Using domains requires API Version 3 or newer
     if proposal["attributes"][@bc_name]["domain_specific_drivers"] &&
         proposal["attributes"][@bc_name]["api"]["version"].to_f < 3.0
-      validation_error("API version 3 or newer is required when enabling domain specific drivers.")
+      validation_error("Keystone API version 3 needs to be enabled in order to use domain specific drivers.")
     end
 
     super


### PR DESCRIPTION
Support of Keystone domain specific drivers is being backported to tex. Fix
migrartion to be prepared for that. Also try clarify proposal validation
message a bit.