### PR TITLE
Update to python-PyMySQL.

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -20,7 +20,7 @@ if %w(rhel suse).include? node[:platform_family]
   package "openstack-cinder"
 else
   package "cinder-common"
-  package "python-mysqldb"
+  package "python-PyMySQL"
   package "python-cinder"
 end
 

--- a/chef/cookbooks/openstack-common/attributes/database.rb
+++ b/chef/cookbooks/openstack-common/attributes/database.rb
@@ -205,7 +205,7 @@ when 'rhel'
   default['openstack']['db']['python_packages']['mysql'] = ['MySQL-python']
   default['openstack']['db']['python_packages']['db2'] = ['python-ibm-db', 'python-ibm-db-sa']
 when 'suse'
-  default['openstack']['db']['python_packages']['mysql'] = ['python-mysql']
+  default['openstack']['db']['python_packages']['mysql'] = ['python-PyMySQL']
 when 'debian'
   default['openstack']['db']['python_packages']['mysql'] = ['python-mysqldb']
 end

--- a/chef/cookbooks/openstack-identity/spec/server_spec.rb
+++ b/chef/cookbooks/openstack-identity/spec/server_spec.rb
@@ -43,7 +43,7 @@ describe "openstack-identity::server" do
     end
 
     it "upgrades mysql python packages" do
-      expect(chef_run).to upgrade_package("python-mysqldb")
+      expect(chef_run).to upgrade_package("python-PyMySQL")
     end
 
     it "upgrades postgresql python packages if explicitly told" do


### PR DESCRIPTION
Updating deprecated python-mysqldb to python-PyMySQL which should be
used by default for newer releases of OpenStack.