### PR TITLE
swift: Fix crash when applying proposal with a deactivated ceph proposal

### DIFF
--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -299,7 +299,8 @@ class SwiftService < PacemakerServiceObject
     # first, check for conflict with ceph
     Proposal.where(barclamp: "ceph").each {|p|
       next unless (p.status == "ready") || (p.status == "pending")
-      elements = (p.status == "ready") ? p.role.elements : p.elements
+      ceph_role = p.role
+      elements = (p.status == "ready" && !ceph_role.nil?) ? ceph_role.elements : p.elements
       if elements.keys.include?("ceph-radosgw") && !elements["ceph-radosgw"].empty?
         @logger.warn("node #{elements['ceph-radosgw']} has ceph-radosgw role")
         validation_error I18n.t("barclamp.#{@bc_name}.validation.radosgw")


### PR DESCRIPTION
It is documented that the proposal status is not something that should
be used to detect if a proposal is deactivated or not. So we need to
check if the role exists for this.