### PR TITLE
magnum: Remove trailing slashes from endpoints

### DIFF
--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -88,11 +88,11 @@ keystone_register "register magnum endpoint" do
   endpoint_service "magnum"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{magnum_protocol}://"\
-                     "#{my_public_host}:#{magnum_port}/v1/"
+                     "#{my_public_host}:#{magnum_port}/v1"
   endpoint_adminURL "#{magnum_protocol}://"\
-                    "#{my_admin_host}:#{magnum_port}/v1/"
+                    "#{my_admin_host}:#{magnum_port}/v1"
   endpoint_internalURL "#{magnum_protocol}://"\
-                       "#{my_admin_host}:#{magnum_port}/v1/"
+                       "#{my_admin_host}:#{magnum_port}/v1"
   action :add_endpoint_template
 end
 


### PR DESCRIPTION
When creating a bay, magnum expects a endpoint without a trailing
slash. Otherwise you get a 404 response when trying to get a
certificate and the error in the instance is:

File "/var/lib/cloud/instance/scripts/part-004", line 138, in
write_server_cert
fp.write(csr_resp.json()['pem'])
KeyError: 'pem'