### PR TITLE
Revert "nova: Skip neutron configuration on VMware compute nodes (bsc#966690)

### DIFF
--- a/chef/cookbooks/nova/recipes/neutron.rb
+++ b/chef/cookbooks/nova/recipes/neutron.rb
@@ -13,9 +13,6 @@
 # limitations under the License.
 #
 
-# vmware compute nodes do not need access to the networking
-return if node.roles.include?("nova-compute-vmware")
-
 node.set[:cookbook] = cookbook_name
 include_recipe "neutron::common_agent"
 node.delete(:cookbook)


### PR DESCRIPTION
This reverts commit 5ff33ee4f720c7e9deed45bfe4be7ee2d2c76194.