### PR TITLE
Re-add crowbar_magnum until crowbarctl is fixed

### DIFF
--- a/bin/crowbar_magnum
+++ b/bin/crowbar_magnum
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
+@barclamp = "magnum"
+@timeout = 3600
+
+main


### PR DESCRIPTION
Adding crowbar_magnum back to avoid dirty hacking in automation script to do crowbarctl actions only for magnum. Its easier to remove a file in bin/ folder than cleaning up hacks in automation scripts. We should remove all bin/ files in one go when we update automation to completely use crowbarctl based comands for deployment. Until then IMO its better to have these redundant files even for new barclamps to ensure automation and CI can be run for the new features. 

Here is a trello card to keep track of crowbarctl changes.
https://trello.com/c/lZouEfeR/1108-use-crowbarctl-in-automation-setup-and-remove-all-obseleted-bin-crowbar-files