### PR TITLE
rabbitmq: Extend epmd.socket unit file to listen on 0.0.0.0 for Leap

### DIFF
--- a/chef/cookbooks/rabbitmq/files/opensuse/epmd.socket-listen.conf
+++ b/chef/cookbooks/rabbitmq/files/opensuse/epmd.socket-listen.conf
@@ -1,0 +1,3 @@
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:4369


### PR DESCRIPTION
Right now, on Leap, epmd.socket makes systemd only listen on 127.0.0.1
which makes rabbitmq-server fail to start. So we extend the socket unit
file to listen on 0.0.0.0.

This is the recommended setup as per
https://bugzilla.suse.com/show_bug.cgi?id=869112

Note that for some reason, it fails when we only listen on the admin IP
address.

See also discussion at
https://bugzilla.redhat.com/show_bug.cgi?id=1104843
