### PR TITLE
[3.0] increase neutron-ha-tool start timeout to 120s (bsc#965886)

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -161,6 +161,7 @@ default[:neutron][:ha][:network][:cisco_ra] = "lsb:#{node[:neutron][:ha][:networ
 default[:neutron][:ha][:network][:linuxbridge_ra] = "lsb:#{node[:neutron][:platform][:lb_agent_name]}"
 default[:neutron][:ha][:network][:ha_tool_ra] = "ocf:openstack:neutron-ha-tool"
 default[:neutron][:ha][:network][:op][:monitor][:interval] = "10s"
+default[:neutron][:ha][:network][:op][:start][:interval] = "120s"
 default[:neutron][:ha][:server][:enabled] = false
 default[:neutron][:ha][:server][:server_ra] = "lsb:#{node[:neutron][:platform][:service_name]}"
 default[:neutron][:ha][:server][:op][:monitor][:interval] = "10s"


### PR DESCRIPTION
https://github.com/SUSE-Cloud/cookbook-openstack-network/pull/1
adds retry logic to neutron-ha-tool so that it will not fail
immediately if there are problems talking to the neutron-server
API.  Therefore we need to give neutron-ha-tool enough time
to have a decent chance of succeeding if the neutron-server
still needs a while to recover after some kind of failover.

https://bugzilla.suse.com/show_bug.cgi?id=965886
(cherry picked from commit 55504e2e8ccfb23abb8a6b5b31e4ff7ef99e911b)

backport of https://github.com/crowbar/crowbar-openstack/pull/344