### PR TITLE
cinder: Allow to use a HA cluster for cinder-volume in active/passive

### DIFF
--- a/chef/cookbooks/cinder/attributes/default.rb
+++ b/chef/cookbooks/cinder/attributes/default.rb
@@ -49,9 +49,11 @@ default[:cinder][:ha][:enabled] = false
 if %w(rhel suse).include? node[:platform_family]
   default[:cinder][:ha][:api_ra] = "lsb:openstack-cinder-api"
   default[:cinder][:ha][:scheduler_ra] = "lsb:openstack-cinder-scheduler"
+  default[:cinder][:ha][:volume_ra] = "lsb:openstack-cinder-volume"
 else
   default[:cinder][:ha][:api_ra] = "lsb:cinder-api"
   default[:cinder][:ha][:scheduler_ra] = "lsb:cinder-scheduler"
+  default[:cinder][:ha][:volume_ra] = "lsb:cinder-volume"
 end
 default[:cinder][:ha][:op][:monitor][:interval] = "10s"
 # Ports to bind to when haproxy is used for the real ports

--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -286,4 +286,37 @@ service "tgt" do
   end
 end
 
-cinder_service("volume")
+volume_elements = node[:cinder][:elements]["cinder-volume"]
+ha_enabled = CrowbarPacemakerHelper.cluster_enabled?(node) &&
+  volume_elements.include?("cluster:#{CrowbarPacemakerHelper.cluster_name(node)}")
+
+cinder_service "volume" do
+  use_pacemaker_provider ha_enabled
+end
+
+if ha_enabled
+  log "HA support for cinder volume is enabled"
+
+  # Create cinder-volume HA specific config file
+  service_host = CrowbarPacemakerHelper.cluster_vhostname(node)
+
+  template "/etc/cinder/cinder-volume.conf" do
+    source "cinder-volume.conf.erb"
+    owner "root"
+    group node[:cinder][:group]
+    mode 0640
+    variables(
+      host: service_host
+    )
+    notifies :restart, "service[cinder-volume]"
+  end
+
+  include_recipe "cinder::volume_ha"
+else
+  log "HA support for cinder volume is disabled"
+
+  file "/etc/cinder/cinder-volume.conf" do
+    action :delete
+    notifies :restart, "service[cinder-volume]"
+  end
+end

--- a/chef/cookbooks/cinder/recipes/volume_ha.rb
+++ b/chef/cookbooks/cinder/recipes/volume_ha.rb
@@ -1,0 +1,45 @@
+# Copyright 2016 SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Wait for all nodes to reach this point so we know that they will have
+# all the required packages installed and configuration files updated
+# before we create the pacemaker resources.
+crowbar_pacemaker_sync_mark "sync-cinder_volume_before_ha"
+
+# Avoid races when creating pacemaker resources
+crowbar_pacemaker_sync_mark "wait-cinder_volume_ha_resources"
+
+transaction_objects = []
+
+service_name = "cinder-volume"
+pacemaker_primitive service_name do
+  agent node[:cinder][:ha][:volume_ra]
+  op node[:cinder][:ha][:op]
+  action :update
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+transaction_objects << "pacemaker_primitive[#{service_name}]"
+
+location_name = openstack_pacemaker_controller_only_location_for service_name
+transaction_objects << "pacemaker_location[#{location_name}]"
+
+pacemaker_transaction "cinder volume" do
+  cib_objects transaction_objects
+  # note that this will also automatically start the resources
+  action :commit_new
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+crowbar_pacemaker_sync_mark "create-cinder_volume_ha_resources"

--- a/chef/cookbooks/cinder/templates/default/cinder-volume.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder-volume.conf.erb
@@ -1,0 +1,6 @@
+# Override some settings for cinder-volume
+
+[DEFAULT]
+# Name of this node.  This can be an opaque identifier. It is not necessarily a
+# host name, FQDN, or IP address. (string value)
+host = <%= @host %>

--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -42,6 +42,7 @@ class CinderService < PacemakerServiceObject
         "cinder-volume" => {
           "unique" => false,
           "count" => -1,
+          "cluster" => true,
           "admin" => false,
           "exclude_platform" => {
             "suse" => "< 12.2",
@@ -91,6 +92,7 @@ class CinderService < PacemakerServiceObject
 
     volume_names = {}
     local_file_names = {}
+    local_count = 0
     raw_count = 0
     raw_want_all = false
     rbd_crowbar = false
@@ -113,6 +115,8 @@ class CinderService < PacemakerServiceObject
 
         file_name = volume["local"]["file_name"]
         local_file_names[file_name] = (local_file_names[file_name] || 0) + 1
+
+        local_count += 1
       end
 
       if backend_driver == "raw"
@@ -166,11 +170,16 @@ class CinderService < PacemakerServiceObject
       end
     end
 
-    if raw_count > 0
+    volume_elements = proposal["deployment"][@bc_name]["elements"]["cinder-volume"]
+    volume_clusters = volume_elements.select { |n| is_cluster? n }
+
+    if (local_count > 0 || raw_count > 0) && volume_clusters.any?
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.lvm_ha")
+    elsif raw_count > 0
         if raw_count > 1 && raw_want_all
           validation_error I18n.t("barclamp.#{@bc_name}.validation.raw_device_backend")
         else
-          nodes_without_suitable_drives = proposal["deployment"][@bc_name]["elements"]["cinder-volume"].select do |node_name|
+          nodes_without_suitable_drives = volume_elements.select do |node_name|
             node = NodeObject.find_node_by_name(node_name)
             if node.nil?
               false
@@ -202,6 +211,15 @@ class CinderService < PacemakerServiceObject
     controller_elements, controller_nodes, ha_enabled = role_expand_elements(role, "cinder-controller")
     reset_sync_marks_on_clusters_founders(controller_elements)
     Openstack::HA.set_controller_role(controller_nodes) if ha_enabled
+
+    volume_elements = role.override_attributes[@bc_name]["elements"]["cinder-volume"] || []
+    volume_ha_elements = volume_elements.select { |e| PacemakerServiceObject.is_cluster? e }
+    unless volume_ha_elements.empty?
+      reset_sync_marks_on_clusters_founders(volume_ha_elements)
+      volume_ha_nodes = volume_ha_elements.map { |e| PacemakerServiceObject.expand_nodes(e) }
+      volume_ha_nodes.flatten!
+      Openstack::HA.set_controller_role(volume_ha_nodes)
+    end
 
     vip_networks = ["admin", "public"]
 

--- a/crowbar_framework/config/locales/cinder/en.yml
+++ b/crowbar_framework/config/locales/cinder/en.yml
@@ -177,6 +177,7 @@ en:
         invalid_filename: 'Invalid file name \"%{file_name}\" for local file-based LVM: file name must be an absolute path.'
         invalid_whitespaces_in_filename: 'Invalid file name \"%{file_name}\" for local file-based LVM: file name cannot contain whitespaces.'
         invalid_backend_filename: '%{count} backends are using \"%{file_name}\" for local file-based LVM.'
+        lvm_ha: 'The Raw Devices and Local File backends cannot be used with High Availability clusters.'
         raw_device_backend: 'There cannot be multiple raw devices backends when one raw device backend is configured to use all disks.'
         missing_unclaimed_disk: 'Nodes %{nodes_without_suitable_drives} for cinder volume role are missing at least one unclaimed disk, required when using raw devices.'
         rados_backends: 'RADOS backends not deployed with Crowbar cannot use /etc/ceph/ceph.conf as configuration files when also using the RADOS backend deployed with Crowbar.'


### PR DESCRIPTION
We cannot do active/active at the moment because there needs to be some
synchonization between the various volume services in that case.

But it turns out that active/passive is relatively easy to achieve: it's
only a matter of making sure that the cinder-volume service on the
various cluster members register with the same host. We use the
vhostname of the cluster for this.

Of course, it doesn't work with the LVM backend, so we have validation
checks for this in Crowbar.

Another restriction is that we cannot use the same cluster for
cinder-controller and cinder-volume: due to the use of the same host in
the config, if we were to allow cinder-controller there too, only one
cinder-scheduler service would be register (with the vhostname of the
cluster), which is wrong in this case.