### PR TITLE
Fix postgresql restore only occuring on 2nd chef-client run (bsc#966575)

### DIFF
--- a/chef/cookbooks/postgresql/recipes/server.rb
+++ b/chef/cookbooks/postgresql/recipes/server.rb
@@ -129,7 +129,7 @@ else
 end
 
 db_dump = node["crowbar"].fetch("upgrade", {})["db_dump_location"]
-if !db_dump.nil? && File.exist?(db_dump) && !File.exist?("#{db_dump}.restored-ok")
+if !db_dump.nil? && !File.exist?("#{db_dump}.restored-ok")
   include_recipe "postgresql::db_restore"
 end
 # NOTE: Consider two facts before modifying "assign-postgres-password":


### PR DESCRIPTION
The file check in the condition for including the restore recipe happened in
the compile phase of chef-client and because of that it failed on the first
iteration in an HA setup (fs-postgresql isn't running at that time).
So we turn those checks into an only_if condition on the resource that actually
does the restore.

Also the ".restored-ok" file is now created only on explicit notification of
the restore resource, as now the recipe might be include also when the restore
step is not being executed.

https://bugzilla.suse.com/show_bug.cgi?id=966575