### PR TITLE
neutron: Revert one piece from a98aa50da5471ea58657d4abf6cbf186fd1096a5

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -140,7 +140,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
     physnet = node[:crowbar_wall][:network][:nets][:nova_fixed].first
     interface_mappings = "physnet1:" + physnet
-    if node.roles.include?("neutron-network")
+    if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
       external_networks = ["nova_floating"]
       external_networks.concat(node[:neutron][:additional_external_networks])
       ext_physnet_map = NeutronHelper.get_neutron_physnets(node, external_networks)


### PR DESCRIPTION
There's no need to drop DVR support for linuxbridge in the cookbook:
what matters is that crowbar makes it impossible; having the cookbook
support this will be helpful when upstream adds support for DVR with
linuxbridge.