### PR TITLE
Add support for Neutron VPNaaS

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -1,5 +1,6 @@
 
 # Copyright (c) 2011 Dell Inc.
+# Copyright (c) 2016 SUSE Linux GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,6 +69,9 @@ when "suse"
     lbaas_agent_pkg: "openstack-neutron-lbaas-agent",
     lbaas_agent_name: "openstack-neutron-lbaas-agent",
     lbaas_haproxy_group: "haproxy",
+    vpnaas_agent_pkg: "openstack-neutron-vpn-agent",
+    vpnaas_agent_name: "openstack-neutron-vpn-agent",
+    vpnaas_agent_device_driver_pkgs: ["strongswan"],
     metadata_agent_name: "openstack-neutron-metadata-agent",
     metadata_agent_pkg: "openstack-neutron-metadata-agent",
     metering_agent_pkg: "openstack-neutron-metering-agent",
@@ -100,6 +104,9 @@ when "rhel"
     lbaas_agent_pkg: "openstack-neutron-lbaas-agent",
     lbaas_agent_name: "neutron-lbaas-agent",
     lbaas_haproxy_group: "nogroup",
+    vpnaas_agent_pkg: "openstack-neutron-vpn-agent",
+    vpnaas_agent_name: "openstack-neutron-vpn-agent",
+    vpnaas_agent_device_driver_pkgs: ["strongswan"],
     metadata_agent_name: "neutron-metadata-agent",
     metadata_agent_pkg: "openstack-neutron",
     metering_agent_pkg: "openstack-neutron-metering-agent",
@@ -132,6 +139,9 @@ else
     lbaas_agent_pkg: "neutron-lbaas-agent",
     lbaas_agent_name: "neutron-lbaas-agent",
     lbaas_haproxy_group: "nogroup",
+    vpnaas_agent_pkg: "openstack-neutron-vpn-agent",
+    vpnaas_agent_name: "openstack-neutron-vpn-agent",
+    vpnaas_agent_device_driver_pkgs: ["strongswan"],
     metadata_agent_name: "neutron-metadata-agent",
     metadata_agent_pkg: "neutron-metadata-agent",
     metering_agent_pkg: "neutron-plugin-metering-agent",
@@ -153,6 +163,7 @@ end
 default[:neutron][:ha][:network][:enabled] = false
 default[:neutron][:ha][:network][:l3_ra] = "lsb:#{node[:neutron][:platform][:l3_agent_name]}"
 default[:neutron][:ha][:network][:lbaas_ra] = "lsb:#{node[:neutron][:platform][:lbaas_agent_name]}"
+default[:neutron][:ha][:network][:vpnaas_ra] = "lsb:#{node[:neutron][:platform][:vpnaas_agent_name]}"
 default[:neutron][:ha][:network][:dhcp_ra] = "lsb:#{node[:neutron][:platform][:dhcp_agent_name]}"
 default[:neutron][:ha][:network][:metadata_ra] = "lsb:#{node[:neutron][:platform][:metadata_agent_name]}"
 default[:neutron][:ha][:network][:metering_ra] = "lsb:#{node[:neutron][:platform][:metering_agent_name]}"

--- a/chef/cookbooks/neutron/files/default/strongswan_charon_stroke.conf
+++ b/chef/cookbooks/neutron/files/default/strongswan_charon_stroke.conf
@@ -1,0 +1,27 @@
+stroke {
+
+    # Treat certificates in ipsec.d/cacerts and ipsec.conf ca sections as CA
+    # certificates even if they don't contain a CA basic constraint.
+    # ignore_missing_ca_basic_constraint = no
+
+    # Whether to load the plugin. Can also be an integer to increase the
+    # priority of this plugin.
+    load = yes
+
+    # Maximum number of stroke messages handled concurrently.
+    # max_concurrent = 4
+
+    # If enabled log level changes via stroke socket are not allowed.
+    # prevent_loglevel_changes = no
+
+    # Location of the ipsec.secrets file
+    # secrets_file = ${sysconfdir}/ipsec.secrets
+
+    # Socket provided by the stroke plugin.
+    # socket = unix://${piddir}/charon.ctl
+
+    # Timeout in ms for any stroke command. Use 0 to disable the timeout.
+    timeout = 5000
+
+}
+

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -110,6 +110,9 @@ service_plugins = "#{service_plugins}, neutron_fwaas.services.firewall.fwaas_plu
 if neutron[:neutron][:use_lbaas] then
   service_plugins = "#{service_plugins}, neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPlugin"
 end
+if node[:neutron][:use_vpnaas] then
+  service_plugins = "#{service_plugins}, neutron_vpnaas.services.vpn.plugin.VPNDriverPlugin"
+end
 
 network_nodes_count = neutron[:neutron][:elements]["neutron-network"].count
 if neutron[:neutron][:elements_expanded]

--- a/chef/cookbooks/neutron/templates/default/neutron_vpnaas.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron_vpnaas.conf.erb
@@ -1,0 +1,12 @@
+[service_providers]
+# Must be in form:
+# service_provider=<service_type>:<name>:<driver>[:default]
+# List of allowed service types includes VPN
+# Combination of <service type> and <name> must be unique; <driver> must also be unique
+# This is multiline option
+#service_provider=VPN:openswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
+service_provider=<%= @service_provider %>
+# Uncomment the following line (and comment out the OpenSwan VPN line) to enable Cisco's VPN driver.
+# service_provider=VPN:cisco:neutron_vpnaas.services.vpn.service_drivers.cisco_ipsec.CiscoCsrIPsecVPNDriver:default
+# Uncomment the following line (and comment out the OpenSwan VPN line) to enable Brocade Vyatta's VPN driver.
+# service_provider=VPN:vyatta:neutron_vpnaas.services.vpn.service_drivers.vyatta_ipsec.VyattaIPsecDriver:default

--- a/chef/cookbooks/neutron/templates/default/vpn_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/vpn_agent.ini.erb
@@ -1,0 +1,48 @@
+[DEFAULT]
+# VPN-Agent configuration file
+# Note vpn-agent inherits l3-agent, so you can use configs on l3-agent also
+
+[vpnagent]
+# vpn device drivers which vpn agent will use
+# If we want to use multiple drivers,  we need to define this option multiple times.
+# NOTE: StrongSwan and openSwan cannot be installed at the same time. Thus, both cannot
+#       be enabled for use. In the future when flavors/STF support is available,
+#       this will still constrain the flavors which can be used together.
+# vpn_device_driver=neutron_vpnaas.services.vpn.device_drivers.ipsec.OpenSwanDriver
+# vpn_device_driver=neutron_vpnaas.services.vpn.device_drivers.cisco_ipsec.CiscoCsrIPsecDriver
+# vpn_device_driver=neutron_vpnaas.services.vpn.device_drivers.vyatta_ipsec.VyattaIPSecDriver
+# vpn_device_driver=neutron_vpnaas.services.vpn.device_drivers.strongswan_ipsec.StrongSwanDriver
+# vpn_device_driver=neutron_vpnaas.services.vpn.device_drivers.fedora_strongswan_ipsec.FedoraStrongSwanDriver
+# vpn_device_driver=neutron_vpnaas.services.vpn.device_drivers.libreswan_ipsec.LibreSwanDriver
+# vpn_device_driver=another_driver
+<% @vpn_device_drivers.each do |driver| %>
+vpn_device_driver=<%= driver %>
+<%end %>
+
+[ipsec]
+# Status check interval
+# ipsec_status_check_interval=60
+
+# Enable detail logging for ipsec pluto process.
+# If the flag set to True, the detailed logging will
+# be written into config_base_dir/<pid>/log."
+# NOTE: this applies to OpenSwan and Libraswan, and
+# that StrongSwan has logging that logs to syslog.
+# enable_detailed_logging=False
+
+[strongswan]
+# For fedora use:
+# default_config_area=/usr/share/strongswan/templates/config/strongswan.d
+# Default is for ubuntu use, /etc/strongswan.d
+# default_config_area=/etc/strongswan.d
+
+[libreswan]
+# Initial interval in seconds for checking if pluto daemon is shutdown
+# shutdown_check_timeout=1
+#
+# The maximum number of retries for checking for pluto daemon shutdown
+# shutdown_check_retries=5
+#
+# A factor to increase the retry interval for each retry
+# shutdown_check_back_off=1.5
+

--- a/chef/data_bags/crowbar/migrate/neutron/100_add_vpnaas.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/100_add_vpnaas.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.include?("use_vpnaas")
+    a["use_vpnaas"] = ta["use_vpnaas"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.include?("use_vpnaas")
+    a.delete("use_vpnaas")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -12,6 +12,7 @@
       "create_default_networks": true,
       "dhcp_domain": "openstack.local",
       "use_lbaas": true,
+      "use_vpnaas": false,
       "use_dvr": false,
       "additional_external_networks": [],
       "networking_plugin": "ml2",
@@ -117,7 +118,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 48,
+      "schema-revision": 100,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -17,6 +17,7 @@
                     "create_default_networks": { "type": "bool", "required": true },
                     "dhcp_domain": { "type": "str", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
+                    "use_vpnaas": { "type": "bool", "required": true },
                     "use_dvr": { "type": "bool", "required": true },
                     "additional_external_networks": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "networking_plugin": { "type": "str", "required": true },


### PR DESCRIPTION
Add a new "use_vpnaas" boolean parameter (default is enabled) to enable the
VPN as a service support in Neutron.