### PR TITLE
neutron: Fix order constraint for neutron-ha-tool

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -157,7 +157,13 @@ pacemaker_primitive ha_tool_primitive_name do
 end
 
 crowbar_pacemaker_order_only_existing "o-#{ha_tool_primitive_name}" do
-  ordering ["g-haproxy", "cl-neutron-server", agents_clone_name, ha_tool_primitive_name]
+  # While neutron-ha-tool technically doesn't directly depend on postgresql or
+  # rabbitmq, if these bits are not running, then neutron-server can run but
+  # can't do what it's being asked. Note that neutron-server does have a
+  # constraint on these services, but it's optional, not mandatory (because it
+  # doesn't need to be restarted when postgresql or rabbitmq are restarted).
+  # So explicitly depend on postgresql and rabbitmq (if they are in the cluster).
+  ordering "( postgresql rabbitmq g-haproxy cl-neutron-server #{agents_clone_name} ) #{ha_tool_primitive_name}"
   score "Mandatory"
   action :create
   only_if { use_l3_agent && CrowbarPacemakerHelper.is_cluster_founder?(node) }


### PR DESCRIPTION
Right now, the order explicitly requires haproxy to be started before
neutron-server, which results in neutron-server being stopped and
started when migration haproxy.

Instead, do not require an order in the dependencies of neutron-ha-tool.
Also depends on postgresql and rabbitmq since without them, this won't
work.

Depends on crowbar/crowbar-ha#29