### PR TITLE
rabbitmq: Fix nodename used for rabbitmq

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -24,7 +24,7 @@
 default[:rabbitmq][:user] = "nova"
 default[:rabbitmq][:vhost] = "/nova"
 
-default[:rabbitmq][:nodename]  = node[:hostname]
+default[:rabbitmq][:nodename]  = "rabbit@#{node[:hostname]}"
 # This is the address for internal usage
 default[:rabbitmq][:address] = nil
 # These are all the addresses, possibly including public one

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq-env.conf.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq-env.conf.erb
@@ -3,6 +3,12 @@
 ###
 
 NODENAME=<%= node[:rabbitmq][:nodename] %>
-<% if node[:rabbitmq][:configfile] %>CONFIG_FILE=<%= node[:rabbitmq][:configfile] %><% end %>
-<% if node[:rabbitmq][:logdir] %>LOG_BASE=<%= node[:rabbitmq][:logdir] %><% end %>
-<% if node[:rabbitmq][:mnesiadir] %>MNESIA_BASE=<%= node[:rabbitmq][:mnesiadir] %><% end %>
+<% if node[:rabbitmq][:configfile] -%>
+CONFIG_FILE=<%= node[:rabbitmq][:configfile] %>
+<% end -%>
+<% if node[:rabbitmq][:logdir] -%>
+LOG_BASE=<%= node[:rabbitmq][:logdir] %>
+<% end -%>
+<% if node[:rabbitmq][:mnesiadir] -%>
+MNESIA_BASE=<%= node[:rabbitmq][:mnesiadir] %>
+<% end -%>


### PR DESCRIPTION
It was missing the rabbit@ part, which is wrong as this could mean a
conflict with other erlang apps.

Note that this change breaks existing deployment of rabbitmq, as
rabbitmq can't get restarted (due to the nodename change). So it's only
okay to get in if we know that the upgrade process will stop rabbitmq.

(+ a cleanup commit)