### PR TITLE
mysql: Fix undefined attribute 'ipaddress' (bsc#921015)

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default["mysql"]["bind_address"]              = ipaddress
+default["mysql"]["bind_address"]              = node["ipaddress"]
 default["mysql"]["storage_engine"]            = "InnoDB"
 default["mysql"]["datadir"]                   = "/var/lib/mysql"
 default["mysql"]["tmpdir"]                    = "/var/lib/mysqltmp"


### PR DESCRIPTION
ipddress fails, needs to be node['ipaddress']