### PR TITLE
nova: Start virtlogd also for SLES 12.1 platform

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -192,7 +192,7 @@ case node[:nova][:libvirt_type]
           provider Chef::Provider::CrowbarPacemakerService
           supports no_crm_maintenance_mode: true
         end
-        only_if { node[:platform_family] == "suse" && node[:platform_version].to_f > 12.1 }
+        only_if { node[:platform_family] == "suse" && node[:platform_version].to_f > 12.0 }
       end
 
       service "libvirtd" do


### PR DESCRIPTION
We recently added newer libvirt packages to our CI and we still use
SLES12SP1 so we need to start virtlogd now also for suse-12.1.

This commit should be reverted once we did the switch to SLE12SP2.