### PR TITLE
ceilometer: Fix RA for mongodb when using HA (bsc#968969)

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -88,7 +88,11 @@ default[:ceilometer][:ha][:polling][:agent] = "lsb:#{polling_service_name}"
 default[:ceilometer][:ha][:polling][:op][:monitor][:interval] = "10s"
 # Ports to bind to when haproxy is used for the real ports
 default[:ceilometer][:ha][:ports][:api] = 5561
-default[:ceilometer][:ha][:mongodb][:agent] = "lsb:mongodb"
+if node[:platform] == "suse" && node[:platform_version].to_f < 12.0
+  default[:ceilometer][:ha][:mongodb][:agent] = "lsb:mongodb"
+else
+  default[:ceilometer][:ha][:mongodb][:agent] = "systemd:mongodb"
+end
 default[:ceilometer][:ha][:mongodb][:op][:monitor][:interval] = "10s"
 default[:ceilometer][:ha][:mongodb][:replica_set][:name] = "crowbar-ceilometer"
 default[:ceilometer][:ha][:mongodb][:replica_set][:member] = false


### PR DESCRIPTION
The LSB init script is only on SLE11; move to systemd for anything else.

https://bugzilla.suse.com/show_bug.cgi?id=968969