### PR TITLE
Create external networks as "flat" provider networks (bsc#946882)

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -140,12 +140,16 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
     physnet = node[:crowbar_wall][:network][:nets][:nova_fixed].first
     interface_mappings = "physnet1:" + physnet
-    if multiple_external_networks
-      neutron[:neutron][:additional_external_networks].each do |net|
-        ext_iface = node[:crowbar_wall][:network][:nets][net].first
-        if ext_iface != physnet
-          mapping = ", " + net + ":" + ext_iface
-          interface_mappings += mapping
+    if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
+      floatingphys = node[:crowbar_wall][:network][:nets][:nova_floating].last
+      interface_mappings += ", floating:" + floatingphys
+      if multiple_external_networks
+        neutron[:neutron][:additional_external_networks].each do |net|
+          ext_iface = node[:crowbar_wall][:network][:nets][net].last
+          if ext_iface != physnet
+            mapping = ", " + net + ":" + ext_iface
+            interface_mappings += mapping
+          end
         end
       end
     end

--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -74,20 +74,15 @@ networking_plugin = node[:neutron][:networking_plugin]
 ml2_type_drivers_default_provider_network = node[:neutron][:ml2_type_drivers_default_provider_network]
 case networking_plugin
 when "ml2"
+  # For ml2 always create the floating network as a flat provider network
+  floating_network_type = "--provider:network_type flat --provider:physical_network floating"
   case ml2_type_drivers_default_provider_network
   when "vlan"
     fixed_network_type = "--provider:network_type vlan --provider:segmentation_id #{fixed_net["vlan"]} --provider:physical_network physnet1"
-    if node[:network][:networks][:nova_floating][:use_vlan]
-      floating_network_type = "--provider:network_type vlan --provider:segmentation_id #{floating_net["vlan"]} --provider:physical_network floating"
-    else
-      floating_network_type = "--provider:network_type flat --provider:physical_network floating"
-    end
   when "gre"
     fixed_network_type = "--provider:network_type gre --provider:segmentation_id 1"
-    floating_network_type = "--provider:network_type flat --provider:physical_network floating"
   when "vxlan"
     fixed_network_type = "--provider:network_type vxlan --provider:segmentation_id #{vni_start}"
-    floating_network_type = "--provider:network_type vxlan --provider:segmentation_id #{vni_start + 1}"
   else
     Chef::Log.error("default provider network ml2 type driver '#{ml2_type_drivers_default_provider_network}' invalid for creating provider networks")
   end

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -151,6 +151,9 @@ end
 #                so the order is important
 tenant_network_types = [[node[:neutron][:ml2_type_drivers_default_tenant_network]] + node[:neutron][:ml2_type_drivers]].flatten.uniq
 
+external_networks = ["floating"]
+external_networks.concat(node[:neutron][:additional_external_networks])
+
 case node[:neutron][:networking_plugin]
 when "ml2"
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
@@ -176,7 +179,8 @@ when "ml2"
       gre_end: gre_end,
       vxlan_start: vni_start,
       vxlan_end: vni_end,
-      vxlan_mcast_group: node[:neutron][:vxlan][:multicast_group]
+      vxlan_mcast_group: node[:neutron][:vxlan][:multicast_group],
+      external_networks: external_networks
     )
   end
 when "vmware"

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -37,6 +37,7 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # flat_networks =
 # Example:flat_networks = physnet1,physnet2
 # Example:flat_networks = *
+flat_networks = <%= @external_networks.join(",") %>
 
 [ml2_type_vlan]
 # (ListOpt) List of <physical_network>[:<vlan_min>:<vlan_max>] tuples


### PR DESCRIPTION
This should work regardless of the mechanism driver that is used  (openvswitch
or neutron) as we have the ml2 type driver "flat" enabled unconditionally. This
is also in line with the behaviour of devstack.

For linuxbridge setups this commit also adjust the interface mappings for
external networks to use the VLAN interface instead for the underlying physical
interface. That's required for "flat" networks.