### PR TITLE
Revert increase timeout for sync of ceilometer HA resources (bsc#935462)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -27,9 +27,7 @@ end.run_action(:create)
 crowbar_pacemaker_sync_mark "sync-ceilometer_server_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-ceilometer_server_ha_resources" do
-  timeout 120
-end
+crowbar_pacemaker_sync_mark "wait-ceilometer_server_ha_resources"
 
 primitives = []
 


### PR DESCRIPTION
crowbar/crowbar-ha@d2c1a01c7 from crowbar/crowbar-ha#45 increased the default timeout from 60 to 180, so it no longer makes sense to set this to 120 which is now lower than the default.

This reverts commit 7b7cd2b571b2e7b0416bf22a9e6fdd5b04129fe4.

See also #138 and #159.