### PR TITLE
horizon: increase timeout in apache config

### DIFF
--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -47,6 +47,8 @@
     Alias /media <%= @horizon_dir %>/media
     Alias /static <%= @horizon_dir %>/static
 
+    Timeout 120
+
     <Location /static>
         SetOutputFilter DEFLATE
         ExpiresActive on


### PR DESCRIPTION
On a slow system, the first request can take a long time due
to online compression. Apache is then running into a:

Timeout when reading response headers from daemon process 'horizon'

error.