### PR TITLE
Save stack user domain id into node data.

### DIFF
--- a/chef/data_bags/crowbar/migrate/heat/102_add_stack_user_domain_id.rb
+++ b/chef/data_bags/crowbar/migrate/heat/102_add_stack_user_domain_id.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["stack_user_domain_id"] = ""
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("stack_user_domain_id")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-heat.json
+++ b/chef/data_bags/crowbar/template-heat.json
@@ -10,6 +10,7 @@
       "database_instance": "none",
       "stack_domain_admin": "heat_domain_admin",
       "stack_domain_admin_password": "",
+      "stack_user_domain_id": "",
       "keystone_instance": "none",
       "service_user": "heat",
       "service_password": "",
@@ -42,7 +43,7 @@
     "heat": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "heat-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
This makes the code bit more readable.

It is supposed to be better alternative to https://github.com/crowbar/crowbar-openstack/pull/399 . Not yet tested.
