### PR TITLE
cinder: Adjust Fujitsu Eternus config

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder_eternus_dx_config.xml.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder_eternus_dx_config.xml.erb
@@ -1,9 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <FUJITSU>
-<EcomServerIp><%= @eternus_params["ip"] %></EcomServerIp>
-<EcomServerPort><%= @eternus_params["port"] %></EcomServerPort>
-<EcomUserName><%= @eternus_params["user"] %></EcomUserName>
-<EcomPassword><%= @eternus_params["password"] %></EcomPassword>
-<SnapPool><%= @eternus_params["pool"] %></SnapPool>
+<EternusIP><%= @eternus_params["ip"] %></EternusIP>
+<EternusPort><%= @eternus_params["port"] %></EternusPort>
+<EternusUser><%= @eternus_params["user"] %></EternusUser>
+<EternusPassword><%= @eternus_params["password"] %></EternusPassword>
+<EternusPool><%= @eternus_params["pool"] %></EternusPool>
+<EternusISCSIIP><%= @eternus_params["iscsi_ip"] %></EternusISCSIIP>
 <Timeout>10</Timeout>
 </FUJITSU>


### PR DESCRIPTION
For Liberty, the driver (which is now out-of-tree) changed the
attribute names of the configuration file.