### PR TITLE
Add tunnel_csum attribute to neutron barclamp

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -215,6 +215,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
         use_l2pop: (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")) && neutron[:neutron][:use_dvr],
         dvr_enabled: neutron[:neutron][:use_dvr],
+        tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
         bridge_mappings: bridge_mappings
       )
     end

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -186,6 +186,9 @@ enable_distributed_routing = True
 # carrying GRE/VXLAN tunnel. The default value is False.
 #
 # tunnel_csum = False
+<% if @tunnel_csum -%>
+tunnel_csum = True
+<% end -%>
 
 # (StrOpt) agent_type to report.
 # This config entry allows configuration of the neutron agent type reported

--- a/chef/data_bags/crowbar/migrate/neutron/100_add_tunnel_csum.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/100_add_tunnel_csum.rb
@@ -1,0 +1,14 @@
+def upgrade(ta, td, a, d)
+  a["ovs"] ||= {}
+  a["ovs"]["tunnel_csum"] = ta["ovs"]["tunnel_csum"]
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if a.key?("ovs")
+    a["ovs"].delete("tunnel_csum")
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -29,6 +29,9 @@
         "vni_end": 99999,
         "multicast_group": "239.1.1.1"
       },
+      "ovs": {
+        "tunnel_csum": false
+      },
       "allow_overlapping_ips": true,
       "use_syslog": false,
       "database_instance": "none",
@@ -117,7 +120,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 48,
+      "schema-revision": 100,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -34,6 +34,9 @@
                       "vni_end": { "type" : "int", "required" : true },
                       "multicast_group": { "type" : "str", "required": true }
                     }},
+                    "ovs": { "type": "map", "required": true, "mapping": {
+                      "tunnel_csum": { "type": "bool", "required": true }
+                    }},
                     "allow_overlapping_ips": { "type": "bool", "required": true },
                     "cisco_switches": {
                       "type" : "map",


### PR DESCRIPTION
As per http://openvswitch.org/pipermail/dev/2015-August/059335.html enabling tunnel_csum on the openvswitch agents may boost the network performance by a huge margin.