### PR TITLE
nova: Fix regression on SLE12 SP1 due to qemu-ovmf-x86_64

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -88,7 +88,8 @@ case node[:nova][:libvirt_type]
             package "qemu-uefi-aarch64"
           end
 
-          if node[:kernel][:machine] == "x86_64"
+          if node[:kernel][:machine] == "x86_64" &&
+              node[:platform_family] == "suse" && node[:platform_version].to_f > 12.1
             package "qemu-ovmf-x86_64"
           end
 


### PR DESCRIPTION
The package only exists in SLE12 SP2 or later.