### PR TITLE
Switch to using the tenant_name for now in the neutron cookbook

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -101,7 +101,6 @@ unless nova[:nova].nil? or nova[:nova][:ssl].nil?
     nova_url: "#{nova_api_protocol}://#{nova_api_host}:#{nova[:nova][:ports][:api]}/v2",
     nova_insecure: nova_insecure,
     nova_admin_username: nova[:nova][:service_user],
-    nova_admin_tenant_id: keystone_settings["service_tenant_id"],
     nova_admin_password: nova[:nova][:service_password]
   }
 end

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -415,12 +415,12 @@ nova_admin_username = <%= @nova_admin_username if @nova_admin_username %>
 
 # The uuid of the admin nova tenant
 # nova_admin_tenant_id =
-nova_admin_tenant_id = <%= @nova_admin_tenant_id if @nova_admin_tenant_id %>
 
 # The name of the admin nova tenant. If the uuid of the admin nova tenant
 # is set, this is optional.  Useful for cases where the uuid of the admin
 # nova tenant is not available when configuration is being done.
 # nova_admin_tenant_name =
+nova_admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
 
 # Password for connection to nova in admin context.
 # nova_admin_password =


### PR DESCRIPTION
All others were / are still using tenant_name, and there seems
to be a caching bug in the chef server with the tenant_id that
we're still investigating. This is a workaround until that bug
is fixed.