### PR TITLE
[3.0] cinder: Do not regenerate secret_uuid due to wrong check in migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/cinder/041_add_rbd_secret_uuid.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/041_add_rbd_secret_uuid.rb
@@ -2,7 +2,7 @@ def upgrade ta, td, a, d
   a["volume_defaults"]["rbd"]["secret_uuid"] = ta["volume_defaults"]["rbd"]["secret_uuid"]
   a["volumes"].each do |volume|
     next if volume["backend_driver"] != "rbd"
-    next unless volume["backend_driver"]["secret_uuid"].nil?
+    next unless volume["rbd"]["secret_uuid"].nil?
     volume["rbd"]["secret_uuid"] = `uuidgen`.strip
   end
   return a, d


### PR DESCRIPTION
(cherry picked from commit 4c71ed5827cc214f856badb9ab894ede604dccd0)

Backport of https://github.com/crowbar/crowbar-openstack/pull/369