### PR TITLE
cinder: Fix nova catalog info settings

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -409,10 +409,11 @@ enabled_backends=<%= @volumes.each_with_index.collect { |backend,idx|
 # separated values of the form: <service_type>:<service_name>:<endpoint_type>
 # (string value)
 #nova_catalog_info = compute:Compute Service:publicURL
-nova_catalog_info = compute:Compute Service:internalURL
+nova_catalog_info = compute:nova:internalURL
 
 # Same as nova_catalog_info, but for admin endpoint. (string value)
 #nova_catalog_admin_info = compute:Compute Service:adminURL
+nova_catalog_admin_info = compute:nova:adminURL
 
 # Override service catalog lookup with template for nova endpoint e.g.
 # http://localhost:8774/v2/%(project_id)s (string value)


### PR DESCRIPTION
They were not using the right service name for nova.