### PR TITLE
[3.0] Do not set unsupported virt_type values (bnc#968656)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2547,7 +2547,9 @@ admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
 # Libvirt domain type (string value)
 # Allowed values: kvm, lxc, qemu, uml, xen, parallels
 #virt_type = kvm
+<% if %w(kvm lxc qemu uml xen parallels).include? @libvirt_type -%>
 virt_type = <%= @libvirt_type %>
+<% end -%>
 
 # Override the default libvirt URI (which is dependent on virt_type) (string
 # value)


### PR DESCRIPTION
(cherry picked from commit bf1d96dae20c579c45aef24357223e9dc3cb6181)