### PR TITLE
nova: Move from exception to log message when compute HA can't be setup

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -18,7 +18,8 @@ return if remote_nodes.empty?
 
 nova = remote_nodes.first
 unless nova.roles.any? { |role| /^nova-compute-/ =~ role }
-  raise "Remote nodes don't have a nova compute role!"
+  Chef::Log.info("Skipping setup of HA for compute nodes as remote nodes don't have a nova compute role yet.")
+  return
 end
 
 unless nova[:nova][:ha][:compute][:enabled]


### PR DESCRIPTION
If the cluster is used for both controller and compute roles, then it
can happen that the nodes don't have the compute roles yet when
chef-client runs on the controller.

Here we don't do a search but really look at the roles attribute, and
this means that we need more than the role being set to the node through
the "crowbar-$node" role, which generally requires chef-client to run.
And that chef-client run would be in the second batch of apply_role
(compute roles), while the exception will be raised from the first batch
(controller role).