### PR TITLE
Fix auth_version value for tempest

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -634,8 +634,7 @@ uri_v3 = <%= @keystone_settings["protocol"] %>://<%= @keystone_settings["interna
 
 # Identity API version to be used for authentication for API tests.
 # (string value)
-#auth_version = v2
-auth_version = <%= "v#{@keystone_settings['api_version'].to_i}" %>
+auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 
 # The identity region name to use. Also used as the other services'
 # region name unless they are set explicitly. If no such region is


### PR DESCRIPTION
This should be in sync with how all the other cookbooks define it.