### PR TITLE
Switch from closure-compiler to uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@
 source "https://rubygems.org"
 
 group :development do
-  gem "closure-compiler", "~> 1.1.10"
+  gem "uglifier", "~> 2.7.2"
   gem "sass", "~> 3.2.19"
   gem "sprockets-standalone", "~> 1.2.1"
   gem "sprockets", "~> 2.11.0"

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ begin
     task.compress = true
     task.digest = true
 
-    sprockets.js_compressor = :closure
+    sprockets.js_compressor = :uglifier
     sprockets.css_compressor = :sass
   end
 


### PR DESCRIPTION
Since we switched to SLE12 we can use the faster uglifier which uses NodeJS.