### PR TITLE
[stable/3.0] backport #354

### DIFF
--- a/chef/cookbooks/neutron/files/default/crowbar-fix-tunnel-networks-mtu
+++ b/chef/cookbooks/neutron/files/default/crowbar-fix-tunnel-networks-mtu
@@ -3,21 +3,11 @@
 import sqlalchemy
 import sys
 from neutron.plugins.common import constants as p_const
-from oslo_config import cfg
 
-_db_opts = [
-    cfg.StrOpt('connection',
-               deprecated_name='sql_connection',
-               default='',
-               secret=True,
-               help='URL to database'),
-]
+if len(sys.argv) != 2:
+    raise ValueError('One and only one argument must be passed: database connection uri')
 
-CONF = cfg.ConfigOpts()
-CONF.register_cli_opts(_db_opts, 'database')
-CONF(project='neutron')
-
-db_uri = CONF.database.connection
+db_uri = sys.argv[1]
 
 db = sqlalchemy.create_engine(db_uri)
 try:

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -181,8 +181,15 @@ if !node[:neutron][:network_mtu_fix] &&
       mode "0755"
     end
 
+    neutron_server_node = if node.roles.include?("neutron-server")
+      node
+    else
+      search(:node, "roles:neutron-server").first
+    end
+
     execute "fix mtu of tunnel networks" do
-      command "/usr/bin/crowbar-fix-tunnel-networks-mtu"
+      command "/usr/bin/crowbar-fix-tunnel-networks-mtu \
+        #{neutron_server_node[:neutron][:db][:sql_connection]}"
       action :run
       # restart local dhcp agent to get dnsmasq restarted so it advertises the
       # correct mtu; this is why we run this on all nodes even with HA


### PR DESCRIPTION
pass database connection uri instead of calculating it
avoids a bug when a node is neutron-network but not neutron-server

https://github.com/crowbar/crowbar-openstack/pull/354