### PR TITLE
magnum: Use correct port for endpoint

### DIFF
--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -20,7 +20,7 @@
 keystone_settings = KeystoneHelper.keystone_settings(node, :magnum)
 network_settings = MagnumHelper.network_settings(node)
 
-magnum_port = network_settings[:api][:bind_port]
+magnum_port = node[:magnum][:api][:bind_port]
 magnum_protocol = node[:magnum][:api][:protocol]
 
 ha_enabled = node[:magnum][:ha][:enabled]


### PR DESCRIPTION
This commit sets the port used for Magnum's service catalog entries to
`node[:magnum][:bind_port]`, as opposed to the port retrieved from `MagnumHelper`
that was used before this commit. The port retrieved from `MagnumHelper` is the
service's actual listening port, which is incorrect in an HA setting. There,
the endpoint catalog entries must use the port where the haproxy instance
forwarding to the actual service port listens.