### PR TITLE
[3.0] horizon: Do not protect apache HA setup with wait/create sync marks

### DIFF
--- a/chef/cookbooks/horizon/recipes/ha.rb
+++ b/chef/cookbooks/horizon/recipes/ha.rb
@@ -36,9 +36,6 @@ end
 # resources
 crowbar_pacemaker_sync_mark "sync-horizon_before_ha"
 
-# Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-horizon_ha_resources"
+# no wait/create sync mark as it's done in crowbar-pacemaker itself
 
 include_recipe "crowbar-pacemaker::apache"
-
-crowbar_pacemaker_sync_mark "create-horizon_ha_resources"


### PR DESCRIPTION
We include another recipe, and that recipe might need to do additional
setup that needs to happen on all nodes. So avoid the sync mark here,
and rely on sync marks there.

We keep our "sync" sync mark because it doesn't hurt.

(cherry picked from commit 99ebd719147db0b1da7ded054ca2bb3eb9e83d06)

Backport of https://github.com/crowbar/crowbar-openstack/pull/316

**Goes with https://github.com/crowbar/crowbar-ha/pull/96**