### PR TITLE
tempest: Disable personality tests

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -514,6 +514,8 @@ interface_attach = <%= @use_interface_attach %>
 
 # Does the test environment support server personality (boolean value)
 #personality = true
+# NOTE(toabctl): to use this, we need to enable inject_partition in nova.conf
+personality = false
 
 # Does the test environment support attaching an encrypted volume to a
 # running server instance? This may depend on the combination of


### PR DESCRIPTION
The tests are currently failing when running a full tempest run.
The tests for personality can not pass because they need an enabled
"inject_partition" in nova.conf .