### PR TITLE
Heat: Change clients endpoints on publicURL

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -667,7 +667,7 @@ insecure = <%= @keystone_settings['insecure'] %>
 # Type of endpoint in Identity service catalog to use for communication with
 # the OpenStack service. (string value)
 #endpoint_type = <None>
-endpoint_type=internalURL
+endpoint_type=publicURL
 
 # Optional CA cert file to use in SSL connections. (string value)
 #ca_file = <None>
@@ -730,7 +730,7 @@ auth_uri = <%= @keystone_settings['public_auth_url'] %>
 # Type of endpoint in Identity service catalog to use for communication with
 # the OpenStack service. (string value)
 #endpoint_type = <None>
-endpoint_type=internalURL
+endpoint_type=publicURL
 
 # Optional CA cert file to use in SSL connections. (string value)
 #ca_file = <None>


### PR DESCRIPTION
We would like to change endpoints on publicURL for Heat
and Magnum clients. This will be used by OS::Heat::WaitCondition
resource and wc_notify.