### PR TITLE
Opendaylight Neutron integration

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -104,6 +104,7 @@ when "suse"
     cisco_opflex_pkgs: ["agent-ovs",
                         "lldpd",
                         "openstack-neutron-opflex-agent"],
+    odl_pkgs: ["python-networking-odl"],
     user: "neutron",
     group: "neutron",
   }
@@ -141,6 +142,7 @@ when "rhel"
     cisco_opflex_pkgs: ["agent-ovs",
                         "lldpd",
                         "neutron-opflex-agent"],
+    odl_pkgs: ["python-networking-odl"],
     user: "neutron",
     group: "neutron",
   }
@@ -175,6 +177,7 @@ else
     cisco_apic_pkgs: [""],
     cisco_apic_gbp_pkgs: [""],
     cisco_opflex_pkgs: [""],
+    odl_pkgs: [""],
     user: "neutron",
     group: "neutron",
   }

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -81,7 +81,8 @@ when "ml2"
   case
   when ml2_mech_drivers.include?("openvswitch") ||
     ml2_mech_drivers.include?("cisco_apic_ml2") ||
-    ml2_mech_drivers.include?("apic_gbp")
+    ml2_mech_drivers.include?("apic_gbp") ||
+    ml2_mech_drivers.include?("opendaylight")
     interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
   when ml2_mech_drivers.include?("linuxbridge")
     interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"

--- a/chef/cookbooks/neutron/recipes/odl_support.rb
+++ b/chef/cookbooks/neutron/recipes/odl_support.rb
@@ -1,0 +1,35 @@
+#
+# Copyright 2016 SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node[:neutron][:platform][:odl_pkgs].each { |p| package p }
+
+odl_controller_ip = node[:neutron][:odl][:controller_ip]
+odl_controller_port = node[:neutron][:odl][:controller_port]
+odl_url = "http://#{odl_controller_ip}:#{odl_controller_port}/controller/nb/v2/neutron"
+
+template "/etc/neutron/plugins/ml2/ml2_conf_odl.ini" do
+  cookbook "neutron"
+  source "ml2_conf_odl.ini.erb"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+  variables(
+    ml2_odl_url: odl_url,
+    ml2_odl_username: node[:neutron][:odl][:username],
+    ml2_odl_password: node[:neutron][:odl][:password]
+  )
+  notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]"
+end

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -64,6 +64,8 @@ template "/etc/sysconfig/neutron" do
     elsif node[:neutron][:ml2_mechanism_drivers].include?("cisco_apic_ml2") ||
         node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
       plugin_cfgs += " /etc/neutron/plugins/ml2/ml2_conf_cisco_apic.ini"
+    elsif node[:neutron][:ml2_mechanism_drivers].include?("opendaylight")
+      plugin_cfgs += " /etc/neutron/plugins/ml2/ml2_conf_odl.ini"
     end
   end
   variables(
@@ -201,6 +203,8 @@ if node[:neutron][:networking_plugin] == "ml2"
   elsif node[:neutron][:ml2_mechanism_drivers].include?("cisco_apic_ml2") ||
       node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
     include_recipe "neutron::cisco_apic_support"
+  elsif node[:neutron][:ml2_mechanism_drivers].include?("opendaylight")
+    include_recipe "neutron::odl_support"
   end
 end
 

--- a/chef/cookbooks/neutron/templates/default/ml2_conf_odl.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf_odl.ini.erb
@@ -1,0 +1,45 @@
+# Configuration for the OpenDaylight MechanismDriver
+
+[ml2_odl]
+# (StrOpt) OpenDaylight REST URL
+# If this is not set then no HTTP requests will be made.
+#
+# url =
+# Example: url = http://192.168.56.1:8080/controller/nb/v2/neutron
+url=<%= @ml2_odl_url %>
+
+# (StrOpt) Username for HTTP basic authentication to ODL.
+#
+# username =
+# Example: username = admin
+username=<%= @ml2_odl_username %>
+
+# (StrOpt) Password for HTTP basic authentication to ODL.
+#
+# password =
+# Example: password = admin
+password=<%= @ml2_odl_password %>
+
+# (IntOpt) Timeout in seconds to wait for ODL HTTP request completion.
+# This is an optional parameter, default value is 10 seconds.
+#
+# timeout = 10
+# Example: timeout = 15
+
+# (IntOpt) Timeout in minutes to wait for a Tomcat session timeout.
+# This is an optional parameter, default value is 30 minutes.
+#
+# session_timeout = 30
+# Example: session_timeout = 60
+
+# (IntOpt) Timeout in seconds for the V2 driver thread to fire off
+# another thread run through the journal database.
+#
+# sync_timeout = 10
+# Example: sync_timeout = 10
+
+# (IntOpt) Number of times to retry a journal transaction before
+# marking it 'failed'.
+#
+# retry_count = 5
+# Example: retry_count = 5

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -110,6 +110,12 @@
                       "service_port": { "type" : "int", "required" : true },
                       "service_host": { "type" : "str", "required" : true }
                     }},
+                    "odl": { "type": "map", "required": false, "mapping": {
+                      "controller_ip": { "type" : "str", "required" : true },
+                      "controller_port": { "type" : "str", "required" : true },
+                      "username": { "type" : "str", "required" : true },
+                      "password": { "type" : "str", "required" : true }
+                    }},
                     "use_infoblox": { "type": "bool", "required": true },
                     "infoblox": { "type": "map", "required": false, "mapping": {
                         "ib_wapi": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -37,7 +37,7 @@ class NeutronService < PacemakerServiceObject
   end
 
   def self.networking_ml2_mechanism_drivers_valid
-    ["linuxbridge", "openvswitch", "cisco_nexus"]
+    ["linuxbridge", "openvswitch", "cisco_nexus", "opendaylight"]
   end
 
   class << self
@@ -241,6 +241,11 @@ class NeutronService < PacemakerServiceObject
   def validate_dvr(proposal)
     plugin = proposal["attributes"]["neutron"]["networking_plugin"]
     ml2_mechanism_drivers = proposal["attributes"]["neutron"]["ml2_mechanism_drivers"]
+
+    if ml2_mechanism_drivers.include?("opendaylight") && \
+        !(ml2_mechanism_drivers == ["opendaylight"])
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.opendaylight_standalone")
+    end
 
     if proposal["attributes"]["neutron"]["use_dvr"]
       if plugin == "vmware"


### PR DESCRIPTION
The integration allows configuration of OpenDayLight Controller as the manager for the openvswitch switches on the compute and controller nodes. The UI is not fully complete but allows for selecting opendaylight as a ML2 Mechanism driver and set the ODL parameters in the raw window to apply the changes. Requires installation of crowbar/crowbar-opendaylight to setup opendaylight controller on the controller node.