### PR TITLE
ha-horizon: use different loadbalancer options

### DIFF
--- a/chef/cookbooks/horizon/recipes/ha.rb
+++ b/chef/cookbooks/horizon/recipes/ha.rb
@@ -18,6 +18,8 @@ haproxy_loadbalancer "horizon" do
   port 80
   use_ssl false
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "horizon", "horizon-server", "plain")
+  options ["defaults", "httpchk"]
+  check ({ inter: 1000, downinter: 3000, rise: 3, fall: 1 })
   action :nothing
 end.run_action(:create)
 
@@ -27,6 +29,7 @@ if node[:horizon][:apache][:ssl]
     port 443
     use_ssl true
     servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "horizon", "horizon-server", "ssl")
+    check ({ inter: 1000, downinter: 3000, rise: 3, fall: 1 })
     action :nothing
   end.run_action(:create)
 end


### PR DESCRIPTION
Depends on https://github.com/crowbar/crowbar-ha/pull/91

Description currently missing, but see also [Reduce haproxy health check intervals (Trello)](https://trello.com/c/Cwc43RXF/1500-reduce-haproxy-health-check-intervals)
