### PR TITLE
Check carefully if the role we are renaming is actually present

### DIFF
--- a/chef/data_bags/crowbar/migrate/ceilometer/023_rename_ceilometer_cagent_role.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/023_rename_ceilometer_cagent_role.rb
@@ -3,6 +3,9 @@ def upgrade(ta, td, a, d)
   d["element_order"] = td["element_order"]
   d["element_run_list_order"] = td["element_run_list_order"]
 
+  # the role might have been already removed from package, see next migration
+  return a, d unless File.exist? "/opt/dell/chef/roles/ceilometer-polling.rb"
+
   # Change the elements to ceilometer-polling
   d["elements"]["ceilometer-polling"] = d["elements"]["ceilometer-cagent"]
   d["elements"].delete("ceilometer-cagent")
@@ -24,6 +27,8 @@ def downgrade(ta, td, a, d)
   d["element_states"] = td["element_states"]
   d["element_order"] = td["element_order"]
   d["element_run_list_order"] = td["element_run_list_order"]
+
+  return a, d unless File.exist? "/opt/dell/chef/roles/ceilometer-polling.rb"
 
   # Change the elements to ceilometer-polling
   d["elements"]["ceilometer-cagent"] = d["elements"]["ceilometer-polling"]

--- a/chef/data_bags/crowbar/migrate/ceilometer/024_bring-central-role-back.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/024_bring-central-role-back.rb
@@ -3,16 +3,20 @@ def upgrade(ta, td, a, d)
   d["element_order"] = td["element_order"]
   d["element_run_list_order"] = td["element_run_list_order"]
 
-  d["elements"]["ceilometer-central"] = d["elements"]["ceilometer-polling"]
-  d["elements"].delete("ceilometer-polling")
+  # check if previous role is still installed (thus previous migration would run)
+  original_role = "ceilometer-cagent"
+  original_role = "ceilometer-polling" if File.exist? "/opt/dell/chef/roles/ceilometer-polling.rb"
+
+  d["elements"]["ceilometer-central"] = d["elements"][original_role]
+  d["elements"].delete(original_role)
 
   # Update the run_list for controller node
-  nodes = NodeObject.find("run_list_map:ceilometer-polling")
+  nodes = NodeObject.find("run_list_map:#{original_role}")
   nodes.each do |node|
     node.add_to_run_list("ceilometer-central",
                          td["element_run_list_order"]["ceilometer-central"],
                          td["element_states"]["ceilometer-central"])
-    node.delete_from_run_list("ceilometer-polling")
+    node.delete_from_run_list(original_role)
     node.save
   end
 
@@ -27,12 +31,15 @@ def downgrade(ta, td, a, d)
   d["elements"]["ceilometer-polling"] = d["elements"]["ceilometer-central"]
   d["elements"].delete("ceilometer-central")
 
+  original_role = "ceilometer-cagent"
+  original_role = "ceilometer-polling" if File.exist? "/opt/dell/chef/roles/ceilometer-polling.rb"
+
   # Update the run_list for controller node
   nodes = NodeObject.find("run_list_map:ceilometer-central")
   nodes.each do |node|
-    node.add_to_run_list("ceilometer-polling",
-                         td["element_run_list_order"]["ceilometer-polling"],
-                         td["element_states"]["ceilometer-polling"])
+    node.add_to_run_list(original_role,
+                         td["element_run_list_order"][original_role],
+                         td["element_states"][original_role])
     node.delete_from_run_list("ceilometer-central")
     node.save
   end


### PR DESCRIPTION
When we are reinstalling packages from cloud5 to cloud6, ceilometer-polling role is not even installed, thus the migration fails.


I did not test it, and it might be completely wrong...