### PR TITLE
ActiveRecord::Base.save doesn't take any arguments

### DIFF
--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -233,12 +233,10 @@ class CinderService < PacemakerServiceObject
       end
     end
     if dirty
-      # This makes the proposal in the UI looked as 'applied', even if you make changes to it
-      proposal.save(applied: true)
+      proposal.save
       role.save
     end
 
     @logger.debug("Cinder apply_role_pre_chef_call: leaving")
   end
 end
-


### PR DESCRIPTION
this failed in one of the CI jobs with:
(wrong number of arguments (1 for 0)

this came to light after introducing:
  https://github.com/crowbar/crowbar-core/pull/582
which is not yet merged but present as a patch in the package