### PR TITLE
Fixup migration for tex backport (again)

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/032_add_domain_specific_drivers.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/032_add_domain_specific_drivers.rb
@@ -1,14 +1,18 @@
 def upgrade ta, td, a, d
-  unless a.has_key? "multi_domain_support"
+  unless a.has_key? "domain_specific_drivers"
     a["domain_specific_drivers"] = ta["domain_specific_drivers"]
+  end
+  unless a.has_key? "domain_config_dir"
     a["domain_config_dir"] = ta["domain_config_dir"]
   end
   return a, d
 end
 
 def downgrade ta, td, a, d
-  unless ta.has_key? "multi_domain_support"
+  unless ta.has_key? "domain_specific_drivers"
     a.delete("domain_specific_drivers")
+  end
+  unless ta.has_key? "domain_config_dir"
     a.delete("domain_config_dir")
   end
   return a, d


### PR DESCRIPTION
Check for the correct attribute. "multi_domain_support" never was an attribute
of the keystone proposal.