### PR TITLE
Add "role recipes" with the goal of simplifying the roles

### DIFF
--- a/chef/cookbooks/ceilometer/metadata.rb
+++ b/chef/cookbooks/ceilometer/metadata.rb
@@ -11,3 +11,5 @@ depends "database"
 depends "crowbar-openstack"
 depends "crowbar-pacemaker"
 depends "utils"
+
+recommends "hyperv"

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_agent.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_agent.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceilometer"
+role = "ceilometer-agent"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "ceilometer::agent"
+  include_recipe "ceilometer::common"
+end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_agent.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_agent.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "ceilometer::agent"
   include_recipe "ceilometer::common"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_agent_hyperv.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_agent_hyperv.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "hyperv::do_setup"
   include_recipe "hyperv::do_ceilometer"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_agent_hyperv.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_agent_hyperv.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceilometer"
+role = "ceilometer-agent-hyperv"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "hyperv::do_setup"
+  include_recipe "hyperv::do_ceilometer"
+end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_cagent.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_cagent.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceilometer"
+role = "ceilometer-cagent"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "ceilometer::central"
+  include_recipe "ceilometer::common"
+end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_cagent.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_cagent.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "ceilometer::central"
   include_recipe "ceilometer::common"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_server.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_server.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "ceilometer::server"
   include_recipe "ceilometer::common"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_server.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_server.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceilometer"
+role = "ceilometer-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "ceilometer::server"
+  include_recipe "ceilometer::common"
+end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_swift_proxy_middleware.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_swift_proxy_middleware.rb
@@ -22,4 +22,6 @@ states_for_role = node[barclamp]["element_states"][role]
 
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "ceilometer::swift"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/ceilometer/recipes/role_ceilometer_swift_proxy_middleware.rb
+++ b/chef/cookbooks/ceilometer/recipes/role_ceilometer_swift_proxy_middleware.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceilometer"
+role = "ceilometer-swift-proxy-middleware"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "ceilometer::swift"
+end

--- a/chef/cookbooks/cinder/recipes/role_cinder_controller.rb
+++ b/chef/cookbooks/cinder/recipes/role_cinder_controller.rb
@@ -25,4 +25,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "cinder::scheduler"
   include_recipe "cinder::controller_ha"
   include_recipe "cinder::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/cinder/recipes/role_cinder_controller.rb
+++ b/chef/cookbooks/cinder/recipes/role_cinder_controller.rb
@@ -1,0 +1,28 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "cinder"
+role = "cinder-controller"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "cinder::api"
+  include_recipe "cinder::scheduler"
+  include_recipe "cinder::controller_ha"
+  include_recipe "cinder::monitor"
+end

--- a/chef/cookbooks/cinder/recipes/role_cinder_volume.rb
+++ b/chef/cookbooks/cinder/recipes/role_cinder_volume.rb
@@ -22,4 +22,6 @@ states_for_role = node[barclamp]["element_states"][role]
 
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "cinder::volume"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/cinder/recipes/role_cinder_volume.rb
+++ b/chef/cookbooks/cinder/recipes/role_cinder_volume.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "cinder"
+role = "cinder-volume"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "cinder::volume"
+end

--- a/chef/cookbooks/database/recipes/role_database_server.rb
+++ b/chef/cookbooks/database/recipes/role_database_server.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "database::crowbar"
   include_recipe "database::server"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/database/recipes/role_database_server.rb
+++ b/chef/cookbooks/database/recipes/role_database_server.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "database"
+role = "database-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "database::crowbar"
+  include_recipe "database::server"
+end

--- a/chef/cookbooks/glance/recipes/role_glance_server.rb
+++ b/chef/cookbooks/glance/recipes/role_glance_server.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "glance"
+role = "glance-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "glance::registry"
+  include_recipe "glance::api"
+  include_recipe "glance::cache"
+  include_recipe "glance::scrubber"
+  include_recipe "glance::ha"
+  include_recipe "glance::setup"
+  include_recipe "glance::monitor"
+end

--- a/chef/cookbooks/glance/recipes/role_glance_server.rb
+++ b/chef/cookbooks/glance/recipes/role_glance_server.rb
@@ -28,4 +28,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "glance::ha"
   include_recipe "glance::setup"
   include_recipe "glance::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/heat/recipes/role_heat_server.rb
+++ b/chef/cookbooks/heat/recipes/role_heat_server.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "heat::server"
   include_recipe "heat::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/heat/recipes/role_heat_server.rb
+++ b/chef/cookbooks/heat/recipes/role_heat_server.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "heat"
+role = "heat-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "heat::server"
+  include_recipe "heat::monitor"
+end

--- a/chef/cookbooks/horizon/recipes/role_horizon_server.rb
+++ b/chef/cookbooks/horizon/recipes/role_horizon_server.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "horizon::server"
   include_recipe "horizon::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/horizon/recipes/role_horizon_server.rb
+++ b/chef/cookbooks/horizon/recipes/role_horizon_server.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "horizon"
+role = "horizon-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "horizon::server"
+  include_recipe "horizon::monitor"
+end

--- a/chef/cookbooks/keystone/recipes/role_keystone_server.rb
+++ b/chef/cookbooks/keystone/recipes/role_keystone_server.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "keystone::server"
   include_recipe "keystone::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/keystone/recipes/role_keystone_server.rb
+++ b/chef/cookbooks/keystone/recipes/role_keystone_server.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "keystone"
+role = "keystone-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "keystone::server"
+  include_recipe "keystone::monitor"
+end

--- a/chef/cookbooks/manila/recipes/role_manila_server.rb
+++ b/chef/cookbooks/manila/recipes/role_manila_server.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "manila"
+role = "manila-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "manila::api"
+  include_recipe "manila::scheduler"
+  include_recipe "manila::controller_ha"
+end

--- a/chef/cookbooks/manila/recipes/role_manila_server.rb
+++ b/chef/cookbooks/manila/recipes/role_manila_server.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "manila::api"
   include_recipe "manila::scheduler"
   include_recipe "manila::controller_ha"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/manila/recipes/role_manila_share.rb
+++ b/chef/cookbooks/manila/recipes/role_manila_share.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "manila"
+role = "manila-share"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "manila::share"
+end

--- a/chef/cookbooks/manila/recipes/role_manila_share.rb
+++ b/chef/cookbooks/manila/recipes/role_manila_share.rb
@@ -22,4 +22,6 @@ states_for_role = node[barclamp]["element_states"][role]
 
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "manila::share"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/neutron/recipes/role_neutron_network.rb
+++ b/chef/cookbooks/neutron/recipes/role_neutron_network.rb
@@ -22,4 +22,6 @@ states_for_role = node[barclamp]["element_states"][role]
 
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "neutron::network_agents"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/neutron/recipes/role_neutron_network.rb
+++ b/chef/cookbooks/neutron/recipes/role_neutron_network.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "neutron"
+role = "neutron-network"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "neutron::network_agents"
+end

--- a/chef/cookbooks/neutron/recipes/role_neutron_server.rb
+++ b/chef/cookbooks/neutron/recipes/role_neutron_server.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "neutron::server"
   include_recipe "neutron::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/neutron/recipes/role_neutron_server.rb
+++ b/chef/cookbooks/neutron/recipes/role_neutron_server.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "neutron"
+role = "neutron-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "neutron::server"
+  include_recipe "neutron::monitor"
+end

--- a/chef/cookbooks/nova/metadata.rb
+++ b/chef/cookbooks/nova/metadata.rb
@@ -15,3 +15,5 @@ depends "memcached"
 depends "nagios"
 depends "neutron"
 depends "utils"
+
+recommends "hyperv"

--- a/chef/cookbooks/nova/recipes/role_nova_compute_docker.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_docker.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "nova::docker"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_docker.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_docker.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "nova"
+role = "nova-compute-docker"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "nova::docker"
+  include_recipe "nova::compute"
+  include_recipe "nova::monitor"
+end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_hyperv.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_hyperv.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "nova"
+role = "nova-compute-hyperv"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "hyperv::do_setup"
+  include_recipe "hyperv::do_nova"
+end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_hyperv.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_hyperv.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "hyperv::do_setup"
   include_recipe "hyperv::do_nova"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_kvm.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_kvm.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "nova::kvm"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_kvm.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_kvm.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "nova"
+role = "nova-compute-kvm"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "nova::kvm"
+  include_recipe "nova::compute"
+  include_recipe "nova::monitor"
+end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_qemu.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_qemu.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "nova"
+role = "nova-compute-qemu"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "nova::qemu"
+  include_recipe "nova::compute"
+  include_recipe "nova::monitor"
+end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_qemu.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_qemu.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "nova::qemu"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_vmware.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_vmware.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "nova::vmware"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_vmware.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_vmware.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "nova"
+role = "nova-compute-vmware"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "nova::vmware"
+  include_recipe "nova::compute"
+  include_recipe "nova::monitor"
+end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_xen.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_xen.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "nova"
+role = "nova-compute-xen"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "nova::xen"
+  include_recipe "nova::compute"
+  include_recipe "nova::monitor"
+end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_xen.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_xen.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "nova::xen"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_zvm.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_zvm.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "nova::zvm"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_zvm.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_zvm.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "nova"
+role = "nova-compute-zvm"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "nova::zvm"
+  include_recipe "nova::compute"
+  include_recipe "nova::monitor"
+end

--- a/chef/cookbooks/nova/recipes/role_nova_controller.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_controller.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "nova"
+role = "nova-controller"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "nova::config"
+  include_recipe "nova::database"
+  include_recipe "nova::api"
+  include_recipe "nova::cert"
+  include_recipe "nova::instances"
+  include_recipe "nova::scheduler"
+  include_recipe "nova::memcached"
+  include_recipe "nova::vncproxy"
+  include_recipe "nova::controller_ha"
+  include_recipe "nova::availability_zones"
+  include_recipe "nova::trusted_flavors"
+  include_recipe "nova::monitor"
+end

--- a/chef/cookbooks/nova/recipes/role_nova_controller.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_controller.rb
@@ -33,4 +33,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "nova::availability_zones"
   include_recipe "nova::trusted_flavors"
   include_recipe "nova::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/rabbitmq/recipes/role_rabbitmq_server.rb
+++ b/chef/cookbooks/rabbitmq/recipes/role_rabbitmq_server.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "rabbitmq"
+role = "rabbitmq-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "rabbitmq::rabbit"
+  include_recipe "rabbitmq::monitor"
+end

--- a/chef/cookbooks/rabbitmq/recipes/role_rabbitmq_server.rb
+++ b/chef/cookbooks/rabbitmq/recipes/role_rabbitmq_server.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "rabbitmq::rabbit"
   include_recipe "rabbitmq::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/swift/recipes/role_swift_dispersion.rb
+++ b/chef/cookbooks/swift/recipes/role_swift_dispersion.rb
@@ -22,4 +22,6 @@ states_for_role = node[barclamp]["element_states"][role]
 
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "swift::dispersion"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/swift/recipes/role_swift_dispersion.rb
+++ b/chef/cookbooks/swift/recipes/role_swift_dispersion.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "swift"
+role = "swift-dispersion"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "swift::dispersion"
+end

--- a/chef/cookbooks/swift/recipes/role_swift_proxy.rb
+++ b/chef/cookbooks/swift/recipes/role_swift_proxy.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "swift"
+role = "swift-proxy"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "swift::default"
+  include_recipe "swift::proxy"
+  include_recipe "swift::monitor"
+end

--- a/chef/cookbooks/swift/recipes/role_swift_proxy.rb
+++ b/chef/cookbooks/swift/recipes/role_swift_proxy.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "swift::default"
   include_recipe "swift::proxy"
   include_recipe "swift::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/swift/recipes/role_swift_ring_compute.rb
+++ b/chef/cookbooks/swift/recipes/role_swift_ring_compute.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "swift::default"
   include_recipe "swift::ring-compute"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/swift/recipes/role_swift_ring_compute.rb
+++ b/chef/cookbooks/swift/recipes/role_swift_ring_compute.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "swift"
+role = "swift-ring-compute"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "swift::default"
+  include_recipe "swift::ring-compute"
+end

--- a/chef/cookbooks/swift/recipes/role_swift_storage.rb
+++ b/chef/cookbooks/swift/recipes/role_swift_storage.rb
@@ -24,4 +24,6 @@ if states_for_role.nil? || states_for_role.include?("all") || states_for_role.in
   include_recipe "swift::default"
   include_recipe "swift::storage"
   include_recipe "swift::monitor"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/swift/recipes/role_swift_storage.rb
+++ b/chef/cookbooks/swift/recipes/role_swift_storage.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "swift"
+role = "swift-storage"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "swift::default"
+  include_recipe "swift::storage"
+  include_recipe "swift::monitor"
+end

--- a/chef/cookbooks/tempest/recipes/role_tempest.rb
+++ b/chef/cookbooks/tempest/recipes/role_tempest.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "tempest"
+role = "tempest"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "tempest::install"
+  include_recipe "tempest::config"
+end

--- a/chef/cookbooks/tempest/recipes/role_tempest.rb
+++ b/chef/cookbooks/tempest/recipes/role_tempest.rb
@@ -23,4 +23,6 @@ states_for_role = node[barclamp]["element_states"][role]
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "tempest::install"
   include_recipe "tempest::config"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/trove/recipes/role_trove_server.rb
+++ b/chef/cookbooks/trove/recipes/role_trove_server.rb
@@ -22,4 +22,6 @@ states_for_role = node[barclamp]["element_states"][role]
 
 if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
   include_recipe "trove::default"
+else
+  Chef::Log.info("Skipping role \"#{role}\" because node is in state \"#{node[:state]}\".")
 end

--- a/chef/cookbooks/trove/recipes/role_trove_server.rb
+++ b/chef/cookbooks/trove/recipes/role_trove_server.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "trove"
+role = "trove-server"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "trove::default"
+end

--- a/chef/roles/ceilometer-agent-hyperv.rb
+++ b/chef/roles/ceilometer-agent-hyperv.rb
@@ -1,9 +1,5 @@
 name "ceilometer-agent-hyperv"
 description "Ceilometer Agent Role on HyperV Hosts"
-run_list(
-         "recipe[hyperv::do_setup]",
-         "recipe[hyperv::do_ceilometer]"
-)
+run_list("recipe[ceilometer::role_ceilometer_agent_hyperv]")
 default_attributes()
 override_attributes()
-

--- a/chef/roles/ceilometer-agent.rb
+++ b/chef/roles/ceilometer-agent.rb
@@ -1,9 +1,5 @@
 name "ceilometer-agent"
 description "Ceilometer Agent Role"
-run_list(
-         "recipe[ceilometer::agent]",
-         "recipe[ceilometer::common]"
-)
+run_list("recipe[ceilometer::role_ceilometer_agent]")
 default_attributes()
 override_attributes()
-

--- a/chef/roles/ceilometer-cagent.rb
+++ b/chef/roles/ceilometer-cagent.rb
@@ -1,9 +1,5 @@
 name "ceilometer-cagent"
 description "Ceilometer Central Agent Role"
-run_list(
-         "recipe[ceilometer::central]",
-         "recipe[ceilometer::common]"
-)
+run_list("recipe[ceilometer::role_ceilometer_cagent]")
 default_attributes()
 override_attributes()
-

--- a/chef/roles/ceilometer-server.rb
+++ b/chef/roles/ceilometer-server.rb
@@ -1,9 +1,5 @@
 name "ceilometer-server"
 description "Ceilometer Server Role"
-run_list(
-         "recipe[ceilometer::server]",
-         "recipe[ceilometer::common]"
-)
+run_list("recipe[ceilometer::role_ceilometer_server]")
 default_attributes()
 override_attributes()
-

--- a/chef/roles/ceilometer-swift-proxy-middleware.rb
+++ b/chef/roles/ceilometer-swift-proxy-middleware.rb
@@ -1,7 +1,5 @@
 name "ceilometer-swift-proxy-middleware"
 description "Ceilometer Swift Support"
-run_list(
-         "recipe[ceilometer::swift]"
-)
+run_list("recipe[ceilometer::role_ceilometer_swift_proxy_middleware]")
 default_attributes()
 override_attributes()

--- a/chef/roles/cinder-controller.rb
+++ b/chef/roles/cinder-controller.rb
@@ -1,10 +1,5 @@
 name "cinder-controller"
 description "Cinder API and Scheduler Role"
-run_list(
-  "recipe[cinder::api]",
-  "recipe[cinder::scheduler]",
-  "recipe[cinder::controller_ha]",
-  "recipe[cinder::monitor]"
-)
+run_list("recipe[cinder::role_cinder_controller]")
 default_attributes()
 override_attributes()

--- a/chef/roles/cinder-volume.rb
+++ b/chef/roles/cinder-volume.rb
@@ -1,7 +1,5 @@
 name "cinder-volume"
 description "Cinder volume Role"
-run_list(
-  "recipe[cinder::volume]"
-)
+run_list("recipe[cinder::role_cinder_volume]")
 default_attributes()
 override_attributes()

--- a/chef/roles/database-server.rb
+++ b/chef/roles/database-server.rb
@@ -1,9 +1,6 @@
 name "database-server"
 description "Database Server Role"
-run_list(
-         "recipe[database::crowbar]",
-         "recipe[database::server]"
-)
+run_list("recipe[database::role_database_server]")
 default_attributes()
 override_attributes()
 

--- a/chef/roles/glance-server.rb
+++ b/chef/roles/glance-server.rb
@@ -1,13 +1,5 @@
 name "glance-server"
 description "Glance Server Role - Image Registry and Delivery Service for the cloud"
-run_list(
-         "recipe[glance::registry]",
-         "recipe[glance::api]",
-         "recipe[glance::cache]",
-         "recipe[glance::scrubber]",
-         "recipe[glance::ha]",
-         "recipe[glance::setup]",
-         "recipe[glance::monitor]"
-)
+run_list("recipe[glance::role_glance_server]")
 default_attributes()
 override_attributes()

--- a/chef/roles/heat-server.rb
+++ b/chef/roles/heat-server.rb
@@ -1,9 +1,6 @@
 name "heat-server"
 description "Heat Server Role"
-run_list(
-         "recipe[heat::server]",
-         "recipe[heat::monitor]"
-)
+run_list("recipe[heat::role_heat_server]")
 default_attributes()
 override_attributes()
 

--- a/chef/roles/horizon-server.rb
+++ b/chef/roles/horizon-server.rb
@@ -1,8 +1,5 @@
 name "horizon-server"
 description "Horizon Server Role"
-run_list(
- "recipe[horizon::server]",
- "recipe[horizon::monitor]"
-)
+run_list("recipe[horizon::role_horizon_server]")
 default_attributes
 override_attributes

--- a/chef/roles/keystone-server.rb
+++ b/chef/roles/keystone-server.rb
@@ -1,8 +1,3 @@
 name "keystone-server"
 description "Keystone server"
-
-run_list(
-  "recipe[keystone::server]",
-  "recipe[keystone::monitor]"
-)
-
+run_list("recipe[keystone::role_keystone_server]")

--- a/chef/roles/manila-server.rb
+++ b/chef/roles/manila-server.rb
@@ -1,9 +1,5 @@
 name "manila-server"
 description "Manila API and Scheduler Role"
-run_list(
-  "recipe[manila::api]",
-  "recipe[manila::scheduler]",
-  "recipe[manila::controller_ha]"
-)
+run_list("recipe[manila::role_manila_server]")
 default_attributes
 override_attributes

--- a/chef/roles/manila-share.rb
+++ b/chef/roles/manila-share.rb
@@ -1,7 +1,5 @@
 name "manila-share"
 description "Manila share Role"
-run_list(
-  "recipe[manila::share]"
-)
+run_list("recipe[manila::role_manila_share]")
 default_attributes
 override_attributes

--- a/chef/roles/neutron-network.rb
+++ b/chef/roles/neutron-network.rb
@@ -1,6 +1,4 @@
 name "neutron-network"
 description "Neutron Network Agents"
 
-run_list(
-  "recipe[neutron::network_agents]"
-)
+run_list("recipe[neutron::role_neutron_network]")

--- a/chef/roles/neutron-server.rb
+++ b/chef/roles/neutron-server.rb
@@ -1,7 +1,4 @@
 name "neutron-server"
 description "Neutron server"
 
-run_list(
-  "recipe[neutron::server]",
-  "recipe[neutron::monitor]"
-)
+run_list("recipe[neutron::role_neutron_server]")

--- a/chef/roles/nova-compute-docker.rb
+++ b/chef/roles/nova-compute-docker.rb
@@ -1,7 +1,3 @@
 name "nova-compute-docker"
 description "Installs requirements to run a Compute node in a Nova cluster"
-run_list(
-         "recipe[nova::docker]",
-         "recipe[nova::compute]",
-         "recipe[nova::monitor]"
-         )
+run_list("recipe[nova::role_nova_compute_docker]")

--- a/chef/roles/nova-compute-hyperv.rb
+++ b/chef/roles/nova-compute-hyperv.rb
@@ -1,8 +1,5 @@
 name "nova-compute-hyperv"
 description "Installs requirements to run a Compute node in a Nova cluster"
-run_list(
-         "recipe[hyperv::do_setup]",
-         "recipe[hyperv::do_nova]"
-)
+run_list("recipe[nova::role_nova_compute_hyperv]")
 default_attributes()
 override_attributes()

--- a/chef/roles/nova-compute-kvm.rb
+++ b/chef/roles/nova-compute-kvm.rb
@@ -1,7 +1,3 @@
 name "nova-compute-kvm"
 description "Installs requirements to run a Compute node in a Nova cluster"
-run_list(
-         "recipe[nova::kvm]",
-         "recipe[nova::compute]",
-         "recipe[nova::monitor]"
-         )
+run_list("recipe[nova::role_nova_compute_kvm]")

--- a/chef/roles/nova-compute-qemu.rb
+++ b/chef/roles/nova-compute-qemu.rb
@@ -1,7 +1,3 @@
 name "nova-compute-qemu"
 description "Installs requirements to run a Compute node in a Nova cluster"
-run_list(
-         "recipe[nova::qemu]",
-         "recipe[nova::compute]",
-         "recipe[nova::monitor]"
-         )
+run_list("recipe[nova::role_nova_compute_qemu]")

--- a/chef/roles/nova-compute-vmware.rb
+++ b/chef/roles/nova-compute-vmware.rb
@@ -1,7 +1,3 @@
 name "nova-compute-vmware"
 description "Installs requirements to run a Compute node in a Nova cluster"
-run_list(
-         "recipe[nova::vmware]",
-         "recipe[nova::compute]",
-         "recipe[nova::monitor]"
-         )
+run_list("recipe[nova::role_nova_compute_vmware]")

--- a/chef/roles/nova-compute-xen.rb
+++ b/chef/roles/nova-compute-xen.rb
@@ -1,7 +1,3 @@
 name "nova-compute-xen"
 description "Installs requirements to run a Compute node in a Nova cluster"
-run_list(
-         "recipe[nova::xen]",
-         "recipe[nova::compute]",
-         "recipe[nova::monitor]"
-         )
+run_list("recipe[nova::role_nova_compute_xen]")

--- a/chef/roles/nova-compute-zvm.rb
+++ b/chef/roles/nova-compute-zvm.rb
@@ -1,7 +1,3 @@
 name "nova-compute-zvm"
 description "Installs requirements to run a Compute node in a Nova cluster"
-run_list(
-         "recipe[nova::zvm]",
-         "recipe[nova::compute]",
-         "recipe[nova::monitor]"
-         )
+run_list("recipe[nova::role_nova_compute_zvm]")

--- a/chef/roles/nova-controller.rb
+++ b/chef/roles/nova-controller.rb
@@ -1,17 +1,4 @@
 name "nova-controller"
 
 description "Installs requirements to run the Controller node in a Nova cluster"
-run_list(
-         "recipe[nova::config]",
-         "recipe[nova::database]",
-         "recipe[nova::api]",
-         "recipe[nova::cert]",
-         "recipe[nova::instances]",
-         "recipe[nova::scheduler]",
-         "recipe[nova::memcached]",
-         "recipe[nova::vncproxy]",
-         "recipe[nova::controller_ha]",
-         "recipe[nova::availability_zones]",
-         "recipe[nova::trusted_flavors]",
-         "recipe[nova::monitor]"
-         )
+run_list("recipe[nova::role_nova_controller]")

--- a/chef/roles/rabbitmq-server.rb
+++ b/chef/roles/rabbitmq-server.rb
@@ -1,7 +1,4 @@
 name "rabbitmq-server"
 description "RabbiMQ server role - Setups the rabbitmq app"
 
-run_list(
-         "recipe[rabbitmq::rabbit]",
-         "recipe[rabbitmq::monitor]"
-)
+run_list("recipe[rabbitmq::role_rabbitmq_server]")

--- a/chef/roles/swift-dispersion.rb
+++ b/chef/roles/swift-dispersion.rb
@@ -16,7 +16,4 @@
 
 name "swift-dispersion"
 description "provides the health check service to swift"
-run_list(
-    "recipe[swift::dispersion]"
-)
-
+run_list("recipe[swift::role_swift_dispersion]")

--- a/chef/roles/swift-proxy.rb
+++ b/chef/roles/swift-proxy.rb
@@ -18,8 +18,4 @@
 
 name "swift-proxy"
 description "provides the proxy and authentication components to swift"
-run_list(
-    "recipe[swift::default]",
-    "recipe[swift::proxy]",
-    "recipe[swift::monitor]"
-)
+run_list("recipe[swift::role_swift_proxy]")

--- a/chef/roles/swift-ring-compute.rb
+++ b/chef/roles/swift-ring-compute.rb
@@ -18,9 +18,6 @@
 
 name "swift-ring-compute"
 
-run_list(
-    "recipe[swift::default]",
-    "recipe[swift::ring-compute]"
-)
+run_list("recipe[swift::role_swift_ring_compute]")
 
 description "A swift role to compute the ring files for the cluster. Should be installed on a single node"

--- a/chef/roles/swift-storage.rb
+++ b/chef/roles/swift-storage.rb
@@ -19,8 +19,4 @@
 name "swift-storage"
 description "configures a swift storage node, including partitioning disks, formatting them as XFS"
 
-run_list(
-    "recipe[swift::default]",
-    "recipe[swift::storage]",
-    "recipe[swift::monitor]"
-)
+run_list("recipe[swift::role_swift_storage]")

--- a/chef/roles/tempest.rb
+++ b/chef/roles/tempest.rb
@@ -1,8 +1,5 @@
 name "tempest"
 description "Tempest Role - does tempest installation"
-run_list(
-        "recipe[tempest::install]",
-        "recipe[tempest::config]"
-)
+run_list("recipe[tempest::role_tempest]")
 default_attributes()
 override_attributes()

--- a/chef/roles/trove-server.rb
+++ b/chef/roles/trove-server.rb
@@ -1,8 +1,6 @@
 name "trove-server"
 description "Trove Role - Node registered as a Trove server"
-run_list(
-         "recipe[trove]"
-)
+run_list("recipe[trove::role_trove_server]")
 default_attributes()
 override_attributes()
 


### PR DESCRIPTION
We want the roles to only reference one recipe, so that we can put some
intelligence in that recipe:

 - in a first step, we will stop changing the run list of a node
   depending on its state, and instead have the role recipe "decide"
   whether something should be done or not, depending on the state. This
   will solve the issue that the search results for nodes are not
   reliable when a node is in some state that is not "readying",
   "applying" or "ready".

 - in a later step, we might want to have a new attribute that will tell
   us which role to apply instead of applying everything.