### PR TITLE
Expose trusts_delegated_roles in Heat barclamp

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -145,28 +145,30 @@ keystone_register "add heat stack user role" do
   action :add_role
 end
 
-keystone_register "add heat stack owner role" do
-  protocol keystone_settings["protocol"]
-  insecure keystone_settings["insecure"]
-  host keystone_settings["internal_url_host"]
-  port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
-  user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
-  role_name "heat_stack_owner"
-  action :add_role
-end
+node[:heat][:trusts_delegated_roles].each do |role|
+  keystone_register "Create stack owner role #{role}" do
+    protocol keystone_settings["protocol"]
+    insecure keystone_settings["insecure"]
+    host keystone_settings["internal_url_host"]
+    port keystone_settings["admin_port"]
+    token keystone_settings["admin_token"]
+    user_name keystone_settings["service_user"]
+    tenant_name keystone_settings["service_tenant"]
+    role_name role
+    action :add_role
+  end
 
-keystone_register "give admin access to stack owner role" do
-  protocol keystone_settings["protocol"]
-  insecure keystone_settings["insecure"]
-  host keystone_settings["internal_url_host"]
-  port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
-  user_name keystone_settings["admin_user"]
-  tenant_name keystone_settings["default_tenant"]
-  role_name "heat_stack_owner"
-  action :add_access
+  keystone_register "give admin access to stack owner role #{role}" do
+    protocol keystone_settings["protocol"]
+    insecure keystone_settings["insecure"]
+    host keystone_settings["internal_url_host"]
+    port keystone_settings["admin_port"]
+    token keystone_settings["admin_token"]
+    user_name keystone_settings["admin_user"]
+    tenant_name keystone_settings["default_tenant"]
+    role_name role
+    action :add_access
+  end
 end
 
 package "python-openstackclient" do
@@ -359,7 +361,8 @@ template "/etc/heat/heat.conf" do
     stack_user_domain: %x[ #{shell_get_stack_user_domain} ].chomp,
     stack_domain_admin: node[:heat]["stack_domain_admin"],
     stack_domain_admin_password: node[:heat]["stack_domain_admin_password"],
-    use_convergence_engine: node[:heat][:use_convergence_engine]
+    use_convergence_engine: node[:heat][:use_convergence_engine],
+    trusts_delegated_roles: node[:heat][:trusts_delegated_roles]
   )
 end
 

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -35,7 +35,7 @@ deferred_auth_method = trusts
 # Subset of trustor roles to be delegated to heat. If left unset, all roles of
 # a user will be delegated to heat when creating a stack. (list value)
 #trusts_delegated_roles =
-trusts_delegated_roles=heat_stack_owner
+trusts_delegated_roles= <%= @trusts_delegated_roles.join(',') %>
 
 # Maximum resources allowed per top-level stack. -1 stands for unlimited.
 # (integer value)

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -1064,6 +1064,9 @@ endpoint_type = internalURL
 
 # Role required for users to be able to manage stacks (string value)
 #stack_owner_role = heat_stack_owner
+<% if @heat_trusts_delegated_roles -%>
+stack_owner_role = <%= @heat_trusts_delegated_roles[0] %>
+<% end -%>
 
 # Time in seconds between build status checks. (integer value)
 #build_interval = 1

--- a/chef/data_bags/crowbar/migrate/heat/100_add_trusts_delegated_roles.rb
+++ b/chef/data_bags/crowbar/migrate/heat/100_add_trusts_delegated_roles.rb
@@ -1,0 +1,18 @@
+def upgrade(ta, td, a, d)
+  # Keep heat_stack_owner as a default for existing installations: operators
+  # of existing clouds may have created user accounts that do not have the
+  # "Member" role in the proposal's default, but do have the "heat_stack_owner"
+  # role (required for Heat to work). Switching trusts_delegated_roles to
+  # "Member" would break heat for such users.
+  unless a.key? "trusts_delegated_roles"
+    a["trusts_delegated_roles"] = ["heat_stack_owner"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if a.key? "trusts_delegated_roles"
+    a.delete("trusts_delegated_roles")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-heat.json
+++ b/chef/data_bags/crowbar/template-heat.json
@@ -15,6 +15,7 @@
       "service_password": "",
       "auth_encryption_key": "",
       "use_convergence_engine": false,
+      "trusts_delegated_roles": [ "Member" ],
       "api": {
         "protocol": "http",
         "cfn_port": 8000,
@@ -33,7 +34,7 @@
     "heat": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 23,
+      "schema-revision": 100,
       "element_states": {
         "heat-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-heat.schema
+++ b/chef/data_bags/crowbar/template-heat.schema
@@ -24,6 +24,11 @@
             "stack_domain_admin_password": { "type": "str", "required": true },
             "auth_encryption_key": { "type": "str", "required": true },
             "use_convergence_engine": { "type": "bool", "required": true },
+            "trusts_delegated_roles": {
+              "type": "seq",
+              "required": true,
+              "sequence": [ { "type": "str" } ]
+            },
             "api": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This commit exposes the previously hardwired trusts_delegated_roles
setting in the Heat barclamp. This allows setting
trusts_delegated_roles to `Member` which is more useful than the
previous hardwired setting of `heat_stack_owner` (the latter will have
to be assigned to each user manually, while most users already have
the former).

trusts_delegated_roles will default to:

* `Member` for new installations
* `heat_stack_owner` for existing installations, so as not to break
  SUSE Cloud installations that have assigned heat_stack_owner to all
  users manually.

In addition to exposing this setting it also uses its value for
assigning the roles required for using Heat to

* the admin user
* the unprivileged account created for Tempest's use

and sets the Tempest setting `stack_owner_role`.

(previously, all of these were also hardwired to
`heat_stack_owner`)

Note: the `stack_owner_role` setting in tempest.conf (relevant for
`tempest account-generator`, which we do not use currently) will only
work for single-entry values in trusts_delegated_roles until
https://bugs.launchpad.net/tempest/+bug/1559078 is fixed.