### PR TITLE
Magnum: Partially revert commit 326bd034d81135f40f5b7dfa887d73e973af52ab

### DIFF
--- a/crowbar_framework/app/models/magnum_service.rb
+++ b/crowbar_framework/app/models/magnum_service.rb
@@ -87,12 +87,6 @@ class MagnumService < PacemakerServiceObject
     base["attributes"][@bc_name][:db][:password] = random_password
     base["attributes"][@bc_name][:trustee][:domain_admin_password] = random_password
 
-    if select_nodes_for_role(nodes, "barbican-controller", "controller").empty?
-      base["attributes"][@bc_name][:cert][:cert_manager_type] = "local"
-    else
-      base["attributes"][@bc_name][:cert][:cert_manager_type] = "barbican"
-    end
-
     @logger.debug("Magnum create_proposal: exiting")
     base
   end


### PR DESCRIPTION
This logic will return nodes for allocation and is not checking if barbican_server exist:
```
    if select_nodes_for_role(nodes, "barbican-server", "controller").empty?
      base["attributes"][@bc_name][:cert][:cert_manager_type] = "local"
    else
      base["attributes"][@bc_name][:cert][:cert_manager_type] = "barbican"
    end
```
