### PR TITLE
Additional fix for renaming ceilometer roles during upgrade

### DIFF
--- a/chef/data_bags/crowbar/migrate/ceilometer/023_rename_ceilometer_cagent_role.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/023_rename_ceilometer_cagent_role.rb
@@ -8,7 +8,7 @@ def upgrade(ta, td, a, d)
   d["elements"].delete("ceilometer-cagent")
 
   # Update the run_list for controller node
-  node = NodeObject.find("roles:ceilometer-cagent").first
+  node = NodeObject.find("run_list_map:ceilometer-cagent").first
   if node
     node.add_to_run_list("ceilometer-polling",
                          td["element_run_list_order"]["ceilometer-polling"],
@@ -30,7 +30,7 @@ def downgrade(ta, td, a, d)
   d["elements"].delete("ceilometer-polling")
 
   # Update the run_list for controller node
-  node = NodeObject.find("roles:ceilometer-polling").first
+  node = NodeObject.find("run_list_map:ceilometer-polling").first
   if node
     node.add_to_run_list("ceilometer-cagent",
                          td["element_run_list_order"]["ceilometer-cagent"],


### PR DESCRIPTION
When upgrading from tex the nodes do not have the ceilometer element roles assigned,
because they are in the "crowbar_upgarde" state.
Use the run_list_map attribute as a search criteria for the nodes instead.

Based on https://github.com/crowbar/crowbar-openstack/pull/259. I didn't test it...