### PR TITLE
Fix Heat WaitCondition URL points to internalURL Endpoint (bug#1459414)

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -569,7 +569,7 @@ insecure = <%= @keystone_settings['insecure'] %>
 # Type of endpoint in Identity service catalog to use for communication with
 # the OpenStack service. (string value)
 #endpoint_type = <None>
-endpoint_type=internalURL
+endpoint_type=publicURL
 
 # Optional CA cert file to use in SSL connections. (string value)
 #ca_file = <None>


### PR DESCRIPTION
When using the WaitCondition resource in Heat the

    { get_attr: ['wait_handle', 'curl_cli'] }

call will return a internal URL as endpoint not a public one.
Since those handles are used to trigger handles from inside the instance,
the internal IP in such cases is usually not usable.

https://bugs.launchpad.net/openstack-ansible/+bug/1459414