### PR TITLE
Remove `use_launch_instance_ng` attribute in Horizon

### DIFF
--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -350,7 +350,6 @@ template local_settings do
     help_url: node[:horizon][:help_url],
     session_timeout: node[:horizon][:session_timeout],
     memcached_locations: memcached_locations,
-    use_launch_instance_ng: node["horizon"]["use_launch_instance_ng"],
     can_set_mount_point: node["horizon"]["can_set_mount_point"],
     can_set_password: node["horizon"]["can_set_password"],
     multi_domain_support: multi_domain_support,

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -260,13 +260,8 @@ OPENSTACK_ENABLE_PASSWORD_RETRIEVE = True
 # Toggle LAUNCH_INSTANCE_LEGACY_ENABLED and LAUNCH_INSTANCE_NG_ENABLED to
 # determine the experience to enable.  Set them both to true to enable
 # both.
-<% if !@use_launch_instance_ng -%>
 #LAUNCH_INSTANCE_LEGACY_ENABLED = True
 #LAUNCH_INSTANCE_NG_ENABLED = False
-<% else -%>
-LAUNCH_INSTANCE_LEGACY_ENABLED = False
-LAUNCH_INSTANCE_NG_ENABLED = True
-<% end -%>
 
 # A dictionary of settings which can be used to provide the default values for
 # properties found in the Launch Instance modal.

--- a/chef/data_bags/crowbar/migrate/horizon/100_remove_use_launch_instance_ng.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/100_remove_use_launch_instance_ng.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("use_launch_instance_ng")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["use_launch_instance_ng"] = ta["use_launch_instance_ng"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -31,7 +31,6 @@
         "network": "neutron_policy.json",
         "telemetry": "ceilometer_policy.json"
       },
-      "use_launch_instance_ng": false,
       "can_set_mount_point": false,
       "can_set_password": false,
       "multi_domain_support": false,
@@ -50,7 +49,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 38,
+      "schema-revision": 100,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -52,7 +52,6 @@
                 "telemetry" : { "type": "str", "required": true }
               }
             },
-            "use_launch_instance_ng": { "type": "bool", "required": true },
             "can_set_mount_point": { "type": "bool", "required": false },
             "can_set_password": { "type": "bool", "required": false },
             "multi_domain_support": { "type": "bool", "required": true },


### PR DESCRIPTION
Made the Angular Launch Instance workflow the default in Horizon.