### PR TITLE
keystone, openstack: Invalidate caches for each chef run (bsc#966214)

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -52,7 +52,16 @@ class CrowbarOpenStackHelper
   def self.database_settings(node, barclamp)
     instance = node[barclamp][:database_instance] || "default"
 
-    # cache the result
+    # Cache the result for each cookbook in an instance variable hash. This
+    # cache needs to be invalidated for each chef-client run from chef-client
+    # daemon (which are all in the same process); so use the ohai time as a
+    # marker for that.
+    if @database_settings_cache_time != node[:ohai_time]
+      Chef::Log.info("Invalidating database settings cache") if @database_settings
+      @database_settings = nil
+      @database_settings_cache_time = node[:ohai_time]
+    end
+
     if @database_settings && @database_settings.include?(instance)
       Chef::Log.info("Database server found at #{@database_settings[instance][:address]} [cached]")
     else
@@ -89,7 +98,16 @@ class CrowbarOpenStackHelper
   def self.rabbitmq_settings(node, barclamp)
     instance = node[barclamp][:rabbitmq_instance] || "default"
 
-    # cache the result
+    # Cache the result for each cookbook in an instance variable hash. This
+    # cache needs to be invalidated for each chef-client run from chef-client
+    # daemon (which are all in the same process); so use the ohai time as a
+    # marker for that.
+    if @rabbitmq_settings_cache_time != node[:ohai_time]
+      Chef::Log.info("Invalidating rabbitmq settings cache") if @rabbitmq_settings
+      @rabbitmq_settings = nil
+      @rabbitmq_settings_cache_time = node[:ohai_time]
+    end
+
     if @rabbitmq_settings && @rabbitmq_settings.include?(instance)
       Chef::Log.info("RabbitMQ server found at #{@rabbitmq_settings[instance][:address]} [cached]")
     else

--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -11,7 +11,17 @@ module KeystoneHelper
   end
 
   def self.keystone_settings(current_node, cookbook_name)
-    # cache the result for each cookbook in an instance variable hash
+    # Cache the result for each cookbook in an instance variable hash. This
+    # cache needs to be invalidated for each chef-client run from chef-client
+    # daemon (which are all in the same process); so use the ohai time as a
+    # marker for that.
+    if @keystone_settings_cache_time != current_node[:ohai_time]
+      Chef::Log.info("Invalidating keystone settings cache") if @keystone_settings
+      @keystone_settings = nil
+      @keystone_node = nil
+      @keystone_settings_cache_time = current_node[:ohai_time]
+    end
+
     unless @keystone_settings && @keystone_settings.include?(cookbook_name)
       node = search_for_keystone(current_node, cookbook_name)
 


### PR DESCRIPTION
We use a cache to avoid querying the same data again and again over the
network. However that cache is surviving chef-client runs inside the
chef-client daemon (since they're all in the same process).

So it needs to be invalidated for each chef-client run at some point. We
use the ohai time as a marker that lets us know if the cache is for the
current run or from a previous run (since ohai time is updated at the
beginning of each run, in the deployer cookbook).

https://bugzilla.suse.com/show_bug.cgi?id=966214

cc @dirkmueller 