### PR TITLE
Raise availability-zone timeout consistently

### DIFF
--- a/chef/cookbooks/nova/recipes/availability_zones.rb
+++ b/chef/cookbooks/nova/recipes/availability_zones.rb
@@ -26,7 +26,8 @@ search_env_filtered(:node, "roles:nova-compute-hyperv") do |n|
   execute "Set availability zone for #{n.hostname}" do
     command command
     timeout 60
-    returns [0, 68]
+    # Any exit code in the range 60-69 is a tempfail
+    returns [0] + (60..69).to_a
     action :nothing
     subscribes :run, "execute[trigger-nova-az-config]", :delayed
   end

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -375,7 +375,7 @@ command = NovaAvailabilityZone.add_arg_to_set_az_command(command_no_arg, node)
 
 execute "Set availability zone for #{node.hostname}" do
   command command
-  timeout 15
+  timeout 60
   # Any exit code in the range 60-69 is a tempfail
   returns [0] + (60..69).to_a
   action :nothing


### PR DESCRIPTION
There were two places that set availability zones. Set both to the same,
higher timeout to accomodate slowness on s390x