### PR TITLE
Add another constraint to the controller only locati

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/ha_helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/ha_helpers.rb
@@ -32,7 +32,7 @@
 module OpenStackHAHelper
   def self.controller_only_location(location, service)
     "location #{location} #{service} resource-discovery=exclusive " \
-      "rule 0: OpenStack-role eq controller"
+      "rule 0: OpenStack-role eq controller and pre-upgrade eq false"
   end
 
   def self.no_compute_location(location, service)


### PR DESCRIPTION
Make sure that the services supposed to run on controller nodes
do not get started when the node is in pre-upgrade state.

See also https://bugzilla.suse.com/show_bug.cgi?id=1005346