### PR TITLE
Upgrade: Fix db_synced reset

### DIFF
--- a/crowbar_framework/lib/openstack/upgrade.rb
+++ b/crowbar_framework/lib/openstack/upgrade.rb
@@ -38,7 +38,7 @@ module Openstack
       NodeObject.all.each do |node|
         save_it = false
         components.each do |component|
-          next unless node[component][:db_synced]
+          next unless node[component] && node[component][:db_synced]
           node[component][:db_synced] = false
           save_it = true
         end


### PR DESCRIPTION
The node[barclamp] attribute might not be there. E.g. if a specific components is not
deployed.