### PR TITLE
Adds cert_manager option to magnum

### DIFF
--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -76,7 +76,7 @@ verbose=<%= node[:magnum][:verbose] %>
 # is ignored if log_config_append is set. (string value)
 # Deprecated group/name - [DEFAULT]/logdir
 #log_dir = <None>
-log_dir=/var/log/magnum 
+log_dir=/var/log/magnum
 
 # Uses logging handler designed to watch file system. When log file is moved or
 # removed this handler will open a new log file with specified path
@@ -386,7 +386,7 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
 
 # Certificate Manager plugin. Defaults to barbican. (string value)
 #cert_manager_type = barbican
-cert_manager_type = local
+cert_manager_type = <%= "#{node[:magnum][:cert][:cert_manager_type]}" %>
 
 # Absolute path of the certificate storage directory. Defaults to
 # /var/lib/magnum/certificates/. (string value)

--- a/chef/data_bags/crowbar/migrate/magnum/100_add_cert_manager_attribute.rb
+++ b/chef/data_bags/crowbar/migrate/magnum/100_add_cert_manager_attribute.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["cert"]["cert_manager_type"] = "local"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["cert"]["cert_manager_type"].delete("local")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-magnum.json
+++ b/chef/data_bags/crowbar/template-magnum.json
@@ -28,6 +28,9 @@
         "password": "",
         "user": "magnum",
         "database": "magnum"
+      },
+      "cert": {
+        "cert_manager_type": "local"
       }
     }
   },
@@ -35,6 +38,7 @@
     "magnum": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
+      "schema-revision": 100,
       "element_states": {
         "magnum-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-magnum.schema
+++ b/chef/data_bags/crowbar/template-magnum.schema
@@ -45,6 +45,13 @@
                 "user": { "type": "str", "required": true },
                 "database": { "type": "str", "required": true }
               }
+            },
+            "cert": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "cert_manager_type": { "type": "str", "required": true }
+              }
             }
           }
         }
@@ -60,6 +67,7 @@
           "mapping": {
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
+            "schema-revision": { "type": "int" },
             "crowbar-applied": { "type": "bool" },
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },

--- a/crowbar_framework/app/helpers/barclamp/magnum_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/magnum_helper.rb
@@ -1,10 +1,12 @@
-# Copyright 2015, SUSE, Inc.
+#
+# Copyright 2011-2013, Dell
+# Copyright 2013-2014, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,15 +15,16 @@
 # limitations under the License.
 #
 
-default[:magnum][:debug] = false
-
-override[:magnum][:user] = "magnum"
-override[:magnum][:group] = "magnum"
-
-default[:magnum][:max_header_line] = 16_384
-
-default[:magnum][:api][:protocol] = "http"
-
-default[:magnum][:ha][:enabled] = false
-
-default[:magnum][:cert][:cert_manager_type] = "local"
+module Barclamp
+  module MagnumHelper
+    def cert_manager_types(selected)
+      options_for_select(
+        [
+          ["Local", "local"],
+          ["Barbican", "barbican"]
+        ],
+        selected.to_s
+      )
+    end
+  end
+end

--- a/crowbar_framework/app/models/magnum_service.rb
+++ b/crowbar_framework/app/models/magnum_service.rb
@@ -87,6 +87,12 @@ class MagnumService < PacemakerServiceObject
     base["attributes"][@bc_name][:db][:password] = random_password
     base["attributes"][@bc_name][:trustee][:domain_admin_password] = random_password
 
+    if select_nodes_for_role(nodes, "barbican-server", "controller").empty?
+      base["attributes"][@bc_name][:cert][:cert_manager_type] = "local"
+    else
+      base["attributes"][@bc_name][:cert][:cert_manager_type] = "barbican"
+    end
+
     @logger.debug("Magnum create_proposal: exiting")
     base
   end

--- a/crowbar_framework/app/views/barclamp/magnum/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/magnum/_edit_attributes.html.haml
@@ -17,3 +17,7 @@
       %legend
         = t('.trustee_header')
       = string_field %w(trustee domain_name)
+    %fieldset
+      %legend
+        = t('.cert_header')
+      = select_field %w(cert cert_manager_type), collection: :cert_manager_types

--- a/crowbar_framework/config/locales/magnum/en.yml
+++ b/crowbar_framework/config/locales/magnum/en.yml
@@ -29,5 +29,7 @@ en:
         trustee_header: 'Trustee Domain'
         trustee:
           domain_name: 'Domain Name'
-          
+        cert_header: 'Certificate Manager'
+        cert:
+          cert_manager_type: 'Plugin'
 


### PR DESCRIPTION
* Adds dropdown to select cert_manager_type in magnum.
* Makes barbican the default cert_manager_type if barbican
  is present else defaults to local.