### PR TITLE
Add missing nova Api DB attributes

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -28,11 +28,23 @@ default[:nova][:db][:password] = nil
 default[:nova][:db][:user] = "nova"
 default[:nova][:db][:database] = "nova"
 
-# SQLAlchemy parameters
+# DB SQLAlchemy parameters
 default[:nova][:db][:max_pool_size] = nil
 default[:nova][:db][:max_overflow] = nil
 default[:nova][:db][:pool_timeout] = nil
 default[:nova][:db][:min_pool_size] = nil
+
+#
+# Api Database Settings
+#
+default[:nova][:api_db][:password] = nil
+default[:nova][:api_db][:user] = "nova_api"
+default[:nova][:api_db][:database] = "nova_api"
+
+# Api DB SQLAlchemy parameters
+default[:nova][:api_db][:max_pool_size] = nil
+default[:nova][:api_db][:max_overflow] = nil
+default[:nova][:api_db][:pool_timeout] = nil
 
 # Feature settings
 default[:nova][:use_migration] = false

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1692,6 +1692,9 @@ connection = <%= @api_database_connection %>
 
 # Maximum number of SQL connections to keep open in a pool. (integer value)
 #max_pool_size = <None>
+<% unless node[:nova][:api_db][:max_pool_size].nil? -%>
+max_pool_size = <%= node[:nova][:api_db][:max_pool_size] %>
+<% end -%>
 
 # Maximum number of database connection retries during startup. Set to -1 to
 # specify an infinite retry count. (integer value)
@@ -1702,6 +1705,9 @@ connection = <%= @api_database_connection %>
 
 # If set, use this value for max_overflow with SQLAlchemy. (integer value)
 #max_overflow = <None>
+<% unless node[:nova][:api_db][:max_overflow].nil? -%>
+max_overflow = <%= node[:nova][:api_db][:max_overflow] %>
+<% end -%>
 
 # Verbosity of SQL debugging information: 0=None, 100=Everything. (integer
 # value)
@@ -1712,6 +1718,9 @@ connection = <%= @api_database_connection %>
 
 # If set, use this value for pool_timeout with SQLAlchemy. (integer value)
 #pool_timeout = <None>
+<% unless node[:nova][:api_db][:pool_timeout].nil? -%>
+pool_timeout = <%= node[:nova][:api_db][:pool_timeout] %>
+<% end -%>
 
 
 [barbican]


### PR DESCRIPTION
Since mitaka, nova has a second DB for the API. We already setup the DB
but the chef attributes were not there yet.
This is similar to what we already do for the other nova db.