### PR TITLE
tempest: increase validation TO for XEN

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -354,6 +354,17 @@ file "#{node[:tempest][:tempest_path]}/flag-xen_only" do
   action xen_only ? :create : :delete
 end
 
+# tempest timeouts for ssh and connection can be different for XEN, a
+# `nil` value will use the tempest default value
+validation_connect_timeout = nil
+validation_ssh_timeout = nil
+if xen_only
+  # Default: 60
+  validation_connect_timeout = 90
+  # Default: 300
+  validation_ssh_timeout = 450
+end
+
 if !docker_compute_nodes.empty? && kvm_compute_nodes.empty?
   image_name = "cirros"
 
@@ -502,6 +513,8 @@ template "/etc/tempest/tempest.conf" do
     image_regex: image_regex,
     # validation settings
     use_run_validation: use_run_validation,
+    validation_connect_timeout: validation_connect_timeout,
+    validation_ssh_timeout: validation_ssh_timeout,
     # volume settings
     cinder_multi_backend: cinder_multi_backend,
     cinder_backend1_name: cinder_backend1_name,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -1339,10 +1339,16 @@ ip_version_for_ssh = 4
 # (integer value)
 # Deprecated group/name - [compute]/ssh_channel_timeout
 #connect_timeout = 60
+<% if @validation_connect_timeout -%>
+connect_timeout = <%= @validation_connect_timeout %>
+<% end -%>
 
 # Timeout in seconds to wait for the ssh banner. (integer value)
 # Deprecated group/name - [compute]/ssh_timeout
 #ssh_timeout = 300
+<% if @validation_ssh_timeout -%>
+ssh_timeout = <%= @validation_ssh_timeout %>
+<% end -%>
 
 
 [volume]


### PR DESCRIPTION
Tempest fails randomly is some tests when reset the VMs and try
to connect to it via SSH. `remote_client.RemoteClient` use
`CONF.validation.ssh_timeout` and `CONF.validation.connect_timeout`
to configure the timeouts for ssh connections.