### PR TITLE
crowbar: Update for Crowbar::Settings.domain new API

### DIFF
--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -124,7 +124,7 @@ class DatabaseService < PacemakerServiceObject
       cluster = database_elements[0]
       # Any change in the generation of the vhostname here must be reflected in
       # CrowbarDatabaseHelper.get_ha_vhostname
-      database_vhostname = "#{role.name.gsub("-config", "")}-#{PacemakerServiceObject.cluster_name(cluster)}.#{ChefObject.cloud_domain}".gsub("_", "-")
+      database_vhostname = "#{role.name.gsub("-config", "")}-#{PacemakerServiceObject.cluster_name(cluster)}.#{Crowbar::Settings.domain}".gsub("_", "-")
       net_svc.allocate_virtual_ip "default", "admin", "host", database_vhostname
     end
 

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -124,7 +124,7 @@ class DatabaseService < PacemakerServiceObject
       cluster = database_elements[0]
       # Any change in the generation of the vhostname here must be reflected in
       # CrowbarDatabaseHelper.get_ha_vhostname
-      database_vhostname = "#{role.name.gsub("-config", "")}-#{PacemakerServiceObject.cluster_name(cluster)}.#{Crowbar::Settings.domain}".gsub("_", "-")
+      database_vhostname = "#{role.name.gsub("-config", "")}-#{PacemakerServiceObject.cluster_name(cluster)}.#{Crowbar::Settings.domain}".tr("_", "-")
       net_svc.allocate_virtual_ip "default", "admin", "host", database_vhostname
     end
 

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -90,7 +90,7 @@ class RabbitmqService < PacemakerServiceObject
         raise "Internal error: HA enabled, but element is not a cluster"
       end
       cluster = rabbitmq_elements[0]
-      rabbitmq_vhostname = "#{role.name.gsub("-config", "")}-#{PacemakerServiceObject.cluster_name(cluster)}.#{ChefObject.cloud_domain}".gsub("_", "-")
+      rabbitmq_vhostname = "#{role.name.gsub("-config", "")}-#{PacemakerServiceObject.cluster_name(cluster)}.#{Crowbar::Settings.domain}".gsub("_", "-")
       net_svc.allocate_virtual_ip "default", "admin", "host", rabbitmq_vhostname
       if role.default_attributes["rabbitmq"]["listen_public"]
         net_svc.allocate_virtual_ip "default", "public", "host", rabbitmq_vhostname

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -90,7 +90,7 @@ class RabbitmqService < PacemakerServiceObject
         raise "Internal error: HA enabled, but element is not a cluster"
       end
       cluster = rabbitmq_elements[0]
-      rabbitmq_vhostname = "#{role.name.gsub("-config", "")}-#{PacemakerServiceObject.cluster_name(cluster)}.#{Crowbar::Settings.domain}".gsub("_", "-")
+      rabbitmq_vhostname = "#{role.name.gsub("-config", "")}-#{PacemakerServiceObject.cluster_name(cluster)}.#{Crowbar::Settings.domain}".tr("_", "-")
       net_svc.allocate_virtual_ip "default", "admin", "host", rabbitmq_vhostname
       if role.default_attributes["rabbitmq"]["listen_public"]
         net_svc.allocate_virtual_ip "default", "public", "host", rabbitmq_vhostname


### PR DESCRIPTION
ChefObject.cloud_domain got moved to Crowbar::Settings.domain.

Needed because https://github.com/crowbar/crowbar-core/pull/519 was merged.