### PR TITLE
Adapt the list of transaction objects with a pre-upgrade location constraint

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh_ha.rb
+++ b/chef/cookbooks/aodh/recipes/aodh_ha.rb
@@ -62,6 +62,9 @@ pacemaker_clone clone_name do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 transaction_objects << "pacemaker_clone[#{clone_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 order_only_existing = ["rabbitmq", "cl-keystone", clone_name]
 

--- a/chef/cookbooks/ceilometer/recipes/central_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/central_ha.rb
@@ -34,6 +34,9 @@ transaction_objects << "pacemaker_primitive[#{service_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for service_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, service_name
+)
 
 pacemaker_transaction "ceilometer central" do
   cib_objects transaction_objects

--- a/chef/cookbooks/ceilometer/recipes/mongodb.rb
+++ b/chef/cookbooks/ceilometer/recipes/mongodb.rb
@@ -68,6 +68,9 @@ if ha_enabled
 
   location_name = openstack_pacemaker_controller_only_location_for clone_name
   transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, transaction_objects, clone_name
+  )
 
   pacemaker_transaction "mongodb" do
     cib_objects transaction_objects

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -82,6 +82,9 @@ end
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "ceilometer server" do
   cib_objects transaction_objects

--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -77,6 +77,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "cinder controller" do
   cib_objects transaction_objects

--- a/chef/cookbooks/cinder/recipes/volume_ha.rb
+++ b/chef/cookbooks/cinder/recipes/volume_ha.rb
@@ -34,6 +34,9 @@ transaction_objects << "pacemaker_primitive[#{service_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for service_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, service_name
+)
 
 pacemaker_transaction "cinder volume" do
   cib_objects transaction_objects

--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -82,6 +82,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "glance server" do
   cib_objects transaction_objects

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -80,6 +80,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "heat server" do
   cib_objects transaction_objects

--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -73,6 +73,9 @@ if node[:keystone][:frontend] == "native"
 
   location_name = openstack_pacemaker_controller_only_location_for clone_name
   transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, transaction_objects, clone_name
+  )
 
   pacemaker_transaction "keystone server" do
     cib_objects transaction_objects

--- a/chef/cookbooks/magnum/recipes/ha.rb
+++ b/chef/cookbooks/magnum/recipes/ha.rb
@@ -76,6 +76,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "magnum server" do
   cib_objects transaction_objects

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -83,6 +83,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "manila controller" do
   cib_objects transaction_objects

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -161,6 +161,9 @@ transaction_objects << "pacemaker_clone[#{agents_clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for agents_clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, agents_clone_name
+)
 
 pacemaker_transaction "neutron agents" do
   cib_objects transaction_objects
@@ -196,6 +199,9 @@ if use_l3_agent
 
   ha_tool_location_name = openstack_pacemaker_controller_only_location_for ha_tool_primitive_name
   ha_tool_transaction_objects << "pacemaker_location[#{ha_tool_location_name}]"
+  ha_tool_transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, ha_tool_transaction_objects, ha_tool_primitive_name
+  )
 
   pacemaker_transaction "neutron ha tool" do
     cib_objects ha_tool_transaction_objects

--- a/chef/cookbooks/neutron/recipes/server_ha.rb
+++ b/chef/cookbooks/neutron/recipes/server_ha.rb
@@ -51,6 +51,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "neutron server" do
   cib_objects transaction_objects

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -120,6 +120,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "nova controller" do
   cib_objects transaction_objects

--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -111,6 +111,13 @@ if node[:database][:ha][:storage][:mode] == "drbd"
   location_name = openstack_pacemaker_controller_only_location_for service_name
   transaction_objects << "pacemaker_location[#{location_name}]"
 
+  transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, transaction_objects, vip_primitive
+  )
+  transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, transaction_objects, service_name
+  )
+
 else
 
   pacemaker_group group_name do
@@ -124,6 +131,10 @@ else
 
   location_name = openstack_pacemaker_controller_only_location_for group_name
   transaction_objects << "pacemaker_location[#{location_name}]"
+
+  transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, transaction_objects, group_name
+  )
 
 end
 

--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -98,6 +98,9 @@ if node[:database][:ha][:storage][:mode] == "drbd"
 
   location_name = openstack_pacemaker_controller_only_location_for ms_name
   transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, transaction_objects, ms_name
+  )
 end
 
 pacemaker_primitive fs_primitive do
@@ -111,6 +114,9 @@ transaction_objects << "pacemaker_primitive[#{fs_primitive}]"
 
 location_name = openstack_pacemaker_controller_only_location_for fs_primitive
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, fs_primitive
+)
 
 if node[:database][:ha][:storage][:mode] == "drbd"
   colocation_constraint = "col-#{fs_primitive}"

--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -94,6 +94,9 @@ if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
 
   ms_location_name = openstack_pacemaker_controller_only_location_for ms_name
   storage_transaction_objects << "pacemaker_location[#{ms_location_name}]"
+  storage_transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, storage_transaction_objects, ms_name
+  )
 end
 
 pacemaker_primitive fs_primitive do
@@ -107,6 +110,9 @@ storage_transaction_objects << "pacemaker_primitive[#{fs_primitive}]"
 
 fs_location_name = openstack_pacemaker_controller_only_location_for fs_primitive
 storage_transaction_objects << "pacemaker_location[#{fs_location_name}]"
+storage_transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, storage_transaction_objects, fs_primitive
+)
 
 if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
   colocation_constraint = "col-#{fs_primitive}"
@@ -246,6 +252,9 @@ pacemaker_primitive admin_vip_primitive do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 service_transaction_objects << "pacemaker_primitive[#{admin_vip_primitive}]"
+service_transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, service_transaction_objects, admin_vip_primitive
+)
 
 if node[:rabbitmq][:listen_public]
   pacemaker_primitive public_vip_primitive do
@@ -302,14 +311,23 @@ if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
 
   admin_vip_location_name = openstack_pacemaker_controller_only_location_for admin_vip_primitive
   service_transaction_objects << "pacemaker_location[#{admin_vip_location_name}]"
+  service_transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, service_transaction_objects, admin_vip_primitive
+  )
 
   if node[:rabbitmq][:listen_public]
     public_vip_location_name = openstack_pacemaker_controller_only_location_for public_vip_primitive
     service_transaction_objects << "pacemaker_location[#{public_vip_location_name}]"
+    service_transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+      node, service_transaction_objects, public_vip_primitive
+    )
   end
 
   location_name = openstack_pacemaker_controller_only_location_for service_name
   service_transaction_objects << "pacemaker_location[#{location_name}]"
+  service_transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, service_transaction_objects, service_name
+  )
 
 else
   # Pacemaker groups do not support parallel startup ordering :-(
@@ -326,6 +344,9 @@ else
 
   location_name = openstack_pacemaker_controller_only_location_for group_name
   service_transaction_objects << "pacemaker_location[#{location_name}]"
+  service_transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+    node, service_transaction_objects, group_name
+  )
 
 end
 

--- a/chef/cookbooks/sahara/recipes/ha.rb
+++ b/chef/cookbooks/sahara/recipes/ha.rb
@@ -71,6 +71,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "sahara server" do
   cib_objects transaction_objects

--- a/chef/cookbooks/swift/recipes/proxy_ha.rb
+++ b/chef/cookbooks/swift/recipes/proxy_ha.rb
@@ -55,6 +55,9 @@ transaction_objects << "pacemaker_clone[#{clone_name}]"
 
 location_name = openstack_pacemaker_controller_only_location_for clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
+transaction_objects = CrowbarPacemakerHelper.add_upgraded_only_location(
+  node, transaction_objects, clone_name
+)
 
 pacemaker_transaction "swift proxy" do
   cib_objects transaction_objects


### PR DESCRIPTION
This constraint ensures services are started on upgraded nodes only.


This is an alternative to https://github.com/crowbar/crowbar-openstack/pull/545

Requires https://github.com/crowbar/crowbar-ha/pull/153