### PR TITLE
[backport 3.0] nova proposal UI: Change Datastore Name

### DIFF
--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -46,7 +46,7 @@ en:
           user: 'vCenter Username'
           password: 'vCenter Password'
           clusters: 'Cluster Names'
-          datastore: 'Datastore Name'
+          datastore: 'Regular Expression to match the name of a datastore'
           interface: 'VLAN Interface'
           ca_file: 'CA file for verifying the vCenter certificate'
           insecure: 'vCenter SSL Certificate is insecure (for instance, self-signed)'


### PR DESCRIPTION
Regex to match the name of a datastore.

(cherry picked from commit b7fa3b2c4e11af6867e19fee7e343ccb806a4e74)