### PR TITLE
Add public IP allocation

### DIFF
--- a/crowbar_framework/app/models/trove_service.rb
+++ b/crowbar_framework/app/models/trove_service.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-class TroveService < ServiceObject
+class TroveService < PacemakerServiceObject
   def initialize(thelogger)
     super(thelogger)
     @bc_name = "trove"
@@ -85,5 +85,32 @@ class TroveService < ServiceObject
         "barclamp.#{@bc_name}.validation.rabbitmq_enabled")
     end
     super
+  end
+
+  def apply_role_pre_chef_call(old_role, role, all_new_nodes)
+    @logger.debug("Trove apply_role_pre_chef_call: entering #{all_new_nodes.inspect}")
+
+    server_elements, server_nodes, ha_enabled = role_expand_elements(role, "trove-server")
+    # FIXME: uncomment commented out code when enabling HA
+    # reset_sync_marks_on_clusters_founders(server_elements)
+    # Openstack::HA.set_controller_role(server_nodes) if ha_enabled
+    #
+    # vip_networks = ["admin", "public"]
+    #
+    # dirty = prepare_role_for_ha_with_haproxy(role, ["trove", "ha", "enabled"],
+    #                                          ha_enabled, server_elements,
+    #                                          vip_networks)
+    # role.save if dirty
+
+    net_svc = NetworkService.new @logger
+    # All nodes must have a public IP, even if part of a cluster; otherwise
+    # the VIP can't be moved to the nodes
+    server_nodes.each do |node|
+      net_svc.allocate_ip "default", "public", "host", node
+    end
+
+    # allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(server_elements, vip_networks)
+
+    @logger.debug("Trove apply_role_pre_chef_call: leaving")
   end
 end


### PR DESCRIPTION
Allocate a public IP in the Trove barclamp so it will also work if it is
deployed on a standalone machine without other barclamps. Without this code it
won't work if it is deployed to a machine that doesn't have at least one other
barclamp assigning a public IP.

Note: since this commit adds a apply_role_pre_chef_call() function to the Trove
barclamp's model it also contains commented HA code to make enabling HA for
Trove easier later on.