### PR TITLE
swift: Include logging recipe

### DIFF
--- a/chef/cookbooks/swift/recipes/default.rb
+++ b/chef/cookbooks/swift/recipes/default.rb
@@ -34,12 +34,14 @@ template "/etc/swift/swift.conf" do
  })
 end
 
-rsyslog_version = `rsyslogd -v | head -1 | sed -e "s/^rsyslogd \\(.*\\), .*$/\\1/"`
-# log swift components into separate log files
-template "/etc/rsyslog.d/11-swift.conf" do
-  source "11-swift.conf.erb"
-  mode "0644"
-  variables(rsyslog_version: rsyslog_version)
-  notifies :restart, "service[rsyslog]"
-  only_if { node[:platform_family] == "suse" } # other distros might not have /var/log/swift
+if node.roles.include?("logging-client")
+  rsyslog_version = `rsyslogd -v | head -1 | sed -e "s/^rsyslogd \\(.*\\), .*$/\\1/"`
+  # log swift components into separate log files
+  template "/etc/rsyslog.d/11-swift.conf" do
+    source "11-swift.conf.erb"
+    mode "0644"
+    variables(rsyslog_version: rsyslog_version)
+    notifies :restart, "service[rsyslog]"
+    only_if { node[:platform_family] == "suse" } # other distros might not have /var/log/swift
+  end
 end


### PR DESCRIPTION
Swift wants to restart the rsyslog service which is defined in
the logging recipe. This fixes:

FATAL: Chef::Exceptions::ResourceNotFound: resource
template[/etc/rsyslog.d/11-swift.conf] is configured to notify resource
service[rsyslog] with action restart, but service[rsyslog] cannot be
found in the resource collection. template[/etc/rsyslog.d/11-swift.conf]
is defined in /var/chef/cache/cookbooks/swift/recipes/default.rb:39:in
`from_file'