### PR TITLE
aarch64/s390x always support KVM

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -118,6 +118,7 @@ class NovaService < PacemakerServiceObject
 
   def node_supports_kvm(node)
     return false if node[:cpu].nil? || node[:cpu]["0"].nil? || node[:cpu]["0"][:flags].nil?
+    return true if node["kernel"]["machine"] =~ /(aarch64|s390x)/
     node[:cpu]["0"][:flags].include?("vmx") or node[:cpu]["0"][:flags].include?("svm")
   end
 


### PR DESCRIPTION
KVM support was implemented in s370 Second Edition, so anything
s390 or newer supports it.

aarch64 also has no feature flag to disable KVM