### PR TITLE
sahara: Use sudoers file from package

### DIFF
--- a/chef/cookbooks/sahara/recipes/common.rb
+++ b/chef/cookbooks/sahara/recipes/common.rb
@@ -48,13 +48,6 @@ nova_insecure = nova[:nova][:ssl][:insecure]
 ceilometers = search_env_filtered(:node, "roles:ceilometer-server")
 use_ceilometer = !ceilometers.empty?
 
-template "/etc/sudoers.d/openstack-sahara" do
-  source "sahara-rootwrap.erb"
-  owner "root"
-  group "root"
-  mode "0440"
-end
-
 template "/etc/sahara/sahara.conf" do
   source "sahara.conf.erb"
   owner "root"

--- a/chef/cookbooks/sahara/templates/default/sahara-rootwrap.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara-rootwrap.erb
@@ -1,1 +1,0 @@
-<%= @node[:sahara][:user] %> ALL = (root) NOPASSWD: /usr/bin/sahara-rootwrap /etc/sahara/rootwrap.conf *


### PR DESCRIPTION
There's no need to override the sudoers file from the package. We
also use the package provided file for the other services.