### PR TITLE
Remove duplicated options in [DEFAULT] section

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -83,14 +83,6 @@ novncproxy_host = <%= @bind_host %>
 novncproxy_port = <%= @bind_port_novncproxy %>
 
 # Host on which to listen for incoming requests (string value)
-#serialproxy_host = 0.0.0.0
-
-# Port on which to listen for incoming requests (integer value)
-# Minimum value: 1
-# Maximum value: 65535
-#serialproxy_port = 6083
-
-# Host on which to listen for incoming requests (string value)
 #html5proxy_host = 0.0.0.0
 
 # Port on which to listen for incoming requests (integer value)

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -82,14 +82,6 @@ novncproxy_host = <%= @bind_host %>
 #novncproxy_port = 6080
 novncproxy_port = <%= @bind_port_novncproxy %>
 
-# Host on which to listen for incoming requests (string value)
-#html5proxy_host = 0.0.0.0
-
-# Port on which to listen for incoming requests (integer value)
-# Minimum value: 1
-# Maximum value: 65535
-#html5proxy_port = 6082
-
 # Driver to use for the console proxy (string value)
 #console_driver = nova.console.xvp.XVPConsoleProxy
 


### PR DESCRIPTION
We would like to remove duplicated options from [DEFAULT] section

Options:
```
# Host on which to listen for incoming requests (string value)
#serialproxy_host = 0.0.0.0

# Port on which to listen for incoming requests (integer value)
# Minimum value: 1
# Maximum value: 65535
#serialproxy_port = 6083
```
were moved to [serial_console] section, it was fixed in upstream https://review.openstack.org/#/c/244177/

Options:
```
# Host on which to listen for incoming requests (string value)
#html5proxy_host = 0.0.0.0

# Port on which to listen for incoming requests (integer value)
# Minimum value: 1
# Maximum value: 65535
#html5proxy_port = 6082
```
were moved to [spice] section, it will be fixed in upstream
https://review.openstack.org/#/c/264271/

All options they have already their own namespaces and in [DEFAULT] section, they are not restricted