### PR TITLE
Additional fix for rename_nova_roles migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/nova/036_rename_nova_roles.rb
+++ b/chef/data_bags/crowbar/migrate/nova/036_rename_nova_roles.rb
@@ -15,7 +15,7 @@ def upgrade(ta, td, a, d)
 
     # Make sure that all nodes that have the multi role
     # in their run_list are migrated to new name
-    nodes = NodeObject.find("roles:nova-multi-#{role}")
+    nodes = NodeObject.find("run_list_map:nova-multi-#{role}")
     nodes.each do |node|
       node.add_to_run_list("nova-#{role}",
                            td["element_run_list_order"]["nova-#{role}"],
@@ -43,7 +43,7 @@ def downgrade(ta, td, a, d)
 
     # Make sure that all nodes that have the multi role
     # in their run_list are migrated to new name
-    nodes = NodeObject.find("roles:nova-#{role}")
+    nodes = NodeObject.find("run_list_map:nova-#{role}")
     nodes.each do |node|
       node.add_to_run_list("nova-multi-#{role}",
                            td["element_run_list_order"]["nova-multi-#{role}"],


### PR DESCRIPTION
When upgrading from tex the nodes do not have the nova element roles assigned.
Because they are in the "crowbar_upgarde" state.  Use the run_list_map
attribute as a search criteria for the nodes instead.