### PR TITLE
Switch off verbose option for better transparency

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -15,6 +15,7 @@
 # This option is deprecated for removal.
 # Its value may be silently ignored in the future.
 #verbose = true
+verbose = false
 
 # The name of a logging configuration file. This file is appended to
 # any existing logging configuration files. For details about logging


### PR DESCRIPTION
Instead of having 

```
2015-12-17 09:19:56,629 18418 INFO     [tempest_lib.common.rest_client] Request (TestNetworkBasicOps:test_update_router_admin_state): 200 GET http://d52-54-77-77-77-01.vc3.cloud.suse.de:8774/v2.1/6d4c3dcb7cbf47459f535ec1cf01a28e/servers/bfbe2f04-a8d5-4f5c-b8b4-3a9783c248c9 0.251s
2015-12-17 09:19:58,251 18418 INFO     [tempest_lib.common.rest_client] Request (TestNetworkBasicOps:test_update_router_admin_state): 200 GET http://d52-54-77-77-77-01.vc3.cloud.suse.de:8774/v2.1/6d4c3dcb7cbf47459f535ec1cf01a28e/servers/bfbe2f04-a8d5-4f5c-b8b4-3a9783c248c9 0.592s
2015-12-17 09:19:58,303 18418 INFO     [tempest.common.waiters] State transition "BUILD/scheduling" ==> "BUILD/block_device_mapping" after 2 second wait
2015-12-17 09:19:59,666 18418 INFO     [tempest_lib.common.rest_client] Request (TestNetworkBasicOps:test_update_router_admin_state): 200 GET http://d52-54-77-77-77-01.vc3.cloud.suse.de:8774/v2.1/6d4c3dcb7cbf47459f535ec1cf01a28e/servers/bfbe2f04-a8d5-4f5c-b8b4-3a9783c248c9 0.348s
2015-12-17 09:19:59,691 18418 INFO     [tempest.common.waiters] State transition "BUILD/block_device_mapping" ==> "BUILD/spawning" after 3 second wait
2015-12-17 09:20:01,000 18418 INFO     [tempest_lib.common.rest_client] Request (TestNetworkBasicOps:test_update_router_admin_state): 200 GET http://d52-54-77-77-77-01.vc3.cloud.suse.de:8774/v2.1/6d4c3dcb7cbf47459f535ec1cf01a28e/servers/bfbe2f04-a8d5-4f5c-b8b4-3a9783c248c9 0.308s
2015-12-17 09:20:02,246 18418 INFO     [tempest_lib.common.rest_client] Request (TestNetworkBasicOps:test_update_router_admin_state): 200 GET http://d52-54-77-77-77-01.vc3.cloud.suse.de:8774/v2.1/6d4c3dcb7cbf47459f535ec1cf01a28e/servers/bfbe2f04-a8d5-4f5c-b8b4-3a9783c248c9 0.185s
2015-12-17 09:20:03,604 18418 INFO     [tempest_lib.common.rest_client] Request (TestNetworkBasicOps:test_update_router_admin_state): 200 GET http://d52-54-77-77-77-01.vc3.cloud.suse.de:8774/v2.1/6d4c3dcb7cbf47459f535ec1cf01a28e/servers/bfbe2f04-a8d5-4f5c-b8b4-3a9783c248c9 0.336s
2015-12-17 09:20:0
```

we will have again nice output from tests

```
tempest.api.compute.flavors.test_flavors.FlavorsV2TestJSON
    test_get_flavor[id-1f12046b-753d-40d2-abb6-d8eb8b30cb2f,smoke]    OK  0.21
    test_list_flavors[id-e36c0eaa-dff5-4082-ad1f-3f9a80aa3f59,smoke]  OK  0.08
tempest.api.compute.security_groups.test_security_group_rules.SecurityGroupRulesTestJSON
    test_security_group_rules_create[id-850795d7-d4d3-4e55-b527-a774c0123d3a,network,smoke]OK  0.62
    test_security_group_rules_list[id-a6154130-5a55-4850-8be4-5e9e796dbf17,network,smoke]OK  0.60
tempest.api.compute.security_groups.test_security_groups.SecurityGroupsTestJSON
    test_security_groups_create_list_delete[id-eb2b087d-633d-4d0d-a7bd-9e6ba35b32de,network,smoke]OK  1.09
setUpClass (tempest.api.compute.servers.test_attach_interfaces
    AttachInterfacesTestJSON)                                         SKIP  0.00
tempest.api.compute.servers.test_create_server.ServersTestJSON
    test_list_servers[id-9a438d88-10c6-4bcd-8b5b-5b6e25e1346f,smoke]  OK  0.08
    test_verify_server_details[id-5de47127-9977-400a-936f-abcfbec1218f,smoke]OK  0.00
tempest.api.compute.servers.test_create_server.ServersTestManualDisk
    test_list_servers[id-9a438d88-10c6-4bcd-8b5b-5b6e25e1346f,smoke]  OK  0.16
    test_verify_server_details[id-5de47127-9977-400a-936f-abcfbec1218f,smoke]OK  0.00
````