### PR TITLE
OpenDayLight Integration with Neutron

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -74,6 +74,12 @@ default[:neutron][:apic][:opflex][:vxlan][:remote_ip] = ""
 default[:neutron][:apic][:opflex][:vxlan][:remote_port] = 8472
 default[:neutron][:apic][:opflex][:vlan][:encap_iface] = ""
 
+default[:neutron][:odl][:protocol] = "http"
+default[:neutron][:odl][:controller_port] = 6653
+default[:neutron][:odl][:manager_port] = 6640
+default[:neutron][:odl][:username] = "admin"
+default[:neutron][:odl][:password] = "admin"
+
 case node[:platform_family]
 when "suse"
   default[:neutron][:platform] = {
@@ -118,6 +124,7 @@ when "suse"
                     "openstack-neutron-infoblox-ipam-agent"],
     vmware_vsphere_pkg: "openstack-neutron-vsphere",
     vmware_vsphere_dvs_agent_pkg: "openstack-neutron-vsphere-dvs-agent",
+    odl_pkgs: ["python-networking-odl"],
     user: "neutron",
     group: "neutron",
   }
@@ -161,6 +168,7 @@ when "rhel"
     infoblox_pkgs: [],
     vmware_vsphere_pkg: "",
     vmware_vsphere_dvs_agent_pkg: "",
+    odl_pkgs: ["python-networking-odl"],
     user: "neutron",
     group: "neutron",
   }
@@ -203,6 +211,7 @@ else
     infoblox_pkgs: [],
     vmware_vsphere_pkg: "openstack-neutron-vsphere",
     vmware_vsphere_dvs_agent_pkg: "openstack-neutron-vsphere-dvs-agent",
+    odl_pkgs: [""],
     user: "neutron",
     group: "neutron",
   }

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -86,6 +86,9 @@ if neutron[:neutron][:networking_plugin] == "ml2" &&
     neutron[:neutron][:ml2_mechanism_drivers].include?("apic_gbp"))
   include_recipe "neutron::cisco_apic_agents"
   return # skip anything else in this recipe
+elsif neutron[:neutron][:ml2_mechanism_drivers].include?("opendaylight")
+  include_recipe "neutron::odl_support"
+  return
 end
 
 multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty?
@@ -102,7 +105,7 @@ if neutron[:neutron][:networking_plugin] == "ml2" &&
     unless neutron.name == node.name
       cookbook_file "/etc/init.d/neutron-ovs-cleanup" do
         source "neutron-ovs-cleanup"
-        mode 00755
+        mode "0755"
       end
       link "/etc/rc2.d/S20neutron-ovs-cleanup" do
         to "../init.d/neutron-ovs-cleanup"
@@ -158,8 +161,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
   end
   ml2_type_drivers = neutron[:neutron][:ml2_type_drivers]
 
-  case
-  when ml2_mech_drivers.include?("zvm")
+  case ml2_mech_drivers
+  when ->(ml2_mech) { ml2_mech.include?("zvm") }
     package node[:neutron][:platform][:zvm_agent_pkg]
 
     neutron_agent = node[:neutron][:platform][:zvm_agent_name]
@@ -167,7 +170,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     physnet = node[:crowbar_wall][:network][:nets][:nova_fixed].first
     interface_mappings = "physnet1:" + physnet
 
-  when ml2_mech_drivers.include?("openvswitch")
+  when ->(ml2_mech) { ml2_mech.include?("openvswitch") }
     # package is already installed
     neutron_agent = node[:neutron][:platform][:ovs_agent_name]
     agent_config_path = "/etc/neutron/plugins/ml2/openvswitch_agent.ini"
@@ -230,12 +233,9 @@ if neutron[:neutron][:networking_plugin] == "ml2"
   include_recipe "neutron::common_config"
 
   # L2 agent
-  case
-  when ml2_mech_drivers.include?("zvm")
-    # accessing the network definition directly, since the node is not using
-    # this network
-    fixed_net_def = Barclamp::Inventory.get_network_definition(neutron, "nova_fixed")
-    vlan_start = fixed_net_def["vlan"]
+  case ml2_mech_drivers
+  when ->(ml2_mech) { ml2_mech.include?("zvm") }
+    vlan_start = neutron[:network][:networks][:nova_fixed][:vlan]
     num_vlans = neutron[:neutron][:num_vlans]
     vlan_end = [vlan_start + num_vlans - 1, 4094].min
 
@@ -251,9 +251,9 @@ if neutron[:neutron][:networking_plugin] == "ml2"
         vlan_end: vlan_end,
       )
     end
-  when ml2_mech_drivers.include?("openvswitch")
+  when ->(ml2_mech) { ml2_mech.include?("openvswitch") }
     directory "/etc/neutron/plugins/openvswitch/" do
-      mode 00755
+      mode "0755"
       owner "root"
       group node[:neutron][:platform][:group]
       action :create
@@ -270,17 +270,16 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
-        use_l2pop: neutron[:neutron][:use_l2pop] &&
-            (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
+        use_l2pop: ml2_type_drivers.include?("gre" || "vxlan") && neutron[:neutron][:use_dvr],
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
         ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
         bridge_mappings: bridge_mappings
       )
     end
-  when ml2_mech_drivers.include?("linuxbridge")
+  when ->(ml2_mech) { ml2_mech.include?("linuxbridge") }
     directory "/etc/neutron/plugins/linuxbridge/" do
-      mode 00755
+      mode "0755"
       owner "root"
       group node[:neutron][:platform][:group]
       action :create
@@ -297,9 +296,9 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         vxlan_mcast_group: neutron[:neutron][:vxlan][:multicast_group],
-        use_l2pop: neutron[:neutron][:use_l2pop] && ml2_type_drivers.include?("vxlan"),
+        use_l2pop: ml2_type_drivers.include?("vxlan") && neutron[:neutron][:use_dvr],
         interface_mappings: interface_mappings
-       )
+      )
     end
   end
 

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -89,6 +89,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     service_plugins = ["cisco_apic_l3"]
   elsif neutron[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
     service_plugins = ["group_policy", "servicechain", "apic_gbp_l3"]
+  elsif neutron[:neutron][:ml2_mechanism_drivers].include?("opendaylight")
+    service_plugins = ["networking_odl.l3.l3_odl.OpenDaylightL3RouterPlugin"]
   end
 end
 service_plugins = service_plugins.join(", ")

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -15,7 +15,8 @@
 
 use_l3_agent = (node[:neutron][:networking_plugin] != "vmware" &&
                 !node[:neutron][:ml2_mechanism_drivers].include?("cisco_apic_ml2") &&
-                !node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp"))
+                !node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp") &&
+                !node[:neutron][:ml2_mechanism_drivers].include?("opendaylight"))
 use_lbaas_agent = node[:neutron][:use_lbaas]
 use_metadata_agent = (!node[:neutron][:ml2_mechanism_drivers].include?("cisco_apic_ml2") &&
                       !node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp"))

--- a/chef/cookbooks/neutron/recipes/odl_support.rb
+++ b/chef/cookbooks/neutron/recipes/odl_support.rb
@@ -1,0 +1,163 @@
+#
+# Copyright 2016 SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+neutron = nil
+if node.attribute?(:cookbook) && node[:cookbook] == "nova"
+  neutrons = node_search_with_cache("roles:neutron-server", node[:nova][:neutron_instance])
+  neutron = neutrons.first || raise("Neutron instance '#{node[:nova][:neutron_instance]}' \
+                                    for nova not found")
+else
+  neutron = node
+end
+
+if node.roles.include?("neutron-server")
+  node[:neutron][:platform][:odl_pkgs].each { |p| package p }
+end
+
+odl_nodes = node_search_with_cache("roles:opendaylight") 
+odl_node = odl_nodes.first  || raise("No Opendaylight node found")
+
+# Stop Neutron openvswitch agents on all nodes
+service node[:neutron][:platform][:ovs_agent_name] do
+  action [:disable, :stop]
+end
+
+# Stop L2 and L3 agents on the Controller
+if node.roles.include?("neutron-network")
+  Chef::Log.warn("Stopping L2 and L3 agent services")
+  service node[:neutron][:platform][:dhcp_agent_name] do
+    action [:disable, :stop]
+  end
+  service node[:neutron][:platform][:l3_agent_name] do
+    action [:disable, :stop]
+  end
+end
+
+# Prepare variables for switch setup for opendaylight controller
+odl_controller_ip = neutron[:neutron][:odl][:controller_ip]
+odl_manager_port = neutron[:neutron][:odl][:manager_port]
+odl_protocol = neutron[:neutron][:odl][:protocol]
+
+ovs_manager = "tcp:#{odl_controller_ip}:#{odl_manager_port}"
+odl_api_port = odl_node[:opendaylight][:port]
+
+# Delete old bridge controllers if they are assigned.
+["br-int", "br-tunnel", "br-fixed", "br-public"].each do |bridge|
+  execute "delete_bridge_controllers" do
+    command "ovs-vsctl del-controller #{bridge}"
+    action :run
+    not_if "out=$(ovs-vsctl br-exists #{bridge}); [ $? != 0 ]"
+  end
+end
+
+# Delete bridges to allow ODL to create and patch them
+["br-int", "br-tunnel", "br-fixed", "br-public"].each do |bridge|
+  execute "delete_bridges" do
+    command "ovs-vsctl del-br #{bridge}"
+    action :run
+    not_if "out=$(ovs-vsctl br-exists #{bridge}); [ $? != 0 ]"
+  end
+end
+
+# Delete ports if already exists
+["br-fixed", "br-public"].each do |bridge|
+  execute "delete_fixed_public_ports" do
+    command "ovs-vsctl del-port br-int #{bridge}"
+    action :run
+    not_if "out=$(ovs-vsctl br-exists #{bridge}); [ $? != 0 ]"
+  end
+end
+
+# Create br-fixed and br-public for ODL to patch
+["br-fixed", "br-public"].each do |bridge|
+  execute "create_fixed_public_bridges" do
+    command "ovs-vsctl --may-exist add-br #{bridge}"
+    action :run
+  end
+end
+
+bash "update_ovs_switches" do
+  user "root"
+  action :run
+  code <<-EOF
+    ovs_id=$(ovs-vsctl show | head -1) 
+    mappings="physnet1:br-fixed,physnet2:br-public"
+    local_ip=$(ifconfig eth0 | grep "inet addr" | awk '{print $2}' | awk -F':' '{print $2}')
+    ovs-vsctl set Open_vSwitch $ovs_id other_config={local_ip=$local_ip}
+    ovs-vsctl set Open_vSwitch $ovs_id other_config:provider_mappings=$mappings
+
+    # After setting the manager path and restart openvswitch, ODL does the following:
+    #   - Creates br-int
+    #   - Creates patch ports for br-fixed and br-public and patches them to br-int
+    #   - Sets ODL controller as the controller for all the bridges.
+    #   - Adds NORMAL flows to br-fixed and br-public and several useful flows on br-int
+    # Short sleep to ensure bridges are setup before the manager is configured.
+    ovs-vsctl del-manager
+    sleep 5
+    ovs-vsctl set-manager #{ovs_manager}
+    service openvswitch restart
+  EOF
+end
+
+if node.roles.include?("neutron-server")
+  # Required as workaround for OpenStack Newton
+  template "/etc/neutron/dhcp_agent.ini" do
+    cookbook "neutron"
+    source "dhcp_agent.ini.erb"
+    mode "0640"
+    owner "root"
+    group node[:neutron][:platform][:group]
+    variables(
+      force_metadata: true,
+      ovsdb_interface: "vsctl"
+    )
+    notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]" 
+  end
+
+
+  odl_url = "#{odl_protocol}://#{odl_controller_ip}:#{odl_api_port}/controller/nb/v2/neutron"
+  template "/etc/neutron/neutron-server.conf.d/100-ml2_conf_odl.ini.conf" do
+    cookbook "neutron"
+    source "ml2_conf_odl.ini.erb"
+    mode "0640"
+    owner "root"
+    group node[:neutron][:platform][:group]
+    variables(
+      ml2_odl_url: odl_url,
+      ml2_odl_username: node[:neutron][:odl][:username],
+      ml2_odl_password: node[:neutron][:odl][:password]
+    )
+    notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]"
+  end
+
+  # (mmnelemane): May revisit include the below configs when working with l3-router
+  # Need to add the new parameters in dhcp_agent.ini.erb if this is enabled.
+  # neutron_options = "--config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2_conf.ini"
+  # execute "neutron_db_sync" do
+  #   command "neutron-db-manage #{neutron_options} upgrade head"
+  #   action :run
+  #   notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]"
+  # end
+
+  # l3_router = ["odl-router"]
+  # template "/etc/neutron/neutron.conf" do
+  #  source "neutron.conf.erb"
+  #  variables(
+  #    service_plugins: l3_router
+  #  )
+  #  notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]"
+  # end
+end

--- a/chef/cookbooks/neutron/templates/default/ml2_conf_odl.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf_odl.ini.erb
@@ -1,0 +1,45 @@
+# Configuration for the OpenDaylight MechanismDriver
+
+[ml2_odl]
+# (StrOpt) OpenDaylight REST URL
+# If this is not set then no HTTP requests will be made.
+#
+# url =
+# Example: url = http://192.168.56.1:8080/controller/nb/v2/neutron
+url=<%= @ml2_odl_url %>
+
+# (StrOpt) Username for HTTP basic authentication to ODL.
+#
+# username =
+# Example: username = admin
+username=<%= @ml2_odl_username %>
+
+# (StrOpt) Password for HTTP basic authentication to ODL.
+#
+# password =
+# Example: password = admin
+password=<%= @ml2_odl_password %>
+
+# (IntOpt) Timeout in seconds to wait for ODL HTTP request completion.
+# This is an optional parameter, default value is 10 seconds.
+#
+# timeout = 10
+# Example: timeout = 15
+
+# (IntOpt) Timeout in minutes to wait for a Tomcat session timeout.
+# This is an optional parameter, default value is 30 minutes.
+#
+# session_timeout = 30
+# Example: session_timeout = 60
+
+# (IntOpt) Timeout in seconds for the V2 driver thread to fire off
+# another thread run through the journal database.
+#
+# sync_timeout = 10
+# Example: sync_timeout = 10
+
+# (IntOpt) Number of times to retry a journal transaction before
+# marking it 'failed'.
+#
+# retry_count = 5
+# Example: retry_count = 5

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -20,6 +20,7 @@ tunnel_csum = True
 tunnel_bridge = br-tunnel
 <% end -%>
 ovsdb_interface = <%= @ovsdb_interface %>
+of_interface = <%= @of_interface %>
 <% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
 local_ip = <%= node.address("os_sdn").addr %>
 <% end -%>

--- a/chef/data_bags/crowbar/migrate/neutron/205_add_odl_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/205_add_odl_attributes.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "odl"
+    a["odl"] = ta["odl"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "odl"
+    a.delete("odl")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -171,7 +171,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 204,
+      "schema-revision": 205,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -163,6 +163,14 @@
                       "service_port": { "type" : "int", "required" : true },
                       "service_host": { "type" : "str", "required" : true }
                     }},
+                    "odl": { "type": "map", "required": false, "mapping": {
+                      "protocol": { "type" : "str", "required" : true },
+                      "controller_ip": { "type" : "str", "required" : true },
+                      "controller_port": { "type" : "str", "required" : true },
+                      "manager_port": { "type" : "str", "required" : true },
+                      "username": { "type" : "str", "required" : true },
+                      "password": { "type" : "str", "required" : true }
+                    }},
                     "use_infoblox": { "type": "bool", "required": true },
                     "infoblox": { "type": "map", "required": false, "mapping": {
                         "cloud_data_center_id": { "type": "int", "required": true },

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -37,7 +37,11 @@ class NeutronService < OpenstackServiceObject
   end
 
   def self.networking_ml2_mechanism_drivers_valid
-    ["linuxbridge", "openvswitch", "cisco_nexus", "vmware_dvs", "cisco_apic_ml2", "apic_gbp"]
+    ["linuxbridge", "openvswitch",
+     "cisco_nexus",
+     "vmware_dvs",
+     "cisco_apic_ml2", "apic_gbp",
+     "opendaylight"]
   end
 
   class << self
@@ -316,6 +320,11 @@ class NeutronService < OpenstackServiceObject
     plugin = proposal["attributes"]["neutron"]["networking_plugin"]
     ml2_mechanism_drivers = proposal["attributes"]["neutron"]["ml2_mechanism_drivers"]
     ml2_type_drivers = proposal["attributes"]["neutron"]["ml2_type_drivers"]
+
+    if ml2_mechanism_drivers.include?("opendaylight") && \
+        !(ml2_mechanism_drivers == ["opendaylight"])
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.opendaylight_standalone")
+    end
 
     if proposal["attributes"]["neutron"]["use_dvr"]
       if (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")) &&

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -145,6 +145,7 @@ en:
         openvswitch_linuxbridge: 'The "openvswitch" and "linuxbridge" mechanism drivers cannot be used in parallel. Only select one of them'
         l2_population: 'L2 population requires GRE and/or VXLAN'
         dvr_requires_l2: 'DVR with GRE or VXLAN requires L2 population'
+        opendaylight_standalone: 'Opendaylight cannot work with other mechanism drivers.' 
         dvr_vmware: 'DVR is not compatible with VMware NSX plugin'
         dvr_linuxbridge: 'DVR is not compatible with Linux Bridge ML2 driver'
         vmware_dvs_vlan: 'The "vmware_dvs" mechanism driver needs the type driver "vlan"'


### PR DESCRIPTION
The integration allows configuration of OpenDayLight Controller as the manager for the openvswitch switches on the compute and controller nodes. The UI is not fully complete but allows for selecting opendaylight as a ML2 Mechanism driver and set the ODL parameters in the raw window to apply the changes. Requires installation of crowbar/crowbar-opendaylight to setup opendaylight controller on the controller node.
