### PR TITLE
Revert "increase timeout for synchronization of HA resources (bsc#935462)"

### DIFF
--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -81,9 +81,7 @@ end
 crowbar_pacemaker_sync_mark "sync-nova_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-nova_ha_resources" do
-  timeout 120
-end
+crowbar_pacemaker_sync_mark "wait-nova_ha_resources"
 
 primitives = []
 


### PR DESCRIPTION
This reverts commit f04bd35ef94822f8e229e6cfb5219a16f1d92cb9.

When we merge this PR https://github.com/crowbar/crowbar-ha/pull/45,
the sync_mark timeout will increase to 180 second by default.