### PR TITLE
Query polling meters only via Keystone v2

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -93,6 +93,9 @@ template "/etc/ceilometer/ceilometer.conf" do
       verbose: node[:ceilometer][:verbose],
       rabbit_settings: fetch_rabbitmq_settings,
       keystone_settings: keystone_settings,
+      internal_auth_url_v2: KeystoneHelper.versioned_service_URL(
+        keystone_settings["protocol"], keystone_settings["internal_url_host"],
+        keystone_settings["service_port"], "2.0"),
       bind_host: bind_host,
       bind_port: bind_port,
       metering_secret: node[:ceilometer][:metering_secret],

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -1421,7 +1421,7 @@ os_tenant_name = <%= @keystone_settings['service_tenant'] %>
 # Auth URL to use for OpenStack service access. (string value)
 # Deprecated group/name - [DEFAULT]/os_auth_url
 #os_auth_url = http://localhost:5000/v2.0
-os_auth_url = <%= @keystone_settings['internal_auth_url'] %>
+os_auth_url = <%= @internal_auth_url_v2 %>
 
 # Region name to use for OpenStack service endpoints. (string value)
 # Deprecated group/name - [DEFAULT]/os_region_name


### PR DESCRIPTION
Ceilometer in Liberty is hardcoded to request a v2 authentication
token with "tenantName", which does not exist anymore in v3 (it is now
projectName). Pass in a v2 url to workaround the problem.