### PR TITLE
tempest: Temporary disable manila tests

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -249,7 +249,9 @@ use_ceilometer = $?.success?
 `#{keystonev2} endpoint-get --service database &> /dev/null`
 use_trove = $?.success?
 `#{keystonev2} endpoint-get --service share &> /dev/null`
-use_manila = $?.success?
+# FIXME(toabctl): temporary disable manila tempest tests
+# use_manila = $?.success?
+use_manila = false
 
 # FIXME: should avoid search with no environment in query
 neutrons = search(:node, "roles:neutron-server") || []


### PR DESCRIPTION
Currently we have the tests disabled in our package but we want
to enable it without breaking the gate. So disable the tests for
now, enable the tests in the package then as see gating results
when reverting this patch.