### PR TITLE
[stable/3.0] nova: Allow to define a custom network for xCAT access (bsc#976778)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -19,7 +19,16 @@
 # limitations under the License.
 #
 
-node.set[:nova][:my_ip] = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+my_ip_net = "admin"
+
+# z/VM compute nodes might need a different "my_ip" setting to be accessible
+# from the xCAT management node
+if node["roles"].include?("nova-compute-zvm")
+  my_ip_net = node["nova"]["zvm"]["zvm_xcat_network"]
+end
+
+node.set[:nova][:my_ip] =
+  Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, my_ip_net).address
 
 package "nova-common" do
   if %w(rhel suse).include?(node[:platform_family])

--- a/chef/data_bags/crowbar/migrate/nova/045_add_zvm_xcat_network.rb
+++ b/chef/data_bags/crowbar/migrate/nova/045_add_zvm_xcat_network.rb
@@ -1,0 +1,15 @@
+def upgrade(ta, td, a, d)
+  unless a["zvm"].key? "zvm_xcat_network"
+    a["zvm"]["zvm_xcat_network"] = "admin"
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["zvm"].key? "zvm_xcat_network"
+    a["zvm"].delete("zvm_xcat_network")
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -56,6 +56,7 @@
         "zvm_xcat_server": "",
         "zvm_xcat_username": "",
         "zvm_xcat_password": "",
+        "zvm_xcat_network": "admin",
         "zvm_diskpool": "",
         "zvm_diskpool_type": "",
         "zvm_host": "",
@@ -95,7 +96,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 44,
+      "schema-revision": 45,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -85,6 +85,7 @@
                 "zvm_xcat_server": { "type": "str", "required": true },
                 "zvm_xcat_username": { "type": "str", "required": true },
                 "zvm_xcat_password": { "type": "str", "required": true },
+                "zvm_xcat_network": { "type": "str", "required": true },
                 "zvm_diskpool": { "type": "str", "required": true },
                 "zvm_diskpool_type": { "type": "str", "required": true },
                 "zvm_host": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -402,4 +402,10 @@ class NovaService < PacemakerServiceObject
   def hyperv_available?
     return File.exist?("/opt/dell/chef/cookbooks/hyperv")
   end
+
+  def network_present?(network_name)
+    net_svc = NetworkService.new @logger
+    network_proposal = Proposal.find_by(barclamp: net_svc.bc_name, name: "default")
+    !network_proposal["attributes"]["network"]["networks"][network_name].nil?
+  end
 end

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -90,3 +90,4 @@ en:
         assigned_node: 'Node %{key} has been assigned to a nova-compute role more than once.'
         assigned_remotes: 'Remotes %{key} has been assigned to a nova-compute role more than once.'
         assigned_node_and_remote: 'Node %{node} has been assigned to a nova-compute role as individual node and as remote node of cluster %{cluster}.'
+        invalid_zvm_xcat_network: 'Network "%{network}" configured for zvm xcat access is not defined in the configuration of the network barclamp.'


### PR DESCRIPTION
This is a backport of: https://github.com/crowbar/crowbar-openstack/pull/530