### PR TITLE
increase timeout for synchronization of horizon HA resources (bsc#935462)

### DIFF
--- a/chef/cookbooks/horizon/recipes/ha.rb
+++ b/chef/cookbooks/horizon/recipes/ha.rb
@@ -37,7 +37,9 @@ end
 crowbar_pacemaker_sync_mark "sync-horizon_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-horizon_ha_resources"
+crowbar_pacemaker_sync_mark "wait-horizon_ha_resources" do
+  timeout 180
+end
 
 include_recipe "crowbar-pacemaker::apache"
 


### PR DESCRIPTION
Horizon HA resources can take over 1 minute to be set up, as seen by [mkcloud failures in ci.suse.de Jenkins](https://trello.com/c/Z1L5phHx).

See also #54 for equivalent tweak to heat.