### PR TITLE
magnum: Use PacemakerServiceObject class

### DIFF
--- a/crowbar_framework/app/models/magnum_service.rb
+++ b/crowbar_framework/app/models/magnum_service.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-class MagnumService < ServiceObject
+class MagnumService < PacemakerServiceObject
   def initialize(thelogger)
     @bc_name = "magnum"
     @logger = thelogger


### PR DESCRIPTION
This fixes:

Failed to apply the proposal: exception before calling chef (undefined
method `role_expand_elements' for #)