### PR TITLE
Raise timeout value for setting availability zone

### DIFF
--- a/chef/cookbooks/nova/recipes/availability_zones.rb
+++ b/chef/cookbooks/nova/recipes/availability_zones.rb
@@ -25,7 +25,7 @@ search_env_filtered(:node, "roles:nova-compute-hyperv") do |n|
 
   execute "Set availability zone for #{n.hostname}" do
     command command
-    timeout 15
+    timeout 60
     returns [0, 68]
     action :nothing
     subscribes :run, "execute[trigger-nova-az-config]", :delayed


### PR DESCRIPTION
On s390x this can easily take 30s due to the slowness of the test
environment (constantly swapping).