### PR TITLE
neutron: Fix metadata agent when neutron is using SSL

### DIFF
--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -71,3 +71,7 @@ metadata_workers = <%= [node["cpu"]["total"]/2, 4].min %>
 # Otherwise default_ttl specifies time in seconds a cache entry is valid for.
 # No cache is used in case no value is passed.
 # cache_url = memory://?default_ttl=5
+
+# Missing in upstream template
+# Ensure that metadata server listening on UNIX socket is not expecting SSL
+use_ssl = False


### PR DESCRIPTION
The metadata agent (neutron-metadata-agent) is receiving requests from
metadata proxies in namespaces (neutron-ns-metadata-proxy) through a
UNIX socket. The requests there are always plain HTTP and since it's not
going through the network, it's fine.

However, if [DEFAULT] use_ssl in neutron.conf is set to true, then
neutron-metadata-agent inherits this and expects HTTPS on this UNIX
socket too. So always override this setting.