### PR TITLE
Add warning for horizon/keystone timeouts

### DIFF
--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -11,7 +11,7 @@
       "site_theme": "",
       "site_branding_link": "",
       "help_url": "http://docs.openstack.org/",
-      "session_timeout": 1440,
+      "session_timeout": 240,
       "db": {
         "database": "horizon",
         "user": "horizon",

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -86,6 +86,18 @@ class HorizonService < PacemakerServiceObject
       end
     end
 
+    horizon_timeout = proposal["attributes"]["horizon"]["session_timeout"]
+    keystone_proposal = Proposal.where(barclamp: "keystone", name: "default").first
+    unless keystone_proposal.nil?
+      keystone_timeout = keystone_proposal["attributes"]["keystone"]["token_expiration"]
+
+      # keystone_timeout is in seconds and horizon_timeout is in minutes
+      if horizon_timeout * 60 > keystone_timeout
+        validation_error("Setting the Horizon timeout (#{horizon_timeout} minutes) longer than the "\
+          "Keystone token expiration timeout (#{keystone_timeout / 60} minutes) is not supported.")
+      end
+    end
+
     super
   end
 

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -84,6 +84,18 @@ class KeystoneService < PacemakerServiceObject
       validation_error("Keystone API version 3 needs to be enabled in order to use domain specific drivers.")
     end
 
+    keystone_timeout = proposal["attributes"]["keystone"]["token_expiration"]
+    horizon_proposal = Proposal.where(barclamp: "horizon", name: "default").first
+    unless horizon_proposal.nil?
+      horizon_timeout = horizon_proposal["attributes"]["horizon"]["session_timeout"]
+
+      # keystone_timeout is in seconds and horizon_timeout is in minutes
+      if horizon_timeout * 60 > keystone_timeout
+        validation_error("Setting the Horizon timeout (#{horizon_timeout} minutes) longer than the "\
+          "Keystone token expiration timeout (#{keystone_timeout / 60} minutes) is not supported.")
+      end
+    end
+
     super
   end
 


### PR DESCRIPTION
Horizon timeout is impacted by keystone token timeout since when the
token gets outdated, then the user is automatically unable to use
horizon. This patch includes a check for the timeout of horizon and
keystone barclamps.

Increased default keystone token expiration timeout to 24 hours up
from 4 hours.