### PR TITLE
Configure proper firewall_driver for ML2 specific agents

### DIFF
--- a/chef/cookbooks/neutron/templates/default/linuxbridge_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/linuxbridge_agent.ini.erb
@@ -66,10 +66,10 @@ l2_population = True
 # quitting_rpc_timeout = 10
 
 [securitygroup]
-firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
 # Firewall driver for realizing neutron security group function
 # firewall_driver = neutron.agent.firewall.NoopFirewallDriver
 # Example: firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
+firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
 
 # Controls if neutron security group is enabled or not.
 # It should be false when you use nova security group.

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -127,7 +127,6 @@ vxlan_group = <%= @vxlan_mcast_group %>
 # Example: max_header_size = 50 (Geneve headers with no additional options)
 
 [securitygroup]
-firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
 # Controls if neutron security group is enabled or not.
 # It should be false when you use nova security group.
 # enable_security_group = True

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -199,6 +199,7 @@ enable_distributed_routing = True
 # Firewall driver for realizing neutron security group function.
 # firewall_driver = neutron.agent.firewall.NoopFirewallDriver
 # Example: firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
 
 # Controls if neutron security group is enabled or not.
 # It should be false when you use nova security group.


### PR DESCRIPTION
For Linux Brigde should be
  `firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver`

For OpenvSwitch  should be
  `firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver`