### PR TITLE
neutron: Do not set external_network_type in ml2_conf.ini

### DIFF
--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -61,7 +61,6 @@ path_mtu = <%= @path_mtu %>
 # network type values configured in type_drivers config option.
 # external_network_type =
 # Example: external_network_type = local
-external_network_type = flat
 
 [ml2_type_flat]
 # (ListOpt) List of physical_network names with which flat networks


### PR DESCRIPTION
This was set to flat, but this results in a config that is invalid for
tempest tests related to external networks
(tempest.api.network.admin.test_external_network_extension.ExternalNetworksTestJSON):
it's simply not possible to create an external network because there's
no way to allocate a segment for the flat type.

Note that this was introduced following https://github.com/crowbar/crowbar-openstack/pull/97#issuecomment-160137507

cc @rhafer