### PR TITLE
swift: Create container-sync-realms.conf on proxy nodes too

### DIFF
--- a/chef/cookbooks/swift/recipes/common_config.rb
+++ b/chef/cookbooks/swift/recipes/common_config.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2016, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ha_enabled = node[:swift][:ha][:enabled]
+ssl_enabled = node[:swift][:ssl][:enabled]
+swift_protocol = ssl_enabled ? "https" : "http"
+proxy_node = get_instance("roles:swift-proxy")
+public_proxy_host = CrowbarHelper.get_host_for_public_url(proxy_node, ssl_enabled, ha_enabled)
+
+proposal_name = node[:swift][:config][:environment].gsub(/^swift-config-/, "")
+
+# this needs to be both on storage nodes and proxy nodes
+template "/etc/swift/container-sync-realms.conf" do
+  source "container-sync-realms.conf.erb"
+  owner "root"
+  group node[:swift][:group]
+  variables(
+    key: node[:swift][:container_sync][:key],
+    key2: node[:swift][:container_sync][:key2],
+    cluster_name: "#{node[:domain]}_#{proposal_name}",
+    proxy_url: "#{swift_protocol}://#{public_proxy_host}:#{node[:swift][:ports][:proxy]}/v1/"
+  )
+end

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -311,6 +311,8 @@ else
 end
 proxy_config[:memcached_ips] = servers
 
+include_recipe "swift::common_config"
+
 ## Create the proxy server configuraiton file
 template "/etc/swift/proxy-server.conf" do
   source "proxy-server.conf.erb"

--- a/chef/cookbooks/swift/recipes/storage.rb
+++ b/chef/cookbooks/swift/recipes/storage.rb
@@ -42,6 +42,8 @@ end
   package pkg
 end
 
+include_recipe "swift::common_config"
+
 storage_ip = Swift::Evaluator.get_ip_by_type(node,:storage_ip_expr)
 
 %w{account-server object-expirer object-server container-server}.each do |service|
@@ -57,26 +59,6 @@ storage_ip = Swift::Evaluator.get_ip_by_type(node,:storage_ip_expr)
       debug: node[:swift][:debug]
     })
   end
-end
-
-ha_enabled = node[:swift][:ha][:enabled]
-ssl_enabled = node[:swift][:ssl][:enabled]
-swift_protocol = ssl_enabled ? "https" : "http"
-proxy_node = get_instance("roles:swift-proxy")
-public_proxy_host = CrowbarHelper.get_host_for_public_url(proxy_node, ssl_enabled, ha_enabled)
-
-proposal_name = node[:swift][:config][:environment].gsub(/^swift-config-/, "")
-
-template "/etc/swift/container-sync-realms.conf" do
-  source "container-sync-realms.conf.erb"
-  owner "root"
-  group node[:swift][:group]
-  variables(
-    key: node[:swift][:container_sync][:key],
-    key2: node[:swift][:container_sync][:key2],
-    cluster_name: "#{node[:domain]}_#{proposal_name}",
-    proxy_url: "#{swift_protocol}://#{public_proxy_host}:#{node[:swift][:ports][:proxy]}/v1/"
-  )
 end
 
 svcs = %w{swift-object swift-object-auditor swift-object-expirer swift-object-replicator swift-object-updater}


### PR DESCRIPTION
The file is needed not just on container/storage nodes, but also on the
proxy node.