### PR TITLE
Stop overwriting auth_url with v2 endpoint

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
@@ -166,10 +166,6 @@ admin_tenant_name =  <%= @keystone_settings['service_tenant'] %>
 # effect and using keystone auth, then URL of keystone can be
 # specified. (string value)
 #auth_url = <None>
-auth_url = <%= KeystoneHelper.versioned_service_URL(@keystone_settings["protocol"],
-                                                    @keystone_settings["internal_url_host"],
-                                                    @keystone_settings["service_port"],
-                                                    "2.0") %>
 
 # The strategy to use for authentication. If "use_user_token" is not
 # in effect, then auth strategy can be specified. (string value)


### PR DESCRIPTION
glance-scrubber can just use normal keystone client methods for
determining access, it doesn't have to fall back to a specific /v2.0
endpoint. this avoids a lot of pointless queries on the /v2.0 endpoint
(which is in my deployment the most often triggered keystone query)