### PR TITLE
keystone: Use apache frontend

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -134,6 +134,8 @@ elsif node[:keystone][:frontend] == "apache"
     service_name node[:keystone][:service_name]
     supports status: true, restart: true
     action [:disable, :stop]
+    # allow to fail here because there may not be a service "keystone"
+    ignore_failure true
   end
 
   include_recipe "apache2"

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -283,7 +283,7 @@ end
 execute "neutron-db-manage migrate fwaas" do
   user node[:neutron][:user]
   group node[:neutron][:group]
-  command "neutron-db-manage --service fwaas upgrade head"
+  command "neutron-db-manage --subproject neutron-fwaas upgrade head"
   only_if { !node[:neutron][:db_synced_fwaas] && (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)) }
 end
 
@@ -301,7 +301,7 @@ if node[:neutron][:use_lbaas]
   execute "neutron-db-manage migrate lbaas" do
     user node[:neutron][:user]
     group node[:neutron][:group]
-    command "neutron-db-manage --service lbaas upgrade head"
+    command "neutron-db-manage --subproject neutron-lbaas upgrade head"
     only_if { !node[:neutron][:db_synced_lbaas] && (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)) }
   end
 

--- a/chef/data_bags/crowbar/migrate/keystone/102_switch_default_frontend.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/102_switch_default_frontend.rb
@@ -1,0 +1,10 @@
+def upgrade(ta, td, a, d)
+  # newton needs the apache frontend so switch to the new default
+  a["frontend"] = ta["frontend"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["frontend"] = ta["frontend"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -4,7 +4,7 @@
   "attributes": {
     "keystone": {
       "debug": false,
-      "frontend": "native",
+      "frontend": "apache",
       "verbose": true,
       "use_syslog": false,
       "policy_file": "policy.json",
@@ -118,7 +118,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
The native frontend (eventlet based) is no longer available and upstream
recommends to use a "real" webserver so use Apache.