### PR TITLE
set retries explicitly from 0 to 5

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -1,7 +1,14 @@
 ha_enabled = node[:ceilometer][:ha][:server][:enabled]
 
 node[:aodh][:platform][:packages].each do |p|
-  package p
+  package p do
+    action :install
+    retries 5
+    retry_delay 2
+    package_name p
+    cookbook_name "aodh"
+    recipe_name "aodh"
+  end
 end
 
 # mongdb setup has been already done by server.rb recipe


### PR DESCRIPTION
there was a zypper 4 error after an upgrade from 6 to 7:
4 - ZYPPER_EXIT_ERR_ZYPP
  A problem reported by ZYPP library.  E.g.  another  instance  of
  ZYPP is running.

NOTE: I am not sure if this is the right solution, or if it is better to investigate why zypper was locking at that moment

the error happens during the upgrade job: https://ci.suse.de/job/openstack-mkcloud/26697