### PR TITLE
Fix nova not using a glance SSL regression

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2064,6 +2064,7 @@ pool_timeout = <%= node[:nova][:db][:pool_timeout] %>
 # (string value)
 # Allowed values: http, https
 #protocol = http
+protocol = <%= @glance_server_protocol %>
 
 # A list of the glance api servers available to nova. Prefix with https:// for
 # ssl-based glance api servers. ([hostname|ip]:port) (list value)


### PR DESCRIPTION
Another regession from the big nova.conf update :-(