### PR TITLE
[3.0] interleave Pacemaker clones to minimise disruption (bsc#965886)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/mongodb.rb
+++ b/chef/cookbooks/ceilometer/recipes/mongodb.rb
@@ -60,7 +60,10 @@ if ha_enabled
   clone_name = "cl-#{service_name}"
   pacemaker_clone clone_name do
     rsc service_name
-    meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+    meta ({
+      "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+      "interleave" => "true",
+    })
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -57,7 +57,10 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -72,7 +72,10 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -74,7 +74,10 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -72,7 +72,10 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -65,7 +65,10 @@ if node[:keystone][:frontend] == "native"
   clone_name = "cl-#{service_name}"
   pacemaker_clone clone_name do
     rsc service_name
-    meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+    meta ({
+      "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+      "interleave" => "true",
+    })
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -78,7 +78,10 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -142,7 +142,10 @@ transaction_objects << "pacemaker_group[#{agents_group_name}]"
 agents_clone_name = "cl-#{agents_group_name}"
 pacemaker_clone agents_clone_name do
   rsc agents_group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/neutron/recipes/server_ha.rb
+++ b/chef/cookbooks/neutron/recipes/server_ha.rb
@@ -43,7 +43,10 @@ transaction_objects << "pacemaker_primitive[#{primitive_name}]"
 clone_name = "cl-#{primitive_name}"
 pacemaker_clone clone_name do
   rsc primitive_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -167,7 +167,10 @@ compute_transaction_objects << "pacemaker_group[#{compute_group_name}]"
 compute_clone_name = "cl-#{compute_group_name}"
 pacemaker_clone compute_clone_name do
   rsc compute_group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_remote_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_remote_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -123,7 +123,10 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/swift/recipes/proxy_ha.rb
+++ b/chef/cookbooks/swift/recipes/proxy_ha.rb
@@ -46,7 +46,10 @@ transaction_objects << "pacemaker_primitive[#{service_name}]"
 clone_name = "cl-#{service_name}"
 pacemaker_clone clone_name do
   rsc service_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta ({
+    "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node),
+    "interleave" => "true",
+  })
   action :update
   # Do not even try to start the daemon if we don't have the ring yet
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) && ::File.exist?("/etc/swift/object.ring.gz") }


### PR DESCRIPTION
By default, Pacemaker clones aren't interleaved.  This means that if
Pacemaker wants to restart a dead clone instance, and there is an order
constraint on that clone, it will do the same restart on all other
nodes, even if all the others are healthy.

More details on interleaving are here:

  https://www.hastexo.com/resources/hints-and-kinks/interleaving-pacemaker-clones/

This behaviour is far more disruptive than we want.  For example, in

  https://bugzilla.suse.com/show_bug.cgi?id=965886

we saw that when a network node dies and Pacemaker wants to stop the
instance of cl-g-neutron-agents on that node, it also stops and restarts
the same clone instances on the healthy nodes.  This means there is a
small window in which there are no neutron agents running anywhere.  If
neutron-ha-tool attempts a router migration during this window, it will
fail, at which point things start to go badly wrong.

In general, the cloned (i.e. active/active) services on our controller
and compute nodes should all behave like independent vertical stacks,
so that a failure on one node should not cause ripple effects on other
nodes.  So we interleave all our clones.

(There is a corresponding commit to crowbar-ha for the Apache clone.)

(cherry picked from commit bdde4b4dc2534e91bf1f2869a66491463134f8c1)


This is a backport of https://github.com/crowbar/crowbar-openstack/pull/330