### PR TITLE
neutron: Disable l2pop mechanism unless DVR is enabled

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -177,7 +177,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
-        use_l2pop: ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"),
+        use_l2pop: (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")) && neutron[:neutron][:use_dvr],
         dvr_enabled: neutron[:neutron][:use_dvr],
         bridge_mappings: bridge_mappings
       )
@@ -201,7 +201,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         vxlan_mcast_group: neutron[:neutron][:vxlan][:multicast_group],
-        use_l2pop: ml2_type_drivers.include?("vxlan"),
+        use_l2pop: ml2_type_drivers.include?("vxlan") && neutron[:neutron][:use_dvr],
         interface_mappings: interface_mappings
        )
     end

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -170,7 +170,7 @@ when "ml2"
   #ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup.push("hyperv")
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
-    ml2_mechanism_drivers.push("l2population")
+    ml2_mechanism_drivers.push("l2population") if node[:neutron][:use_dvr]
     mtu_value = 1400
   end
 


### PR DESCRIPTION
We see quite some failures in the HA gating that seem to be related to
the use of l2pop. Until this is fixed, let's just not use l2pop for now,
unless we need it for DVR.

cc @rossella  @abel-navarro 