### PR TITLE
bsc# 984128: Match MTU values of VLAN and Neutron ml2

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -126,6 +126,9 @@ if neutron[:neutron][:elements_expanded]
   network_nodes_count = neutron[:neutron][:elements_expanded]["neutron-network"].count
 end
 
+os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
+mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
+
 template "/etc/neutron/neutron.conf" do
     cookbook "neutron"
     source "neutron.conf.erb"
@@ -157,7 +160,8 @@ template "/etc/neutron/neutron.conf" do
       allow_overlapping_ips: neutron[:neutron][:allow_overlapping_ips],
       dvr_enabled: neutron[:neutron][:use_dvr],
       network_nodes_count: network_nodes_count,
-      dns_domain: neutron[:neutron][:dhcp_domain]
+      dns_domain: neutron[:neutron][:dhcp_domain],
+      mtu_value: mtu_value
     }.merge(nova_notify))
 end
 

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -133,6 +133,9 @@ when "ml2"
     physnets.push(node[:neutron][:zvm][:zvm_xcat_mgt_vswitch])
   end
 
+  os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
+  mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
+
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv
@@ -167,6 +170,7 @@ when "ml2"
       vxlan_end: vni_end,
       vxlan_mcast_group: node[:neutron][:vxlan][:multicast_group],
       external_networks: physnets,
+      mtu_value: mtu_value
     )
   end
 when "vmware"

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -37,12 +37,13 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # path_mtu - max encap header size).  If <=0, the path MTU is
 # indeterminate and no calculation takes place.
 # path_mtu = 0
-path_mtu = 1500
+path_mtu = <%= @mtu_value %>
 
 # (IntOpt) Segment MTU.  The maximum permissible size of an
 # unfragmented packet travelling a L2 network segment.  If <=0,
 # the segment MTU is indeterminate and no calculation takes place.
 # segment_mtu = 0
+segment_mtu = <%= @mtu_value %>
 
 # (ListOpt) Physical network MTUs.  List of mappings of physical
 # network to MTU value.  The format of the mapping is

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -197,7 +197,17 @@ allow_overlapping_ips = False
 # when the network's preferred MTU is known.
 # advertise_mtu = False
 advertise_mtu = True
+
+# MTU of the underlying physical network. Neutron uses this value to calculate
+# MTU for all virtual network components. For flat and VLAN networks, neutron
+# uses this value without modification. For overlay networks such as VXLAN,
+# neutron automatically subtracts the overlay protocol overhead from this value.
+# Defaults to 1500, the standard value for Ethernet. If using the ML2 plug-in
+# with overlay/tunnel networks, also configure the ml2 path_mtu option with the
+# same value as the global_physnet_mtu option.
+global_physnet_mtu = <%= @mtu_value %>
 # ======== end of items for MTU selection and advertisement =========
+
 
 # =========== items for agent management extension =============
 # Seconds to regard the agent as down; should be at least twice


### PR DESCRIPTION
Neutron correctly subtracts the GRE or VXLAN overheads and the MTU for Neutron
routers can be set to the MTU of the underlying NIC.

Forward port of https://github.com/crowbar/crowbar-openstack/pull/411.