### PR TITLE
Do not set virt_type for docker (bnc#968656)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2548,7 +2548,9 @@ admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
 # Libvirt domain type (string value)
 # Allowed values: kvm, lxc, qemu, uml, xen, parallels
 #virt_type = kvm
+<% if %w(kvm lxc qemu uml xen parallels).include? @libvirt_type -%>
 virt_type = <%= @libvirt_type %>
+<% end -%>
 
 # Override the default libvirt URI (which is dependent on virt_type) (string
 # value)


### PR DESCRIPTION
So yes, booting docker instance works. Thanks to @vuntz for spotting this.