### PR TITLE
nova: Fix  "undefined method `pretty_target_platform'"

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -386,7 +386,7 @@ class NovaService < PacemakerServiceObject
       validation_error I18n.t(
         "barclamp.#{@bc_name}.validation.xen",
         n: n,
-        platform: CrowbarService.pretty_target_platform(node_platform),
+        platform: Crowbar::Platform.pretty_target_platform(node_platform),
         arch: node["kernel"]["machine"]
       )
     end unless elements["nova-compute-xen"].nil?


### PR DESCRIPTION
When deploying Xen and the target platform is not supported, the
warning message used the wrong class.