### PR TITLE
Updates mtu configuration to use neutron config options.

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -101,16 +101,9 @@ template "/etc/neutron/metering_agent.ini" do
   )
 end
 
-ml2_drivers = node[:neutron][:ml2_type_drivers]
-template "/etc/neutron/dnsmasq-neutron.conf" do
-  source "dnsmasq-neutron.conf.erb"
-  owner "root"
-  group "root"
-  mode "0644"
-  variables(
-    # nil means to leave the default MTU
-    force_mtu: ml2_drivers.include?("gre") || ml2_drivers.include?("vxlan") ? 1400 : nil
-  )
+# Delete pre-existing configuration file.
+file "/etc/neutron/dnsmasq-neutron.conf" do
+  action :delete
 end
 
 dns_list = node[:dns][:forwarders].join(",")
@@ -174,7 +167,6 @@ service node[:neutron][:platform][:dhcp_agent_name] do
   action [:enable, :start]
   subscribes :restart, resources("template[/etc/neutron/neutron.conf]")
   subscribes :restart, resources("template[/etc/neutron/dhcp_agent.ini]")
-  subscribes :restart, resources("template[/etc/neutron/dnsmasq-neutron.conf]")
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
 

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -164,12 +164,14 @@ when "ml2"
   physnet_map = NeutronHelper.get_neutron_physnets(network_node, external_networks)
   physnets = physnet_map.values
 
+  mtu_value = 0
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   #TODO(vuntz): temporarily disable the hyperv mechanism since we're lacking networking-hyperv from stackforge
   #ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup.push("hyperv")
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
     ml2_mechanism_drivers.push("l2population")
+    mtu_value = 1400
   end
 
   ml2_mech_drivers = node[:neutron][:ml2_mechanism_drivers]
@@ -193,7 +195,8 @@ when "ml2"
       vxlan_start: vni_start,
       vxlan_end: vni_end,
       vxlan_mcast_group: node[:neutron][:vxlan][:multicast_group],
-      external_networks: physnets
+      external_networks: physnets,
+      path_mtu: mtu_value
     )
   end
 when "vmware"

--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -82,7 +82,6 @@ dhcp_domain = <%= @dhcp_domain %>
 
 # Override the default dnsmasq settings with this file
 # dnsmasq_config_file =
-dnsmasq_config_file = /etc/neutron/dnsmasq-neutron.conf
 
 # Comma-separated list of DNS servers which will be used by dnsmasq
 # as forwarders.

--- a/chef/cookbooks/neutron/templates/default/dnsmasq-neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/dnsmasq-neutron.conf.erb
@@ -1,4 +1,0 @@
-# this file is managed by chef to give extra options to dnsmasq
-<% if @force_mtu -%>
-dhcp-option-force=26,<%= @force_mtu.to_s %>
-<% end -%>

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -37,6 +37,7 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # path_mtu - max encap header size).  If <=0, the path MTU is
 # indeterminate and no calculation takes place.
 # path_mtu = 0
+path_mtu = <%= @path_mtu %>
 
 # (IntOpt) Segment MTU.  The maximum permissible size of an
 # unfragmented packet travelling a L2 network segment.  If <=0,

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -199,6 +199,7 @@ allow_overlapping_ips = False
 # settings to VMs via network methods (ie. DHCP and RA MTU options)
 # when the network's preferred MTU is known.
 # advertise_mtu = False
+advertise_mtu = True
 # ======== end of items for MTU selection and advertisement =========
 
 # =========== items for agent management extension =============


### PR DESCRIPTION
Removes custom dnsmasq-neutron.conf.erb and sets mtu options via.
neutron ml2_conf.ini.erb.