### PR TITLE
Switch to OpenStack Identity API version 3 by default

### DIFF
--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -34,7 +34,7 @@
         "api_host": "0.0.0.0",
         "admin_port": 35357,
         "admin_host": "0.0.0.0",
-        "version": "2.0",
+        "version": "3",
         "region": "RegionOne"
       },
       "admin": {


### PR DESCRIPTION
New deployments should be using v3 as it provides more
features onwards, and starting with Liberty v3-only should
be possible (however this change still enables both versions).