### PR TITLE
Use patched tgtd.service to work around bnc#950946

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -275,6 +275,15 @@ if node[:platform] == "suse" && node[:platform_version].to_f < 12.0
   end
 end
 
+# use patched tgtd.service to work around bnc#950946
+template "/usr/lib/systemd/system/tgtd.service" do
+  source "tgtd.service.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+  only_if { node[:platform] == "suse" && node[:platform_version].to_f >= 12.0 }
+end
+
 service "tgt" do
   supports status: true, restart: true, reload: true
   action [:enable, :start]

--- a/chef/cookbooks/cinder/templates/default/tgtd.service.erb
+++ b/chef/cookbooks/cinder/templates/default/tgtd.service.erb
@@ -1,0 +1,26 @@
+[Unit]
+Description=iSCSI target framework daemon
+Documentation=man:tgtd(8)
+After=network.target
+ConditionPathExists=/etc/tgt/targets.conf
+
+[Service]
+Type=forking
+Environment=TGTD_CONFIG=/etc/tgt/targets.conf
+EnvironmentFile=-/etc/sysconfig/tgt
+
+ExecStart=/usr/sbin/tgtd $TGTD_OPTS
+ExecStartPost=/bin/bash -c "sleep 0.5"
+ExecStartPost=/usr/sbin/tgtadm --op update --mode sys --name State -v offline
+ExecStartPost=/usr/sbin/tgtadm --op update --mode sys --name State -v ready
+ExecStartPost=/usr/sbin/tgt-admin -e -c ${TGTD_CONFIG}
+
+ExecReload=/usr/sbin/tgt-admin --update ALL -f -c ${TGTD_CONFIG}
+
+ExecStop=/usr/sbin/tgtadm --op update --mode sys --name State -v offline
+ExecStop=/usr/sbin/tgt-admin --offline ALL
+ExecStop=/usr/sbin/tgt-admin --update ALL -c /dev/null -f
+ExecStop=/usr/sbin/tgtadm  --op delete --mode system
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
(added a small sleep between starting tgtd by bmwiedemann


This is an alternative way of "fixing" the problem when tgtd fails to start and breaks cinder deployment.
Better option is probably https://build.suse.de/request/show/77987
Even better would be having the fixed package in SLE11SP1 GM.