### PR TITLE
Revert "neutron: Disable l2pop mechanism unless DVR is enabled"

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -207,7 +207,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
-        use_l2pop: (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")) && neutron[:neutron][:use_dvr],
+        use_l2pop: ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"),
         dvr_enabled: neutron[:neutron][:use_dvr],
         bridge_mappings: bridge_mappings
       )
@@ -231,7 +231,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         vxlan_mcast_group: neutron[:neutron][:vxlan][:multicast_group],
-        use_l2pop: ml2_type_drivers.include?("vxlan") && neutron[:neutron][:use_dvr],
+        use_l2pop: ml2_type_drivers.include?("vxlan"),
         interface_mappings: interface_mappings
        )
     end

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -139,7 +139,7 @@ when "ml2"
     ml2_mechanism_drivers.push("zvm")
   end
   if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
-    ml2_mechanism_drivers.push("l2population") if node[:neutron][:use_dvr]
+    ml2_mechanism_drivers.push("l2population")
   end
 
   ml2_mech_drivers = node[:neutron][:ml2_mechanism_drivers]


### PR DESCRIPTION
This was a workaround for a HA issue, but the HA issue was actually
broken ordering of HA resources (see
f5e6477147533a4f6aeddcfcdbb6e6d0cf5d1f0c)

So we should be able to enable l2pop by default.

This reverts commit 92a316a639acc1004e930a371fe53b76c3fc95af.