### PR TITLE
manila: Add CephFS driver support

### DIFF
--- a/chef/cookbooks/manila/libraries/helpers.rb
+++ b/chef/cookbooks/manila/libraries/helpers.rb
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2016 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ManilaHelper
+  def self.has_cephfs_share?(node)
+    # check if any share uses cephfs
+    node[:manila][:shares].each do |share|
+      return true if share["backend_driver"] == "cephfs"
+    end
+    false
+  end
+
+  def self.has_cephfs_internal_cluster?(node)
+    # are we using a crowbar-deployed ceph cluster?
+    node[:manila][:shares].each do |share|
+      next unless share[:backend_driver] == "cephfs"
+      return true if share[:cephfs][:use_crowbar]
+    end
+    false
+  end
+end

--- a/chef/cookbooks/manila/recipes/cephfs.rb
+++ b/chef/cookbooks/manila/recipes/cephfs.rb
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2016 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Cookbook Name:: manila
+# Recipe:: cephfs
+#
+
+package "ceph-common"
+
+if ManilaHelper.has_cephfs_internal_cluster? node
+  # use a crowbar deployed ceph cluster
+  Chef::Log.info("Using internal ceph cluster for Manila.")
+
+  ceph_conf = "/etc/ceph/ceph.conf"
+  admin_keyring = "/etc/ceph/ceph.client.admin.keyring"
+  ceph_user = "manila"
+  # see http://docs.openstack.org/developer/manila/devref/cephfs_native_driver.html#authorize-the-driver-to-communicate-with-ceph
+  ceph_caps = {
+    "mds" => "allow *",
+    "osd" => "allow rw",
+    "mon" => "allow r, allow command \"auth del\", allow command \"auth caps\", allow command \"auth get\", allow command \"auth get-or-create\"",
+  }
+
+  ceph_client ceph_user do
+    ceph_conf ceph_conf
+    admin_keyring admin_keyring
+    caps ceph_caps
+    keyname "client.#{ceph_user}"
+    filename "/etc/ceph/ceph.client.#{ceph_user}.keyring"
+    owner "root"
+    group node[:manila][:group]
+    mode 0640
+  end
+end

--- a/chef/cookbooks/manila/recipes/common.rb
+++ b/chef/cookbooks/manila/recipes/common.rb
@@ -114,6 +114,9 @@ else
   Chef::Log.warn("cinder-controller not found")
 end
 
+enabled_share_protocols = ["NFS", "CIFS"]
+enabled_share_protocols << ["CEPHFS"] if ManilaHelper.has_cephfs_share? node
+
 template "/etc/manila/manila.conf" do
   source "manila.conf.erb"
   owner "root"
@@ -121,6 +124,7 @@ template "/etc/manila/manila.conf" do
   mode 0640
   variables(
     shares: node[:manila][:shares],
+    enabled_share_protocols: enabled_share_protocols,
     bind_host: bind_host,
     bind_port: bind_port,
     sql_connection: sql_connection,

--- a/chef/cookbooks/manila/recipes/share.rb
+++ b/chef/cookbooks/manila/recipes/share.rb
@@ -34,4 +34,8 @@ node[:manila][:shares].each_with_index do |share, share_idx|
   end
 end
 
+if ManilaHelper.has_cephfs_share? node
+  include_recipe "#{@cookbook_name}::cephfs"
+end
+
 manila_service("share")

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -141,6 +141,7 @@ enabled_share_backends=<%= @shares.each_with_index.collect { |share, share_idx|
 # Available values are '('NFS', 'CIFS', 'GLUSTERFS', 'HDFS',
 # 'CEPHFS')' (list value)
 #enabled_share_protocols = NFS,CIFS
+enabled_share_protocols = <%= @enabled_share_protocols.join(',') %>
 
 # The full class name of the Compute API class to use. (string value)
 #compute_api_class = manila.compute.nova.API
@@ -2613,6 +2614,21 @@ hds_hnas_ssh_private_key = <%= share['hitachi']['hds_hnas_ssh_private_key'] %>
 hds_hnas_stalled_job_timeout = <%= share['hitachi']['hds_hnas_stalled_job_timeout'] %>
 hds_hnas_user = <%= share['hitachi']['hds_hnas_user'] %>
 <% end -%> <%# hitachi driver %>
+<% if share['backend_driver'] == 'cephfs' -%>
+share_backend_name=<%= share['backend_name'] %>
+share_driver = manila.share.drivers.cephfs.cephfs_native.CephFSNativeDriver
+driver_handles_share_servers = False
+<% if share['use_crowbar'] -%>
+cephfs_conf_path = /etc/ceph/ceph.conf
+cephfs_auth_id = manila
+cephfs_cluster_name = ceph
+<% else -%>
+cephfs_conf_path = <%= share['cephfs']['cephfs_conf_path'] %>
+cephfs_auth_id = <%= share['cephfs']['cephfs_auth_id'] %>
+cephfs_cluster_name = <%= share['cephfs']['cephfs_cluster_name'] %>
+<% end -%>
+cephfs_enable_snapshots = False
+<% end -%> <%# cephfs driver %>
 <% if share['backend_driver'] == 'manual' -%>
 share_backend_name=<%= share['backend_name'] %>
 share_driver=<%= share['manual']['driver'] %>

--- a/chef/data_bags/crowbar/migrate/manila/101_add_cephfs_config.rb
+++ b/chef/data_bags/crowbar/migrate/manila/101_add_cephfs_config.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  a["share_defaults"]["cephfs"] = ta["share_defaults"]["cephfs"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta["share_defaults"].key? "cephfs"
+    a["share_defaults"]["cephfs"] = ta["share_defaults"]["cephfs"]
+  else
+    a["share_defaults"].delete("cephfs")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-manila.json
+++ b/chef/data_bags/crowbar/template-manila.json
@@ -64,6 +64,12 @@
           "hds_hnas_stalled_job_timeout": 30,
           "hds_hnas_user": "None"
         },
+        "cephfs": {
+          "use_crowbar": true,
+          "cephfs_conf_path": "/etc/ceph/ceph.conf",
+          "cephfs_auth_id": "manila",
+          "cephfs_cluster_name": "ceph"
+        },
         "manual": {
           "driver": "",
           "config": ""
@@ -90,7 +96,7 @@
     "manila": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "manila-server": [ "readying", "ready", "applying" ],
         "manila-share": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-manila.schema
+++ b/chef/data_bags/crowbar/template-manila.schema
@@ -82,6 +82,14 @@
                      "hds_hnas_user": { "type": "str", "required": true }
                    }
                 },
+                "cephfs": {
+                   "type": "map", "mapping": {
+                     "use_crowbar": { "type": "bool", "required": true },
+                     "cephfs_conf_path": { "type": "str", "required": true },
+                     "cephfs_auth_id": { "type": "str", "required": true },
+                     "cephfs_cluster_name": { "type": "str", "required": true }
+                   }
+                },
                 "manual": {
                 "type": "map", "mapping": {
                     "driver": { "type": "str", "required": true },
@@ -129,6 +137,14 @@
                       "hds_hnas_ssh_private_key": { "type": "str", "required": true },
                       "hds_hnas_stalled_job_timeout": { "type": "int", "required": true },
                       "hds_hnas_user": { "type": "str", "required": true }
+                    }
+                  },
+                  "cephfs": {
+                    "type": "map", "mapping": {
+                      "use_crowbar": { "type": "bool", "required": true },
+                      "cephfs_conf_path": { "type": "str", "required": true },
+                      "cephfs_auth_id": { "type": "str", "required": true },
+                      "cephfs_cluster_name": { "type": "str", "required": true }
                     }
                   },
                   "manual": {

--- a/crowbar_framework/app/helpers/manila_barclamp_helper.rb
+++ b/crowbar_framework/app/helpers/manila_barclamp_helper.rb
@@ -31,6 +31,7 @@ module ManilaBarclampHelper
         [t(".shares.generic_share_driver"), "generic"],
         [t(".shares.hitachi_share_driver"), "hitachi"],
         [t(".shares.netapp_share_driver"), "netapp"],
+        [t(".shares.cephfs_share_driver"), "cephfs"],
         [t(".shares.manual_share_driver"), "manual"]
       ],
       selected.to_s

--- a/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
@@ -64,6 +64,19 @@
               = string_field %w(shares {{@index}} hitachi hds_hnas_ssh_private_key)
               = integer_field %w(shares {{@index}} hitachi hds_hnas_stalled_job_timeout)
           {{/if_eq}}
+          {{#if_eq backend_driver 'cephfs'}}
+          %li.list-group-item
+            %fieldset
+              %legend
+                = t('.shares.cephfs_parameters')
+
+              = boolean_field %w(shares {{@index}} cephfs use_crowbar), "data-hideit" => "true", "data-hideit-target" => "#cephfs_conf_path_{{@index}}", "data-hideit-direct" => "true"
+              %div{:id => "cephfs_conf_path_{{@index}}"}
+                = string_field %w(shares {{@index}} cephfs cephfs_conf_path)
+                = string_field %w(shares {{@index}} cephfs cephfs_clustername)
+                = string_field %w(shares {{@index}} cephfs cephfs_auth_id)
+
+          {{/if_eq}}
           {{#if_eq backend_driver 'manual'}}
           %li.list-group-item
             %fieldset

--- a/crowbar_framework/config/locales/manila/en.yml
+++ b/crowbar_framework/config/locales/manila/en.yml
@@ -34,10 +34,12 @@ en:
           generic_parameters: 'Generic backend parameters'
           netapp_parameters: "NetApp parameters"
           hitachi_parameters: "Hitachi parameters"
+          cephfs_parameters: "CephFS parameters"
           manual_parameters: 'Other driver parameters'
           generic_share_driver: 'Generic driver'
           netapp_share_driver: 'NetApp driver'
           hitachi_share_driver: 'Hitachi driver'
+          cephfs_share_driver: 'CephFS driver'
           manual_share_driver: 'Other driver'
           generic:
             not_supported: 'The generic driver can be used for testing but is not supported.'
@@ -70,6 +72,11 @@ en:
               hds_hnas_ssh_private_key: 'RSA/DSA private key value used to connect into HNAS. Required only if password is not provided.'
               hds_hnas_stalled_job_timeout: 'The time (in seconds) to wait for stalled HNAS jobs before aborting.'
               hds_hnas_user: 'HNAS username Base64 String in order to perform tasks such as create file-systems and network interfaces.'
+            cephfs:
+              use_crowbar: 'Use Ceph deployed by Crowbar'
+              cephfs_conf_path: 'Path to Ceph configuration file'
+              cephfs_clustername: 'Cluster name'
+              cephfs_auth_id: 'Authentication ID'
             manual:
               config: 'Options'
               driver: 'Driver'
@@ -90,3 +97,5 @@ en:
           service_net_name_or_ip: 'Service network name/IP can not be empty'
           tenant_net_name_or_ip: 'Tenant network name/IP can not be empty'
           password_or_private_key: 'Password or private key path must be given'
+        cephfs:
+          ceph_mds_not_deployed: 'The "ceph-mds" role is not deployed. Please check the Ceph proposal or use an external Ceph cluster'


### PR DESCRIPTION
Manila has a CephFS driver since Mitaka. Allow the usage from Crowbar.
