### PR TITLE
swift: install keystonemiddleware package in case of keystone auth

### DIFF
--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -105,13 +105,14 @@ template "/etc/swift/dispersion.conf" do
   #notifies :run, "execute[populate-dispersion]", :immediately
 end
 
-# NOTE(toabctl): swift-dispersion-populate process hangs so add a timeout as workaround
+# NOTE(aplanas): swift-dispersion-populate process can be slow, and
+# produce a timeout in the sync-marks in other HA recipes.  The more
+# correct approach is to create a one-shot service for this command.
 execute "populate-dispersion" do
-  command "#{dispersion_cmd}"
+  command "nohup #{dispersion_cmd} &> /dev/null &"
   user node[:swift][:user]
   group node[:swift][:group]
   action :run
   ignore_failure true
-  timeout 120
   only_if "#{swift_cmd} -V #{keystone_settings["api_version"]} --os-tenant-name #{service_tenant} --os-username #{service_user} --os-password '#{service_password}' --os-auth-url #{keystone_settings["internal_auth_url"]} --os-endpoint-type internalURL stat dispersion_objects 2>&1 | grep 'Container.*not found'"
 end

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -147,6 +147,7 @@ case proxy_config[:auth_method]
    when "keystone"
      keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
+     package "python-keystonemiddleware"
      package "python-keystoneclient"
 
      proxy_config[:keystone_settings] = keystone_settings


### PR DESCRIPTION
switf-proxy can be configured with keystone auth. Paste will try
to load the authtoken filter_factory, that resides in the package
python-keystonemiddleware.

Without this package, the service proxy-swift will fail to load
with an error:

ImportError: No module named keystonemiddleware.auth_token