### PR TITLE
nova: Allow overcommitting disk when spawning instances

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -73,6 +73,7 @@ default[:nova][:vcenter][:interface] = ""
 #
 default[:nova][:scheduler][:ram_allocation_ratio] = 1.0
 default[:nova][:scheduler][:cpu_allocation_ratio] = 16.0
+default[:nova][:scheduler][:disk_allocation_ratio] = 1.0
 
 #
 # Shared Settings

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1147,6 +1147,7 @@ memcached_servers = <%= @memcached_servers.join(',') %>
 
 # Virtual disk to physical disk allocation ratio (floating point value)
 #disk_allocation_ratio = 1.0
+disk_allocation_ratio = <%= node[:nova][:scheduler][:disk_allocation_ratio] %>
 
 # Tells filters to ignore hosts that have this many or more instances currently
 # in build, resize, snapshot, migrate, rescue or unshelve task states (integer

--- a/chef/data_bags/crowbar/migrate/nova/042_disk_allocation_ratio.rb
+++ b/chef/data_bags/crowbar/migrate/nova/042_disk_allocation_ratio.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["scheduler"]["disk_allocation_ratio"] = ta["scheduler"]["disk_allocation_ratio"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["scheduler"].delete("disk_allocation_ratio")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -26,7 +26,8 @@
       "vnc_keymap": "en-us",
       "scheduler": {
         "ram_allocation_ratio": 1.0,
-        "cpu_allocation_ratio": 16.0
+        "cpu_allocation_ratio": 16.0,
+        "disk_allocation_ratio": 1.0
       },
       "db": {
         "password": "",
@@ -89,7 +90,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 41,
+      "schema-revision": 42,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -39,7 +39,8 @@
               "type": "map",
               "mapping": {
                 "ram_allocation_ratio": { "type": "number" },
-                "cpu_allocation_ratio": { "type": "number" }
+                "cpu_allocation_ratio": { "type": "number" },
+                "disk_allocation_ratio": { "type": "number" }
               }
             },
             "db": {

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -20,6 +20,7 @@
 
       = float_field %w(scheduler ram_allocation_ratio)
       = float_field %w(scheduler cpu_allocation_ratio)
+      = float_field %w(scheduler disk_allocation_ratio)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -33,6 +33,7 @@ en:
         scheduler:
           ram_allocation_ratio: 'Virtual RAM to Physical RAM allocation ratio'
           cpu_allocation_ratio: 'Virtual CPU to Physical CPU allocation ratio'
+          disk_allocation_ratio: 'Virtual Disk to Physical Disk allocation ratio'
         live_migration_header: 'Live Migration Support'
         setup_shared_instance_storage: 'Set up Shared Storage on nova-controller for Nova instances'
         use_shared_instance_storage: 'Shared Storage for Nova instances has been manually configured'


### PR DESCRIPTION
We allow setting the disk_allocation_ratio option, like we do for the
cpu and ram options.