### PR TITLE
Log which barclamp we're invalidating the caches on behalf of

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -57,7 +57,10 @@ class CrowbarOpenStackHelper
     # daemon (which are all in the same process); so use the ohai time as a
     # marker for that.
     if @database_settings_cache_time != node[:ohai_time]
-      Chef::Log.info("Invalidating database settings cache") if @database_settings
+      if @database_settings
+        Chef::Log.info("Invalidating database settings cache " \
+                       "on behalf of #{barclamp}")
+      end
       @database_settings = nil
       @database_settings_cache_time = node[:ohai_time]
     end
@@ -103,7 +106,10 @@ class CrowbarOpenStackHelper
     # daemon (which are all in the same process); so use the ohai time as a
     # marker for that.
     if @rabbitmq_settings_cache_time != node[:ohai_time]
-      Chef::Log.info("Invalidating rabbitmq settings cache") if @rabbitmq_settings
+      if @rabbitmq_settings
+        Chef::Log.info("Invalidating rabbitmq settings cache " \
+                       "on behalf of #{barclamp}")
+      end
       @rabbitmq_settings = nil
       @rabbitmq_settings_cache_time = node[:ohai_time]
     end

--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -16,7 +16,10 @@ module KeystoneHelper
     # daemon (which are all in the same process); so use the ohai time as a
     # marker for that.
     if @keystone_settings_cache_time != current_node[:ohai_time]
-      Chef::Log.info("Invalidating keystone settings cache") if @keystone_settings
+      if @keystone_settings
+        Chef::Log.info("Invalidating keystone settings cache " \
+                       "on behalf of #{cookbook_name}")
+      end
       @keystone_settings = nil
       @keystone_node = nil
       @keystone_settings_cache_time = current_node[:ohai_time]


### PR DESCRIPTION
This makes it more obvious why cache invalidation is being triggered...

and AFAICS, `ohai_time` gets updated more than once per run, so the cache gets invalidating too often, although this is obviously not a huge issue.  I even saw `ohai_time` go backwards within the run!?

Continuation of #281.