### PR TITLE
nova: Skip neutron configuration on VMware compute nodes (bsc#966690)

### DIFF
--- a/chef/cookbooks/nova/recipes/neutron.rb
+++ b/chef/cookbooks/nova/recipes/neutron.rb
@@ -13,6 +13,9 @@
 # limitations under the License.
 #
 
+# vmware compute nodes do not need access to the networking
+return if node.roles.include?("nova-compute-vmware")
+
 node.set[:cookbook] = cookbook_name
 include_recipe "neutron::common_agent"
 node.delete(:cookbook)


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=966690