### PR TITLE
glance: Put swift config in /etc/glance/glance-swift.conf

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -87,6 +87,17 @@ template node[:glance][:api][:config_file] do
   )
 end
 
+template "/etc/glance/glance-swift.conf" do
+  source "glance-swift.conf.erb"
+  owner "root"
+  group node[:glance][:group]
+  mode 0640
+  variables(
+    keystone_settings: keystone_settings
+  )
+  notifies :restart, "service[#{node[:glance][:api][:service_name]}]"
+end
+
 ha_enabled = node[:glance][:ha][:enabled]
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(node, node[:glance][:api][:protocol] == "https", ha_enabled)

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -833,33 +833,31 @@ swift_store_create_container_on_put = <%= node[:glance][:swift][:store_create_co
 # The reference to the default swift account/backing store parameters
 # to use for adding new images. (string value)
 #default_swift_reference = ref1
+default_swift_reference = crowbar
 
 # Version of the authentication service to use. Valid versions are 2
 # and 3 for keystone and 1 (deprecated) for swauth and rackspace.
 # (deprecated - use "auth_version" in swift_store_config_file) (string
 # value)
 #swift_store_auth_version = 2
-swift_store_auth_version = <%= @keystone_settings['api_version'] %>
 
 # The address where the Swift authentication service is listening.
 # (deprecated - use "auth_address" in swift_store_config_file) (string
 # value)
 #swift_store_auth_address = <None>
-swift_store_auth_address = <%= @keystone_settings['internal_auth_url'] %>
 
 # The user to authenticate against the Swift authentication service
 # (deprecated - use "user" in swift_store_config_file) (string value)
 #swift_store_user = <None>
-swift_store_user = <%= @keystone_settings['service_tenant'] %>:<%= @keystone_settings['service_user'] %>
 
 # Auth key for the user authenticating against the Swift
 # authentication service. (deprecated - use "key" in
 # swift_store_config_file) (string value)
 #swift_store_key = <None>
-swift_store_key = <%= @keystone_settings['service_password'] %>
 
 # The config file that has the swift account(s)configs. (string value)
 #swift_store_config_file = <None>
+swift_store_config_file = /etc/glance/glance-swift.conf
 
 # ESX/ESXi or vCenter Server target system. The server value can be an
 # IP address or a DNS name. (string value)

--- a/chef/cookbooks/glance/templates/default/glance-swift.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-swift.conf.erb
@@ -1,0 +1,16 @@
+# glance-swift.conf
+#
+# Specify the reference name in []
+# For each section, specify the auth_address, user and key.
+#
+# WARNING:
+# * If any of auth_address, user or key is not specified,
+# the glance-api's swift store will fail to configure
+
+[crowbar]
+auth_version = <%= @keystone_settings['api_version'] %>
+auth_address = <%= @keystone_settings['internal_auth_url'] %>
+user = <%= @keystone_settings['service_tenant'] %>:<%= @keystone_settings['service_user'] %>
+key = <%= @keystone_settings['service_password'] %>
+user_domain_id = default
+project_domain_id = default


### PR DESCRIPTION
This seems to be required now with keystone v3, as glance is unable to
authenticate with swift without specifying the domain.