### PR TITLE
Removes public endpoint from keystone conf (bsc#954957)

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -242,7 +242,6 @@ template "/etc/keystone/keystone.conf" do
       bind_service_host: bind_service_host,
       bind_admin_port: bind_admin_port,
       bind_service_port: bind_service_port,
-      public_endpoint: node[:keystone][:api][:public_URL],
       admin_endpoint: node[:keystone][:api][:admin_URL],
       use_syslog: node[:keystone][:use_syslog],
       signing_token_format: node[:keystone][:signing][:token_format],

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -19,7 +19,6 @@ admin_token = <%= @admin_token %>
 # only need to set this value if the base URL contains a path (e.g. /prefix/v3)
 # or the endpoint should be found on a different server. (string value)
 #public_endpoint = <None>
-public_endpoint = <%= @public_endpoint %>
 
 # The base admin endpoint URL for Keystone that is advertised to clients (NOTE:
 # this does NOT affect how Keystone listens for connections). Defaults to the


### PR DESCRIPTION
Removing the public endpoint fixes the issue of mismatched endpoints.