### PR TITLE
glance: Do not create /etc/cron.d/glance-scrubber on SUSE platforms

### DIFF
--- a/chef/cookbooks/glance/recipes/scrubber.rb
+++ b/chef/cookbooks/glance/recipes/scrubber.rb
@@ -45,5 +45,6 @@ template "/etc/cron.d/glance-scrubber" do
     glance_user: node[:glance][:user],
     glance_command: "/usr/bin/glance-scrubber "\
                        "--config-dir #{node[:glance][:config_dir]}")
+  not_if { node[:platform_family] == "suse" }
 end
 


### PR DESCRIPTION
We have /etc/cron.hourly/openstack-glance in the package already.