### PR TITLE
Adds encoding (bsc#953786)

### DIFF
--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
Adding this allows to use non-ASCII characters
in config file for openstack-dashboard.