### PR TITLE
nova: Only install openvswitch-kmp-xen on SLE 12 <= SP1

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -122,7 +122,8 @@ case node[:nova][:libvirt_type]
             package pkg
           end
           # openSUSE and SLES12SP2 use the module shipped with upstream kernel
-          if node[:platform] == "suse" && node[:platform_version].to_f < 12.2
+          if node[:network][:needs_openvswitch] &&
+              node[:platform] == "suse" && node[:platform_version].to_f < 12.2
             package "openvswitch-kmp-xen"
           end
 

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -118,10 +118,12 @@ case node[:nova][:libvirt_type]
           end
 
         when "xen"
-          %w{kernel-xen xen xen-tools openvswitch-kmp-xen}.each do |pkg|
-            package pkg do
-              action :install
-            end
+          %w{kernel-xen xen xen-tools}.each do |pkg|
+            package pkg
+          end
+          # openSUSE and SLES12SP2 use the module shipped with upstream kernel
+          if node[:platform] == "suse" && node[:platform_version].to_f < 12.2
+            package "openvswitch-kmp-xen"
           end
 
           service "xend" do


### PR DESCRIPTION
openSUSE and SLES12SP2 use the module shipped with upstream kernel.

See https://github.com/crowbar/crowbar-core/pull/517