### PR TITLE
interleave Pacemaker clones to minimise disruption (bsc#965886)

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh_ha.rb
+++ b/chef/cookbooks/aodh/recipes/aodh_ha.rb
@@ -59,7 +59,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/barbican/recipes/ha.rb
+++ b/chef/cookbooks/barbican/recipes/ha.rb
@@ -78,7 +78,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta("clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node))
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/ceilometer/recipes/mongodb.rb
+++ b/chef/cookbooks/ceilometer/recipes/mongodb.rb
@@ -60,7 +60,7 @@ if ha_enabled
   clone_name = "cl-#{service_name}"
   pacemaker_clone clone_name do
     rsc service_name
-    meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+    meta CrowbarPacemakerHelper.clone_meta(node)
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -59,7 +59,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -71,7 +71,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -76,7 +76,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -74,7 +74,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/magnum/recipes/ha.rb
+++ b/chef/cookbooks/magnum/recipes/ha.rb
@@ -70,7 +70,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta("clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node))
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -77,7 +77,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -143,7 +143,7 @@ transaction_objects << "pacemaker_group[#{agents_group_name}]"
 agents_clone_name = "cl-#{agents_group_name}"
 pacemaker_clone agents_clone_name do
   rsc agents_group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
@@ -167,7 +167,7 @@ if use_lbaas_agent && node[:neutron][:lbaasv2_driver] == "f5"
   f5_clone_name = "cl-#{f5_agent_primitive}"
   pacemaker_clone f5_clone_name do
     rsc f5_agent_primitive
-    meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+    meta CrowbarPacemakerHelper.clone_meta(node)
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/neutron/recipes/server_ha.rb
+++ b/chef/cookbooks/neutron/recipes/server_ha.rb
@@ -67,7 +67,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta({"clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node)})
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -186,7 +186,7 @@ compute_transaction_objects << "pacemaker_group[#{compute_group_name}]"
 compute_clone_name = "cl-#{compute_group_name}"
 pacemaker_clone compute_clone_name do
   rsc compute_group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_remote_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node, remote: true)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -118,7 +118,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/sahara/recipes/ha.rb
+++ b/chef/cookbooks/sahara/recipes/ha.rb
@@ -65,7 +65,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node)
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/swift/recipes/proxy_ha.rb
+++ b/chef/cookbooks/swift/recipes/proxy_ha.rb
@@ -48,7 +48,7 @@ transaction_objects << "pacemaker_primitive[#{service_name}]"
 clone_name = "cl-#{service_name}"
 pacemaker_clone clone_name do
   rsc service_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   # Do not even try to start the daemon if we don't have the ring yet
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) && ::File.exist?("/etc/swift/object.ring.gz") }


### PR DESCRIPTION
~~**requires crowbar/crowbar-ha#172**~~

**NEEDS MORE TESTING**

By default, Pacemaker clones aren't interleaved.  This means that if Pacemaker wants to restart a dead clone instance, and there is an order constraint on that clone, it will do the same restart on all other nodes, even if all the others are healthy.

More details on interleaving are here:
- https://www.hastexo.com/resources/hints-and-kinks/interleaving-pacemaker-clones/

This behaviour is far more disruptive than we want.  For example, in
[bsc#965886 (L3: neutron-ha-tool not migrating dhcp networks during failover)](https://bugzilla.suse.com/show_bug.cgi?id=965886) we saw that when a network node dies and Pacemaker wants to stop the instance of cl-g-neutron-agents on that node, it also stops and restarts the same clone instances on the healthy nodes.  This means there is a small window in which there are no neutron agents running anywhere.  If neutron-ha-tool attempts a router migration during this window, it will fail, at which point things start to go badly wrong.

In general, the cloned (i.e. active/active) services on our controller and compute nodes should all behave like independent vertical stacks, so that a failure on one node should not cause ripple effects on other nodes.  So we interleave all our clones.

(There is [a corresponding commit to crowbar-ha for the Apache clone](https://github.com/crowbar/crowbar-ha/pull/98).)
