### PR TITLE
Use reset_sync_marks_on_clusters_founders to avoid drift (bsc#935462)

### DIFF
--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -43,9 +43,7 @@ end.run_action(:create)
 crowbar_pacemaker_sync_mark "sync-heat_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-heat_ha_resources" do
-  timeout 300
-end
+crowbar_pacemaker_sync_mark "wait-heat_ha_resources"
 
 primitives = []
 transaction_objects = []

--- a/chef/cookbooks/horizon/recipes/ha.rb
+++ b/chef/cookbooks/horizon/recipes/ha.rb
@@ -37,9 +37,7 @@ end
 crowbar_pacemaker_sync_mark "sync-horizon_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-horizon_ha_resources" do
-  timeout 180
-end
+crowbar_pacemaker_sync_mark "wait-horizon_ha_resources"
 
 include_recipe "crowbar-pacemaker::apache"
 

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -24,9 +24,7 @@ use_lbaas_agent = node[:neutron][:use_lbaas]
 crowbar_pacemaker_sync_mark "sync-neutron-agents_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-neutron-agents_ha_resources" do
-  timeout 180
-end
+crowbar_pacemaker_sync_mark "wait-neutron-agents_ha_resources"
 
 l3_agent_primitive = "neutron-l3-agent"
 dhcp_agent_primitive = "neutron-dhcp-agent"

--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -27,7 +27,7 @@ db_settings = fetch_database_settings
 
 crowbar_pacemaker_sync_mark "wait-nova_database" do
   # the db sync is very slow for nova
-  timeout 240
+  timeout 120
 end
 
 # Creates empty nova database

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -161,6 +161,7 @@ class CeilometerService < PacemakerServiceObject
     end
 
     server_elements, server_nodes, ha_enabled = role_expand_elements(role, "ceilometer-server")
+    reset_sync_marks_on_clusters_founders(server_elements)
 
     vip_networks = ["admin", "public"]
 
@@ -182,8 +183,9 @@ class CeilometerService < PacemakerServiceObject
     # the VIP of the cluster to be setup
     allocate_virtual_ips_for_any_cluster_in_networks(server_elements, vip_networks)
 
-    _polling_elements, _polling_nodes, polling_ha_enabled = \
+    polling_elements, _polling_nodes, polling_ha_enabled = \
         role_expand_elements(role, "ceilometer-polling")
+    reset_sync_marks_on_clusters_founders(polling_elements)
 
     role.save if prepare_role_for_ha(role,\
                                      ["ceilometer", "ha", "polling", "enabled"],\

--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -200,6 +200,7 @@ class CinderService < PacemakerServiceObject
     return if all_nodes.empty?
 
     controller_elements, controller_nodes, ha_enabled = role_expand_elements(role, "cinder-controller")
+    reset_sync_marks_on_clusters_founders(controller_elements)
 
     vip_networks = ["admin", "public"]
 

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -112,6 +112,7 @@ class DatabaseService < PacemakerServiceObject
 
     database_elements, database_nodes, database_ha_enabled = role_expand_elements(role, "database-server")
     prepare_role_for_ha(role, ["database", "ha", "enabled"], database_ha_enabled)
+    reset_sync_marks_on_clusters_founders(database_elements)
 
     if database_ha_enabled
       net_svc = NetworkService.new @logger

--- a/crowbar_framework/app/models/glance_service.rb
+++ b/crowbar_framework/app/models/glance_service.rb
@@ -86,6 +86,7 @@ class GlanceService < PacemakerServiceObject
 
     # Role can be assigned to clusters, so we need to expand the elements to get the actual list of nodes.
     server_elements, server_nodes, has_expanded = role_expand_elements(role, "glance-server")
+    reset_sync_marks_on_clusters_founders(server_elements)
 
     # If glance_elements != glance_nodes, has_expanded will be true, which currently means we want to use HA.
     ha_enabled = has_expanded

--- a/crowbar_framework/app/models/heat_service.rb
+++ b/crowbar_framework/app/models/heat_service.rb
@@ -94,6 +94,7 @@ class HeatService < PacemakerServiceObject
     vip_networks = ["admin", "public"]
 
     server_elements, server_nodes, ha_enabled = role_expand_elements(role, "heat-server")
+    reset_sync_marks_on_clusters_founders(server_elements)
 
     role.save if prepare_role_for_ha_with_haproxy(role, ["heat", "ha", "enabled"], ha_enabled, server_elements, vip_networks)
 

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -109,6 +109,7 @@ class HorizonService < PacemakerServiceObject
     return if all_nodes.empty?
 
     server_elements, server_nodes, ha_enabled = role_expand_elements(role, "horizon-server")
+    reset_sync_marks_on_clusters_founders(server_elements)
 
     vip_networks = ["admin", "public"]
 

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -109,6 +109,7 @@ class KeystoneService < PacemakerServiceObject
     @logger.debug("Keystone apply_role_pre_chef_call: entering #{all_nodes.inspect}")
 
     server_elements, server_nodes, ha_enabled = role_expand_elements(role, "keystone-server")
+    reset_sync_marks_on_clusters_founders(server_elements)
 
     vip_networks = ["admin", "public"]
 

--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -114,6 +114,7 @@ end
     controller_elements,
     controller_nodes,
     ha_enabled = role_expand_elements(role, "manila-server")
+    reset_sync_marks_on_clusters_founders(controller_elements)
     vip_networks = ["admin", "public"]
 
     dirty = prepare_role_for_ha_with_haproxy(

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -380,7 +380,9 @@ class NeutronService < PacemakerServiceObject
     end
 
     server_elements, server_nodes, server_ha_enabled = role_expand_elements(role, "neutron-server")
+    reset_sync_marks_on_clusters_founders(server_elements)
     network_elements, network_nodes, network_ha_enabled = role_expand_elements(role, "neutron-network")
+    reset_sync_marks_on_clusters_founders(network_elements)
 
     vip_networks = ["admin", "public"]
 

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -183,6 +183,7 @@ class NovaService < PacemakerServiceObject
     end
 
     controller_elements, controller_nodes, ha_enabled = role_expand_elements(role, "nova-controller")
+    reset_sync_marks_on_clusters_founders(controller_elements)
 
     vip_networks = ["admin", "public"]
 

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -73,6 +73,7 @@ class RabbitmqService < PacemakerServiceObject
 
     rabbitmq_elements, rabbitmq_nodes, rabbitmq_ha_enabled = role_expand_elements(role, "rabbitmq-server")
     role.save if prepare_role_for_ha(role, ["rabbitmq", "ha", "enabled"], rabbitmq_ha_enabled)
+    reset_sync_marks_on_clusters_founders(rabbitmq_elements)
 
     net_svc = NetworkService.new @logger
     # Allocate public IP if rabbitmq should listen on public interface


### PR DESCRIPTION
This depends on https://github.com/crowbar/crowbar-ha/pull/60