### PR TITLE
postgresql: Use 9.4 for openSUSE

### DIFF
--- a/chef/cookbooks/postgresql/attributes/default.rb
+++ b/chef/cookbooks/postgresql/attributes/default.rb
@@ -153,13 +153,15 @@ when "suse"
 
 when "opensuse"
 
-  default["postgresql"]["version"] = "9.3"
+  # This is valid as of openSUSE Leap 42.1
+
+  default["postgresql"]["version"] = "9.4"
   default["postgresql"]["client"]["packages"] = [
-    "postgresql93",
+    "postgresql94",
     "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-pg"
   ]
-  default["postgresql"]["server"]["packages"] = ["postgresql93-server"]
-  default["postgresql"]["contrib"]["packages"] = ["postgresql93-contrib"]
+  default["postgresql"]["server"]["packages"] = ["postgresql94-server"]
+  default["postgresql"]["contrib"]["packages"] = ["postgresql94-contrib"]
 
   default["postgresql"]["dir"] = "/var/lib/pgsql/data"
   default["postgresql"]["sysconfig"] = "/etc/sysconfig/postgresql"


### PR DESCRIPTION
This is the latest version of postgresql in Leap.