### PR TITLE
Allow enablement of glance image backend optimizations (bsc#945043)

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -34,11 +34,13 @@ if glance_servers.length > 0
   glance_server_protocol = glance_server[:glance][:api][:protocol]
   glance_server_port = glance_server[:glance][:api][:bind_port]
   glance_server_insecure = glance_server_protocol == "https" && glance_server[:glance][:ssl][:insecure]
+  glance_show_storage_location = glance_server[:glance][:show_storage_location]
 else
   glance_server_host = nil
   glance_server_port = nil
   glance_server_protocol = nil
   glance_server_insecure = nil
+  glance_show_storage_location = false
 end
 Chef::Log.info("Glance server at #{glance_server_host}")
 
@@ -171,6 +173,7 @@ template "/etc/cinder/cinder.conf" do
     glance_server_host: glance_server_host,
     glance_server_port: glance_server_port,
     glance_server_insecure: glance_server_insecure,
+    show_storage_location: glance_show_storage_location,
     nova_api_insecure: nova_api_insecure,
     availability_zone: availability_zone,
     keystone_settings: KeystoneHelper.keystone_settings(node, :cinder),

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -512,6 +512,7 @@ glance_api_servers=<%= @glance_server_protocol %>://<%= @glance_server_host %>:<
 
 # Version of the glance API to use (integer value)
 #glance_api_version=1
+glance_api_version=2
 
 # Number retries when downloading an image from glance
 # (integer value)

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -741,6 +741,10 @@ nova_api_insecure=<%= @nova_api_insecure %>
 # the direct_url.  Currently supported schemes: [file]. (list
 # value)
 #allowed_direct_url_schemes=
+<% if @show_storage_location -%>
+### Enable file and rbd if available
+allowed_direct_url_schemes=cinder
+<% end -%>
 
 
 #
@@ -1015,6 +1019,11 @@ use_syslog=<%= node[:cinder][:use_syslog] ? "True" : "False" %>
 
 <% if @use_multi_backend -%>
 [<%= backend_id %>]
+<% end -%>
+
+<% if @show_storage_location -%>
+image_upload_use_cinder_backend = True
+image_upload_use_internal_tenant = False
 <% end -%>
 
 #

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -70,6 +70,7 @@
 # security risk, so use this setting with caution!  The overrides
 # show_image_direct_url. (boolean value)
 #show_multiple_locations = false
+show_multiple_locations = <%= node[:glance][:show_storage_location] %>
 
 # Maximum size of image a user can upload in bytes. Defaults to
 # 1099511627776 bytes (1 TB).WARNING: this value should only be

--- a/chef/data_bags/crowbar/migrate/glance/026_add_store_location.rb
+++ b/chef/data_bags/crowbar/migrate/glance/026_add_store_location.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "show_storage_location"
+    a["show_storage_location"] = ta["show_storage_location"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "show_storage_location"
+    a.delete("show_storage_location")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -32,6 +32,7 @@
       },
       "enable_caching": false,
       "use_cachemanagement": false,
+      "show_storage_location": false,
       "image_cache_datadir": "/var/lib/glance/image-cache",
       "image_cache_stall_timeout": 86400,
       "image_cache_max_size": 10737418240,
@@ -72,7 +73,7 @@
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 25,
+      "schema-revision": 26,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-glance.schema
+++ b/chef/data_bags/crowbar/template-glance.schema
@@ -55,6 +55,7 @@
             },
             "enable_caching": { "type": "bool", "required": true },
             "use_cachemanagement": { "type": "bool", "required": true },
+            "show_storage_location": { "type": "bool", "required": true },
             "image_cache_datadir": { "type": "str", "required": true },
             "image_cache_stall_timeout": { "type": "int", "required": true },
             "image_cache_max_size": { "type": "int", "required": true },

--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -11,6 +11,7 @@
       %legend
         = t(".store_header")
       = select_field :default_store, :collection => :default_stores_for_glance, "data-showit" => "file", "data-showit-target" => "#default_store_info", "data-showit-direct" => "true"
+      = boolean_field :show_storage_location
       #default_store_info
         .alert.alert-info{ "data-show-for-clusters-only" => "true", "data-elements-path" => "glance-server" }
           = t('.store.file_ha_info')

--- a/crowbar_framework/config/locales/glance/en.yml
+++ b/crowbar_framework/config/locales/glance/en.yml
@@ -23,6 +23,7 @@ en:
         rabbitmq_instance: 'RabbitMQ'
         keystone_instance: 'Keystone Instance'
         store_header: 'Image Storage'
+        show_storage_location: 'Expose Backend Store Location'
         store:
           file_ha_info: 'Shared storage must be used on each node of the High Availability cluster for the file store.'
           file_header: 'File Store Parameters'


### PR DESCRIPTION
By storing images in cinder backend, an efficient COW initialisation of volumes can be used, which saves both time and disk usage.
