### PR TITLE
nova: don't install python-suds for vmware

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -111,9 +111,6 @@ case node[:nova][:libvirt_type]
   when "zvm"
     package "openstack-nova-virt-zvm"
 
-  when "vmware"
-    package "python-suds"
-
   when "docker"
     package "docker"
     package "openstack-nova-docker"


### PR DESCRIPTION
python-nova already depends on python-oslo.vmware which depends
on python-suds-jirko which is the successor of python-suds.