### PR TITLE
Allow to remove unused images after creating them

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2023,6 +2023,7 @@ firewall_driver=nova.virt.firewall.NoopFirewallDriver
 # Unused unresized base images younger than this will not be
 # removed (integer value)
 #remove_unused_original_minimum_age_seconds=86400
+remove_unused_original_minimum_age_seconds=0
 
 
 #


### PR DESCRIPTION
This is fixing develcloud6 (4/linuxbridge/-t -s/all/ ) gating