### PR TITLE
Sync codeclimate config, remove bundler-audit

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,8 +8,6 @@ engines:
     enabled: true
   scss-lint:
     enabled: true
-  bundler-audit:
-    enabled: true
 
 ratings:
   paths:


### PR DESCRIPTION
Remove bundler-audit check, it won't work as we are not providing any Gemfile.lock within git.