### PR TITLE
cinder: Ugly hack to make cinder quotas work again

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -2705,6 +2705,8 @@ pool_timeout=<%= node[:cinder][:pool_timeout] %>
 
 # Authentication url for encryption service. (string value)
 #encryption_auth_url=http://localhost:5000/v2.0
+# FIXME: this is really a bug in cinder which is abusing this option for fetching info about quotas (lp#1516085) and requires v3 API (lp#1517043)
+encryption_auth_url=<%= "#{@keystone_settings['protocol']}://#{@keystone_settings['internal_url_host']}:#{@keystone_settings['service_port']}/v3" %>
 
 # Url for encryption service. (string value)
 #encryption_api_url=http://localhost:9311/v1


### PR DESCRIPTION
We set [keymgr] encryption_auth_url in cinder.conf to the keystone v3
auth URI. This is terrible because that's unrelated to this setting and
this hardcodes a need for the v3 API, but that's really upstream bugs.

See upstream bugs:
  https://bugs.launchpad.net/cinder/+bug/1517043
  https://bugs.launchpad.net/cinder/+bug/1516085
  https://bugs.launchpad.net/cinder/+bug/1511960
  https://bugs.launchpad.net/cinder/+bug/1509308

On top of this, the quotas are broken when using insecure SSL with
keystone, but it's not something we can fix here.