### PR TITLE
add manilaclient.conf for tests

### DIFF
--- a/chef/cookbooks/manila/recipes/common.rb
+++ b/chef/cookbooks/manila/recipes/common.rb
@@ -142,4 +142,17 @@ template "/etc/manila/manila.conf" do
   )
 end
 
+# dependency for manilaclient tests
+package "python-manilaclient"
+
+template "/etc/manilaclient/manilaclient.conf" do
+  source "manilaclient.conf.erb"
+  owner "root"
+  group node[:manila][:group]
+  mode 0640
+  variables(
+    keystone_settings: KeystoneHelper.keystone_settings(node, :manila)
+  )
+end
+
 node.save

--- a/chef/cookbooks/manila/templates/default/manilaclient.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manilaclient.conf.erb
@@ -1,0 +1,202 @@
+[DEFAULT]
+
+#
+# From manilaclient.config
+#
+
+# This should be the username of a user WITHOUT administrative
+# privileges. (string value)
+username=<%= @keystone_settings["service_user"] %>
+
+# The non-administrative user's tenant name. (string value)
+tenant_name=<%= @keystone_settings["service_tenant"] %>
+
+# The non-administrative user's password. (string value)
+password=<%= @keystone_settings["service_password"] %>
+
+# URL for where to find the OpenStack Identity admin API endpoint.
+# (string value)
+auth_url=<%= @keystone_settings["internal_auth_url"] %>
+
+# This should be the username of a user WITH administrative
+# privileges. (string value)
+#admin_username = <None>
+admin_username=<%= @keystone_settings["admin_user"] %>
+
+# The administrative user's tenant name. (string value)
+#admin_tenant_name = <None>
+admin_tenant_name=<%= @keystone_settings["admin_tenant"] %>
+
+# The administrative user's password. (string value)
+#admin_password = <None>
+admin_password=<%= @keystone_settings["admin_password"] %>
+
+# URL for where to find the OpenStack Identity admin API endpoint.
+# (string value)
+#admin_auth_url = <None>
+admin_auth_url=<%= @keystone_settings["internal_auth_url"] %> 
+
+#
+# From manilaclient.config
+#
+
+# The path to manilaclient to be executed. (string value)
+#manila_exec_dir = /usr/bin
+
+# Whether to suppress errors with clean up operation or not. (boolean
+# value)
+#suppress_errors_in_cleanup = true
+
+#
+# From manilaclient.config
+#
+
+# Share network Name or ID, that will be used for shares. Some backend
+# drivers require a share network for share creation. (string value)
+#share_network = <None>
+
+# Share network Name or ID, that will be used for shares in admin
+# tenant. (string value)
+#admin_share_network = <None>
+
+# Share type Name or ID, that will be used with share creation
+# scheduling. Optional. (string value)
+#share_type = <None>
+
+# List of all enabled protocols. The first protocol in the list will
+# be used as the default protocol. (list value)
+#enable_protocols = nfs,cifs
+
+# Time in seconds between share availability checks. (integer value)
+#build_interval = 3
+
+# Timeout in seconds to wait for a share to become available. (integer
+# value)
+#build_timeout = 500
+
+# Dict contains access types mapping to share protocol. It will be
+# used to create access rules for shares. Format: '<protocol>: <type1>
+# <type2>',...Allowed share protocols: nfs, cifs, glusterfs, hdfs.
+# (dict value)
+#access_types_mapping = cifs:ip,nfs:ip
+
+# Dict contains access levels mapping to share protocol. It will be
+# used to create access rules for shares. Format: '<protocol>:
+# <level1> <level2>',... Allowed share protocols: nfs, cifs,
+# glusterfs, hdfs.  (dict value)
+#access_levels_mapping = cifs:rw,nfs:rw ro
+
+# Username, that will be used in share access tests for user type of
+# access. (string value)
+#username_for_user_rules = TESTDOMAIN\Administrator
+
+#
+# From manilaclient.config
+#
+
+# Print debugging output (set logging level to DEBUG instead of
+# default INFO level). (boolean value)
+#debug = false
+
+# If set to false, will disable INFO logging level, making WARNING the
+# default. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#verbose = true
+
+# The name of a logging configuration file. This file is appended to
+# any existing logging configuration files. For details about logging
+# configuration files, see the Python logging module documentation.
+# Note that when logging configuration files are used then all logging
+# configuration is set in the configuration file and other logging
+# configuration options are ignored (for example, log_format). (string
+# value)
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# DEPRECATED. A logging.Formatter log message format string which may
+# use any of the available logging.LogRecord attributes. This option
+# is deprecated.  Please use logging_context_format_string and
+# logging_default_format_string instead. This option is ignored if
+# log_config_append is set. (string value)
+#log_format = <None>
+
+# Format string for %%(asctime)s in log records. Default: %(default)s
+# . This option is ignored if log_config_append is set. (string value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to output to. If no default is set,
+# logging will go to stdout. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative --log-file paths.
+# This option is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# (Optional) Uses logging handler designed to watch file system. When
+# log file is moved or removed this handler will open a new log file
+# with specified path instantaneously. It makes sense only if log-file
+# option is specified and Linux platform is used. This option is
+# ignored if log_config_append is set. (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and
+# will be changed later to honor RFC5424. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_syslog = false
+
+# (Optional) Enables or disables syslog rfc5424 format for logging. If
+# enabled, prefixes the MSG part of the syslog message with APP-NAME
+# (RFC5424). The format without the APP-NAME is deprecated in Kilo,
+# and will be removed in Mitaka, along with this option. This option
+# is ignored if log_config_append is set. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#use_syslog_rfc_format = true
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_stderr = true
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages without context. (string
+# value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Data to append to log format when level is DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string
+# value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# List of logger=LEVEL pairs. This option is ignored if
+# log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message.
+# (string value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message.
+# (string value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Format string for user_identity field of the
+# logging_context_format_string (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false


### PR DESCRIPTION
Functional tests use manilaclient.conf at /etc/manilaclient for reading credentials. In order to run functional tests without actually modifying the test code, the deployment needs to have the conf file installed. The installation of the directory is handled by https://build.opensuse.org/request/show/351091 and https://build.opensuse.org/request/show/351092. This commit copies manilaclient.conf file to the required path and updates the credentials for admin user and service user. 