### PR TITLE
[3.0] Fix EternusDX support for Liberty+

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -298,6 +298,7 @@ image_ssh_password = cubswin:)
 # User name used to authenticate to an instance using the alternate
 # image. (string value)
 #image_alt_ssh_user = root
+image_alt_ssh_user = cirros
 
 # Time in seconds between build status checks. (integer value)
 #build_interval = 1
@@ -821,7 +822,7 @@ flavor_regex = ^tempest-stuff$
 
 # List of user mapped to regex to matching image names. (string value)
 #ssh_user_regex = [["^.*[Cc]irros.*$", "cirros"]]
-ssh_user_regex = [["^.*[Cc]irros.*$", "root"]]
+ssh_user_regex = [["^.*[Cc]irros.*$", "cirros"]]
 
 
 [messaging]
@@ -1304,6 +1305,7 @@ events = true
 # resources to enable remote access (boolean value)
 # Deprecated group/name - [compute]/run_ssh
 #run_validation = false
+run_validation = true
 
 # Enable/disable security groups. (boolean value)
 #security_group = true


### PR DESCRIPTION
pool was split into snappool and "storage" pool, so we need
to adjust parameters and make both snapshot and storage pool
configurable. The migration ensures that the content of the
previous pool parameter is now renamed to snappool.

(cherry picked from commit e4795da878aa6f6893fd49ec5855d90b3686c9cf)