### PR TITLE
heat, horizon, neutron: Symlink the suse templates as opensuse

### DIFF
--- a/chef/cookbooks/heat/templates/opensuse/loadbalancer.template.erb
+++ b/chef/cookbooks/heat/templates/opensuse/loadbalancer.template.erb
@@ -1,0 +1,1 @@
+../suse/loadbalancer.template.erb

--- a/chef/cookbooks/horizon/templates/opensuse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/opensuse/openstack-dashboard.conf.erb
@@ -1,0 +1,1 @@
+../suse/openstack-dashboard.conf.erb

--- a/chef/cookbooks/neutron/templates/opensuse/sysconfig.neutron.erb
+++ b/chef/cookbooks/neutron/templates/opensuse/sysconfig.neutron.erb
@@ -1,0 +1,1 @@
+../suse/sysconfig.neutron.erb


### PR DESCRIPTION
We want the same set of templates for both SUSE and openSUSE.