### PR TITLE
ceilometer: Fix broken migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/ceilometer/023_rename_ceilometer_cagent_role.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/023_rename_ceilometer_cagent_role.rb
@@ -8,12 +8,14 @@ def upgrade(ta, td, a, d)
   d["elements"].delete("ceilometer-cagent")
 
   # Update the run_list for controller node
-  node = NodeObject.find("roles:ceilometer-cagent")
-  node.add_to_run_list("ceilometer-polling",
-                       td["element_run_list_order"]["ceilometer-polling"],
-                       td["element_states"]["ceilometer-polling"])
-  node.delete_from_run_list("ceilometer-cagent")
-  node.save
+  node = NodeObject.find("roles:ceilometer-cagent").first
+  if node
+    node.add_to_run_list("ceilometer-polling",
+                         td["element_run_list_order"]["ceilometer-polling"],
+                         td["element_states"]["ceilometer-polling"])
+    node.delete_from_run_list("ceilometer-cagent")
+    node.save
+  end
 
   return a, d
 end
@@ -28,12 +30,14 @@ def downgrade(ta, td, a, d)
   d["elements"].delete("ceilometer-polling")
 
   # Update the run_list for controller node
-  node = NodeObject.find("roles:ceilometer-polling")
-  node.add_to_run_list("ceilometer-cagent",
-                       td["element_run_list_order"]["ceilometer-cagent"],
-                       td["element_states"]["ceilometer-cagent"])
-  node.delete_from_run_list("ceilometer-polling")
-  node.save
+  node = NodeObject.find("roles:ceilometer-polling").first
+  if node
+    node.add_to_run_list("ceilometer-cagent",
+                         td["element_run_list_order"]["ceilometer-cagent"],
+                         td["element_states"]["ceilometer-cagent"])
+    node.delete_from_run_list("ceilometer-polling")
+    node.save
+  end
 
   return a, d
 end


### PR DESCRIPTION
There's only one element that is central-agent/polling, and we were
assuming that find would return this element and only this one, but find
returns an array.