### PR TITLE
Rename nova roles to not have "multi-" in their names

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/agent.rb
+++ b/chef/cookbooks/ceilometer/recipes/agent.rb
@@ -24,7 +24,7 @@ end
 
 include_recipe "#{@cookbook_name}::common"
 
-is_compute = node.roles.any?{ |role| /^nova-multi-compute-/ =~ role }
+is_compute = node.roles.any?{ |role| /^nova-compute-/ =~ role }
 
 service "ceilometer-agent-compute" do
   if %w(suse).include?(node.platform)

--- a/chef/cookbooks/ceilometer/recipes/agent.rb
+++ b/chef/cookbooks/ceilometer/recipes/agent.rb
@@ -24,7 +24,7 @@ end
 
 include_recipe "#{@cookbook_name}::common"
 
-is_compute = node.roles.any?{ |role| /^nova-compute-/ =~ role }
+is_compute = node.roles.any? { |role| /^nova-compute-/ =~ role }
 
 service "ceilometer-agent-compute" do
   if %w(suse).include?(node.platform)

--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -47,7 +47,7 @@ else
   db_connection = "#{db_settings[:url_scheme]}://#{node[:ceilometer][:db][:user]}:#{db_password}@#{db_settings[:address]}/#{node[:ceilometer][:db][:database]}"
 end
 
-is_compute_agent = node.roles.include?("ceilometer-agent") && node.roles.any?{ |role| /^nova-compute-/ =~ role }
+is_compute_agent = node.roles.include?("ceilometer-agent") && node.roles.any? { |role| /^nova-compute-/ =~ role }
 is_swift_proxy = node.roles.include?("ceilometer-swift-proxy-middleware") && node.roles.include?("swift-proxy")
 
 # Find hypervisor inspector

--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -47,14 +47,14 @@ else
   db_connection = "#{db_settings[:url_scheme]}://#{node[:ceilometer][:db][:user]}:#{db_password}@#{db_settings[:address]}/#{node[:ceilometer][:db][:database]}"
 end
 
-is_compute_agent = node.roles.include?("ceilometer-agent") && node.roles.any?{ |role| /^nova-multi-compute-/ =~ role }
+is_compute_agent = node.roles.include?("ceilometer-agent") && node.roles.any?{ |role| /^nova-compute-/ =~ role }
 is_swift_proxy = node.roles.include?("ceilometer-swift-proxy-middleware") && node.roles.include?("swift-proxy")
 
 # Find hypervisor inspector
 hypervisor_inspector = nil
 libvirt_type = nil
 if is_compute_agent
-  if node.roles.include?("nova-multi-compute-vmware")
+  if node.roles.include?("nova-compute-vmware")
     hypervisor_inspector = "vsphere"
   else
     hypervisor_inspector = "libvirt"

--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -42,7 +42,7 @@ else
 end
 Chef::Log.info("Glance server at #{glance_server_host}")
 
-nova_apis = search(:node, "roles:nova-multi-controller") || []
+nova_apis = search(:node, "roles:nova-controller") || []
 if nova_apis.length > 0
   nova_api = nova_apis[0]
   nova_api_insecure = nova_api[:nova][:ssl][:enabled] && nova_api[:nova][:ssl][:insecure]

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -91,7 +91,7 @@ if cinders.length > 0
 end
 
 #TODO: similarly with nova
-use_docker = !search(:node, "roles:nova-multi-compute-docker").empty?
+use_docker = !search(:node, "roles:nova-compute-docker").empty?
 
 network_settings = GlanceHelper.network_settings(node)
 

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -202,7 +202,7 @@ else
   neutron_use_vpnaas = false
 end
 
-nova = get_instance("roles:nova-multi-controller")
+nova = get_instance("roles:nova-controller")
 nova_insecure = (nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]) rescue false
 
 directory "/var/lib/openstack-dashboard" do

--- a/chef/cookbooks/manila/recipes/common.rb
+++ b/chef/cookbooks/manila/recipes/common.rb
@@ -82,7 +82,7 @@ else
 end
 
 # get Nova data
-nova = search(:node, "roles:nova-multi-controller") || []
+nova = search(:node, "roles:nova-controller") || []
 if nova.length > 0
   nova = nova[0]
   nova_insecure = (

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -258,7 +258,7 @@ if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
 
   #TODO: nova should depend on neutron, but neutron also depends on nova
   # so we have to do something like this
-  novas = search(:node, "roles:nova-multi-controller") || []
+  novas = search(:node, "roles:nova-controller") || []
   if novas.length > 0
     nova = novas[0]
     nova = node if nova.name == node.name

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -83,7 +83,7 @@ end
 
 #TODO: nova should depend on neutron, but neutron also depends on nova
 # so we have to do something like this
-novas = search(:node, "roles:nova-multi-controller") || []
+novas = search(:node, "roles:nova-controller") || []
 if novas.length > 0
   nova = novas[0]
   nova = node if nova.name == node.name

--- a/chef/cookbooks/nova/recipes/availability_zones.rb
+++ b/chef/cookbooks/nova/recipes/availability_zones.rb
@@ -20,7 +20,7 @@
 command_no_arg = NovaAvailabilityZone.fetch_set_az_command_no_arg(node, @cookbook_name)
 
 # non-hyperv nodes set their AZ themselves, so only look for hyperv nodes
-search_env_filtered(:node, "roles:nova-multi-compute-hyperv") do |n|
+search_env_filtered(:node, "roles:nova-compute-hyperv") do |n|
   command = NovaAvailabilityZone.add_arg_to_set_az_command(command_no_arg, n)
 
   execute "Set availability zone for #{n.hostname}" do

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -284,7 +284,7 @@ cookbook_file "/etc/nova/nova-compute.conf" do
 end unless node.platform == "suse"
 
 env_filter = " AND nova_config_environment:#{node[:nova][:config][:environment]}"
-nova_controller = search(:node, "roles:nova-multi-controller#{env_filter}")
+nova_controller = search(:node, "roles:nova-controller#{env_filter}")
 
 # Note: since we do not allow shared storage with a cluster, we know that the
 # first controller is the right one to use (ie, the only one)
@@ -332,19 +332,19 @@ ruby_block "nova_read_ssh_public_key" do
 end
 
 ssh_auth_keys = ""
-search_env_filtered(:node, "roles:nova-multi-compute-kvm") do |n|
+search_env_filtered(:node, "roles:nova-compute-kvm") do |n|
   ssh_auth_keys += n[:nova][:service_ssh_key]
 end
-search_env_filtered(:node, "roles:nova-multi-compute-xen") do |n|
+search_env_filtered(:node, "roles:nova-compute-xen") do |n|
   ssh_auth_keys += n[:nova][:service_ssh_key]
 end
-search_env_filtered(:node, "roles:nova-multi-compute-docker") do |n|
+search_env_filtered(:node, "roles:nova-compute-docker") do |n|
   ssh_auth_keys += n[:nova][:service_ssh_key]
 end
-search_env_filtered(:node, "roles:nova-multi-compute-qemu") do |n|
+search_env_filtered(:node, "roles:nova-compute-qemu") do |n|
   ssh_auth_keys += n[:nova][:service_ssh_key]
 end
-search_env_filtered(:node, "roles:nova-multi-compute-zvm") do |n|
+search_env_filtered(:node, "roles:nova-compute-zvm") do |n|
   ssh_auth_keys += n[:nova][:service_ssh_key]
 end
 

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -169,7 +169,7 @@ else
 end
 
 # only require certs for nova controller
-if (api_ha_enabled || vncproxy_ha_enabled || api == node) and api[:nova][:ssl][:enabled] and node["roles"].include?("nova-controller")
+if (api_ha_enabled || vncproxy_ha_enabled || api == node) && api[:nova][:ssl][:enabled] && node["roles"].include?("nova-controller")
   if api[:nova][:ssl][:generate_certs]
     package "openssl"
     ruby_block "generate_certs for nova" do

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -29,7 +29,7 @@ haproxy_loadbalancer "nova-api" do
   address "0.0.0.0"
   port node[:nova][:ports][:api]
   use_ssl node[:nova][:ssl][:enabled]
-  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-multi-controller", "api")
+  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "api")
   action :nothing
 end.run_action(:create)
 
@@ -37,7 +37,7 @@ haproxy_loadbalancer "nova-api-ec2" do
   address "0.0.0.0"
   port node[:nova][:ports][:api_ec2]
   use_ssl node[:nova][:ssl][:enabled]
-  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-multi-controller", "api_ec2")
+  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "api_ec2")
   action :nothing
 end.run_action(:create)
 
@@ -45,7 +45,7 @@ haproxy_loadbalancer "nova-metadata" do
   address cluster_admin_ip
   port node[:nova][:ports][:metadata]
   use_ssl node[:nova][:ssl][:enabled]
-  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-multi-controller", "metadata")
+  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "metadata")
   action :nothing
 end.run_action(:create)
 
@@ -53,7 +53,7 @@ haproxy_loadbalancer "nova-objectstore" do
   address "0.0.0.0"
   port node[:nova][:ports][:objectstore]
   use_ssl false
-  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-multi-controller", "objectstore")
+  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "objectstore")
   action :nothing
 end.run_action(:create)
 
@@ -62,7 +62,7 @@ if node[:nova][:use_novnc]
     address "0.0.0.0"
     port node[:nova][:ports][:novncproxy]
     use_ssl node[:nova][:novnc][:ssl][:enabled]
-    servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-multi-controller", "novncproxy")
+    servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "novncproxy")
     action :nothing
   end.run_action(:create)
 else
@@ -70,7 +70,7 @@ else
     address "0.0.0.0"
     port node[:nova][:ports][:xvpvncproxy]
     use_ssl false
-    servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-multi-controller", "xvpvncproxy")
+    servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "xvpvncproxy")
     action :nothing
   end.run_action(:create)
 end

--- a/chef/cookbooks/nova/recipes/monitor.rb
+++ b/chef/cookbooks/nova/recipes/monitor.rb
@@ -36,36 +36,36 @@ search_env_filtered(:node, "roles:nova-single-machine") do |n|
   nova_scale[:apis] << n
 end
 
-search_env_filtered(:node, "roles:nova-multi-controller") do |n|
+search_env_filtered(:node, "roles:nova-controller") do |n|
   nova_scale[:schedulers] << n
   nova_scale[:apis] << n
 end
 
-search_env_filtered(:node, "roles:nova-multi-compute-docker") do |n|
+search_env_filtered(:node, "roles:nova-compute-docker") do |n|
   nova_scale[:computes] << n
 end
 
-search_env_filtered(:node, "roles:nova-multi-compute-hyperv") do |n|
+search_env_filtered(:node, "roles:nova-compute-hyperv") do |n|
   nova_scale[:computes] << n
 end
 
-search_env_filtered(:node, "roles:nova-multi-compute-kvm") do |n|
+search_env_filtered(:node, "roles:nova-compute-kvm") do |n|
   nova_scale[:computes] << n
 end
 
-search_env_filtered(:node, "roles:nova-multi-compute-qemu") do |n|
+search_env_filtered(:node, "roles:nova-compute-qemu") do |n|
   nova_scale[:computes] << n
 end
 
-search_env_filtered(:node, "roles:nova-multi-compute-vmware") do |n|
+search_env_filtered(:node, "roles:nova-compute-vmware") do |n|
   nova_scale[:computes] << n
 end
 
-search_env_filtered(:node, "roles:nova-multi-compute-xen") do |n|
+search_env_filtered(:node, "roles:nova-compute-xen") do |n|
   nova_scale[:computes] << n
 end
 
-search_env_filtered(:node, "roles:nova-multi-compute-zvm") do |n|
+search_env_filtered(:node, "roles:nova-compute-zvm") do |n|
   nova_scale[:computes] << n
 end
 

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-nova = get_instance("roles:nova-multi-controller")
+nova = get_instance("roles:nova-controller")
 keystone_settings = KeystoneHelper.keystone_settings(nova, "nova")
 
 alt_comp_user = keystone_settings["default_user"]
@@ -338,8 +338,8 @@ if backend_names.length > 1
   cinder_backend2_name = backend_names[1]
 end
 
-kvm_compute_nodes = search(:node, "roles:nova-multi-compute-kvm") || []
-docker_compute_nodes = search(:node, "roles:nova-multi-compute-docker") || []
+kvm_compute_nodes = search(:node, "roles:nova-compute-kvm") || []
+docker_compute_nodes = search(:node, "roles:nova-compute-docker") || []
 
 use_resize = kvm_compute_nodes.length > 1
 use_livemigration = nova[:nova][:use_migration] && kvm_compute_nodes.length > 1

--- a/chef/cookbooks/trove/recipes/default.rb
+++ b/chef/cookbooks/trove/recipes/default.rb
@@ -39,8 +39,8 @@ node["openstack"]["endpoints"]["identity-admin"]["host"] = keystone_server["fqdn
 node["openstack"]["endpoints"]["identity-admin"]["scheme"] = keystone_server["keystone"]["api"]["protocol"]
 node["openstack"]["endpoints"]["identity-admin"]["port"] = keystone_server["keystone"]["api"]["admin_port"]
 
-nova_multi_controller = get_instance("roles:nova-multi-controller")
-Chef::Log.info("Found nova-multi-controller instance on #{nova_multi_controller}.")
+nova_multi_controller = get_instance("roles:nova-controller")
+Chef::Log.info("Found nova-controller instance on #{nova_multi_controller}.")
 node.set_unless["openstack"]["endpoints"]["compute-api"] = {}
 node["openstack"]["endpoints"]["compute-api"]["host"] = nova_multi_controller["fqdn"]
 node["openstack"]["endpoints"]["compute-api"]["scheme"] = nova_multi_controller["nova"]["ssl"]["enabled"] ? "https" : "http"

--- a/chef/data_bags/crowbar/migrate/neutron/043_add_ovs_bridge.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/043_add_ovs_bridge.rb
@@ -2,6 +2,7 @@ def upgrade(ta, td, a, d)
   ns = NeutronService.new Rails.logger
   nodes = NodeObject.find("roles:neutron-network")
   nodes << NodeObject.find("roles:nova-multi-compute-* NOT roles:nova-multi-compute-vmware")
+  nodes << NodeObject.find("roles:nova-compute-* NOT roles:nova-compute-vmware")
   nodes.flatten!
   nodes.each do |node|
     ns.update_ovs_bridge_attributes(a, node)

--- a/chef/data_bags/crowbar/migrate/nova/035_rename_nova_roles.rb
+++ b/chef/data_bags/crowbar/migrate/nova/035_rename_nova_roles.rb
@@ -1,0 +1,47 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  %w(controller compute-docker compute-hyperv compute-kvm compute-qemu compute-vmware compute-xen compute-zvm).each do |role|
+    d["elements"]["nova-#{role}"] = d["elements"]["nova-multi-#{role}"]
+    d["elements"].delete("nova-multi-#{role}")
+
+    # Make sure that all nodes that have the multi role
+    # in their run_list are migrated to new name
+    nodes = NodeObject.find("roles:nova-multi-#{role}")
+    nodes.each do |node|
+      node.add_to_run_list("nova-#{role}",
+                           td["element_run_list_order"]["nova-#{role}"],
+                           td["element_states"]["nova-#{role}"])
+      node.delete_from_run_list("nova-multi-#{role}")
+      node.save
+    end
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  %w(controller compute-docker compute-hyperv compute-kvm compute-qemu compute-vmware compute-xen compute-zvm).each do |role|
+    d["elements"]["nova-multi-#{role}"] = d["elements"]["nova-#{role}"]
+    d["elements"].delete("nova-#{role}")
+
+    # Make sure that all nodes that have the multi role
+    # in their run_list are migrated to new name
+    nodes = NodeObject.find("roles:nova-#{role}")
+    nodes.each do |node|
+      node.add_to_run_list("nova-multi-#{role}",
+                           td["element_run_list_order"]["nova-multi-#{role}"],
+                           td["element_states"]["nova-multi-#{role}"])
+      node.delete_from_run_list("nova-#{role}")
+      node.save
+    end
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -84,39 +84,39 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 34,
+      "schema-revision": 35,
       "element_states": {
-        "nova-multi-controller": [ "readying", "ready", "applying" ],
-        "nova-multi-compute-docker": [ "readying", "ready", "applying" ],
-        "nova-multi-compute-hyperv": [ "readying", "ready", "applying" ],
-        "nova-multi-compute-kvm": [ "readying", "ready", "applying" ],
-        "nova-multi-compute-qemu": [ "readying", "ready", "applying" ],
-        "nova-multi-compute-vmware": [ "readying", "ready", "applying" ],
-        "nova-multi-compute-xen": [ "readying", "ready", "applying" ],
-        "nova-multi-compute-zvm": [ "readying", "ready", "applying" ]
+        "nova-controller": [ "readying", "ready", "applying" ],
+        "nova-compute-docker": [ "readying", "ready", "applying" ],
+        "nova-compute-hyperv": [ "readying", "ready", "applying" ],
+        "nova-compute-kvm": [ "readying", "ready", "applying" ],
+        "nova-compute-qemu": [ "readying", "ready", "applying" ],
+        "nova-compute-vmware": [ "readying", "ready", "applying" ],
+        "nova-compute-xen": [ "readying", "ready", "applying" ],
+        "nova-compute-zvm": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
-        [ "nova-multi-controller" ],
+        [ "nova-controller" ],
         [
-          "nova-multi-compute-docker",
-          "nova-multi-compute-hyperv",
-          "nova-multi-compute-kvm",
-          "nova-multi-compute-qemu",
-          "nova-multi-compute-vmware",
-          "nova-multi-compute-xen",
-          "nova-multi-compute-zvm"
+          "nova-compute-docker",
+          "nova-compute-hyperv",
+          "nova-compute-kvm",
+          "nova-compute-qemu",
+          "nova-compute-vmware",
+          "nova-compute-xen",
+          "nova-compute-zvm"
         ]
       ],
       "element_run_list_order": {
-        "nova-multi-controller": 95,
-        "nova-multi-compute-docker": 97,
-        "nova-multi-compute-hyperv": 97,
-        "nova-multi-compute-kvm": 97,
-        "nova-multi-compute-qemu": 97,
-        "nova-multi-compute-vmware": 97,
-        "nova-multi-compute-xen": 97,
-        "nova-multi-compute-zvm": 97
+        "nova-controller": 95,
+        "nova-compute-docker": 97,
+        "nova-compute-hyperv": 97,
+        "nova-compute-kvm": 97,
+        "nova-compute-qemu": 97,
+        "nova-compute-vmware": 97,
+        "nova-compute-xen": 97,
+        "nova-compute-zvm": 97
       },
       "config": {
         "environment": "nova-config-base",

--- a/chef/roles/nova-compute-docker.rb
+++ b/chef/roles/nova-compute-docker.rb
@@ -1,7 +1,7 @@
-name "nova-multi-compute-kvm"
+name "nova-compute-docker"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
-         "recipe[nova::kvm]",
+         "recipe[nova::docker]",
          "recipe[nova::compute]",
          "recipe[nova::monitor]"
          )

--- a/chef/roles/nova-compute-hyperv.rb
+++ b/chef/roles/nova-compute-hyperv.rb
@@ -1,4 +1,4 @@
-name "nova-multi-compute-hyperv"
+name "nova-compute-hyperv"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
          "recipe[hyperv::do_setup]",

--- a/chef/roles/nova-compute-kvm.rb
+++ b/chef/roles/nova-compute-kvm.rb
@@ -1,7 +1,7 @@
-name "nova-multi-compute-zvm"
+name "nova-compute-kvm"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
-         "recipe[nova::zvm]",
+         "recipe[nova::kvm]",
          "recipe[nova::compute]",
          "recipe[nova::monitor]"
          )

--- a/chef/roles/nova-compute-qemu.rb
+++ b/chef/roles/nova-compute-qemu.rb
@@ -1,7 +1,7 @@
-name "nova-multi-compute-vmware"
+name "nova-compute-qemu"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
-         "recipe[nova::vmware]",
+         "recipe[nova::qemu]",
          "recipe[nova::compute]",
          "recipe[nova::monitor]"
          )

--- a/chef/roles/nova-compute-vmware.rb
+++ b/chef/roles/nova-compute-vmware.rb
@@ -1,7 +1,7 @@
-name "nova-multi-compute-docker"
+name "nova-compute-vmware"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
-         "recipe[nova::docker]",
+         "recipe[nova::vmware]",
          "recipe[nova::compute]",
          "recipe[nova::monitor]"
          )

--- a/chef/roles/nova-compute-xen.rb
+++ b/chef/roles/nova-compute-xen.rb
@@ -1,7 +1,7 @@
-name "nova-multi-compute-qemu"
+name "nova-compute-xen"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
-         "recipe[nova::qemu]",
+         "recipe[nova::xen]",
          "recipe[nova::compute]",
          "recipe[nova::monitor]"
          )

--- a/chef/roles/nova-compute-zvm.rb
+++ b/chef/roles/nova-compute-zvm.rb
@@ -1,7 +1,7 @@
-name "nova-multi-compute-xen"
+name "nova-compute-zvm"
 description "Installs requirements to run a Compute node in a Nova cluster"
 run_list(
-         "recipe[nova::xen]",
+         "recipe[nova::zvm]",
          "recipe[nova::compute]",
          "recipe[nova::monitor]"
          )

--- a/chef/roles/nova-controller.rb
+++ b/chef/roles/nova-controller.rb
@@ -1,4 +1,4 @@
-name "nova-multi-controller"
+name "nova-controller"
 
 description "Installs requirements to run the Controller node in a Nova cluster"
 run_list(

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -92,12 +92,12 @@ class CeilometerService < PacemakerServiceObject
     base["attributes"][@bc_name]["rabbitmq_instance"] = find_dep_proposal("rabbitmq")
     base["attributes"][@bc_name]["keystone_instance"] = find_dep_proposal("keystone")
 
-    agent_nodes = NodeObject.find("roles:nova-multi-compute-kvm") +
-      NodeObject.find("roles:nova-multi-compute-qemu") +
-      NodeObject.find("roles:nova-multi-compute-vmware") +
-      NodeObject.find("roles:nova-multi-compute-xen")
+    agent_nodes = NodeObject.find("roles:nova-compute-kvm") +
+      NodeObject.find("roles:nova-compute-qemu") +
+      NodeObject.find("roles:nova-compute-vmware") +
+      NodeObject.find("roles:nova-compute-xen")
 
-    hyperv_agent_nodes = NodeObject.find("roles:nova-multi-compute-hyperv")
+    hyperv_agent_nodes = NodeObject.find("roles:nova-compute-hyperv")
 
     nodes       = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -152,10 +152,10 @@ class NovaService < PacemakerServiceObject
     #   TODO add it here once a compute node can run inside z/VM
     base["deployment"]["nova"]["elements"] = {
       "nova-controller" => [controller.name],
-      "nova-compute-hyperv" => hyperv.map { |x| x.name },
-      "nova-compute-kvm" => kvm.map { |x| x.name },
-      "nova-compute-qemu" => qemu.map { |x| x.name },
-      "nova-compute-xen" => xen.map { |x| x.name }
+      "nova-compute-hyperv" => hyperv.map(&:name),
+      "nova-compute-kvm" => kvm.map(&:name),
+      "nova-compute-qemu" => qemu.map(&:name),
+      "nova-compute-xen" => xen.map(&:name)
     }
 
     base["attributes"][@bc_name]["itxt_instance"] = find_dep_proposal("itxt", true)
@@ -232,7 +232,9 @@ class NovaService < PacemakerServiceObject
     if proposal["attributes"][@bc_name]["use_shared_instance_storage"]
       elements["nova-controller"].each do |element|
         if is_cluster? element
-          validation_error("Shared storage cannot be automatically setup when a cluster has the nova-controller role. Please consider using the NFS Client barclamp instead.")
+          validation_error("Shared storage cannot be automatically setup when "\
+            "a cluster has the nova-controller role. Please consider using "\
+            "the NFS Client barclamp instead.")
           break
         end
       end unless elements["nova-controller"].nil?

--- a/crowbar_framework/app/models/tempest_service.rb
+++ b/crowbar_framework/app/models/tempest_service.rb
@@ -51,7 +51,7 @@ class TempestService < ServiceObject
     base = super
     @logger.debug("Tempest create_proposal: leaving base part")
 
-    nodes = NodeObject.find("roles:nova-multi-controller")
+    nodes = NodeObject.find("roles:nova-controller")
     nodes.delete_if { |n| n.nil? or n.admin? }
     unless nodes.empty?
       base["deployment"]["tempest"]["elements"] = {

--- a/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
@@ -113,7 +113,7 @@
                 .empty.alert.alert-info.text-center
                   = t(".port_hint")
 
-            - nodes_by_role("nova-multi-compute-*").each do |node|
+            - nodes_by_role("nova-compute-*").each do |node|
               %tr.edit
                 %td
                   = text_field_tag "port[node]", node.alias, :placeholder => t(".port_node"), :class => "form-control", :disabled => "disabled"

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -34,7 +34,7 @@ en:
           ram_allocation_ratio: 'Virtual RAM to Physical RAM allocation ratio'
           cpu_allocation_ratio: 'Virtual CPU to Physical CPU allocation ratio'
         live_migration_header: 'Live Migration Support'
-        use_shared_instance_storage: 'Set up Shared Storage on nova-multi-controller for Nova instances'
+        use_shared_instance_storage: 'Set up Shared Storage on nova-controller for Nova instances'
         use_migration: 'Enable Libvirt Migration'
         kvm_header: 'KVM Options'
         kvm:

--- a/crowbar_framework/examples/HA-cloud.yaml
+++ b/crowbar_framework/examples/HA-cloud.yaml
@@ -106,9 +106,9 @@ proposals:
       ksm_enabled: true
   deployment:
     elements:
-      nova-multi-controller:
+      nova-controller:
         - cluster:cluster1
-      nova-multi-compute-qemu:
+      nova-compute-qemu:
         - "@@compute1@@"
 - barclamp: horizon
   deployment:

--- a/crowbar_framework/examples/simple-cloud.yaml
+++ b/crowbar_framework/examples/simple-cloud.yaml
@@ -63,9 +63,9 @@ proposals:
       ksm_enabled: true
   deployment:
     elements:
-      nova-multi-controller:
+      nova-controller:
         - "@@controller1@@"
-      nova-multi-compute-qemu:
+      nova-compute-qemu:
         - "@@compute1@@"
 - barclamp: horizon
   deployment:


### PR DESCRIPTION
This is really useless, not consistent with what we do for everything
else and confusing for users. So let's fix it.