### PR TITLE
neutron: Fix broken MTU for tunnel networks after upgrade (bsc#968426)

### DIFF
--- a/chef/cookbooks/neutron/files/default/crowbar-fix-tunnel-networks-mtu
+++ b/chef/cookbooks/neutron/files/default/crowbar-fix-tunnel-networks-mtu
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+import sqlalchemy
+import sys
+from neutron.plugins.common import constants as p_const
+from oslo_config import cfg
+
+_db_opts = [
+    cfg.StrOpt('connection',
+               deprecated_name='sql_connection',
+               default='',
+               secret=True,
+               help='URL to database'),
+]
+
+CONF = cfg.ConfigOpts()
+CONF.register_cli_opts(_db_opts, 'database')
+CONF(project='neutron')
+
+db_uri = CONF.database.connection
+
+db = sqlalchemy.create_engine(db_uri)
+try:
+    connection = db.connect()
+except sqlalchemy.exc.SQLAlchemyError as e:
+    print >>sys.stderr, 'Cannot connect to database: %s' % e
+    sys.exit(1)
+
+ret = connection.execute(
+    "UPDATE networks SET mtu=%s "
+    "FROM ml2_network_segments "
+    "WHERE ml2_network_segments.network_type=%s "
+    "AND networks.mtu IS NULL "
+    "AND networks.id=ml2_network_segments.network_id;",
+    1500 - p_const.GRE_ENCAP_OVERHEAD, "gre")
+
+ret = connection.execute(
+    "UPDATE networks SET mtu=%s "
+    "FROM ml2_network_segments "
+    "WHERE ml2_network_segments.network_type=%s "
+    "AND networks.mtu IS NULL "
+    "AND networks.id=ml2_network_segments.network_id;",
+    1500 - p_const.VXLAN_ENCAP_OVERHEAD, "vxlan")

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -170,6 +170,34 @@ service node[:neutron][:platform][:dhcp_agent_name] do
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
 
+# Fix broken MTU on upgrade from Juno (bsc#968426)
+# This is only an issue on upgrade (hence the check for an existence of an old
+# file) and for tunnels (gre/vxlan -- was only available with ovs)
+if !node[:neutron][:network_mtu_fix] &&
+    File.exist?("/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini.rpmsave")
+  if node[:neutron][:networking_plugin] == "ml2" && ml2_mech_drivers.include?("openvswitch")
+    cookbook_file "crowbar-fix-tunnel-networks-mtu" do
+      path "/usr/bin/crowbar-fix-tunnel-networks-mtu"
+      mode "0755"
+    end
+
+    execute "fix mtu of tunnel networks" do
+      command "/usr/bin/crowbar-fix-tunnel-networks-mtu"
+      action :run
+      # restart local dhcp agent to get dnsmasq restarted so it advertises the
+      # correct mtu; this is why we run this on all nodes even with HA
+      notifies :restart, "service[#{node[:neutron][:platform][:dhcp_agent_name]}]"
+    end
+  end
+
+  ruby_block "mark node for having the networks mtus fixed (bsc#968426)" do
+    block do
+      node[:neutron][:network_mtu_fix] = true
+      node.save
+    end
+  end
+end
+
 if ha_enabled
   log "HA support for neutron agents is enabled"
   include_recipe "neutron::network_agents_ha"


### PR DESCRIPTION
When upgrading from Juno, we move the MTU advertisement from
/etc/neutron/dnsmasq-neutron.conf (custom dnsmasq config file) to new
settings in configuration files.

However, the MTU for each network is saved in the database and the
database migration from Juno to Liberty just set this to NULL, resulting
in broken MTU.

This is only an issue for networks with a tunnel type. In tex/Juno, we
only had two such possibilities: gre and vxlan (and with ovs only).

We fix this by tweaking the MTU in the database directly and restarting
the DHCP agents, which results in restarting dnsmasq for each network
with the correct settings.

https://bugzilla.suse.com/show_bug.cgi?id=968426