### PR TITLE
Add segment_mtu setting for neutron

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -183,7 +183,9 @@ when "ml2"
     physnets.push(node[:neutron][:zvm][:zvm_xcat_mgt_vswitch])
   end
 
-  mtu_value = 0
+  os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
+  mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
+
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv
@@ -194,7 +196,6 @@ when "ml2"
   end
   if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
     ml2_mechanism_drivers.push("l2population") if node[:neutron][:use_dvr]
-    mtu_value = 1400
   end
 
   ml2_mech_drivers = node[:neutron][:ml2_mechanism_drivers]
@@ -219,7 +220,7 @@ when "ml2"
       vxlan_end: vni_end,
       vxlan_mcast_group: node[:neutron][:vxlan][:multicast_group],
       external_networks: physnets,
-      path_mtu: mtu_value
+      mtu_value: mtu_value
     )
   end
 when "vmware"

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -37,12 +37,13 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # path_mtu - max encap header size).  If <=0, the path MTU is
 # indeterminate and no calculation takes place.
 # path_mtu = 0
-path_mtu = <%= @path_mtu %>
+path_mtu = <%= @mtu_value %>
 
 # (IntOpt) Segment MTU.  The maximum permissible size of an
 # unfragmented packet travelling a L2 network segment.  If <=0,
 # the segment MTU is indeterminate and no calculation takes place.
 # segment_mtu = 0
+segment_mtu = <%= @mtu_value %>
 
 # (ListOpt) Physical network MTUs.  List of mappings of physical
 # network to MTU value.  The format of the mapping is


### PR DESCRIPTION
For Layer 2 traffic, neutron needs to know the segment_mtu to correctly
calculate the the MTU of networks. The `mtu_value` has to match the MTU values
of the physical interfaces.