### PR TITLE
Skip installation of qemu-block-rbd on s390x

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -110,7 +110,11 @@ case node[:nova][:libvirt_type]
 
           if node[:nova][:libvirt_type] == "kvm"
             package "qemu-kvm" if node[:kernel][:machine] == "x86_64"
-            package "qemu-block-rbd"
+
+            # only install on architectures that support Ceph
+            if node[:kernel][:machine] =~ /aarch64|x86_64/
+              package "qemu-block-rbd"
+            end
 
             # load modules only when appropriate kernel is present
             execute "loading kvm modules" do


### PR DESCRIPTION
This only exists on platforms for which ceph exists, which is
aarch64 and x86_64 right now.