### PR TITLE
manila: Disable tempest tests for now

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -274,8 +274,10 @@ use_ceilometer = $?.success?
 use_aodh = $?.success?
 `#{keystonev2} endpoint-get --service database &> /dev/null`
 use_trove = $?.success?
-`#{keystonev2} endpoint-get --service share &> /dev/null`
-use_manila = $?.success?
+# FIXME(toabctl): disable tests for now
+# `#{keystonev2} endpoint-get --service share &> /dev/null`
+# use_manila = $?.success?
+use_manila = false
 `#{keystonev2} endpoint-get --service container &> /dev/null`
 use_magnum = $?.success?
 


### PR DESCRIPTION
Currently the tests are disabled in the package but we want to enable
the tests in the package and disable them there to have gating when we
reenable the tests (with a revert PR for this PR).