### PR TITLE
neutron: Simplify code to get nova_fixed interface

### DIFF
--- a/chef/cookbooks/neutron/libraries/helpers.rb
+++ b/chef/cookbooks/neutron/libraries/helpers.rb
@@ -30,9 +30,7 @@ module NeutronHelper
     fixed_physnet = ""
     if node[:crowbar_wall][:network][:nets][:nova_fixed]
       nova_fixed_net = BarclampLibrary::Barclamp::Inventory.get_network_by_type(node, "nova_fixed")
-      fixed_conduit = nova_fixed_net.conduit
-      fixed_interface = BarclampLibrary::Barclamp::Inventory.lookup_interface_info(
-        node, fixed_conduit)[0]
+      fixed_interface = nova_fixed_net.interface
       fixed_physnet = "physnet1"
     end
 


### PR DESCRIPTION
We're using the Barclamp::Inventory.Network class now.

Note: Barclamp::Inventory.Network.interface() returns the interface name
including the vlan tag if use_vlan is true for the network while
Barclamp::Inventory.Network.lookup_interface_info didn't include it.
This is not a real problem for "nova_fixed". As "use_vlan" is always set to
"false" when the "nova_fixed" network is enabled on any node (see
NeutronService.rb).