### PR TITLE
nova: Allow defining on which network live migration happens

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -65,6 +65,14 @@ case node[:nova][:libvirt_type]
         node.save
       end
 
+      if node[:nova]["use_migration"]
+        migration_network = node[:nova][:migration][:network]
+        listen_addr = Barclamp::Inventory.get_network_by_type(node, migration_network).address
+      else
+        # still put a valid address
+        listen_addr = Barclamp::Inventory.get_network_by_type(node, "admin").address
+      end
+
       template "/etc/libvirt/libvirtd.conf" do
         source "libvirtd.conf.erb"
         group "root"
@@ -73,7 +81,7 @@ case node[:nova][:libvirt_type]
         variables(
           libvirtd_host_uuid: node[:nova][:host_uuid],
           libvirtd_listen_tcp: node[:nova]["use_migration"] ? 1 : 0,
-          libvirtd_listen_addr: Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address,
+          libvirtd_listen_addr: listen_addr,
           libvirtd_auth_tcp: node[:nova]["use_migration"] ? "none" : "sasl"
         )
         notifies :restart, "service[libvirtd]", :delayed

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -272,6 +272,13 @@ template vendordata_jsonfile do
   )
 end
 
+# Allow to use some specific NICs for live migration
+migration_host = if node[:nova][:migration][:network] == "admin"
+  "%s"
+else
+  "#{node[:nova][:migration][:network]}.%s"
+end
+
 template "/etc/nova/nova.conf" do
   source "nova.conf.erb"
   user "root"
@@ -293,6 +300,7 @@ template "/etc/nova/nova.conf" do
             ec2_host: admin_api_host,
             ec2_dmz_host: public_api_host,
             libvirt_migration: node[:nova]["use_migration"],
+            migration_host: migration_host,
             libvirt_enable_multipath: node[:nova][:libvirt_use_multipath],
             shared_instances: node[:nova]["use_shared_instance_storage"],
             force_config_drive: node[:nova]["force_config_drive"],

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2590,7 +2590,7 @@ virt_type = <%= @libvirt_type %>
 # Migration target URI (any included "%s" is replaced with the migration target
 # hostname) (string value)
 #live_migration_uri = qemu+tcp://%s/system
-live_migration_uri = xenmigr://%s/system
+live_migration_uri = xenmigr://<%= @migration_host %>/system
 
 # Migration flags to be set for live migration (string value)
 #live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_LIVE, VIR_MIGRATE_TUNNELLED
@@ -2603,6 +2603,7 @@ live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_LIVE
 # Migration target URI (any included "%s" is replaced with the migration target
 # hostname) (string value)
 #live_migration_uri = qemu+tcp://%s/system
+live_migration_uri = qemu+tcp://<%= @migration_host %>/system
 
   <% if @libvirt_migration -%>
     <% if @shared_instances -%>

--- a/chef/data_bags/crowbar/migrate/nova/103_add_migration_network.rb
+++ b/chef/data_bags/crowbar/migrate/nova/103_add_migration_network.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "migration"
+    a["migration"] = ta["migration"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "migration"
+    a.delete("migration")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -20,6 +20,9 @@
       "setup_shared_instance_storage": false,
       "use_shared_instance_storage": false,
       "use_migration": false,
+      "migration": {
+        "network": "admin"
+      },
       "use_syslog": false,
       "neutron_url_timeout": 30,
       "force_config_drive": false,
@@ -103,7 +106,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 103,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -27,6 +27,13 @@
             "max_header_line": { "type": "int", "required": true },
             "trusted_flavors": { "type": "bool", "required": true },
             "use_migration": { "type": "bool", "required": true },
+            "migration": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "network": { "type": "str", "required": true }
+              }
+            },
             "setup_shared_instance_storage": { "type": "bool", "required": true },
             "use_shared_instance_storage": { "type": "bool", "required": true },
             "use_syslog": { "type": "bool", "required": true },

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -305,6 +305,10 @@ class NovaService < PacemakerServiceObject
       neutron_service.enable_neutron_networks(neutron["attributes"]["neutron"],
                                               n, net_svc,
                                               neutron["attributes"]["neutron"]["use_dvr"])
+      if role.default_attributes["nova"]["use_migration"]
+        net_svc.allocate_ip("default", role.default_attributes["nova"]["migration"]["network"],
+                            "host", n)
+      end
     end unless all_nodes.nil?
 
     @logger.debug("Nova apply_role_pre_chef_call: leaving")
@@ -392,6 +396,16 @@ class NovaService < PacemakerServiceObject
           node: remote_node,
           cluster: cluster_name(remote_cluster)
         )
+      end
+    end
+
+    if proposal["attributes"][@bc_name]["use_migration"]
+      migration_net = proposal["attributes"][@bc_name]["migration"]["network"]
+
+      net_svc = NetworkService.new @logger
+      network_proposal = Proposal.find_by(barclamp: net_svc.bc_name, name: "default")
+      if network_proposal["attributes"]["network"]["networks"][migration_net].nil?
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.invalid_migration_network", network: migration_net)
       end
     end
 

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -90,4 +90,5 @@ en:
         assigned_node: 'Node %{key} has been assigned to a nova-compute role more than once.'
         assigned_remotes: 'Remotes %{key} has been assigned to a nova-compute role more than once.'
         assigned_node_and_remote: 'Node %{node} has been assigned to a nova-compute role as individual node and as remote node of cluster %{cluster}.'
+        invalid_migration_network: 'Network "%{network}" configured for live migration is not defined in the configuration of the network barclamp.'
         vendor_data_invalid_json: "The provided vendordata for the metadata server is invalid JSON."


### PR DESCRIPTION
Right now, live migration is being done only on the admin network.
However, the admin network might be on a 1G interface, while some other
network might be defined with 10G interface. It'd be better to use such
a network for live migration, to speed up things.

We add a new attribute to specify which network to use.

It's important to keep in mind that the public network is not
appropriate here, as it would make the compute nodes publicly reachable,
and libvirt listen on the public IP. So it's better to define a new
private network, or use an existing one like the storage network.