### PR TITLE
horizon: Enable password retrieve option

### DIFF
--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -210,6 +210,7 @@ OPENSTACK_KEYSTONE_BACKEND = {
 # Setting this to True, will add a new "Retrieve Password" action on instance,
 # allowing Admin session password retrieval/decryption.
 #OPENSTACK_ENABLE_PASSWORD_RETRIEVE = False
+OPENSTACK_ENABLE_PASSWORD_RETRIEVE = True
 
 # The Launch Instance user experience has been significantly enhanced.
 # You can choose whether to enable the new launch instance experience,


### PR DESCRIPTION
When launching windows instances, there is no ssh and no public key can be
injected via cloud-init. But cloud-init for windows can generate a password
and expose that. The nova CLI already can get the password via
"nova get-password" and the same option is now enabled via the web UI.
Note: The password is still encrypted with the public ssh key so when getting the
password you need to provide the private ssh key to decrypt the password.

(cherry picked from commit f1d0687aaa49ee484bc2a9ac3aba40be404d7c32)