### PR TITLE
nova: Install open-iscsi before starting its daemon

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -91,6 +91,7 @@ end
 if %w(rhel suse).include?(node[:platform_family])
   # Start open-iscsi daemon, since nova-compute is going to use it and stumble over the
   # "starting daemon" messages otherwise
+  package "open-iscsi"
   service "open-iscsi" do
     supports status: true, start: true, stop: true, restart: true
     action [:enable, :start]


### PR DESCRIPTION
We explicitly start the iscsid daemon to help nova-compute, but we
didn't make sure it was installed, and it's not a dependency of nova.

It's generally okay because it's a dependency of libvirt, but on docker
nodes, the package is actually not installed by default (at least on
Leap).