### PR TITLE
nova: Don't specify ssl certificates in nova.conf for compute-only nodes

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -186,12 +186,12 @@ end
 
 # if there's no certificate for novnc, use the ones from nova-api
 if api[:nova][:novnc][:ssl][:enabled] && node["roles"].include?("nova-controller")
-  unless api[:nova][:novnc][:ssl][:certfile].empty?
-    api_novnc_ssl_certfile = api[:nova][:novnc][:ssl][:certfile]
-    api_novnc_ssl_keyfile = api[:nova][:novnc][:ssl][:keyfile]
-  else
+  if api[:nova][:novnc][:ssl][:certfile].empty?
     api_novnc_ssl_certfile = api[:nova][:ssl][:certfile]
     api_novnc_ssl_keyfile = api[:nova][:ssl][:keyfile]
+  else
+    api_novnc_ssl_certfile = api[:nova][:novnc][:ssl][:certfile]
+    api_novnc_ssl_keyfile = api[:nova][:novnc][:ssl][:keyfile]
   end
 else
   api_novnc_ssl_certfile = ""
@@ -199,7 +199,8 @@ else
 end
 
 # only require certs for nova controller
-if (api_ha_enabled || vncproxy_ha_enabled || api == node) && api[:nova][:ssl][:enabled] && node["roles"].include?("nova-controller")
+if (api_ha_enabled || vncproxy_ha_enabled || api == node) && \
+    api[:nova][:ssl][:enabled] && node["roles"].include?("nova-controller")
   if api[:nova][:ssl][:generate_certs]
     package "openssl"
     ruby_block "generate_certs for nova" do
@@ -264,7 +265,8 @@ if (api_ha_enabled || vncproxy_ha_enabled || api == node) && api[:nova][:ssl][:e
   end
 end
 
-if (api_ha_enabled || vncproxy_ha_enabled || api == node) && api[:nova][:novnc][:ssl][:enabled] && node["roles"].include?("nova-controller")
+if (api_ha_enabled || vncproxy_ha_enabled || api == node) && \
+    api[:nova][:novnc][:ssl][:enabled] && node["roles"].include?("nova-controller")
   # No check if we're using certificate info from nova-api
   unless ::File.exist?(api_novnc_ssl_certfile) || api[:nova][:novnc][:ssl][:certfile].empty?
     message = "Certificate \"#{api_novnc_ssl_certfile}\" is not present."


### PR DESCRIPTION
Nova now tries to use the certificates also when creating a client for
glance: https://review.openstack.org/#/c/72974/

Since we really only have this setting to control whether the controller
uses SSL, always put empty paths for ssl certificates on compute-only
nodes.