### PR TITLE
neutron: Add attribute to disable creation of fixed/floating networks

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -369,7 +369,8 @@ end
 # have multiple routers with the same name). To avoid this race-condition we
 # make sure that the post_install_conf recipe is only executed on a single node
 # of the cluster.
-if !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)
+if node[:neutron][:create_default_networks] && \
+    (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node))
   include_recipe "neutron::post_install_conf"
 end
 

--- a/chef/data_bags/crowbar/migrate/neutron/045_create_default_networks.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/045_create_default_networks.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "create_default_networks"
+    a["create_default_networks"] = ta["create_default_networks"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("create_default_networks")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -9,6 +9,7 @@
       "max_header_line": 16384,
       "debug": false,
       "verbose": true,
+      "create_default_networks": true,
       "dhcp_domain": "openstack.local",
       "use_lbaas": true,
       "use_dvr": false,
@@ -67,7 +68,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 44,
+      "schema-revision": 45,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -14,6 +14,7 @@
                     "service_password": { "type": "str" },
                     "rabbitmq_instance": { "type": "str", "required": true },
                     "keystone_instance": { "type": "str", "required": true },
+                    "create_default_networks": { "type": "bool", "required": true },
                     "dhcp_domain": { "type": "str", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
                     "use_dvr": { "type": "bool", "required": true },


### PR DESCRIPTION
This is a common request we receive; ideally, we would simply move the
definitions of the networks to the barclamp, and add a way to disable
them there, but in the meantime, this should be good enough.

http://bugzilla.suse.com/show_bug.cgi?id=963007