### PR TITLE
neutron: Set path_mtu to 1500 and not 1400 for tunnel types

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -179,7 +179,6 @@ when "ml2"
   physnet_map = NeutronHelper.get_neutron_physnets(network_node, external_networks)
   physnets = physnet_map.values
 
-  mtu_value = 0
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv
@@ -190,7 +189,6 @@ when "ml2"
   end
   if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
     ml2_mechanism_drivers.push("l2population") if node[:neutron][:use_dvr]
-    mtu_value = 1400
   end
 
   ml2_mech_drivers = node[:neutron][:ml2_mechanism_drivers]
@@ -215,7 +213,6 @@ when "ml2"
       vxlan_end: vni_end,
       vxlan_mcast_group: node[:neutron][:vxlan][:multicast_group],
       external_networks: physnets,
-      path_mtu: mtu_value
     )
   end
 when "vmware"

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -37,7 +37,7 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # path_mtu - max encap header size).  If <=0, the path MTU is
 # indeterminate and no calculation takes place.
 # path_mtu = 0
-path_mtu = <%= @path_mtu %>
+path_mtu = 1500
 
 # (IntOpt) Segment MTU.  The maximum permissible size of an
 # unfragmented packet travelling a L2 network segment.  If <=0,


### PR DESCRIPTION
Neutron already substracts the overhead caused by tunnels (length of
tunnel headers), so no need to put a lower value.

cc @abel-navarro @rossella 