### PR TITLE
Fix novnc for HA deployments

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1122,6 +1122,7 @@ security_group_api = neutron
 
 # Memcached servers or None for in process cache. (list value)
 #memcached_servers = <None>
+memcached_servers = <%= @memcached_servers.join(',') %>
 
 #
 # From nova.openstack.common.policy


### PR DESCRIPTION
Without specifying a memcache server, the indivual nova-consoleauth
instances can not synchronise their state between each other in
the cluster.