### PR TITLE
Enable multipath for image xfer also on cinder-volume

### DIFF
--- a/chef/cookbooks/cinder/attributes/default.rb
+++ b/chef/cookbooks/cinder/attributes/default.rb
@@ -33,6 +33,13 @@ default[:cinder][:ssl][:insecure] = false
 default[:cinder][:ssl][:cert_required] = false
 default[:cinder][:ssl][:ca_certs] = "/etc/cinder/ssl/certs/ca.pem"
 
+# Keep in sync with nova cookbook
+if node[:platform_family] == "suse"
+  default[:cinder][:use_multipath_for_xfer] = true
+else
+  default[:cinder][:use_multipath_for_xfer] = false
+end
+
 #sqlalchemy parameters
 default[:cinder][:max_pool_size] = 30
 default[:cinder][:max_overflow] = 10

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -1095,6 +1095,9 @@ volume_backend_name=<%= volume['backend_name'] %>
 # volume to image and image to volume transfers? (boolean
 # value)
 #use_multipath_for_image_xfer=false
+<% if node[:cinder][:use_multipath_for_xfer] -%>
+use_multipath_for_image_xfer=true
+<% end -%>
 
 # Method used to wipe old volumes (valid options are: none,
 # zero, shred) (string value)

--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -36,6 +36,8 @@ default[:nova][:use_shared_instance_storage] = false
 # Hypervisor Settings
 #
 default[:nova][:libvirt_type] = "kvm"
+
+# Keep in sync with cinder cookbook
 if node[:platform_family] == "suse"
   default[:nova][:libvirt_use_multipath] = true
 else


### PR DESCRIPTION
Without the settings on Nova and Cinder-volume in sync, there are
interesting side effects in several drivers since they pass through
inconsistent information between Cinder and Nova, that causes undesired
artefacts.