### PR TITLE
[mention-bot] only mention SUSE employees for now

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -32,7 +32,7 @@
   "fileBlacklist": [],
   "userBlacklist": [],
   "userBlacklistForPR": [],
-  "requiredOrgs": ["crowbar"],
+  "requiredOrgs": ["SUSE"],
   "actions": ["opened", "synchronize"],
   "skipAlreadyAssignedPR": true,
   "assignToReviewer": false,


### PR DESCRIPTION
as we don't have any contributors outside the SUSE org it does not
make sense to mention people that haven't contributed for a long
time.
This prevents spamming for now, and if crowbar grows to form an
infrastructure for a wider community we can adapt the list again.
Main reason for this change is to stop spamming non-active
contributors.