### PR TITLE
Revert "manila: Disable tempest tests for now"

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -274,10 +274,8 @@ use_ceilometer = $?.success?
 use_aodh = $?.success?
 `#{keystonev2} endpoint-get --service database &> /dev/null`
 use_trove = $?.success?
-# FIXME(toabctl): disable tests for now
-# `#{keystonev2} endpoint-get --service share &> /dev/null`
-# use_manila = $?.success?
-use_manila = false
+`#{keystonev2} endpoint-get --service share &> /dev/null`
+use_manila = $?.success?
 `#{keystonev2} endpoint-get --service container &> /dev/null`
 use_magnum = $?.success?
 


### PR DESCRIPTION
Tests are now enabled in the package so let's enable the tests here, too.

This reverts commit 0ceb7e2e4ce0a0207608e737516d707884471517.