### PR TITLE
Fixes barbican barclamp description

### DIFF
--- a/barbican.yml
+++ b/barbican.yml
@@ -27,7 +27,7 @@
 barclamp:
   name: 'barbican'
   display: 'Barbican'
-  description: 'OpenStack Key Manager: Secure storage, provisioning and management of secret data'
+  description: 'Key Manager Service: Secure storage, provisioning and management of secret data'
   version: 0
   requires:
     - '@crowbar'


### PR DESCRIPTION
As pointed out by Andreas Jaeger after todays review
meeting that the description for barbican should not be
prefixed with OpenStack as the offical way is Key Manager Service.