### PR TITLE
trove: Fix to work with insecure ssl

### DIFF
--- a/chef/cookbooks/openstack-database/recipes/api.rb
+++ b/chef/cookbooks/openstack-database/recipes/api.rb
@@ -89,6 +89,7 @@ end
 
 admin_token = get_password("token", "openstack_identity_bootstrap_token")
 identity_admin_uri = endpoint("identity-admin")
+identity_insecure = node["openstack"]["identity"]["insecure"]
 
 directory ::File.dirname(node["openstack"]["database"]["api"]["auth"]["cache_dir"]) do
   owner node["openstack"]["database"]["user"]
@@ -104,6 +105,7 @@ template "/etc/trove/api-paste.ini" do
   variables(
     identity_admin_uri: identity_admin_uri,
     identity_uri: identity_uri,
+    identity_insecure: identity_insecure,
     admin_token: admin_token
     )
 

--- a/chef/cookbooks/openstack-database/templates/default/api-paste.ini.erb
+++ b/chef/cookbooks/openstack-database/templates/default/api-paste.ini.erb
@@ -26,6 +26,7 @@ admin_token = <%= @admin_token %>
 # middleware should be sufficient.  It will create a temporary directory
 # in the home directory for the user the trove process is running as.
 signing_dir = <%= node["openstack"]["database"]["api"]["auth"]["cache_dir"] %>
+insecure = <%= @identity_insecure %>
 
 [filter:authorization]
 paste.filter_factory = trove.common.auth:AuthorizationMiddleware.factory

--- a/chef/cookbooks/trove/recipes/default.rb
+++ b/chef/cookbooks/trove/recipes/default.rb
@@ -92,6 +92,7 @@ node.set["openstack"]["mq"]["database"]["rabbit"]["vhost"] = rabbitmq[:trove][:v
 node.set["openstack"]["secret"][rabbitmq[:trove][:user]]["user"] = rabbitmq[:trove][:password]
 
 node.set["openstack"]["insecure"] = keystone_settings["insecure"]
+node.set["openstack"]["identity"]["insecure"] = keystone_settings["insecure"]
 node.set["openstack"]["compute"]["insecure"] = nova_multi_controller[:nova][:ssl][:insecure]
 node.set["openstack"]["block-storage"]["insecure"] = cinder_controller[:cinder][:ssl][:insecure]
 node.set["openstack"]["object-storage"]["insecure"] = swift_proxy[:swift][:ssl][:insecure]


### PR DESCRIPTION
The keystone configuration in api-paste.ini was missing the insecure
bit.