### PR TITLE
Make xCAT ssh key configurable

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -339,20 +339,14 @@ ruby_block "nova_read_ssh_public_key" do
 end
 
 ssh_auth_keys = ""
-search_env_filtered(:node, "roles:nova-compute-kvm") do |n|
-  ssh_auth_keys += n[:nova][:service_ssh_key]
+%w(kvm xen docker qemu zvm).each do |hypervisor|
+  search_env_filtered(:node, "roles:nova-compute-#{hypervisor}") do |n|
+    ssh_auth_keys += n[:nova][:service_ssh_key]
+  end
 end
-search_env_filtered(:node, "roles:nova-compute-xen") do |n|
-  ssh_auth_keys += n[:nova][:service_ssh_key]
-end
-search_env_filtered(:node, "roles:nova-compute-docker") do |n|
-  ssh_auth_keys += n[:nova][:service_ssh_key]
-end
-search_env_filtered(:node, "roles:nova-compute-qemu") do |n|
-  ssh_auth_keys += n[:nova][:service_ssh_key]
-end
-search_env_filtered(:node, "roles:nova-compute-zvm") do |n|
-  ssh_auth_keys += n[:nova][:service_ssh_key]
+
+if node["roles"].include?("nova-compute-zvm")
+  ssh_auth_keys += node[:nova][:zvm][:zvm_xcat_ssh_key]
 end
 
 file "#{node[:nova][:home_dir]}/.ssh/authorized_keys" do

--- a/chef/data_bags/crowbar/migrate/nova/039_add_zvm_xcat_ssh_key.rb
+++ b/chef/data_bags/crowbar/migrate/nova/039_add_zvm_xcat_ssh_key.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["zvm"]["zvm_xcat_ssh_key"] = ta["zvm"]["zvm_xcat_ssh_key"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["zvm"].delete("zvm_xcat_ssh_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -59,7 +59,8 @@
         "zvm_host": "",
         "zvm_scsi_pool": "",
         "zvm_user_profile": "",
-        "zvm_xcat_master": ""
+        "zvm_xcat_master": "",
+        "zvm_xcat_ssh_key": ""
       },
       "ssl": {
         "enabled": false,
@@ -87,7 +88,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 38,
+      "schema-revision": 39,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -88,7 +88,8 @@
                 "zvm_host": { "type": "str", "required": true },
                 "zvm_scsi_pool": { "type": "str", "required": true },
                 "zvm_user_profile": { "type": "str", "required": true },
-                "zvm_xcat_master": { "type": "str", "required": true }
+                "zvm_xcat_master": { "type": "str", "required": true },
+                "zvm_xcat_ssh_key": { "type": "str", "required": true }
               }
             },
             "ssl": {

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -62,6 +62,7 @@
       = string_field %w(zvm zvm_user_profile)
       = string_field %w(zvm zvm_scsi_pool)
       = string_field %w(zvm zvm_xcat_master)
+      = string_field %w(zvm zvm_xcat_ssh_key)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -61,6 +61,7 @@ en:
           zvm_scsi_pool: 'Default zFCP SCSI Disk Pool'
           zvm_user_profile: 'User profile for creating a z/VM userid'
           zvm_xcat_master: 'The xCAT MN node name'
+          zvm_xcat_ssh_key: 'The xCAT MN node public SSH key'
         ssl_header: 'SSL Support'
         ssl:
           enabled: 'Protocol'


### PR DESCRIPTION
The user needs to enter the xCAT public key to the nova
user in order to scp the images from the node.