### PR TITLE
trove: Add insecure options for openstack services in trove.conf

### DIFF
--- a/chef/cookbooks/openstack-database/recipes/api.rb
+++ b/chef/cookbooks/openstack-database/recipes/api.rb
@@ -59,6 +59,11 @@ object_storage_uri = endpoint("object-storage-api")
 rabbit = node["openstack"]["mq"]["database"]["rabbit"]
 rabbit_pass = get_password("user", rabbit["userid"])
 
+insecure = node["openstack"]["insecure"]
+compute_insecure = node["openstack"]["compute"]["insecure"]
+block_storage_insecure = node["openstack"]["block-storage"]["insecure"]
+object_storage_insecure = node["openstack"]["object-storage"]["insecure"]
+
 template "/etc/trove/trove.conf" do
   source "trove.conf.erb"
   owner node["openstack"]["database"]["user"]
@@ -70,9 +75,13 @@ template "/etc/trove/trove.conf" do
     rabbit: rabbit,
     rabbit_pass: rabbit_pass,
     identity_uri: identity_uri,
+    insecure: insecure,
     compute_uri: compute_uri,
+    compute_insecure: compute_insecure,
     block_storage_uri: block_storage_uri,
-    object_storage_uri: object_storage_uri
+    block_storage_insecure: block_storage_insecure,
+    object_storage_uri: object_storage_uri,
+    object_storage_insecure: object_storage_insecure
     )
 
   notifies :restart, "service[trove-api]", :immediately

--- a/chef/cookbooks/openstack-database/recipes/taskmanager.rb
+++ b/chef/cookbooks/openstack-database/recipes/taskmanager.rb
@@ -47,6 +47,11 @@ object_storage_uri = endpoint("object-storage-api")
 rabbit = node["openstack"]["mq"]["database"]["rabbit"]
 rabbit_pass = get_password("user", rabbit["userid"])
 
+insecure = node["openstack"]["insecure"]
+compute_insecure = node["openstack"]["compute"]["insecure"]
+block_storage_insecure = node["openstack"]["block-storage"]["insecure"]
+object_storage_insecure = node["openstack"]["object-storage"]["insecure"]
+
 template "/etc/trove/trove-taskmanager.conf" do
   source "trove-taskmanager.conf.erb"
   owner node["openstack"]["database"]["user"]
@@ -57,9 +62,13 @@ template "/etc/trove/trove-taskmanager.conf" do
     rabbit: rabbit,
     rabbit_pass: rabbit_pass,
     identity_uri: identity_uri,
+    insecure: insecure,
     compute_uri: compute_uri,
+    compute_insecure: compute_insecure,
     block_storage_uri: block_storage_uri,
-    object_storage_uri: object_storage_uri
+    block_storage_insecure: block_storage_insecure,
+    object_storage_uri: object_storage_uri,
+    object_storage_insecure: object_storage_insecure
     )
 
   notifies :restart, "service[trove-taskmanager]", :immediately

--- a/chef/cookbooks/openstack-database/templates/default/trove-taskmanager.conf.erb
+++ b/chef/cookbooks/openstack-database/templates/default/trove-taskmanager.conf.erb
@@ -37,10 +37,14 @@ sql_idle_timeout = 3600
 db_api_implementation = trove.db.sqlalchemy.api
 
 # Configuration options for talking to nova via the novaclient.
+api_insecure = <%= @insecure %>
 trove_auth_url = <%= @identity_uri %>
 nova_compute_url = <%= @compute_uri %>
+nova_api_insecure = <%= @compute_insecure %>
 cinder_url = <%= @block_storage_uri %>
+cinder_api_insecure = <%= @block_storage_insecure %>
 swift_url = <%= @object_storage_uri %>
+swift_api_insecure = <%= @object_storage_insecure %>
 
 # Config options for enabling volume service
 trove_volume_support = <%= node['openstack']['database']['volume_support'] %>

--- a/chef/cookbooks/openstack-database/templates/default/trove.conf.erb
+++ b/chef/cookbooks/openstack-database/templates/default/trove.conf.erb
@@ -48,10 +48,14 @@ db_api_implementation = "trove.db.sqlalchemy.api"
 api_extensions_path = $pybasedir/extensions/routes
 
 # Configuration options for talking to nova via the novaclient.
+api_insecure = <%= @insecure %>
 trove_auth_url = <%= @identity_uri %>
 nova_compute_url = <%= @compute_uri %>
+nova_api_insecure = <%= @compute_insecure %>
 cinder_url = <%= @block_storage_uri %>
+cinder_api_insecure = <%= @block_storage_insecure %>
 swift_url = <%= @object_storage_uri %>
+swift_api_insecure = <%= @object_storage_insecure %>
 
 # Config option for showing the IP address that nova doles out
 add_addresses = True

--- a/chef/cookbooks/trove/recipes/default.rb
+++ b/chef/cookbooks/trove/recipes/default.rb
@@ -92,6 +92,9 @@ node.set["openstack"]["mq"]["database"]["rabbit"]["vhost"] = rabbitmq[:trove][:v
 node.set["openstack"]["secret"][rabbitmq[:trove][:user]]["user"] = rabbitmq[:trove][:password]
 
 node.set["openstack"]["insecure"] = keystone_settings["insecure"]
+node.set["openstack"]["compute"]["insecure"] = nova_multi_controller[:nova][:ssl][:insecure]
+node.set["openstack"]["block-storage"]["insecure"] = cinder_controller[:cinder][:ssl][:insecure]
+node.set["openstack"]["object-storage"]["insecure"] = swift_proxy[:swift][:ssl][:insecure]
 node.set["openstack"]["database"]["insecure"] = keystone_settings["insecure"]
 node.set["openstack"]["region"] = keystone_settings["endpoint_region"]
 node.set["openstack"]["database"]["region"] = keystone_settings["endpoint_region"]


### PR DESCRIPTION
This depends on upstream trove patch that we need to backport:
https://review.openstack.org/#/c/272686/