### PR TITLE
trove: Register trove endpoint directly for the right region (bsc#955…

### DIFF
--- a/chef/cookbooks/trove/recipes/default.rb
+++ b/chef/cookbooks/trove/recipes/default.rb
@@ -92,6 +92,7 @@ node.set["openstack"]["mq"]["database"]["rabbit"]["vhost"] = rabbitmq[:trove][:v
 node.set["openstack"]["secret"][rabbitmq[:trove][:user]]["user"] = rabbitmq[:trove][:password]
 
 node.set["openstack"]["region"] = keystone_settings["endpoint_region"]
+node.set["openstack"]["database"]["region"] = keystone_settings["endpoint_region"]
 # XXX mysql configuration
 # this part should go away once trove supports postgresl
 


### PR DESCRIPTION
…863)

We were relying on convergence to get the endpoint registered for the
right region, which had the side-effect of also having an endpoint
registered for RegionOne.

https://bugzilla.suse.com/show_bug.cgi?id=955863