### PR TITLE
manila: Fix default proposal for generic backend

### DIFF
--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -2061,10 +2061,10 @@ share_driver=manila.share.drivers.generic.GenericShareDriver
 share_backend_name=<%= share['backend_name'] %>
 driver_handles_share_servers=False
 service_instance_user=<%= share['generic']['service_instance_user'] %>
-<% if share['generic'].key?('service_instance_password') -%>
+<% if share['generic'].key?('service_instance_password') && !share['generic']['service_instance_password'].empty? -%>
 service_instance_password=<%= share['generic']['service_instance_password'] %>
 <% end -%>
-<% if share['generic'].key?('path_to_private_key') -%>
+<% if share['generic'].key?('path_to_private_key') && !share['generic']['path_to_private_key'].empty? -%>
 path_to_private_key=<%= share['generic']['path_to_private_key'] %>
 <% end -%>
 service_instance_name_or_id=<%= share['generic']['service_instance_name_or_id'] %>

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -2064,7 +2064,7 @@ service_instance_user=<%= share['generic']['service_instance_user'] %>
 <% unless share['generic']['service_instance_password'].empty? -%>
 service_instance_password=<%= share['generic']['service_instance_password'] %>
 <% end -%>
-<% if share['generic'].key?('path_to_private_key') && !share['generic']['path_to_private_key'].empty? -%>
+<% unless share['generic']['path_to_private_key'].empty? -%>
 path_to_private_key=<%= share['generic']['path_to_private_key'] %>
 <% end -%>
 service_instance_name_or_id=<%= share['generic']['service_instance_name_or_id'] %>

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -2061,7 +2061,7 @@ share_driver=manila.share.drivers.generic.GenericShareDriver
 share_backend_name=<%= share['backend_name'] %>
 driver_handles_share_servers=False
 service_instance_user=<%= share['generic']['service_instance_user'] %>
-<% if share['generic'].key?('service_instance_password') && !share['generic']['service_instance_password'].empty? -%>
+<% unless share['generic']['service_instance_password'].empty? -%>
 service_instance_password=<%= share['generic']['service_instance_password'] %>
 <% end -%>
 <% if share['generic'].key?('path_to_private_key') && !share['generic']['path_to_private_key'].empty? -%>

--- a/chef/data_bags/crowbar/migrate/manila/014_generic_required_keys.rb
+++ b/chef/data_bags/crowbar/migrate/manila/014_generic_required_keys.rb
@@ -1,0 +1,20 @@
+# ta->template_attributes, td->template_deployment, a->attributes, d->deployment
+def upgrade(ta, td, a, d)
+  # update shares
+  a["shares"].each do |share|
+    next if share["backend_driver"] != "generic"
+    unless share["generic"].key? "service_instance_password"
+      share["generic"]["service_instance_password"] =
+        ta["share_defaults"]["generic"]["service_instance_password"]
+    end
+    unless share["generic"].key? "path_to_private_key"
+      share["generic"]["path_to_private_key"] =
+        ta["share_defaults"]["generic"]["path_to_private_key"]
+    end
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-manila.json
+++ b/chef/data_bags/crowbar/template-manila.json
@@ -79,7 +79,7 @@
     "manila": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 13,
+      "schema-revision": 14,
       "element_states": {
         "manila-server": [ "readying", "ready", "applying" ],
         "manila-share": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-manila.json
+++ b/chef/data_bags/crowbar/template-manila.json
@@ -64,9 +64,12 @@
           "backend_name": "default",
           "generic": {
             "service_instance_user": "root",
+            "service_instance_password": "",
+            "path_to_private_key": "",
             "service_instance_name_or_id": "",
             "service_net_name_or_ip": "",
-            "tenant_net_name_or_ip": ""
+            "tenant_net_name_or_ip": "",
+            "share_volume_fstype": "ext4"
           }
         }
       ]

--- a/chef/data_bags/crowbar/template-manila.schema
+++ b/chef/data_bags/crowbar/template-manila.schema
@@ -85,7 +85,7 @@
                   "generic": {
                     "type": "map", "mapping": {
                       "service_instance_user": { "type": "str", "required": true },
-                      "service_instance_password": { "type": "str", "required": false },
+                      "service_instance_password": { "type": "str", "required": true },
                       "path_to_private_key": { "type": "str", "required": false },
                       "service_instance_name_or_id": { "type": "str", "required": true },
                       "service_net_name_or_ip": { "type": "str", "required": true },

--- a/chef/data_bags/crowbar/template-manila.schema
+++ b/chef/data_bags/crowbar/template-manila.schema
@@ -86,7 +86,7 @@
                     "type": "map", "mapping": {
                       "service_instance_user": { "type": "str", "required": true },
                       "service_instance_password": { "type": "str", "required": true },
-                      "path_to_private_key": { "type": "str", "required": false },
+                      "path_to_private_key": { "type": "str", "required": true },
                       "service_instance_name_or_id": { "type": "str", "required": true },
                       "service_net_name_or_ip": { "type": "str", "required": true },
                       "tenant_net_name_or_ip": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -134,7 +134,7 @@ end
         end
         # there must be a private ssh key path or a password
         unless ["service_instance_password", "path_to_private_key"].any? do |s|
-          share[backend_driver].key?(s) && !share[backend_driver][s].empty?
+          !share[backend_driver][s].empty?
         end
           validation_error I18n.t(
             "barclamp.#{@bc_name}.validation.generic.password_or_private_key")

--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -133,7 +133,9 @@ end
             "barclamp.#{@bc_name}.validation.generic.tenant_net_name_or_ip")
         end
         # there must be a private ssh key path or a password
-        unless ["service_instance_password", "path_to_private_key"].any? { |s| share[backend_driver].key? s }
+        unless ["service_instance_password", "path_to_private_key"].any? do |s|
+          share[backend_driver].key?(s) && !share[backend_driver][s].empty?
+        end
           validation_error I18n.t(
             "barclamp.#{@bc_name}.validation.generic.password_or_private_key")
         end


### PR DESCRIPTION
The default proposal has a generic backend with no password nor key;
however, the UI makes you believe that a password is set (it actually
displays "undefined").

To have this work, we need to change the validation to not check that
there's one attribute between password and key, but also to check that
there's one non-empty attribute.

cc @toabctl 