### PR TITLE
keystone: switch default token format to uuid

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -49,7 +49,7 @@ default[:keystone][:assignment][:driver] = "sql"
 
 default[:keystone][:sql][:idle_timeout] = 30
 
-default[:keystone][:signing][:token_format] = "PKI"
+default[:keystone][:signing][:token_format] = "UUID"
 default[:keystone][:signing][:certfile] = "/etc/keystone/ssl/certs/signing_cert.pem"
 default[:keystone][:signing][:keyfile] = "/etc/keystone/ssl/private/signing_key.pem"
 default[:keystone][:signing][:ca_certs] = "/etc/keystone/ssl/certs/ca.pem"

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -58,7 +58,7 @@
         "driver": "sql"
       },
       "signing": {
-        "token_format": "PKI",
+        "token_format": "UUID",
         "certfile": "/etc/keystone/ssl/certs/signing_cert.pem",
         "keyfile": "/etc/keystone/ssl/private/signing_key.pem",
         "ca_certs": "/etc/keystone/ssl/certs/ca.pem"


### PR DESCRIPTION
While investigating performance issues we recognized that
using PKI tokens is a lot slower.
I.e. running "cinder list" needs 3s instead of 1s with uuid tokens.