### PR TITLE
nova proposal UI: Change Datastore Name

### DIFF
--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -47,7 +47,7 @@ en:
           user: 'vCenter Username'
           password: 'vCenter Password'
           clusters: 'Cluster Names'
-          datastore: 'Datastore Name'
+          datastore: 'Regular Expression to match the name of a datastore'
           interface: 'VLAN Interface'
           ca_file: 'CA file for verifying the vCenter certificate'
           insecure: 'vCenter SSL Certificate is insecure (for instance, self-signed)'


### PR DESCRIPTION
Regex to match the name of a datastore.

This was reported to documentation too
https://github.com/SUSE-Cloud/doc-cloud/pull/15