### PR TITLE
nova: Only accept suse nodes for xen compute role

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -83,8 +83,8 @@ class NovaService < PacemakerServiceObject
         "nova-multi-compute-xen" => {
           "unique" => false,
           "count" => -1,
-          "exclude_platform" => {
-            "windows" => "/.*/"
+          "platform" => {
+            "suse" => "/.*/"
           }
         }
       }


### PR DESCRIPTION
This was already enforced during validation, but we can add an explicit
constraint for it.