### PR TITLE
swift: Fix variable replacement in error message

### DIFF
--- a/crowbar_framework/config/locales/swift/en.yml
+++ b/crowbar_framework/config/locales/swift/en.yml
@@ -128,7 +128,7 @@ en:
       validation:
         radosgw: 'Ceph with RadosGW support is already deployed. Only one of Ceph with RadosGW and Swift can be deployed at any time.'
         replica: 'Need at least 1 replica.'
-        zone: 'Need at least as many swift-storage nodes as zones; only %{swift-storage} swift-storage node was set for %{swift_zone} zones.'
-        zones: 'Need at least as many swift-storage nodes as zones; only %{swift-storage} swift-storage nodes were set for %{swift_zone} zones.'
+        zone: 'Need at least as many swift-storage nodes as zones; only %{swift_storage} swift-storage node was set for %{swift_zone} zones.'
+        zones: 'Need at least as many swift-storage nodes as zones; only %{swift_storage} swift-storage nodes were set for %{swift_zone} zones.'
         public_containers: 'Public containers must be allowed (keystone_delay_auth_decision attribute) when one of the FormPOST, StaticWeb and TempURL middlewares is enabled.'
         no_valid_xml: 'Cross-domain policy line %{html_escape} does not look like valid XML.'


### PR DESCRIPTION
When deploying swift and not enough storage nodes are available, the error
message was:

Need at least as many swift-storage nodes as zones; only %{swift-storage}
     swift-storage node was set for 2 zones.