### PR TITLE
increase nova_database sync timeout to 240 (bsc#935462)

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -27,7 +27,7 @@ db_settings = fetch_database_settings
 
 crowbar_pacemaker_sync_mark "wait-nova_database" do
   # the db sync is very slow for nova
-  timeout 120
+  timeout 240
 end
 
 # Creates empty nova database


### PR DESCRIPTION
The default sync timeout is now 180 seconds, so we definitely don't want to decrease it here; if anything it should be longer since nova is towards the end of a full run list, so the nodes are more likely to have drifted by this point.

https://bugzilla.suse.com/show_bug.cgi?id=935462

See also #138 which does something similar for `nova_ha_resources`.