### PR TITLE
Add ceilometer-polling service as required for Liberty installation

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -16,13 +16,7 @@
 default[:ceilometer][:user]="ceilometer"
 default[:ceilometer][:group]="ceilometer"
 
-central_service_name = "ceilometer-agent-central"
-if %w(suse).include?(node[:platform_family])
-  central_service_name = "openstack-ceilometer-agent-central"
-elsif %w(rhel).include?(node[:platform_family])
-  central_service_name = "openstack-ceilometer-central"
-end
-
+polling_service_name = "ceilometer-polling"
 api_service_name = "ceilometer-api"
 collector_service_name = "ceilometer-collector"
 agent_notification_service_name = "ceilometer-agent-notification"
@@ -30,6 +24,7 @@ alarm_evaluator_service_name = "ceilometer-alarm-evaluator"
 alarm_notifier_service_name = "ceilometer-alarm-notifier"
 
 if %w(rhel suse).include?(node[:platform_family])
+  polling_service_name = "openstack-ceilometer-polling"
   api_service_name = "openstack-ceilometer-api"
   collector_service_name = "openstack-ceilometer-collector"
   agent_notification_service_name = "openstack-ceilometer-agent-notification"
@@ -40,7 +35,7 @@ end
 default[:ceilometer][:api][:service_name] = api_service_name
 default[:ceilometer][:collector][:service_name] = collector_service_name
 default[:ceilometer][:agent_notification][:service_name] = agent_notification_service_name
-default[:ceilometer][:central][:service_name] = central_service_name
+default[:ceilometer][:polling][:service_name] = polling_service_name
 default["ceilometer"]["alarm_evaluator"]["service_name"] = alarm_evaluator_service_name
 default["ceilometer"]["alarm_notifier"]["service_name"] = alarm_notifier_service_name
 
@@ -88,9 +83,9 @@ default["ceilometer"]["ha"]["alarm_evaluator"]["op"]["monitor"]["interval"] = "1
 default["ceilometer"]["ha"]["alarm_notifier"]["agent"] = "lsb:#{alarm_notifier_service_name}"
 default["ceilometer"]["ha"]["alarm_notifier"]["op"]["monitor"]["interval"] = "10s"
 
-default[:ceilometer][:ha][:central][:enabled] = false
-default[:ceilometer][:ha][:central][:agent] = "lsb:#{central_service_name}"
-default[:ceilometer][:ha][:central][:op][:monitor][:interval] = "10s"
+default[:ceilometer][:ha][:polling][:enabled] = false
+default[:ceilometer][:ha][:polling][:agent] = "lsb:#{polling_service_name}"
+default[:ceilometer][:ha][:polling][:op][:monitor][:interval] = "10s"
 # Ports to bind to when haproxy is used for the real ports
 default[:ceilometer][:ha][:ports][:api] = 5561
 default[:ceilometer][:ha][:mongodb][:agent] = "lsb:mongodb"

--- a/chef/cookbooks/ceilometer/recipes/polling.rb
+++ b/chef/cookbooks/ceilometer/recipes/polling.rb
@@ -13,21 +13,19 @@
 # limitations under the License.
 #
 
-package "ceilometer-agent-central" do
-  if %w(suse).include?(node[:platform_family])
-    package_name "openstack-ceilometer-agent-central"
-  elsif %w(rhel).include?(node[:platform_family])
-    package_name "openstack-ceilometer-central"
+package "ceilometer-polling" do
+  if %w(rhel suse).include?(node[:platform_family])
+    package_name "openstack-ceilometer-polling"
   end
   action :install
 end
 
 include_recipe "#{@cookbook_name}::common"
 
-ha_enabled = node[:ceilometer][:ha][:central][:enabled]
+ha_enabled = node[:ceilometer][:ha][:polling][:enabled]
 
-service "ceilometer-agent-central" do
-  service_name node[:ceilometer][:central][:service_name]
+service "ceilometer-polling" do
+  service_name node[:ceilometer][:polling][:service_name]
   supports status: true, restart: true, start: true, stop: true
   action [:enable, :start]
   subscribes :restart, resources("template[/etc/ceilometer/ceilometer.conf]")
@@ -36,8 +34,8 @@ service "ceilometer-agent-central" do
 end
 
 if ha_enabled
-  log "HA support for ceilometer-central is enabled"
-  include_recipe "ceilometer::central_ha"
+  log "HA support for ceilometer-polling is enabled"
+  include_recipe "ceilometer::polling_ha"
 else
-  log "HA support for ceilometer-central is disabled"
+  log "HA support for ceilometer-polling is disabled"
 end

--- a/chef/cookbooks/ceilometer/recipes/polling_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/polling_ha.rb
@@ -16,24 +16,24 @@
 # Wait for all nodes to reach this point so we know that they will have
 # all the required packages installed and configuration files updated
 # before we create the pacemaker resources.
-crowbar_pacemaker_sync_mark "sync-ceilometer_central_before_ha"
+crowbar_pacemaker_sync_mark "sync-ceilometer_polling_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-ceilometer_central_ha_resources"
+crowbar_pacemaker_sync_mark "wait-ceilometer_polling_ha_resources"
 
-service_name = "ceilometer-agent-central"
+service_name = "ceilometer-polling"
 
 # Allow one retry, to avoid races where two nodes create the primitive at the
 # same time when it wasn't created yet (only one can obviously succeed)
 pacemaker_primitive service_name do
-  agent node[:ceilometer][:ha][:central][:agent]
-  op node[:ceilometer][:ha][:central][:op]
-  # use these params with ocf:openstack:ceilometer-agent-central:
+  agent node[:ceilometer][:ha][:polling][:agent]
+  op node[:ceilometer][:ha][:polling][:op]
+  # use these params with ocf:openstack:ceilometer-polling:
   #params ({
   #  "user"    => node[:ceilometer][:user],
-  #  "binary"  => "/usr/bin/ceilometer-agent-central",
+  #  "binary"  => "/usr/bin/ceilometer-polling",
   #  "use_service"    => true,
-  #  "service" => node[:ceilometer][:central][:service_name]
+  #  "service" => node[:ceilometer][:polling][:service_name]
   #})
   action [:create, :start]
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
@@ -46,4 +46,4 @@ crowbar_pacemaker_order_only_existing "o-#{service_name}" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_sync_mark "create-ceilometer_central_ha_resources"
+crowbar_pacemaker_sync_mark "create-ceilometer_polling_ha_resources"

--- a/chef/data_bags/crowbar/migrate/ceilometer/023_rename_ceilometer_cagent_role.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/023_rename_ceilometer_cagent_role.rb
@@ -1,0 +1,39 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  # Change the elements to ceilometer-polling
+  d["elements"]["ceilometer-polling"] = d["elements"]["ceilometer-cagent"]
+  d["elements"].delete("ceilometer-cagent")
+
+  # Update the run_list for controller node
+  node = NodeObject.find("roles:ceilometer-cagent")
+  node.add_to_run_list("ceilometer-polling",
+                       td["element_run_list_order"]["ceilometer-polling"],
+                       td["element_states"]["ceilometer-polling"])
+  node.delete_from_run_list("ceilometer-cagent")
+  node.save
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  # Change the elements to ceilometer-polling
+  d["elements"]["ceilometer-cagent"] = d["elements"]["ceilometer-polling"]
+  d["elements"].delete("ceilometer-polling")
+
+  # Update the run_list for controller node
+  node = NodeObject.find("roles:ceilometer-polling")
+  node.add_to_run_list("ceilometer-cagent",
+                       td["element_run_list_order"]["ceilometer-cagent"],
+                       td["element_states"]["ceilometer-cagent"])
+  node.delete_from_run_list("ceilometer-polling")
+  node.save
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -36,10 +36,10 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 22,
+      "schema-revision": 23,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
-        "ceilometer-cagent": [ "readying", "ready", "applying" ],
+        "ceilometer-polling": [ "readying", "ready", "applying" ],
         "ceilometer-agent": [ "readying", "ready", "applying" ],
         "ceilometer-agent-hyperv": [ "readying", "ready", "applying" ],
         "ceilometer-swift-proxy-middleware": [ "readying", "ready", "applying" ]
@@ -47,14 +47,14 @@
       "elements": {},
       "element_order": [
         [ "ceilometer-server" ],
-        [ "ceilometer-cagent" ], 
+        [ "ceilometer-polling" ], 
         [ "ceilometer-agent" ],
         [ "ceilometer-agent-hyperv" ],
         [ "ceilometer-swift-proxy-middleware" ]
       ],
       "element_run_list_order": {
         "ceilometer-server": 101,
-        "ceilometer-cagent": 102,
+        "ceilometer-polling": 102,
         "ceilometer-agent": 103,
         "ceilometer-agent-hyperv": 104,
         "ceilometer-swift-proxy-middleware" : 80

--- a/chef/roles/ceilometer-cagent.rb
+++ b/chef/roles/ceilometer-cagent.rb
@@ -1,9 +1,0 @@
-name "ceilometer-cagent"
-description "Ceilometer Central Agent Role"
-run_list(
-         "recipe[ceilometer::central]",
-         "recipe[ceilometer::common]"
-)
-default_attributes()
-override_attributes()
-

--- a/chef/roles/ceilometer-polling.rb
+++ b/chef/roles/ceilometer-polling.rb
@@ -1,0 +1,8 @@
+name "ceilometer-polling"
+description "Ceilometer Polling Agent Role"
+run_list(
+         "recipe[ceilometer::polling]",
+         "recipe[ceilometer::common]"
+)
+default_attributes()
+override_attributes()


### PR DESCRIPTION
Services agent-central, agent-ipmi have been deprecated upstream from Kilo release onwards. These are now replaced by ceilometer-polling. The current ceilometer barclamp does not address this deprecation. Neither ceilometer-agent-central nor ceilometer-polling services run on the control node failing some ceilometer functionalities (like metering for control node services). This change updates the barclamp to install and start ceilometer-polling service instead of the deprecated services.