### PR TITLE
tempest: Disable aodh and magnum tempest tests for now

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -267,10 +267,18 @@ raise("Cannot fetch EC2 credentials ") if ec2_access.empty? || ec2_secret.empty?
 
 `#{keystonev2} endpoint-get --service metering &> /dev/null`
 use_ceilometer = $?.success?
+# `#{keystonev2} endpoint-get --service alarming &> /dev/null`
+# use_aodh = $?.success?
+# FIXME(toabctl): enable when tempest tests pass
+use_aodh = false
 `#{keystonev2} endpoint-get --service database &> /dev/null`
 use_trove = $?.success?
 `#{keystonev2} endpoint-get --service share &> /dev/null`
 use_manila = $?.success?
+# `#{keystonev2} endpoint-get --service container &> /dev/null`
+# use_magnum = $?.success?
+# FIXME(toabctl): enable when tempest tests pass
+use_magnum = false
 
 # FIXME: should avoid search with no environment in query
 neutrons = search(:node, "roles:neutron-server") || []
@@ -456,8 +464,10 @@ template "/etc/tempest/tempest.conf" do
     use_horizon: use_horizon,
     use_heat: use_heat,
     use_ceilometer: use_ceilometer,
+    use_aodh: use_aodh,
     use_trove: use_trove,
     use_manila: use_manila,
+    use_magnum: use_magnum,
     # boto settings
     ec2_protocol: nova[:nova][:ssl][:enabled] ? "https" : "http",
     ec2_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova][:ha][:enabled]),

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -1207,6 +1207,9 @@ heat = <%= @use_heat %>
 #ceilometer = true
 ceilometer = <%= @use_ceilometer %>
 
+# Whether or not Aodh plugin is expected to be available (boolean value)
+aodh_plugin = <%= @use_aodh %>
+
 # Whether or not Horizon is expected to be available (boolean value)
 #horizon = true
 horizon = <%= @use_horizon %>
@@ -1226,6 +1229,9 @@ trove = <%= @use_trove %>
 
 # Whether or not Manila is expected to be available (boolean value)
 manila = <%= @use_manila %>
+
+# Whether or not Magnum is expected to be available (boolean value)
+magnum = <%= @use_magnum %>
 
 
 [stress]


### PR DESCRIPTION
This needs to be fixed when the tempest tests pass. But
for now we want to add the tests to the packages but don't run them.