### PR TITLE
Do not use polling as a role, bring central role back.

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -16,7 +16,7 @@
 default[:ceilometer][:user]="ceilometer"
 default[:ceilometer][:group]="ceilometer"
 
-polling_service_name = "ceilometer-polling"
+central_service_name = "ceilometer-agent-central"
 api_service_name = "ceilometer-api"
 collector_service_name = "ceilometer-collector"
 agent_notification_service_name = "ceilometer-agent-notification"
@@ -24,7 +24,7 @@ alarm_evaluator_service_name = "ceilometer-alarm-evaluator"
 alarm_notifier_service_name = "ceilometer-alarm-notifier"
 
 if %w(rhel suse).include?(node[:platform_family])
-  polling_service_name = "openstack-ceilometer-polling"
+  central_service_name = "openstack-ceilometer-agent-central"
   api_service_name = "openstack-ceilometer-api"
   collector_service_name = "openstack-ceilometer-collector"
   agent_notification_service_name = "openstack-ceilometer-agent-notification"
@@ -35,7 +35,7 @@ end
 default[:ceilometer][:api][:service_name] = api_service_name
 default[:ceilometer][:collector][:service_name] = collector_service_name
 default[:ceilometer][:agent_notification][:service_name] = agent_notification_service_name
-default[:ceilometer][:polling][:service_name] = polling_service_name
+default[:ceilometer][:central][:service_name] = central_service_name
 default["ceilometer"]["alarm_evaluator"]["service_name"] = alarm_evaluator_service_name
 default["ceilometer"]["alarm_notifier"]["service_name"] = alarm_notifier_service_name
 
@@ -83,9 +83,9 @@ default["ceilometer"]["ha"]["alarm_evaluator"]["op"]["monitor"]["interval"] = "1
 default["ceilometer"]["ha"]["alarm_notifier"]["agent"] = "lsb:#{alarm_notifier_service_name}"
 default["ceilometer"]["ha"]["alarm_notifier"]["op"]["monitor"]["interval"] = "10s"
 
-default[:ceilometer][:ha][:polling][:enabled] = false
-default[:ceilometer][:ha][:polling][:agent] = "lsb:#{polling_service_name}"
-default[:ceilometer][:ha][:polling][:op][:monitor][:interval] = "10s"
+default[:ceilometer][:ha][:central][:enabled] = false
+default[:ceilometer][:ha][:central][:agent] = "lsb:#{central_service_name}"
+default[:ceilometer][:ha][:central][:op][:monitor][:interval] = "10s"
 # Ports to bind to when haproxy is used for the real ports
 default[:ceilometer][:ha][:ports][:api] = 5561
 if node[:platform] == "suse" && node[:platform_version].to_f < 12.0

--- a/chef/cookbooks/ceilometer/recipes/central.rb
+++ b/chef/cookbooks/ceilometer/recipes/central.rb
@@ -13,19 +13,19 @@
 # limitations under the License.
 #
 
-package "ceilometer-polling" do
+package "ceilometer-agent-central" do
   if %w(rhel suse).include?(node[:platform_family])
-    package_name "openstack-ceilometer-polling"
+    package_name "openstack-ceilometer-agent-central"
   end
   action :install
 end
 
 include_recipe "#{@cookbook_name}::common"
 
-ha_enabled = node[:ceilometer][:ha][:polling][:enabled]
+ha_enabled = node[:ceilometer][:ha][:central][:enabled]
 
-service "ceilometer-polling" do
-  service_name node[:ceilometer][:polling][:service_name]
+service "ceilometer-agent-central" do
+  service_name node[:ceilometer][:central][:service_name]
   supports status: true, restart: true, start: true, stop: true
   action [:enable, :start]
   subscribes :restart, resources("template[/etc/ceilometer/ceilometer.conf]")
@@ -34,8 +34,8 @@ service "ceilometer-polling" do
 end
 
 if ha_enabled
-  log "HA support for ceilometer-polling is enabled"
-  include_recipe "ceilometer::polling_ha"
+  log "HA support for ceilometer-central is enabled"
+  include_recipe "ceilometer::central_ha"
 else
-  log "HA support for ceilometer-polling is disabled"
+  log "HA support for ceilometer-central is disabled"
 end

--- a/chef/cookbooks/ceilometer/recipes/central_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/central_ha.rb
@@ -16,24 +16,17 @@
 # Wait for all nodes to reach this point so we know that they will have
 # all the required packages installed and configuration files updated
 # before we create the pacemaker resources.
-crowbar_pacemaker_sync_mark "sync-ceilometer_polling_before_ha"
+crowbar_pacemaker_sync_mark "sync-ceilometer_central_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-ceilometer_polling_ha_resources"
+crowbar_pacemaker_sync_mark "wait-ceilometer_central_ha_resources"
 
 transaction_objects = []
 
-service_name = "ceilometer-polling"
+service_name = "ceilometer-central"
 pacemaker_primitive service_name do
-  agent node[:ceilometer][:ha][:polling][:agent]
-  op node[:ceilometer][:ha][:polling][:op]
-  # use these params with ocf:openstack:ceilometer-polling:
-  #params ({
-  #  "user"    => node[:ceilometer][:user],
-  #  "binary"  => "/usr/bin/ceilometer-polling",
-  #  "use_service"    => true,
-  #  "service" => node[:ceilometer][:polling][:service_name]
-  #})
+  agent node[:ceilometer][:ha][:central][:agent]
+  op node[:ceilometer][:ha][:central][:op]
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
@@ -42,7 +35,7 @@ transaction_objects << "pacemaker_primitive[#{service_name}]"
 location_name = openstack_pacemaker_controller_only_location_for service_name
 transaction_objects << "pacemaker_location[#{location_name}]"
 
-pacemaker_transaction "ceilometer polling" do
+pacemaker_transaction "ceilometer central" do
   cib_objects transaction_objects
   # note that this will also automatically start the resources
   action :commit_new
@@ -56,4 +49,4 @@ crowbar_pacemaker_order_only_existing "o-#{service_name}" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_sync_mark "create-ceilometer_polling_ha_resources"
+crowbar_pacemaker_sync_mark "create-ceilometer_central_ha_resources"

--- a/chef/data_bags/crowbar/migrate/ceilometer/101_bring-central-role-back.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/101_bring-central-role-back.rb
@@ -1,0 +1,44 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  # ceilometer-central might be already present if the setup is an upgrade from Cloud6
+  unless d["elements"].key? "ceilometer-central"
+    d["elements"]["ceilometer-central"] = d["elements"]["ceilometer-polling"]
+    d["elements"].delete("ceilometer-polling")
+  end
+
+  # Update the run_list for controller node
+  nodes = NodeObject.find("run_list_map:ceilometer-polling")
+  nodes.each do |node|
+    node.add_to_run_list("ceilometer-central",
+                         td["element_run_list_order"]["ceilometer-central"],
+                         td["element_states"]["ceilometer-central"])
+    node.delete_from_run_list("ceilometer-polling")
+    node.save
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  d["elements"]["ceilometer-polling"] = d["elements"]["ceilometer-central"]
+  d["elements"].delete("ceilometer-central")
+
+  # Update the run_list for controller node
+  nodes = NodeObject.find("run_list_map:ceilometer-central")
+  nodes.each do |node|
+    node.add_to_run_list("ceilometer-polling",
+                         td["element_run_list_order"]["ceilometer-polling"],
+                         td["element_states"]["ceilometer-polling"])
+    node.delete_from_run_list("ceilometer-central")
+    node.save
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -36,10 +36,10 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 23,
+      "schema-revision": 101,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
-        "ceilometer-polling": [ "readying", "ready", "applying" ],
+        "ceilometer-central": [ "readying", "ready", "applying" ],
         "ceilometer-agent": [ "readying", "ready", "applying" ],
         "ceilometer-agent-hyperv": [ "readying", "ready", "applying" ],
         "ceilometer-swift-proxy-middleware": [ "readying", "ready", "applying" ]
@@ -47,14 +47,14 @@
       "elements": {},
       "element_order": [
         [ "ceilometer-server" ],
-        [ "ceilometer-polling" ], 
+        [ "ceilometer-central" ],
         [ "ceilometer-agent" ],
         [ "ceilometer-agent-hyperv" ],
         [ "ceilometer-swift-proxy-middleware" ]
       ],
       "element_run_list_order": {
         "ceilometer-server": 101,
-        "ceilometer-polling": 102,
+        "ceilometer-central": 102,
         "ceilometer-agent": 103,
         "ceilometer-agent-hyperv": 104,
         "ceilometer-swift-proxy-middleware" : 80

--- a/chef/roles/ceilometer-agent.rb
+++ b/chef/roles/ceilometer-agent.rb
@@ -1,9 +1,8 @@
 name "ceilometer-agent"
 description "Ceilometer Agent Role"
 run_list(
-         "recipe[ceilometer::agent]",
-         "recipe[ceilometer::common]"
+  "recipe[ceilometer::agent]"
 )
-default_attributes()
-override_attributes()
+default_attributes
+override_attributes
 

--- a/chef/roles/ceilometer-central.rb
+++ b/chef/roles/ceilometer-central.rb
@@ -1,0 +1,7 @@
+name "ceilometer-central"
+description "Ceilometer Central Agent Role"
+run_list(
+  "recipe[ceilometer::central]"
+)
+default_attributes
+override_attributes

--- a/chef/roles/ceilometer-polling.rb
+++ b/chef/roles/ceilometer-polling.rb
@@ -1,8 +1,0 @@
-name "ceilometer-polling"
-description "Ceilometer Polling Agent Role"
-run_list(
-         "recipe[ceilometer::polling]",
-         "recipe[ceilometer::common]"
-)
-default_attributes()
-override_attributes()

--- a/chef/roles/ceilometer-server.rb
+++ b/chef/roles/ceilometer-server.rb
@@ -1,9 +1,8 @@
 name "ceilometer-server"
 description "Ceilometer Server Role"
 run_list(
-         "recipe[ceilometer::server]",
-         "recipe[ceilometer::common]"
+  "recipe[ceilometer::server]"
 )
-default_attributes()
-override_attributes()
+default_attributes
+override_attributes
 

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -44,7 +44,7 @@ class CeilometerService < PacemakerServiceObject
             "windows" => "/.*/"
           }
         },
-        "ceilometer-polling" => {
+        "ceilometer-central" => {
           "unique" => false,
           "count" => 1,
           "exclude_platform" => {
@@ -110,7 +110,7 @@ class CeilometerService < PacemakerServiceObject
     base["deployment"]["ceilometer"]["elements"] = {
         "ceilometer-agent" => agent_nodes.map { |x| x.name },
         "ceilometer-agent-hyperv" => hyperv_agent_nodes.map { |x| x.name },
-        "ceilometer-polling" => [server_nodes.first.name],
+        "ceilometer-central" => [server_nodes.first.name],
         "ceilometer-server" => [server_nodes.first.name],
         "ceilometer-swift-proxy-middleware" => swift_proxy_nodes.map { |x| x.name }
     } unless agent_nodes.nil? or server_nodes.nil?
@@ -124,7 +124,7 @@ class CeilometerService < PacemakerServiceObject
   end
 
   def validate_proposal_after_save(proposal)
-    validate_one_for_role proposal, "ceilometer-polling"
+    validate_one_for_role proposal, "ceilometer-central"
     validate_one_for_role proposal, "ceilometer-server"
 
     validate_minimum_three_nodes_in_cluster(proposal)
@@ -184,10 +184,10 @@ class CeilometerService < PacemakerServiceObject
     # the VIP of the cluster to be setup
     allocate_virtual_ips_for_any_cluster_in_networks(server_elements, vip_networks)
 
-    polling_elements, polling_nodes, polling_ha_enabled = \
-        role_expand_elements(role, "ceilometer-polling")
-    reset_sync_marks_on_clusters_founders(polling_elements)
-    Openstack::HA.set_controller_role(polling_nodes) if polling_ha_enabled
+    central_elements, central_nodes, central_ha_enabled = \
+      role_expand_elements(role, "ceilometer-central")
+    reset_sync_marks_on_clusters_founders(central_elements)
+    Openstack::HA.set_controller_role(central_nodes) if central_ha_enabled
 
     # set aodh attributes (outside of ceilometer cookbook)
     role.default_attributes["aodh"] ||= {}
@@ -200,8 +200,8 @@ class CeilometerService < PacemakerServiceObject
       role.override_attributes["ceilometer"]["crowbar-revision"]
 
     role.save if prepare_role_for_ha(role,\
-                                     ["ceilometer", "ha", "polling", "enabled"],\
-                                     polling_ha_enabled)
+                                     ["ceilometer", "ha", "central", "enabled"],\
+                                     central_ha_enabled)
 
     @logger.debug("Ceilometer apply_role_pre_chef_call: leaving")
   end


### PR DESCRIPTION
ceilometer-polling service will be used as the one being executed by central/compute/ipmi services with different arguments.

This needs to go together with https://build.opensuse.org/request/show/397382


Relevant documentation: 
- http://specs.openstack.org/openstack/ceilometer-specs/specs/kilo/merge-compute-and-central-agents.html
- http://docs.openstack.org/developer/ceilometer/architecture.html
- http://docs.openstack.org/admin-guide/telemetry-data-collection.html