### PR TITLE
Use consistent naming schema for OpenStack barclamps

### DIFF
--- a/ceilometer.yml
+++ b/ceilometer.yml
@@ -18,7 +18,7 @@
 barclamp:
   name: 'ceilometer'
   display: 'Ceilometer'
-  description: 'Telemetry Module: Measurements collection for monitoring and metering'
+  description: 'OpenStack Telemetry: Measurements collection for monitoring and metering'
   version: 0
   user_managed: true
   requires:

--- a/heat.yml
+++ b/heat.yml
@@ -18,7 +18,7 @@
 barclamp:
   name: 'heat'
   display: 'Heat'
-  description: 'Orchestration Module: Orchestration engine for composite cloud applications'
+  description: 'OpenStack Orchestration: Orchestration engine for composite cloud applications'
   version: 0
   user_managed: true
   requires:

--- a/manila.yml
+++ b/manila.yml
@@ -27,7 +27,7 @@
 barclamp:
   name: 'manila'
   display: 'Manila'
-  description: 'File Share Module: Management of shared filesystems'
+  description: 'OpenStack File Share: Management of shared filesystems'
   version: 0
   requires:
     - '@crowbar'


### PR DESCRIPTION
OpenStack barclamp description follow the format:

"OpenStack projectname: description".