### PR TITLE
nova: Allow some SUSE specific vendordata

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -159,3 +159,8 @@ default[:nova][:ha][:compute][:fence][:op][:monitor][:interval] = "10m"
 #
 default[:nova][:block_device][:allocate_retries] = 60
 default[:nova][:block_device][:allocate_retries_interval] = 3
+
+#
+# metadata/vendordata
+#
+default[:nova][:metadata][:vendordata][:json] = "{}"

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -260,6 +260,18 @@ else
   bind_port_xvpvncproxy = node[:nova][:ports][:xvpvncproxy]
 end
 
+vendordata_jsonfile = "/etc/nova/suse-vendor-data.json"
+
+template vendordata_jsonfile do
+  source "suse-vendor-data.json.erb"
+  user "root"
+  group node[:nova][:group]
+  mode 0640
+  variables(
+    vendor_data: node[:nova][:metadata][:vendordata][:json]
+  )
+end
+
 template "/etc/nova/nova.conf" do
   source "nova.conf.erb"
   user "root"
@@ -290,6 +302,7 @@ template "/etc/nova/nova.conf" do
             glance_server_insecure: glance_server_insecure || keystone_settings["insecure"],
             metadata_bind_address: metadata_bind_address,
             vnc_enabled: node[:kernel][:machine] != "aarch64",
+            vendordata_jsonfile: vendordata_jsonfile,
             vncproxy_public_host: vncproxy_public_host,
             vncproxy_ssl_enabled: api[:nova][:novnc][:ssl][:enabled],
             vncproxy_cert_file: api_novnc_ssl_certfile,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -522,6 +522,9 @@ wsgi_keep_alive = false
 
 # File to load JSON formatted vendor data from (string value)
 #vendordata_jsonfile_path = <None>
+<% if @vendordata_jsonfile %>
+vendordata_jsonfile_path = <%= @vendordata_jsonfile %>
+<% end -%>
 
 # Permit instance snapshot operations. (boolean value)
 #allow_instance_snapshots = true

--- a/chef/cookbooks/nova/templates/default/suse-vendor-data.json.erb
+++ b/chef/cookbooks/nova/templates/default/suse-vendor-data.json.erb
@@ -1,0 +1,1 @@
+<%= @vendor_data %>

--- a/chef/data_bags/crowbar/migrate/nova/102_nova_add_metadata_vendordata.rb
+++ b/chef/data_bags/crowbar/migrate/nova/102_nova_add_metadata_vendordata.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "metadata"
+    a["metadata"] = ta["metadata"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "metadata"
+    a.delete("metadata")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -91,6 +91,11 @@
       "block_device": {
         "allocate_retries": 60,
         "allocate_retries_interval": 3
+      },
+      "metadata": {
+        "vendordata": {
+          "json": "{}"
+        }
       }
     }
   },
@@ -98,7 +103,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -136,6 +136,15 @@
                 "allocate_retries": { "type": "number", "required" : true },
                 "allocate_retries_interval": { "type": "number", "required" : true }
               }
+            },
+            "metadata": {
+              "type": "map", "required": true, "mapping": {
+                "vendordata": {
+                  "type": "map", "required": true, "mapping": {
+                    "json": { "type": "str", "required" : true }
+                  }
+                }
+              }
             }
           }
         }

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -395,6 +395,13 @@ class NovaService < PacemakerServiceObject
       end
     end
 
+    # vendordata must be valid json
+    begin
+      JSON.parse(proposal["attributes"][@bc_name]["metadata"]["vendordata"]["json"])
+    rescue JSON::ParserError
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.vendor_data_invalid_json")
+    end
+
     super
   end
 

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -90,3 +90,4 @@ en:
         assigned_node: 'Node %{key} has been assigned to a nova-compute role more than once.'
         assigned_remotes: 'Remotes %{key} has been assigned to a nova-compute role more than once.'
         assigned_node_and_remote: 'Node %{node} has been assigned to a nova-compute role as individual node and as remote node of cluster %{cluster}.'
+        vendor_data_invalid_json: "The provided vendordata for the metadata server is invalid JSON."


### PR DESCRIPTION
Create a vendordata.json file which will be served through the metadata
server to the guest VM.
This vedordata.json contains some information about a possible SMT server.
The provided information is then used by the SUSE guest images to automatically
configure the repositories for the guest.
This is based on a solution the public cloud team is already using.