### PR TITLE
limit OpenStack services by node role

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/pacemaker_helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/pacemaker_helpers.rb
@@ -1,0 +1,46 @@
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# These helper methods provides a convenient way to create Pacemaker
+# location constraints which limit resources to only run on OpenStack
+# controller nodes or compute nodes.
+#
+# Example usage:
+#
+#   service_name = "keystone"
+#   location_name = "l-#{service_name}-controller"
+#   pacemaker_location location_name do
+#     definition controller_only_location(location_name, service_name)
+#     action :update
+#     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+#   end
+#   transaction_objects << "pacemaker_location[#{location_name}]"
+
+class Chef
+  class Resource
+    class PacemakerLocation
+      def controller_only_location(location, service)
+        "location #{location} #{service} resource-discovery=exclusive " +
+          "rule 0: OpenStack-role eq controller"
+      end
+
+      def compute_only_location(location, service)
+        "location #{location} #{service} resource-discovery=exclusive " +
+          "rule 0: OpenStack-role eq compute"
+      end
+    end
+  end
+end

--- a/chef/cookbooks/crowbar-openstack/recipes/compute.rb
+++ b/chef/cookbooks/crowbar-openstack/recipes/compute.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: crowbar-openstack
+# Recipe:: compute
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ha_enabled = !node[:pacemaker].nil?
+
+execute "set OpenStack-role to compute" do
+  command "crm node attribute #{node[:nodename]} set OpenStack-role compute"
+  # The cluster only does a transition if the attribute value changes,
+  # so checking the value before setting would only slow things down
+  # for no benefit.
+  only_if ha_enabled
+end

--- a/chef/cookbooks/crowbar-openstack/recipes/controller.rb
+++ b/chef/cookbooks/crowbar-openstack/recipes/controller.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: crowbar-openstack
+# Recipe:: controller
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ha_enabled = !node[:pacemaker].nil?
+
+execute "set OpenStack-role to controller" do
+  command "crm node attribute #{node[:nodename]} set OpenStack-role controller"
+  # The cluster only does a transition if the attribute value changes,
+  # so checking the value before setting would only slow things down
+  # for no benefit.
+  only_if ha_enabled
+end

--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -65,10 +65,18 @@ if node[:keystone][:frontend] == "native"
   clone_name = "cl-#{service_name}"
   pacemaker_clone clone_name do
     rsc service_name
+    meta ({ "clone-max" => 2 })
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
   transaction_objects << "pacemaker_clone[#{clone_name}]"
+
+  location_name = "l-#{clone_name}-controller"
+  pacemaker_location location_name do
+    definition controller_only_location(location_name, clone_name)
+    action :update
+  end
+  transaction_objects << "pacemaker_location[#{location_name}]"
 
   pacemaker_transaction "#{clone_name} clone" do
     cib_objects transaction_objects

--- a/chef/cookbooks/postgresql/metadata.rb
+++ b/chef/cookbooks/postgresql/metadata.rb
@@ -21,3 +21,4 @@ end
 end
 
 depends "openssl"
+depends "crowbar-openstack"

--- a/chef/roles/openstack-compute.rb
+++ b/chef/roles/openstack-compute.rb
@@ -1,0 +1,7 @@
+name "openstack-compute"
+description "Generic OpenStack compute role"
+run_list(
+  "recipe[crowbar-openstack::compute]"
+)
+default_attributes
+override_attributes

--- a/chef/roles/openstack-controller.rb
+++ b/chef/roles/openstack-controller.rb
@@ -1,0 +1,7 @@
+name "openstack-controller"
+description "Generic OpenStack controller role"
+run_list(
+  "recipe[crowbar-openstack::controller]"
+)
+default_attributes
+override_attributes


### PR DESCRIPTION
**WIP - the helpers do not work due to Chef internals.  Need to be replaced with definitions or wrapper LWRPs.**

Now that `pacemaker_remote` can extend the cluster beyond the core corosync nodes, we have to ensure that controller services only run on the core nodes, and compute services only run on the compute nodes.  We do this by introducing new `crowbar-openstack::controller` and `crowbar-openstack::compute` roles, which new rule-based `location` constraints can then reference.

**N.B. These new constraints require https://github.com/crowbar/crowbar-ha/pull/54 to work.**

This PR is currently based on #139, but will be rebased when that is merged.