### PR TITLE
tempest: Use correct endpoint type for manila

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -1383,7 +1383,7 @@ catalog_type = share
 # The endpoint type to use for the share service
 # Expected values are 'public', 'admin', 'internal', 'publicURL', 'adminURL' and 'internalURL'
 # endpoint_type = publicURL
-endpoint_type = internal_URL
+endpoint_type = internalURL
 
 # This option is used to determine backend driver type, multitenant driver uses share-networks,
 # but single-tenant doesn't


### PR DESCRIPTION
There is no "internal_URL". It's "internalURL".

This fixes:

ConfigFileValueError: Value for option endpoint_type is not valid