### PR TITLE
nova: Sort fencing_topology used for compute HA

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -282,7 +282,7 @@ unless %w(disabled manual).include? node[:pacemaker][:stonith][:mode]
   # TODO: implement proper LWRP for this, and move this as part of the
   # transaction for controller bits
   bash "crm configure fencing_topology" do
-    code "echo fencing_topology #{topology.join(" ")} | crm configure load update -"
+    code "echo fencing_topology #{topology.sort.join(" ")} | crm configure load update -"
   end
 end
 


### PR DESCRIPTION
This just makes it more readable, and will be better for avoiding random
changes if we move to a LWRP later on.