### PR TITLE
Dropping VMware API insecure option from Glance

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -904,7 +904,6 @@ vmware_store_image_dir = <%= node[:glance][:vsphere][:store_image_dir] %>
 
 # Allow to perform insecure SSL requests to ESX/VC. (boolean value)
 #vmware_api_insecure = false
-<%= "vmware_api_insecure = #{node[:glance][:vsphere][:api_insecure]}" if node[:glance][:vsphere][:api_insecure] %>
 
 # A list of datastores where the image can be stored. This option may
 # be specified multiple times for specifying multiple datastores.

--- a/chef/data_bags/crowbar/migrate/glance/025_remove_vsphere_api_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/glance/025_remove_vsphere_api_insecure.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["vsphere"].delete("api_insecure")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["vsphere"]["api_insecure"] = ta["vsphere"]["api_insecure"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -59,8 +59,7 @@
         "password": "",
         "datastore": "",
         "datacenter_path": "ha-datacenter",
-        "store_image_dir": "/openstack_glance",
-        "api_insecure": false
+        "store_image_dir": "/openstack_glance"
       },
       "sql_idle_timeout": 3600,
       "keystone_instance": "none",
@@ -73,7 +72,7 @@
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 24,
+      "schema-revision": 25,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-glance.schema
+++ b/chef/data_bags/crowbar/template-glance.schema
@@ -89,8 +89,7 @@
                 "password": { "type": "str", "required": true },
                 "datastore": { "type": "str", "required": true },
                 "datacenter_path": { "type": "str", "required": true },
-                "store_image_dir": { "type": "str", "required": true },
-                "api_insecure": { "type" : "bool", "required" : true }
+                "store_image_dir": { "type": "str", "required": true }
               }
             },
             "sql_idle_timeout": { "type": "int", "required": true },

--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -39,7 +39,6 @@
       = password_field %w(vsphere password)
       = string_field %w(vsphere datastore)
       = string_field %w(vsphere datacenter_path)
-      = boolean_field %w(vsphere api_insecure)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/glance/en.yml
+++ b/crowbar_framework/config/locales/glance/en.yml
@@ -42,7 +42,6 @@ en:
           password: 'vCenter Password'
           datastore: 'Datastore Name'
           datacenter_path: 'Datacenter Path'
-          api_insecure: 'Insecure SSL requests to vCenter'
         api:
           protocol: 'Protocol'
         ssl_header: 'SSL Support'


### PR DESCRIPTION
Because of discussion in https://github.com/crowbar/crowbar-openstack/pull/131#discussion-diff-46124162, we decided to drop it