### PR TITLE
nova: Reset sync marks of clusters that are in compute roles

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -287,6 +287,8 @@ class NovaService < PacemakerServiceObject
           end
           nodes.concat(remote_nodes)
 
+          cluster = PacemakerServiceObject.cluster_from_remotes(element)
+          reset_sync_marks_on_clusters_founders([cluster])
           Openstack::HA.set_compute_role(remote_nodes)
         else
           set_ha_compute(element, false)


### PR DESCRIPTION
We want to reset sync marks of all clusters, not just the one that might
be in the controller role. Otherwise, we might still get a drift.