### PR TITLE
Use internalURL for communication with OpenStack

### DIFF
--- a/chef/cookbooks/keystone/templates/default/openrc.erb
+++ b/chef/cookbooks/keystone/templates/default/openrc.erb
@@ -2,12 +2,13 @@
 export OS_USERNAME='<%= @keystone_settings['admin_user'] %>'
 export OS_PASSWORD='<%= @keystone_settings['admin_password'] %>'
 export OS_TENANT_NAME='<%= @keystone_settings['default_tenant'] %>'
+export OS_ENDPOINT_TYPE='internalURL'
 <% if @keystone_settings['api_version'] != '2.0' %>
 export OS_IDENTITY_API_VERSION='<%= @keystone_settings['api_version'] %>'
 export OS_USER_DOMAIN_NAME='Default'
 export OS_PROJECT_DOMAIN_NAME='Default'
 export OS_AUTH_VERSION='<%= @keystone_settings['api_version'] %>'
 <% end %>
-export OS_AUTH_URL='<%= @keystone_settings['public_auth_url'] %>'
+export OS_AUTH_URL='<%= @keystone_settings['internal_auth_url'] %>'
 export OS_AUTH_STRATEGY=keystone
 export OS_REGION_NAME='<%= @keystone_settings['endpoint_region'] %>'


### PR DESCRIPTION
In case the public network is down, debugging is rather painful.
I think if you're on the node that has the .openrc then the
internalURL should always work, so use that instead.