### PR TITLE
trigger mention-bot on PR "synchronize" events

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -33,7 +33,7 @@
   "userBlacklist": [],
   "userBlacklistForPR": [],
   "requiredOrgs": ["crowbar"],
-  "actions": ["opened"],
+  "actions": ["opened", "synchronize"],
   "skipAlreadyAssignedPR": true,
   "assignToReviewer": false,
   "skipTitle": "",


### PR DESCRIPTION
A PR could be updated via a git push, in which case github will send a PR event of type `synchronize` to the webhook.  We want the mention-bot to react to this, because the push probably introduces new changes which might require additional reviewers.

This also makes testing the bot easier :-)

There appears to be little documentation covering exactly when `synchronize` is invoked, but there is this, at least:

  https://developer.github.com/v3/activity/events/types/#pullrequestevent