### PR TITLE
glance: Avoid greenthreads hanging endlessly on "slowloris" attack

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -180,6 +180,7 @@ max_header_line = <%= node[:glance][:max_header_line] %>
 # have to set this option to False when you create a wsgi server.
 # (boolean value)
 #http_keepalive = true
+http_keepalive = false
 
 # Timeout for client connections' socket operations. If an incoming
 # connection is idle for this number of seconds it will be closed. A

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -171,6 +171,7 @@ workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 # have to set this option to False when you create a wsgi server.
 # (boolean value)
 #http_keepalive = true
+http_keepalive = false
 
 # Timeout for client connections' socket operations. If an incoming
 # connection is idle for this number of seconds it will be closed. A


### PR DESCRIPTION
See https://bugs.launchpad.net/nova/+bug/1361360 for the full
story.