### PR TITLE
tempest: Hide menu item that leads to tempest dashboard

### DIFF
--- a/tempest.yml
+++ b/tempest.yml
@@ -36,9 +36,3 @@ crowbar:
 
 smoketest:
   timeout: 2400
-
-nav:
-  utils:
-    tempest:
-      order: 30
-      route: 'tempest_dashboard_path'


### PR DESCRIPTION
The tempest dashboard is non-functional right now, so at least hide it.

This can be reverted once https://github.com/crowbar/crowbar-openstack/pull/191 is completed.