### PR TITLE
nova: Avoid greenthreads hanging endlessly on "slowloris" attack

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -506,6 +506,7 @@ max_header_line = <%= node[:nova][:max_header_line] %>
 
 # If False, closes the client socket connection explicitly. (boolean value)
 #wsgi_keep_alive = true
+wsgi_keep_alive = false
 
 # Timeout for client connections' socket operations. If an incoming connection
 # is idle for this number of seconds it will be closed. A value of '0' means


### PR DESCRIPTION
See https://bugs.launchpad.net/nova/+bug/1361360 for the full
story.