### PR TITLE
[3.0] glance: Fix glance-scrubber to work with insecure SSL for keystone

### DIFF
--- a/chef/cookbooks/glance/recipes/cache.rb
+++ b/chef/cookbooks/glance/recipes/cache.rb
@@ -28,6 +28,8 @@ end
 
 network_settings = GlanceHelper.network_settings(node)
 
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+
 template node[:glance][:cache][:config_file] do
   source "glance-cache.conf.erb"
   owner "root"
@@ -35,7 +37,8 @@ template node[:glance][:cache][:config_file] do
   mode 0640
   variables(
     registry_bind_host: network_settings[:registry][:bind_host],
-    registry_bind_port: network_settings[:registry][:bind_port]
+    registry_bind_port: network_settings[:registry][:bind_port],
+    keystone_settings: keystone_settings
   )
 end
 

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -322,6 +322,7 @@ registry_client_protocol = http
 # equivalent of specifying --insecure on the command line using
 # glanceclient for the API. (boolean value)
 #registry_client_insecure = false
+registry_client_insecure = <%= @keystone_settings["insecure"] %>
 
 # The period of time, in seconds, that the API server will wait for a
 # registry request to complete. A value of 0 implies no timeout.

--- a/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
@@ -135,6 +135,9 @@ registry_host = <%= @registry_bind_host %>
 #registry_port = 9191
 registry_port = <%= @registry_bind_port %>
 
+<% # Missing in upstream template -%>
+registry_client_insecure = <%= @keystone_settings["insecure"] %>
+
 # Whether to pass through the user token when making requests to the
 # registry. To prevent failures with token expiration during big files
 # upload, it is recommended to set this parameter to False.If

--- a/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
@@ -191,6 +191,9 @@ registry_host = <%= @registry_bind_host %>
 #registry_port = 9191
 registry_port = <%= @registry_bind_port %>
 
+<% # Missing in upstream template -%>
+registry_client_insecure = <%= @keystone_settings["insecure"] %>
+
 #
 # From oslo.log
 #


### PR DESCRIPTION
Backport of https://github.com/crowbar/crowbar-openstack/pull/306