### PR TITLE
cinder, glance: Install qemu-img only when needed

### DIFF
--- a/chef/cookbooks/cinder/recipes/scheduler.rb
+++ b/chef/cookbooks/cinder/recipes/scheduler.rb
@@ -19,10 +19,6 @@
 
 include_recipe "#{@cookbook_name}::common"
 
-if node.platform == "ubuntu"
- package "qemu-utils"
-end
-
 cinder_service "scheduler" do
   use_pacemaker_provider node[:cinder][:ha][:enabled]
 end

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -6,8 +6,12 @@
 
 include_recipe "#{@cookbook_name}::common"
 
-if node.platform == "ubuntu"
- package "qemu-utils"
+# Install qemu-img (dependency present in suse packages)
+case node[:platform_family]
+when "debian"
+  package "qemu-utils"
+when "rhel", "fedora"
+  package "qemu-img"
 end
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)


### PR DESCRIPTION
qemu-img is used by some bits of both cinder and glance.