### PR TITLE
swift: Add timeout when running swift-dispersion-populate

### DIFF
--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -105,11 +105,13 @@ template "/etc/swift/dispersion.conf" do
   #notifies :run, "execute[populate-dispersion]", :immediately
 end
 
+# NOTE(toabctl): swift-dispersion-populate process hangs so add a timeout as workaround
 execute "populate-dispersion" do
   command "#{dispersion_cmd}"
   user node[:swift][:user]
   group node[:swift][:group]
   action :run
   ignore_failure true
+  timeout 120
   only_if "#{swift_cmd} -V #{keystone_settings["api_version"]} --os-tenant-name #{service_tenant} --os-username #{service_user} --os-password '#{service_password}' --os-auth-url #{keystone_settings["internal_auth_url"]} --os-endpoint-type internalURL stat dispersion_objects 2>&1 | grep 'Container.*not found'"
 end


### PR DESCRIPTION
The execute statement calling "swift-dispersion-populate" hangs
so add a timeout as workaround for now.