### PR TITLE
ceilometer: Use auth_type to password (bsc#1001273)

### DIFF
--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -1506,6 +1506,7 @@ interface = internalURL
 # Authentication type to load (string value)
 # Deprecated group/name - [DEFAULT]/auth_plugin
 #auth_type = <None>
+auth_type = password
 
 # Config Section from which to load plugin specific options (string value)
 #auth_section = <None>
@@ -1554,7 +1555,8 @@ project_name = <%= @keystone_settings['service_tenant'] %>
 # Username (string value)
 # Deprecated group/name - [DEFAULT]/username
 #username = <None>
-username = <%= @keystone_settings['service_user'] %>
+# NOTE(aplanas) not a typo. The new key is user-name.
+user-name = <%= @keystone_settings['service_user'] %>
 
 # User's domain id (string value)
 #user_domain_id = <None>


### PR DESCRIPTION
Ceilometer 7.0 change the section service_credentials.  If auth_type
is not set, some queries to keytone will use the legacy v2.0 API,
and this cause problems (POST can be blocked in SSL connections).

If we set this value to `password` V3 will be used.

Update `username` parameter to `user-name`, to avoid deprecation
warning.