### PR TITLE
nova: Also enable libvirtd debug logs when debug is true

### DIFF
--- a/chef/cookbooks/nova/templates/default/libvirtd.conf.erb
+++ b/chef/cookbooks/nova/templates/default/libvirtd.conf.erb
@@ -287,6 +287,9 @@ auth_tcp = "<%= @libvirtd_auth_tcp %>"
 # Logging level: 4 errors, 3 warnings, 2 information, 1 debug
 # basically 1 will log everything possible
 #log_level = 3
+<% if node[:nova][:debug] %>
+log_level = 1
+<% end %>
 
 # Logging filters:
 # A filter allows to select a different logging level for a given category


### PR DESCRIPTION
When debugging nova problems and setting the debug attribute to true,
also enable libvirtd debugging which can be very useful.