### PR TITLE
Fix rubocop ruby version

### DIFF
--- a/.hound.ruby.yml
+++ b/.hound.ruby.yml
@@ -1,6 +1,7 @@
 inherit_from: .hound.suse.yml
 
 AllCops:
+  TargetRubyVersion: 2.1
   Rails:
     Enabled: true
   DisplayStyleGuide: true


### PR DESCRIPTION
Same as https://github.com/crowbar/crowbar/pull/2267 but for crowbar-openstack