### PR TITLE
[magnum] Fix Magnum API host and port options

### DIFF
--- a/chef/cookbooks/magnum/recipes/common.rb
+++ b/chef/cookbooks/magnum/recipes/common.rb
@@ -33,8 +33,6 @@ my_ipaddress = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
   node, "admin").address
 node.set[:magnum][:api][:bind_host] = my_ipaddress
 magnum_ha_enabled = node[:magnum][:ha][:enabled]
-public_api_host = CrowbarHelper.get_host_for_public_url(
-  node, (node[:magnum][:api][:protocol] == "http"), magnum_ha_enabled)
 # TODO : Handle HA condition
 bind_port = node[:magnum][:api][:bind_port]
 bind_host = node[:magnum][:api][:bind_host]
@@ -47,7 +45,6 @@ template "/etc/magnum/magnum.conf" do
   mode 0640
   variables(
     trustee: node[:magnum][:trustee],
-    api_host: public_api_host,
     bind_host: bind_host,
     bind_port: bind_port,
     sql_connection: sql_connection,

--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -270,10 +270,11 @@ control_exchange = magnum
 # Minimum value: 0
 # Maximum value: 65535
 #port = 9511
+port = <%= @bind_port %>
 
 # The listen IP for the Magnum API server. (IP address value)
 #host = 127.0.0.1
-host=<%= @api_host %>
+host = <%= @bind_host %>
 
 # The maximum number of items returned in a single response from a collection
 # resource. (integer value)


### PR DESCRIPTION
Magnum API should listen on "0.0.0.0" and port "9511" otherwise we will get following stacktrace:

/var/log/magnum/magnum-api.log
```
2016-07-05 11:44:28.621 6512 CRITICAL magnum [-] ConfigFileValueError: Value for option host is not valid: public.d52-54-77-77-77-01.virtual.cloud.suse.de is not IPv4 or IPv6 address
2016-07-05 11:44:28.621 6512 ERROR magnum Traceback (most recent call last):
2016-07-05 11:44:28.621 6512 ERROR magnum   File "/usr/bin/magnum-api", line 10, in <module>
2016-07-05 11:44:28.621 6512 ERROR magnum     sys.exit(main())
2016-07-05 11:44:28.621 6512 ERROR magnum   File "/usr/lib/python2.7/site-packages/magnum/cmd/api.py", line 46, in main
2016-07-05 11:44:28.621 6512 ERROR magnum     host, port = cfg.CONF.api.host, cfg.CONF.api.port
2016-07-05 11:44:28.621 6512 ERROR magnum   File "/usr/lib/python2.7/site-packages/oslo_config/cfg.py", line 2946, in __getattr__
2016-07-05 11:44:28.621 6512 ERROR magnum     return self._conf._get(name, self._group)
2016-07-05 11:44:28.621 6512 ERROR magnum   File "/usr/lib/python2.7/site-packages/oslo_config/cfg.py", line 2567, in _get
2016-07-05 11:44:28.621 6512 ERROR magnum     value = self._do_get(name, group, namespace)
2016-07-05 11:44:28.621 6512 ERROR magnum   File "/usr/lib/python2.7/site-packages/oslo_config/cfg.py", line 2610, in _do_get
2016-07-05 11:44:28.621 6512 ERROR magnum     % (opt.name, str(ve)))
2016-07-05 11:44:28.621 6512 ERROR magnum ConfigFileValueError: Value for option host is not valid: public.d52-54-77-77-77-01.virtual.cloud.suse.de is not IPv4 or IPv6 address
2016-07-05 11:44:28.621 6512 ERROR magnum 
```