### PR TITLE
nova: Remove wrong TODO about nova-evacuate order constraint

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -287,7 +287,11 @@ unless %w(disabled manual).include? node[:pacemaker][:stonith][:mode]
 end
 
 crowbar_pacemaker_order_only_existing "o-#{evacuate_primitive}" do
-  # TODO: pretty sure we shouldn't have all of these in the order
+  # We need services required to boot an instance; most of these services are
+  # obviously required. Some additional notes:
+  #  - cinder is used in case of boot from volume
+  #  - neutron agents are used even with DVR, if only to have a DHCP server for
+  #    the instance to get an IP address
   ordering "( postgresql rabbitmq cl-keystone cl-g-glance cl-g-cinder-controller cl-neutron-server cl-g-neutron-agents cl-g-nova-controller ) #{evacuate_primitive}"
   score "Mandatory"
   action :create

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -289,10 +289,11 @@ end
 crowbar_pacemaker_order_only_existing "o-#{evacuate_primitive}" do
   # We need services required to boot an instance; most of these services are
   # obviously required. Some additional notes:
+  #  - swift is used in case it's the backend for glance
   #  - cinder is used in case of boot from volume
   #  - neutron agents are used even with DVR, if only to have a DHCP server for
   #    the instance to get an IP address
-  ordering "( postgresql rabbitmq cl-keystone cl-g-glance cl-g-cinder-controller cl-neutron-server cl-g-neutron-agents cl-g-nova-controller ) #{evacuate_primitive}"
+  ordering "( postgresql rabbitmq cl-keystone cl-swift-proxy cl-g-glance cl-g-cinder-controller cl-neutron-server cl-g-neutron-agents cl-g-nova-controller ) #{evacuate_primitive}"
   score "Mandatory"
   action :create
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }


### PR DESCRIPTION
All services are indeed required because nova-evacuate will trigger nova
instances to be spawned. And that indeed requires a lot of services.

And we're actually missing swift-proxy...