### PR TITLE
nova: Revert vmware compute nodes don't need direct access to networking

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -274,8 +274,6 @@ class NovaService < PacemakerServiceObject
     role.override_attributes["nova"]["elements"].each do |role_name, elements|
       # only care about compute nodes
       next unless role_name =~ /^nova-compute-/
-      # vmware compute nodes do not need access to the networking
-      next if role_name == "nova-compute-vmware"
 
       nodes = []
 


### PR DESCRIPTION
This revert partially commit 6b20c0b