### PR TITLE
Avoid usage of admin_token in cookbooks

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -224,12 +224,16 @@ end
 
 crowbar_pacemaker_sync_mark "wait-ceilometer_register"
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant: keystone_settings["admin_tenant"] }
+
 keystone_register "ceilometer wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   action :wakeup
 end
 
@@ -238,7 +242,7 @@ keystone_register "register ceilometer user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   tenant_name keystone_settings["service_tenant"]
@@ -250,7 +254,7 @@ keystone_register "give ceilometer user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   tenant_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -265,7 +269,7 @@ unless swift_middlewares.empty?
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    token keystone_settings["admin_token"]
+    auth register_auth_hash
     user_name keystone_settings["service_user"]
     tenant_name keystone_settings["service_tenant"]
     role_name "ResellerAdmin"
@@ -279,7 +283,7 @@ keystone_register "register ceilometer service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "ceilometer"
   service_type "metering"
   service_description "Openstack Telemetry Service"
@@ -291,7 +295,7 @@ keystone_register "register ceilometer endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "ceilometer"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{node[:ceilometer][:api][:protocol]}://#{my_public_host}:#{node[:ceilometer][:api][:port]}"

--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -33,12 +33,16 @@ my_public_host = CrowbarHelper.get_host_for_public_url(node, node[:cinder][:api]
 
 crowbar_pacemaker_sync_mark "wait-cinder_register"
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant: keystone_settings["admin_tenant"] }
+
 keystone_register "cinder api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   action :wakeup
 end
 
@@ -47,7 +51,7 @@ keystone_register "register cinder user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   tenant_name keystone_settings["service_tenant"]
@@ -59,7 +63,7 @@ keystone_register "give cinder user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   tenant_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -71,7 +75,7 @@ keystone_register "register cinder service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "cinder"
   service_type "volume"
   service_description "Openstack Cinder Service"
@@ -83,7 +87,7 @@ keystone_register "register cinder endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "cinder"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{cinder_protocol}://#{my_public_host}:#{cinder_port}/v1/$(tenant_id)s"
@@ -99,7 +103,7 @@ keystone_register "register cinder service v2" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "cinderv2"
   service_type "volumev2"
   service_description "Openstack Cinder Service V2"
@@ -111,7 +115,7 @@ keystone_register "register cinder endpoint v2" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "cinderv2"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{cinder_protocol}://#{my_public_host}:#{cinder_port}/v2/$(tenant_id)s"

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -156,12 +156,16 @@ glance_protocol = node[:glance][:api][:protocol]
 
 crowbar_pacemaker_sync_mark "wait-glance_register_service"
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant: keystone_settings["admin_tenant"] }
+
 keystone_register "register glance service" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "glance"
   service_type "image"
   service_description "Openstack Glance Service"
@@ -173,7 +177,7 @@ keystone_register "register glance endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "glance"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{glance_protocol}://#{endpoint_public_ip}:#{api_port}"

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -75,12 +75,16 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 crowbar_pacemaker_sync_mark "wait-glance_register_user"
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant:  keystone_settings["admin_tenant"] }
+
 keystone_register "glance wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   action :wakeup
 end
 
@@ -89,7 +93,7 @@ keystone_register "register glance user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   tenant_name keystone_settings["service_tenant"]
@@ -101,7 +105,7 @@ keystone_register "give glance user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   tenant_name keystone_settings["service_tenant"]
   role_name "admin"

--- a/chef/cookbooks/manila/recipes/api.rb
+++ b/chef/cookbooks/manila/recipes/api.rb
@@ -33,12 +33,16 @@ my_public_host = CrowbarHelper.get_host_for_public_url(
 
 crowbar_pacemaker_sync_mark "wait-manila_register"
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant: keystone_settings["admin_tenant"] }
+
 keystone_register "manila api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   action :wakeup
 end
 
@@ -47,7 +51,7 @@ keystone_register "register manila user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   tenant_name keystone_settings["service_tenant"]
@@ -59,7 +63,7 @@ keystone_register "give manila user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   tenant_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -71,7 +75,7 @@ keystone_register "register manila service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "manila"
   service_type "share"
   service_description "Openstack Manila shared filesystem service"
@@ -83,7 +87,7 @@ keystone_register "register manila endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "manila"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{manila_protocol}://"\
@@ -103,7 +107,7 @@ keystone_register "register manila service v2" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "manilav2"
   service_type "sharev2"
   service_description "Openstack Manila shared filesystem service V2"
@@ -115,7 +119,7 @@ keystone_register "register manila endpoint v2" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "manilav2"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{manila_protocol}://"\

--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -25,12 +25,16 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 crowbar_pacemaker_sync_mark "wait-neutron_register"
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant: keystone_settings["admin_tenant"] }
+
 keystone_register "neutron api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   action :wakeup
 end
 
@@ -39,7 +43,7 @@ keystone_register "register neutron user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   tenant_name keystone_settings["service_tenant"]
@@ -51,7 +55,7 @@ keystone_register "give neutron user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   tenant_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -63,7 +67,7 @@ keystone_register "register neutron service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "neutron"
   service_type "network"
   service_description "Openstack Neutron Service"
@@ -75,7 +79,7 @@ keystone_register "register neutron endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "neutron"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{neutron_protocol}://#{my_public_host}:#{api_port}/"

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -46,12 +46,16 @@ api_protocol = api[:nova][:ssl][:enabled] ? "https" : "http"
 
 crowbar_pacemaker_sync_mark "wait-nova_register"
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant: keystone_settings["admin_tenant"] }
+
 keystone_register "nova api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   action :wakeup
 end
 
@@ -60,7 +64,7 @@ keystone_register "register nova user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   tenant_name keystone_settings["service_tenant"]
@@ -72,7 +76,7 @@ keystone_register "give nova user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["service_user"]
   tenant_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -84,7 +88,7 @@ keystone_register "register nova service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "nova"
   service_type "compute"
   service_description "Openstack Nova Service"
@@ -96,7 +100,7 @@ keystone_register "register ec2 service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "ec2"
   service_type "ec2"
   service_description "EC2 Compatibility Layer"
@@ -108,7 +112,7 @@ keystone_register "register nova_legacy service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   service_name "nova_legacy"
   service_type "compute_legacy"
   service_description "Openstack Nova Compute Service (Legacy 2.0)"
@@ -120,7 +124,7 @@ keystone_register "register nova endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "nova"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v2.1/$(tenant_id)s"
@@ -136,7 +140,7 @@ keystone_register "register nova ec2 endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "ec2"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_ec2_port}/services/Cloud"
@@ -152,7 +156,7 @@ keystone_register "register nova_legacy endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   endpoint_service "nova_legacy"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v2/$(tenant_id)s"

--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -39,12 +39,16 @@ service_tenant = node[:swift][:dispersion][:service_tenant]
 service_user = node[:swift][:dispersion][:service_user]
 service_password = node[:swift][:dispersion][:service_password]
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant: keystone_settings["admin_tenant"] }
+
 keystone_register "swift dispersion wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   action :wakeup
 end
 
@@ -53,7 +57,7 @@ keystone_register "create tenant #{service_tenant} for dispersion" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   tenant_name service_tenant
   action :add_tenant
 end
@@ -63,7 +67,7 @@ keystone_register "add #{service_user}:#{service_tenant} user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name service_user
   user_password service_password
   tenant_name service_tenant
@@ -75,7 +79,7 @@ keystone_register "add #{service_user}:#{service_tenant} user admin role" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name service_user
   role_name "admin"
   tenant_name service_tenant

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -155,12 +155,16 @@ case proxy_config[:auth_method]
 
      crowbar_pacemaker_sync_mark "wait-swift_register"
 
+     register_auth_hash = { user: keystone_settings["admin_user"],
+                            password: keystone_settings["admin_password"],
+                            tenant: keystone_settings["admin_tenant"] }
+
      keystone_register "swift proxy wakeup keystone" do
        protocol keystone_settings["protocol"]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
        port keystone_settings["admin_port"]
-       token keystone_settings["admin_token"]
+       auth register_auth_hash
        action :wakeup
      end
 
@@ -171,7 +175,7 @@ case proxy_config[:auth_method]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
        port keystone_settings["admin_port"]
-       token keystone_settings["admin_token"]
+       auth register_auth_hash
        role_name role
        action :add_role
      end
@@ -181,7 +185,7 @@ case proxy_config[:auth_method]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
        port keystone_settings["admin_port"]
-       token keystone_settings["admin_token"]
+       auth register_auth_hash
        user_name keystone_settings["service_user"]
        user_password keystone_settings["service_password"]
        tenant_name keystone_settings["service_tenant"]
@@ -193,7 +197,7 @@ case proxy_config[:auth_method]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
        port keystone_settings["admin_port"]
-       token keystone_settings["admin_token"]
+       auth register_auth_hash
        user_name keystone_settings["service_user"]
        tenant_name keystone_settings["service_tenant"]
        role_name "admin"
@@ -204,7 +208,7 @@ case proxy_config[:auth_method]
        protocol keystone_settings["protocol"]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
-       token keystone_settings["admin_token"]
+       auth register_auth_hash
        port keystone_settings["admin_port"]
        service_name "swift"
        service_type "object-store"
@@ -216,7 +220,7 @@ case proxy_config[:auth_method]
          protocol keystone_settings["protocol"]
          insecure keystone_settings["insecure"]
          host keystone_settings["internal_url_host"]
-         token keystone_settings["admin_token"]
+         auth register_auth_hash
          port keystone_settings["admin_port"]
          endpoint_service "swift"
          endpoint_region keystone_settings["endpoint_region"]

--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -726,8 +726,6 @@ service_host = <%= @keystone_settings['internal_url_host'] %>
 auth_port = <%= @keystone_settings['admin_port'] %>
 auth_host = <%= @keystone_settings['internal_url_host'] %>
 auth_protocol = <%= @keystone_settings['protocol'] %>
-auth_token = <%= @keystone_settings['admin_token'] %>
-admin_token = <%= @keystone_settings['admin_token'] %>
 
 [filter:swauth]
 use = egg:swauth#swauth

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -38,12 +38,16 @@ tempest_adm_pass = node[:tempest][:tempest_adm_password]
 # manila (share)
 tempest_manila_settings = node[:tempest][:manila]
 
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       tenant: keystone_settings["admin_tenant"] }
+
 keystone_register "tempest tempest wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   action :wakeup
 end.run_action(:wakeup)
 
@@ -52,8 +56,7 @@ keystone_register "create tenant #{tempest_comp_tenant} for tempest" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
-
+  auth register_auth_hash
   tenant_name tempest_comp_tenant
   action :add_tenant
 end.run_action(:add_tenant)
@@ -84,7 +87,7 @@ users.each do |user|
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    token keystone_settings["admin_token"]
+    auth register_auth_hash
     user_name user["name"]
     user_password user["pass"]
     tenant_name tempest_comp_tenant
@@ -96,7 +99,7 @@ users.each do |user|
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    token keystone_settings["admin_token"]
+    auth register_auth_hash
     user_name user["name"]
     role_name user["role"]
     tenant_name tempest_comp_tenant
@@ -108,11 +111,7 @@ users.each do |user|
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth ({
-      tenant: keystone_settings["admin_tenant"],
-      user: keystone_settings["admin_user"],
-      password: keystone_settings["admin_password"]
-    })
+    auth register_auth_hash
     user_name user["name"]
     tenant_name tempest_comp_tenant
     action :nothing
@@ -125,7 +124,7 @@ keystone_register "add #{keystone_settings['admin_user']}:#{tempest_comp_tenant}
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  token keystone_settings["admin_token"]
+  auth register_auth_hash
   user_name keystone_settings["admin_user"]
   role_name "admin"
   tenant_name tempest_comp_tenant
@@ -419,7 +418,7 @@ horizons = search(:node, "roles:horizon-server") || []
 if horizons.empty?
   use_horizon = false
   horizon_host = "localhost"
-  horizont_protocol = "http"
+  horizon_protocol = "http"
 else
   horizon = horizons[0]
   use_horizon = true


### PR DESCRIPTION
Keystone register is modified to generate token from user name and password and all the cookbooks (except Trove and Keystone) use this logic instead of directly using the admin_token. There is a follow-up card to handle bootstrapping for Trove and Keystone cookbooks here https://trello.com/c/ipXUuRQl/1052-adapt-usage-of-keystone-manage-bootstrap-for-bootstrapping-keystone-service.

co-authored with @rhafer 