### PR TITLE
neutron: Always automatically enable l2pop whenever possible

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -179,7 +179,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
-        use_l2pop: neutron[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
+        use_l2pop: ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"),
         dvr_enabled: neutron[:neutron][:use_dvr],
         bridge_mappings: bridge_mappings
       )
@@ -203,7 +203,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         vxlan_mcast_group: neutron[:neutron][:vxlan][:multicast_group],
-        use_l2pop: neutron[:neutron][:use_l2pop] && ml2_type_drivers.include?("vxlan"),
+        use_l2pop: ml2_type_drivers.include?("vxlan"),
         interface_mappings: interface_mappings
        )
     end

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -160,7 +160,7 @@ when "ml2"
   #TODO(vuntz): temporarily disable the hyperv mechanism since we're lacking networking-hyperv from stackforge
   #ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup.push("hyperv")
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
-  if node[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"))
+  if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
     ml2_mechanism_drivers.push("l2population")
   end
 

--- a/chef/data_bags/crowbar/migrate/neutron/044_drop_use_l2pop.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/044_drop_use_l2pop.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  a.delete("use_l2pop")
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # Explicitly disable on downgrade as this can create some temporary networking
+  # outage on existing deployments
+  a["use_l2pop"] = false
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -11,7 +11,6 @@
       "verbose": true,
       "dhcp_domain": "openstack.local",
       "use_lbaas": true,
-      "use_l2pop": true,
       "use_dvr": false,
       "additional_external_networks": [],
       "networking_plugin": "ml2",
@@ -68,7 +67,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 43,
+      "schema-revision": 44,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -16,7 +16,6 @@
                     "keystone_instance": { "type": "str", "required": true },
                     "dhcp_domain": { "type": "str", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
-                    "use_l2pop": { "type": "bool", "required": true },
                     "use_dvr": { "type": "bool", "required": true },
                     "additional_external_networks": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "networking_plugin": { "type": "str", "required": true },

--- a/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
@@ -274,9 +274,6 @@ function ml2_type_drivers_check() {
     $('#vxlan_container').hide();
   }
 
-  var use_l2pop = (values.indexOf("gre") >= 0 || values.indexOf("vxlan") >= 0);
-  $('#proposal_attributes').writeJsonAttribute('use_l2pop', use_l2pop);
-
   if (values.length <= 1) {
     $('#ml2_type_drivers_default_provider_network_container').hide();
     $('#ml2_type_drivers_default_tenant_network_container').hide();

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -257,20 +257,10 @@ class NeutronService < PacemakerServiceObject
       validation_error I18n.t("barclamp.#{@bc_name}.validation.openvswitch_linuxbridge")
     end
 
-    if proposal["attributes"]["neutron"]["use_l2pop"]
-      unless ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
-        validation_error I18n.t("barclamp.#{@bc_name}.validation.l2_population")
-      end
-    end
-
     if proposal["attributes"]["neutron"]["use_dvr"]
       if !ml2_mechanism_drivers.include?("openvswitch") ||
          (!ml2_type_drivers.include?("gre") && !ml2_type_drivers.include?("vxlan"))
         validation_error I18n.t("barclamp.#{@bc_name}.validation.dvr")
-      end
-
-      if !proposal["attributes"]["neutron"]["use_l2pop"]
-        validation_error I18n.t("barclamp.#{@bc_name}.validation.dvr_requires_l2")
       end
 
       unless proposal["deployment"]["neutron"]["elements"].fetch("neutron-network", []).empty?

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -106,7 +106,5 @@ en:
         mechanism_driver: 'The mechanism driver "%{drv}" needs the type driver "vlan"'
         cisco_nexus: 'The "cisco_nexus" mechanism driver needs also the "openvswitch" mechanism driver'
         openvswitch_linuxbridge: 'The "openvswitch" and "linuxbridge" mechanism drivers cannot be used in parallel. Only select one of them'
-        l2_population: 'L2 population requires GRE and/or VXLAN'
         dvr: 'DVR can only be used with openvswitch and GRE/VXLAN'
-        dvr_requires_l2: 'DVR requires L2 population'
         dvr_ha: 'DVR is not compatible with High Availability for neutron-network'


### PR DESCRIPTION
The only reason we had an attribute for it is that it was not possible
to automatically set this up during a maintenance upgrade as it was
possibly creating some downtime. Since we're moving to a new version,
there will be downtime anyway, so let's use this as an opportunity to
enable l2pop.

There should be no big downside to just always enable l2pop when it's
possible to use it.