### PR TITLE
tempest: Configure and enable magnum tests

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -38,6 +38,9 @@ tempest_adm_pass = node[:tempest][:tempest_adm_password]
 # manila (share)
 tempest_manila_settings = node[:tempest][:manila]
 
+# magnum (container)
+tempest_magnum_settings = node[:tempest][:magnum]
+
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
                        tenant: keystone_settings["admin_tenant"] }
@@ -273,10 +276,8 @@ use_aodh = $?.success?
 use_trove = $?.success?
 `#{keystonev2} endpoint-get --service share &> /dev/null`
 use_manila = $?.success?
-# `#{keystonev2} endpoint-get --service container &> /dev/null`
-# use_magnum = $?.success?
-# FIXME(toabctl): enable when tempest tests pass
-use_magnum = false
+`#{keystonev2} endpoint-get --service container &> /dev/null`
+use_magnum = $?.success?
 
 # FIXME: should avoid search with no environment in query
 neutrons = search(:node, "roles:neutron-server") || []
@@ -531,7 +532,9 @@ template "/etc/tempest/tempest.conf" do
     vendor_name: vendor_name,
     use_docker: use_docker,
     # manila (share) settings
-    manila_settings: tempest_manila_settings
+    manila_settings: tempest_manila_settings,
+    # magnum (container) settings
+    magnum_settings: tempest_magnum_settings
   )
 end
 

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -869,6 +869,41 @@ ssh_user_regex = [["^.*[Cc]irros.*$", "cirros"]]
 #max_claim_grace = 43200
 
 
+[magnum]
+
+#
+# From tempest.config
+#
+
+# Image id to be used for baymodel. (string value)
+#image_id = fedora-21-atomic-5
+image_id = <%= @magnum_settings['image_id'] %>
+
+# NIC id. (string value)
+#nic_id = public
+nic_id = floating
+
+# Keypair id to use to log into nova instances. (string value)
+#keypair_id = default
+
+# Flavor id to use for baymodels. (string value)
+#flavor_id = s1.magnum
+flavor_id = <%= @magnum_settings['flavor_id'] %>
+
+# Bypass URL for Magnum to skip service catalog lookup (string value)
+#magnum_url = <None>
+
+# Master flavor id to use for baymodels. (string value)
+#master_flavor_id = m1.magnum
+master_flavor_id = <%= @magnum_settings['master_flavor_id'] %>
+
+# CSR location for certificates. (string value)
+#csr_location = /opt/stack/new/magnum/default.csr
+
+# Specify whether to copy nova server logs on failure. (string value)
+#copy_logs = True
+
+
 [negative]
 
 #

--- a/chef/data_bags/crowbar/migrate/tempest/100_add_magnum_options.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/100_add_magnum_options.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["magnum"] = ta["magnum"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("magnum")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -17,6 +17,11 @@
         "image_username": "root",
         "image_password": "",
         "default_share_type_name": "default"
+      },
+      "magnum": {
+        "image_id": "magnum-service-image",
+        "flavor_id": "m1.small",
+        "master_flavor_id": "m1.medium"
       }
     }
   },
@@ -24,7 +29,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 12,
+      "schema-revision": 100,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -29,6 +29,14 @@
                 "image_password": { "type": "str", "required": true },
                 "default_share_type_name": { "type": "str", "required": true }
               }
+            },
+            "magnum": {
+              "type": "map",
+              "mapping": {
+                "image_id": { "type": "str", "required": true },
+                "flavor_id": { "type": "str", "required": true },
+                "master_flavor_id": { "type": "str", "required": true }
+              }
             }
           }
         }


### PR DESCRIPTION
The tempest tests for magnum need a couple of configuration options.
Add theses options and use sane defaults.