### PR TITLE
Avoid greenthreads hanging endlessly on "slowloris" attack

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -2434,6 +2434,7 @@ max_header_line = <%= node[:cinder][:max_header_line] %>
 # to maintain backward compatibility. Recommended setting is set it to False.
 # (boolean value)
 #wsgi_keep_alive = true
+wsgi_keep_alive = false
 
 # Sets the value of TCP_KEEPALIVE (True/False) for each server socket. (boolean
 # value)


### PR DESCRIPTION
See https://bugs.launchpad.net/nova/+bug/1361360 for the full
story.