### PR TITLE
Adding hyperv driver to the front end

### DIFF
--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -37,7 +37,7 @@ class NeutronService < PacemakerServiceObject
   end
 
   def self.networking_ml2_mechanism_drivers_valid
-    ["linuxbridge", "openvswitch", "cisco_nexus"]
+    ["linuxbridge", "openvswitch", "cisco_nexus", "hyperv"]
   end
 
   class << self


### PR DESCRIPTION
This is needed for the hyperv agent on windows to run correctly and
allocate ip's
This PR is a dependency of https://github.com/crowbar/crowbar-hyperv/pull/10