### PR TITLE
Help Docker instances get proper MTU value

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -143,12 +143,15 @@ if neutron_servers.length > 0
   neutron_service_user = neutron_server[:neutron][:service_user]
   neutron_service_password = neutron_server[:neutron][:service_password]
   neutron_dhcp_domain = neutron_server[:neutron][:dhcp_domain]
+  neutron_ml2_drivers = neutron_server[:neutron][:ml2_type_drivers]
+  neutron_has_tunnel = neutron_ml2_drivers.include?("gre") || neutron_ml2_drivers.include?("vxlan")
 else
   neutron_server_host = nil
   neutron_server_port = nil
   neutron_service_user = nil
   neutron_service_password = nil
   neutron_dhcp_domain = "novalocal"
+  neutron_has_tunnel = false
 end
 Chef::Log.info("Neutron server at #{neutron_server_host}")
 
@@ -318,6 +321,7 @@ template "/etc/nova/nova.conf" do
             neutron_service_user: neutron_service_user,
             neutron_service_password: neutron_service_password,
             neutron_dhcp_domain: neutron_dhcp_domain,
+            neutron_has_tunnel: neutron_has_tunnel,
             keystone_settings: keystone_settings,
             cinder_insecure: cinder_insecure || keystone_settings["insecure"],
             ceph_user: ceph_user,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1487,6 +1487,9 @@ security_group_api=neutron
 # DEPRECATED: THIS VALUE SHOULD BE SET WHEN CREATING THE
 # NETWORK. MTU setting for network interface. (integer value)
 #network_device_mtu=<None>
+<% if @libvirt_type.eql?('docker') && @neutron_has_tunnel -%>
+network_device_mtu=1400
+<% end -%>
 
 
 #


### PR DESCRIPTION
We already send the right MTU value to instances via an option in DHCP,
but this mechanism may not work in all Docker instances because some of
them won't even run a DHCP client. Having the right MTU setting on
instance creation is needed. There's an option (network_device_mtu)
that can be configured in nova.conf to achieve that.

The 1500-byte MTU is too big when a tunneling underlay is used. The
overhead caused by the tunneling is usually 20-byte for IPv4 header,
8-byte for either GRE or VxLAN and 14-byte for Ethernet, totalling
42 bytes. In this situation the right MTU should be 1458 bytes. In
this patch we use 1450 in case two additional VLAN headers are added
in the overlay. This should also be revisited when the underlay or
overlay are using IPv6.

This is only needed when the compute node is running Docker instances
and the networking requires tunneling.