### PR TITLE
added toggle to disable creation of non-admin user

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -47,6 +47,8 @@ module KeystoneHelper
                                                 node[:keystone][:api][:service_port],
                                                 node[:keystone][:api][:version])
 
+      has_default_user = node["keystone"]["default"]["create_user"]
+
       @keystone_settings ||= Hash.new
       @keystone_settings[cookbook_name] = {
         "api_version" => node[:keystone][:api][:version],
@@ -72,8 +74,8 @@ module KeystoneHelper
         "admin_password" => node["keystone"]["admin"]["password"],
         "default_tenant" => node["keystone"]["default"]["tenant"],
         "default_tenant_id" => node["keystone"]["default"]["tenant_id"],
-        "default_user" => node["keystone"]["default"]["username"],
-        "default_password" => node["keystone"]["default"]["password"],
+        "default_user" => has_default_user ? node["keystone"]["default"]["username"] : nil,
+        "default_password" => has_default_user ? node["keystone"]["default"]["password"] : nil,
         "service_tenant" => node["keystone"]["service"]["tenant"],
         "service_tenant_id" => node["keystone"]["service"]["tenant_id"]
       }

--- a/chef/data_bags/crowbar/migrate/keystone/100_non_admin_user_create_flag.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/100_non_admin_user_create_flag.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["default"]["create_user"] = ta["default"]["create_user"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["default"].delete("create_user")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -47,6 +47,7 @@
         "token": "999888777666"
       },
       "default": {
+        "create_user": true,
         "tenant": "openstack",
         "username": "crowbar",
         "password": "crowbar"
@@ -139,7 +140,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 35,
+      "schema-revision": 100,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -52,6 +52,7 @@
                       "token": { "type": "str", "required" : true }
                     }},
                     "default" : { "type" : "map", "required" : true, "mapping": {
+                      "create_user": { "type" : "bool", "required" : true },
                       "tenant": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required" : true },
                       "password": { "type" : "str", "required" : true }

--- a/crowbar_framework/app/models/tempest_service.rb
+++ b/crowbar_framework/app/models/tempest_service.rb
@@ -74,6 +74,13 @@ class TempestService < ServiceObject
   def validate_proposal_after_save(proposal)
     validate_one_for_role proposal, "tempest"
 
+    ks_svc = KeystoneService.new @logger
+    keystone = Proposal.find_by(barclamp: ks_svc.bc_name)
+
+    unless keystone[:attributes][:keystone][:default][:create_user]
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.no_alt_user")
+    end
+
     super
   end
 

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -16,8 +16,15 @@
       = string_field %w(default tenant)
       = string_field %w(admin username)
       = password_field %w(admin password)
-      = string_field %w(default username)
-      = password_field %w(default password)
+
+      = boolean_field %w(default create_user),
+        "data-showit" => "true",
+        "data-showit-target" => "#default_user_container",
+        "data-showit-direct" => "true"
+
+      #default_user_container
+        = string_field %w(default username)
+        = password_field %w(default password)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -27,6 +27,7 @@ en:
         default_credentials: 'Default Credentials'
         default:
           tenant: 'Default Tenant'
+          create_user: 'Create Regular User'
           username: 'Regular User Username'
           password: 'Regular User Password'
         admin:

--- a/crowbar_framework/config/locales/tempest/en.yml
+++ b/crowbar_framework/config/locales/tempest/en.yml
@@ -70,3 +70,6 @@ en:
         tempest_adm_password: 'Choose Tempest admin password'
         tempest_user_tenant: 'Choose tenant'
         nova_instance: 'Nova'
+
+      validation:
+        no_alt_user: 'Creation of the regular user is required in the Keystone proposal.'


### PR DESCRIPTION
This adds the option "Create Regular User" to the barclamp UI and respective handling in the keystone cookbook. See: https://trello.com/c/lF2pdHYl/21-3-make-creation-of-non-admin-user-in-keystone-barclamp-optional