### PR TITLE
Revert "tempest: Temporary disable manila tests"

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -252,9 +252,7 @@ use_ceilometer = $?.success?
 `#{keystonev2} endpoint-get --service database &> /dev/null`
 use_trove = $?.success?
 `#{keystonev2} endpoint-get --service share &> /dev/null`
-# FIXME(toabctl): temporary disable manila tempest tests
-# use_manila = $?.success?
-use_manila = false
+use_manila = $?.success?
 
 # FIXME: should avoid search with no environment in query
 neutrons = search(:node, "roles:neutron-server") || []


### PR DESCRIPTION
This reverts commit 2d27de339d69f5a6ea938d38632563e0e3994d76.