### PR TITLE
Add support for Midonet plugin

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -108,6 +108,7 @@ when "suse"
     cisco_opflex_pkgs: ["agent-ovs",
                         "lldpd",
                         "openstack-neutron-opflex-agent"],
+    midonet_pkgs: ["python-networking-midonet"],
     user: "neutron",
     group: "neutron",
   }
@@ -149,6 +150,7 @@ when "rhel"
     cisco_opflex_pkgs: ["agent-ovs",
                         "lldpd",
                         "neutron-opflex-agent"],
+    midonet_pkgs: ["python-networking-midonet"],
     user: "neutron",
     group: "neutron",
   }
@@ -187,6 +189,7 @@ else
     cisco_apic_pkgs: [""],
     cisco_apic_gbp_pkgs: [""],
     cisco_opflex_pkgs: [""],
+    midonet_pkgs: ["python-networking-midonet"],
     user: "neutron",
     group: "neutron",
   }
@@ -201,6 +204,13 @@ default[:neutron][:lbaas][:f5][:icontrol_hostname] = ""
 default[:neutron][:lbaas][:f5][:icontrol_username] = "admin"
 default[:neutron][:lbaas][:f5][:icontrol_password] = "admin"
 default[:neutron][:lbaas][:f5][:parent_ssl_profile] = "clientssl"
+
+default[:neutron][:midonet][:host] = ""
+default[:neutron][:midonet][:port] = "8080"
+default[:neutron][:midonet][:username] = ""
+default[:neutron][:midonet][:password] = ""
+default[:neutron][:midonet][:openstack_user] = "midonet"
+default[:neutron][:midonet][:openstack_password] = ""
 
 default[:neutron][:ha][:network][:enabled] = false
 default[:neutron][:ha][:network][:l3_ra] = "lsb:#{node[:neutron][:platform][:l3_agent_name]}"

--- a/chef/cookbooks/neutron/files/default/midonet-network.filters
+++ b/chef/cookbooks/neutron/files/default/midonet-network.filters
@@ -1,0 +1,94 @@
+# nova-rootwrap command filters for network nodes
+# This file should be owned by (and only-writeable by) the root user
+
+[Filters]
+# nova/virt/libvirt/vif.py: 'ip', 'tuntap', 'add', dev, 'mode', 'tap'
+# nova/virt/libvirt/vif.py: 'ip', 'link', 'set', dev, 'up'
+# nova/virt/libvirt/vif.py: 'ip', 'link', 'delete', dev
+# nova/network/linux_net.py: 'ip', 'addr', 'add', str(floating_ip)+'/32'i..
+# nova/network/linux_net.py: 'ip', 'addr', 'del', str(floating_ip)+'/32'..
+# nova/network/linux_net.py: 'ip', 'addr', 'add', '169.254.169.254/32',..
+# nova/network/linux_net.py: 'ip', 'addr', 'show', 'dev', dev, 'scope',..
+# nova/network/linux_net.py: 'ip', 'addr', 'del/add', ip_params, dev)
+# nova/network/linux_net.py: 'ip', 'addr', 'del', params, fields[-1]
+# nova/network/linux_net.py: 'ip', 'addr', 'add', params, bridge
+# nova/network/linux_net.py: 'ip', '-f', 'inet6', 'addr', 'change', ..
+# nova/network/linux_net.py: 'ip', 'link', 'set', 'dev', dev, 'promisc',..
+# nova/network/linux_net.py: 'ip', 'link', 'add', 'link', bridge_if ...
+# nova/network/linux_net.py: 'ip', 'link', 'set', interface, address,..
+# nova/network/linux_net.py: 'ip', 'link', 'set', interface, 'up'
+# nova/network/linux_net.py: 'ip', 'link', 'set', bridge, 'up'
+# nova/network/linux_net.py: 'ip', 'addr', 'show', 'dev', interface, ..
+# nova/network/linux_net.py: 'ip', 'link', 'set', dev, address, ..
+# nova/network/linux_net.py: 'ip', 'link', 'set', dev, 'up'
+# nova/network/linux_net.py: 'ip', 'route', 'add', ..
+# nova/network/linux_net.py: 'ip', 'route', 'del', .
+# nova/network/linux_net.py: 'ip', 'route', 'show', 'dev', dev
+ip: CommandFilter, ip, root
+
+# nova/virt/libvirt/vif.py: 'ovs-vsctl', ...
+# nova/virt/libvirt/vif.py: 'ovs-vsctl', 'del-port', ...
+# nova/network/linux_net.py: 'ovs-vsctl', ....
+ovs-vsctl: CommandFilter, ovs-vsctl, root
+
+# nova/network/linux_net.py: 'ovs-ofctl', ....
+ovs-ofctl: CommandFilter, ovs-ofctl, root
+
+# nova/virt/libvirt/vif.py: 'ivs-ctl', ...
+# nova/virt/libvirt/vif.py: 'ivs-ctl', 'del-port', ...
+# nova/network/linux_net.py: 'ivs-ctl', ....
+ivs-ctl: CommandFilter, ivs-ctl, root
+
+# nova/virt/libvirt/vif.py: 'ifc_ctl', ...
+ifc_ctl: CommandFilter, /opt/pg/bin/ifc_ctl, root
+
+# nova/virt/libvirt/vif.py: 'ebrctl', ...
+ebrctl: CommandFilter, ebrctl, root
+
+# nova/virt/libvirt/vif.py: 'mm-ctl', ...
+mm-ctl: CommandFilter, mm-ctl, root
+
+# nova/network/linux_net.py: 'ebtables', '-D' ...
+# nova/network/linux_net.py: 'ebtables', '-I' ...
+ebtables: CommandFilter, ebtables, root
+ebtables_usr: CommandFilter, ebtables, root
+
+# nova/network/linux_net.py: 'ip[6]tables-save' % (cmd, '-t', ...
+iptables-save: CommandFilter, iptables-save, root
+ip6tables-save: CommandFilter, ip6tables-save, root
+
+# nova/network/linux_net.py: 'ip[6]tables-restore' % (cmd,)
+iptables-restore: CommandFilter, iptables-restore, root
+ip6tables-restore: CommandFilter, ip6tables-restore, root
+
+# nova/network/linux_net.py: 'arping', '-U', floating_ip, '-A', '-I', ...
+# nova/network/linux_net.py: 'arping', '-U', network_ref['dhcp_server'],..
+arping: CommandFilter, arping, root
+
+# nova/network/linux_net.py: 'dhcp_release', dev, address, mac_address
+dhcp_release: CommandFilter, dhcp_release, root
+
+# nova/network/linux_net.py: 'kill', '-9', pid
+# nova/network/linux_net.py: 'kill', '-HUP', pid
+kill_dnsmasq: KillFilter, root, /usr/sbin/dnsmasq, -9, -HUP
+
+# nova/network/linux_net.py: 'kill', pid
+kill_radvd: KillFilter, root, /usr/sbin/radvd
+
+# nova/network/linux_net.py: dnsmasq call
+dnsmasq: EnvFilter, env, root, CONFIG_FILE=, NETWORK_ID=, dnsmasq
+
+# nova/network/linux_net.py: 'radvd', '-C', '%s' % _ra_file(dev, 'conf'..
+radvd: CommandFilter, radvd, root
+
+# nova/network/linux_net.py: 'brctl', 'addbr', bridge
+# nova/network/linux_net.py: 'brctl', 'setfd', bridge, 0
+# nova/network/linux_net.py: 'brctl', 'stp', bridge, 'off'
+# nova/network/linux_net.py: 'brctl', 'addif', bridge, interface
+brctl: CommandFilter, brctl, root
+
+# nova/network/linux_net.py: 'sysctl', ....
+sysctl: CommandFilter, sysctl, root
+
+# nova/network/linux_net.py: 'conntrack'
+conntrack: CommandFilter, conntrack, root

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -56,6 +56,10 @@ if neutron[:neutron][:networking_plugin] == "ml2" &&
     neutron[:neutron][:ml2_mechanism_drivers].include?("apic_gbp"))
   include_recipe "neutron::cisco_apic_agents"
   return # skip anything else in this recipe
+elsif neutron[:neutron][:networking_plugin] == "midonet"
+  # nothing to do in the case of midonet
+  include_recipe "neutron::midonet_agents"
+  return
 end
 
 multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty?

--- a/chef/cookbooks/neutron/recipes/midonet_agents.rb
+++ b/chef/cookbooks/neutron/recipes/midonet_agents.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2016 SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# we only need to act on compute nodes
+if node.roles.any? { |role| /^nova-compute-/ =~ role }
+  # for /etc/nova/rootwrap.d/
+  package "openstack-nova"
+
+  cookbook_file "/etc/nova/rootwrap.d/network.filters" do
+    source "midonet-network.filters"
+    mode "0644"
+  end
+end

--- a/chef/cookbooks/neutron/recipes/midonet_support.rb
+++ b/chef/cookbooks/neutron/recipes/midonet_support.rb
@@ -1,0 +1,61 @@
+#
+# Copyright 2016 SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node[:neutron][:platform][:midonet_pkgs].each { |p| package p }
+
+if node.roles.include?("neutron-server")
+  keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+
+  crowbar_pacemaker_sync_mark "wait-midonet_register"
+
+  keystone_register "register midonet service" do
+    protocol keystone_settings["protocol"]
+    insecure keystone_settings["insecure"]
+    host keystone_settings["internal_url_host"]
+    port keystone_settings["admin_port"]
+    token keystone_settings["admin_token"]
+    service_name "midonet"
+    service_type "midonet"
+    service_description "MidoNet API Service"
+    action :add_service
+  end
+
+  keystone_register "add #{node[:neutron][:midonet][:openstack_user]} user" do
+    protocol keystone_settings["protocol"]
+    insecure keystone_settings["insecure"]
+    host keystone_settings["internal_url_host"]
+    port keystone_settings["admin_port"]
+    token keystone_settings["admin_token"]
+    user_name node[:neutron][:midonet][:openstack_user]
+    user_password node[:neutron][:midonet][:openstack_password]
+    tenant_name keystone_settings["service_tenant"]
+    action :add_user
+  end
+
+  keystone_register "add admin role for #{node[:neutron][:midonet][:openstack_user]}" do
+    protocol keystone_settings["protocol"]
+    insecure keystone_settings["insecure"]
+    host keystone_settings["internal_url_host"]
+    port keystone_settings["admin_port"]
+    token keystone_settings["admin_token"]
+    user_name node[:neutron][:midonet][:openstack_user]
+    role_name "admin"
+    tenant_name keystone_settings["service_tenant"]
+    action :add_access
+  end
+
+  crowbar_pacemaker_sync_mark "create-midonet_register"
+end

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -14,6 +14,11 @@
 # limitations under the License.
 #
 
+if node[:neutron][:networking_plugin] == "midonet"
+  # nothing to do in the case of midonet
+  return
+end
+
 include_recipe "neutron::common_agent"
 
 package node[:neutron][:platform][:dhcp_agent_pkg]

--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -100,10 +100,10 @@ when "ml2"
     Chef::Log.error("default provider network ml2 type driver " \
         "'#{ml2_type_drivers_default_provider_network}' invalid for creating provider networks")
   end
-when "vmware"
+when "midonet", "vmware"
   fixed_network_type = ""
   # We would like to be sure that floating network will be created
-  # without any additional options, NSX will take care about everything.
+  # without any additional options, the SDN will take care of everything.
   floating_network_type = ""
 else
   Chef::Log.error("networking plugin '#{networking_plugin}' invalid for creating provider networks")

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -177,11 +177,11 @@ when "ml2"
   end
 when "vmware"
   directory "/etc/neutron/plugins/vmware/" do
-     mode 0755
-     owner "root"
-     group node[:neutron][:platform][:group]
-     action :create
-     not_if { node[:platform_family] == "suse" }
+    mode "0755"
+    owner "root"
+    group node[:neutron][:platform][:group]
+    action :create
+    not_if { node[:platform_family] == "suse" }
   end
 
   template plugin_cfg_path do
@@ -195,10 +195,10 @@ when "vmware"
   end
 when "midonet"
   directory "/etc/neutron/plugins/midonet/" do
-     mode 0755
-     owner "root"
-     group node[:neutron][:platform][:group]
-     action :create
+    mode "0755"
+    owner "root"
+    group node[:neutron][:platform][:group]
+    action :create
   end
 
   keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
@@ -388,11 +388,12 @@ if node[:neutron][:networking_plugin] == "ml2"
   end
 elsif node[:neutron][:networking_plugin] == "midonet"
   # See comments for "neutron-db-manage migrate" above
+  is_cluster_founder = CrowbarPacemakerHelper.is_cluster_founder?(node)
   execute "neutron-db-manage migrate midonet" do
     user node[:neutron][:user]
     group node[:neutron][:group]
     command "neutron-db-manage --subproject networking-midonet upgrade head"
-    only_if { !node[:neutron][:db_synced_midonet] && (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)) }
+    only_if { !node[:neutron][:db_synced_midonet] && (!ha_enabled || is_cluster_founder) }
   end
 
   ruby_block "mark node for neutron db_sync midonet" do

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -46,6 +46,8 @@ include_recipe "neutron::common_config"
 
 if node[:neutron][:networking_plugin] == "vmware"
   plugin_cfg_path = "/etc/neutron/plugins/vmware/nsx.ini"
+elsif node[:neutron][:networking_plugin] == "midonet"
+  plugin_cfg_path = "/etc/neutron/plugins/midonet/midonet.ini"
 else
   plugin_cfg_path = "/etc/neutron/plugins/ml2/ml2_conf.ini"
 end
@@ -175,22 +177,40 @@ when "ml2"
   end
 when "vmware"
   directory "/etc/neutron/plugins/vmware/" do
-     mode 00755
+     mode 0755
      owner "root"
      group node[:neutron][:platform][:group]
      action :create
-     recursive true
      not_if { node[:platform_family] == "suse" }
   end
 
   template plugin_cfg_path do
-    cookbook "neutron"
     source "nsx.ini.erb"
     owner "root"
     group node[:neutron][:platform][:group]
     mode "0640"
     variables(
       vmware_config: node[:neutron][:vmware]
+    )
+  end
+when "midonet"
+  directory "/etc/neutron/plugins/midonet/" do
+     mode 0755
+     owner "root"
+     group node[:neutron][:platform][:group]
+     action :create
+  end
+
+  keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+
+  template plugin_cfg_path do
+    source "midonet.ini.erb"
+    owner "root"
+    group node[:neutron][:platform][:group]
+    mode "0640"
+    variables(
+      midonet_config: node[:neutron][:midonet],
+      keystone_settings: keystone_settings
     )
   end
 end
@@ -202,6 +222,8 @@ if node[:neutron][:networking_plugin] == "ml2"
       node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
     include_recipe "neutron::cisco_apic_support"
   end
+elsif node[:neutron][:networking_plugin] == "midonet"
+  include_recipe "neutron::midonet_support"
 end
 
 if node[:neutron][:use_lbaas]
@@ -216,7 +238,8 @@ if node[:neutron][:use_lbaas]
       interface_driver: interface_driver,
       use_lbaasv2: node[:neutron][:use_lbaasv2],
       lbaasv2_driver: node[:neutron][:lbaasv2_driver],
-      keystone_settings: keystone_settings
+      keystone_settings: keystone_settings,
+      networking_plugin: node[:neutron][:networking_plugin]
     )
   end
 
@@ -362,6 +385,23 @@ if node[:neutron][:networking_plugin] == "ml2"
       action :nothing
       subscribes :create, "execute[gbp-db-manage upgrade head]", :immediately
     end
+  end
+elsif node[:neutron][:networking_plugin] == "midonet"
+  # See comments for "neutron-db-manage migrate" above
+  execute "neutron-db-manage migrate midonet" do
+    user node[:neutron][:user]
+    group node[:neutron][:group]
+    command "neutron-db-manage --subproject networking-midonet upgrade head"
+    only_if { !node[:neutron][:db_synced_midonet] && (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)) }
+  end
+
+  ruby_block "mark node for neutron db_sync midonet" do
+    block do
+      node.set[:neutron][:db_synced_midonet] = true
+      node.save
+    end
+    action :nothing
+    subscribes :create, "execute[neutron-db-manage migrate midonet]", :immediately
   end
 end
 

--- a/chef/cookbooks/neutron/templates/default/midonet.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/midonet.ini.erb
@@ -1,0 +1,8 @@
+[MIDONET]
+# MidoNet API URL
+midonet_uri = http://<%= @midonet_config["host"] %>:<%= @midonet_config["port"] %>/midonet-api
+# MidoNet administrative user in Keystone
+username = <%= @midonet_config["username"] %>
+password = <%= @midonet_config["password"] %>
+# MidoNet administrative user's tenant
+project_id = <%= @keystone_settings["service_tenant"] %>

--- a/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
@@ -74,7 +74,11 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
 # Combination of <service type> and <name> must be unique; <driver> must also be unique
 # This is multiline option
 # service_provider=LOADBALANCER:name:lbaas_plugin_driver_path:default
-# service_provider=LOADBALANCER:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
+<% if @networking_plugin != "midonet" -%>
+service_provider=LOADBALANCER:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
+<% else -%>
+service_provider=LOADBALANCER:Midonet:midonet.neutron.services.loadbalancer.driver.MidonetLoadbalancerDriver:default
+<% end -%>
 # service_provider = LOADBALANCER:radware:neutron_lbaas.services.loadbalancer.drivers.radware.driver.LoadBalancerDriver:default
 # service_provider = LOADBALANCERV2:radwarev2:neutron_lbaas.drivers.radware.v2_driver.RadwareLBaaSV2Driver:default
 # service_provider=LOADBALANCER:NetScaler:neutron_lbaas.services.loadbalancer.drivers.netscaler.netscaler_driver.NetScalerPluginDriver

--- a/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
@@ -74,11 +74,6 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
 # Combination of <service type> and <name> must be unique; <driver> must also be unique
 # This is multiline option
 # service_provider=LOADBALANCER:name:lbaas_plugin_driver_path:default
-<% if @networking_plugin != "midonet" -%>
-service_provider=LOADBALANCER:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
-<% else -%>
-service_provider=LOADBALANCER:Midonet:midonet.neutron.services.loadbalancer.driver.MidonetLoadbalancerDriver:default
-<% end -%>
 # service_provider = LOADBALANCER:radware:neutron_lbaas.services.loadbalancer.drivers.radware.driver.LoadBalancerDriver:default
 # service_provider = LOADBALANCERV2:radwarev2:neutron_lbaas.drivers.radware.v2_driver.RadwareLBaaSV2Driver:default
 # service_provider=LOADBALANCER:NetScaler:neutron_lbaas.services.loadbalancer.drivers.netscaler.netscaler_driver.NetScalerPluginDriver
@@ -102,10 +97,13 @@ service_provider=LOADBALANCER:Midonet:midonet.neutron.services.loadbalancer.driv
       "LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
   end
 %>
-service_provider=<%= service_provider %>
 <% elsif @use_lbaas -%>
-service_provider=LOADBALANCER:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
+  service_provider = "LOADBALANCER:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
 <% end -%>
+<% if @networking_plugin.eql?("midonet") -%>
+  service_provider = "LOADBALANCER:Midonet:midonet.neutron.services.loadbalancer.driver.MidonetLoadbalancerDriver:default"
+<% end -%>
+service_provider=<%= service_provider %>
 
 [certificates]
 # cert_manager_type = barbican

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -186,6 +186,15 @@ case node[:nova][:libvirt_type]
         libvirt_group = "root"
       end
 
+      dev_net_tun_acl = false
+
+      neutron_server = search_env_filtered(:node, "roles:neutron-server").first
+      if !neutron_server.nil? && neutron_server[:neutron][:networking_plugin] == "midonet"
+        libvirt_user = "root"
+        libvirt_group = "root"
+        dev_net_tun_acl = true
+      end
+
       template "/etc/libvirt/qemu.conf" do
         source "qemu.conf.erb"
         group "root"
@@ -193,7 +202,8 @@ case node[:nova][:libvirt_type]
         mode 0644
         variables(
             user: libvirt_user,
-            group: libvirt_group
+            group: libvirt_group,
+            dev_net_tun_acl: dev_net_tun_acl
         )
         notifies :restart, "service[libvirtd]"
       end

--- a/chef/cookbooks/nova/templates/default/qemu.conf.erb
+++ b/chef/cookbooks/nova/templates/default/qemu.conf.erb
@@ -292,6 +292,16 @@ group = "<%= @group %>"
 #   "/dev/infiniband/umad0",
 #   "/dev/infiniband/umad1",
 #   "/dev/infiniband/uverbs0"
+#
+<% if @dev_net_tun_acl -%>
+cgroup_device_acl = [
+    "/dev/null", "/dev/full", "/dev/zero",
+    "/dev/random", "/dev/urandom",
+    "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
+    "/dev/rtc","/dev/hpet", "/dev/vfio/vfio",
+    "/dev/net/tun"
+]
+<% end -%>
 
 
 # The default format for Qemu/KVM guest save images is raw; that is, the

--- a/chef/data_bags/crowbar/migrate/neutron/049_add_midonet_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/049_add_midonet_attributes.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  unless a.key?("midonet")
+    a["midonet"] = ta["midonet"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("midonet")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -54,6 +54,14 @@
         "tz_uuid": "",
         "l3_gw_uuid": ""
       },
+      "midonet": {
+        "host": "",
+        "port": "8080",
+        "username": "",
+        "password": "",
+        "openstack_user": "midonet",
+        "openstack_password": ""
+      },
       "zvm": {
         "zvm_xcat_server": "",
         "zvm_xcat_username": "",

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -88,6 +88,14 @@
                       "tz_uuid": { "type" : "str", "required" : true },
                       "l3_gw_uuid": { "type" : "str", "required" : true }
                     }},
+                    "midonet": { "type": "map", "required": true, "mapping": {
+                      "host": { "type" : "str", "required" : true },
+                      "port": { "type" : "str", "required" : true },
+                      "username": { "type" : "str", "required" : true },
+                      "password": { "type" : "str", "required" : true },
+                      "openstack_user": { "type" : "str", "required" : true },
+                      "openstack_password": { "type" : "str", "required" : true }
+                    }},
                     "zvm": { "type": "map", "required": true, "mapping": {
                       "zvm_xcat_server": { "type": "str", "required": true },
                       "zvm_xcat_username": { "type": "str", "required": true },

--- a/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
@@ -232,6 +232,7 @@ function networking_plugin_check() {
   switch ($('#networking_plugin').val()) {
   case 'ml2':
     $('#vmware_container').hide();
+    $('#midonet_container').hide();
     $('#ml2_mechanism_drivers_container').show();
     $('#ml2_type_drivers_container').show();
     $('#ml2_type_drivers_default_provider_network_container').show();
@@ -242,6 +243,21 @@ function networking_plugin_check() {
     break;
   case 'vmware':
     $('#vmware_container').show();
+    $('#midonet_container').hide();
+    $('#ml2_mechanism_drivers_container').hide();
+    $('#ml2_type_drivers_container').hide();
+    $('#ml2_type_drivers_default_provider_network_container').hide();
+    $('#ml2_type_drivers_default_tenant_network_container').hide();
+    $('#dvr_container').hide();
+    $('#num_vlans_container').hide();
+    $('#gre_container').hide();
+    $('#vxlan_container').hide();
+    $('#cisco_switches').hide();
+    $('#cisco_ports').hide();
+    break;
+  case 'midonet':
+    $('#midonet_container').show();
+    $('#vmware_container').hide();
     $('#ml2_mechanism_drivers_container').hide();
     $('#ml2_type_drivers_container').hide();
     $('#ml2_type_drivers_default_provider_network_container').hide();

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -29,7 +29,7 @@ class NeutronService < PacemakerServiceObject
   end
 
   def self.networking_plugins_valid
-    ["ml2", "vmware"]
+    ["ml2", "vmware", "midonet"]
   end
 
   def self.networking_ml2_type_drivers_valid
@@ -245,6 +245,10 @@ class NeutronService < PacemakerServiceObject
     if proposal["attributes"]["neutron"]["use_dvr"]
       if plugin == "vmware"
         validation_error I18n.t("barclamp.#{@bc_name}.validation.dvr_vmware")
+      end
+
+      if plugin == "midonet"
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.dvr_midonet")
       end
 
       if ml2_mechanism_drivers.include? "linuxbridge"

--- a/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
@@ -40,6 +40,14 @@
         = string_field %w(vmware tz_uuid)
         = string_field %w(vmware l3_gw_uuid)
 
+      #midonet_container
+        = string_field %w(midonet host)
+        = string_field %w(midonet port)
+        = string_field %w(midonet username)
+        = password_field %w(midonet password)
+        = string_field %w(midonet openstack_user)
+        = password_field %w(midonet openstack_password)
+
       #num_vlans_container
         %fieldset
           %legend

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -66,6 +66,13 @@ en:
           controllers: 'VMware NSX Controllers'
           tz_uuid: 'UUID of the NSX Transport Zone'
           l3_gw_uuid: 'UUID of the NSX Gateway Service'
+        midonet:
+          host: 'Midonet Host'
+          port: 'Midonet Port'
+          username: 'Midonet Username'
+          password: 'Midonet Password'
+          openstack_user: 'Midonet OpenStack Username'
+          openstack_password: 'Midonet OpenStack User password'
         zvm_header: 'z/VM Configuration'
         zvm:
           zvm_xcat_server: 'xCAT Host/IP Address'
@@ -117,5 +124,6 @@ en:
         cisco_nexus_ovs: 'The "cisco_nexus" mechanism driver needs also the "openvswitch" mechanism driver'
         openvswitch_linuxbridge: 'The "openvswitch" and "linuxbridge" mechanism drivers cannot be used in parallel. Only select one of them'
         dvr_vmware: 'DVR is not compatible with VMware NSX plugin'
+        dvr_midonet: 'DVR is not compatible with Midonet plugin'
         dvr_linuxbridge: 'DVR is not compatible with Linux Bridge ML2 driver'
         dvr_ha: 'DVR is not compatible with High Availability for neutron-network'


### PR DESCRIPTION
Add support for Midonet plugin for neutron and facilitate selection of Midonet as one of the possible networking plugins from crowbar UI for neutron. Customer already has a patch on Cloud6 without crowbar_framework integration. This is a forward-port of the patch for integration into Cloud7 product.
