### PR TITLE
cinder: Add configuration option for multipath (bsc#997607)

### DIFF
--- a/chef/cookbooks/cinder/attributes/default.rb
+++ b/chef/cookbooks/cinder/attributes/default.rb
@@ -33,13 +33,6 @@ default[:cinder][:ssl][:insecure] = false
 default[:cinder][:ssl][:cert_required] = false
 default[:cinder][:ssl][:ca_certs] = "/etc/cinder/ssl/certs/ca.pem"
 
-# Keep in sync with nova cookbook
-if node[:platform_family] == "suse"
-  default[:cinder][:use_multipath_for_xfer] = true
-else
-  default[:cinder][:use_multipath_for_xfer] = false
-end
-
 #sqlalchemy parameters
 default[:cinder][:max_pool_size] = 30
 default[:cinder][:max_overflow] = 10

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -660,9 +660,7 @@ volume_backend_name = <%= volume['backend_name'] %>
 # Do we attach/detach volumes in cinder using multipath for volume to image and
 # image to volume transfers? (boolean value)
 #use_multipath_for_image_xfer = false
-<% if node[:cinder][:use_multipath_for_xfer] -%>
-use_multipath_for_image_xfer = true
-<% end -%>
+<%= "use_multipath_for_image_xfer = true" if node[:cinder][:use_multipath] %>
 
 # If this is set to True, attachment of volumes for image transfer will be
 # aborted when multipathd is not running. Otherwise, it will fallback to single

--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -44,13 +44,6 @@ default[:nova][:use_shared_instance_storage] = false
 #
 default[:nova][:libvirt_type] = "kvm"
 
-# Keep in sync with cinder cookbook
-if node[:platform_family] == "suse"
-  default[:nova][:libvirt_use_multipath] = true
-else
-  default[:nova][:libvirt_use_multipath] = false
-end
-
 #
 # KVM Settings
 #

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -346,11 +346,15 @@ execute "set vhost_net module" do
   command "grep -q 'vhost_net' /etc/modules || echo 'vhost_net' >> /etc/modules"
 end
 
-if node[:nova][:libvirt_use_multipath]
-  package "multipath-tools"
+cinder_servers = search_env_filtered(:node, "roles:cinder-controller") || []
+unless cinder_servers.empty?
+  cinder_server = cinder_servers[0]
+  if cinder_server[:cinder][:use_multipath]
+    package "multipath-tools"
 
-  service "multipathd" do
-    action [:enable, :start]
+    service "multipathd" do
+      action [:enable, :start]
+    end
   end
 
   service "boot.multipath" do

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -116,10 +116,13 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 rbd_enabled = false
 
+use_multipath = false
+
 cinder_servers = search_env_filtered(:node, "roles:cinder-controller") || []
 if cinder_servers.length > 0
   cinder_server = cinder_servers[0]
   cinder_insecure = cinder_server[:cinder][:api][:protocol] == "https" && cinder_server[:cinder][:ssl][:insecure]
+  use_multipath = cinder_server[:cinder][:use_multipath]
 
   if node.roles.include? "nova-compute-kvm"
     cinder_server[:cinder][:volumes].each do |volume|
@@ -325,7 +328,6 @@ template "/etc/nova/nova.conf" do
             ec2_host: admin_api_host,
             ec2_dmz_host: public_api_host,
             libvirt_migration: node[:nova]["use_migration"],
-            libvirt_enable_multipath: node[:nova][:libvirt_use_multipath],
             shared_instances: node[:nova]["use_shared_instance_storage"],
             force_config_drive: node[:nova]["force_config_drive"],
             glance_server_protocol: glance_server_protocol,
@@ -348,6 +350,7 @@ template "/etc/nova/nova.conf" do
             neutron_has_tunnel: neutron_has_tunnel,
             keystone_settings: keystone_settings,
             cinder_insecure: cinder_insecure || keystone_settings["insecure"],
+            use_multipath: use_multipath,
             ceph_user: ceph_user,
             ceph_uuid: ceph_uuid,
             ssl_enabled: api[:nova][:ssl][:enabled],

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2776,7 +2776,7 @@ block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_M
 
 # Use multipath connection of the iSCSI volume (boolean value)
 #iscsi_use_multipath = false
-<%= "iscsi_use_multipath = true" if @libvirt_enable_multipath %>
+<%= "iscsi_use_multipath = true" if @use_multipath %>
 
 # The iSCSI transport iface to use to connect to target in case offload support
 # is desired. Default format is of the form <transport_name>.<hwaddress> where
@@ -2792,7 +2792,7 @@ block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_M
 
 # Use multipath connection of the iSER volume (boolean value)
 #iser_use_multipath = false
-<%= "iser_use_multipath = true" if @libvirt_enable_multipath %>
+<%= "iser_use_multipath = true" if @use_multipath %>
 
 
 [matchmaker_redis]

--- a/chef/data_bags/crowbar/migrate/cinder/49_use_multipath.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/49_use_multipath.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "use_multipath"
+    a["use_multipath"] = ta["use_multipath"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "use_multipath"
+    del a["use_multipath"]
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -18,6 +18,7 @@
       "pool_timeout": 30,
       "rpc_response_timeout": 60,
       "use_multi_backend": true,
+      "use_multipath": false,
       "volume_defaults": {
         "raw": {
           "volume_name": "cinder-volumes",
@@ -160,7 +161,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 48,
+      "schema-revision": 49,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -27,6 +27,7 @@
             "pool_timeout": { "type": "int", "required": true },
             "rpc_response_timeout": { "type": "int", "required": true },
             "use_multi_backend": { "type": "bool", "required": true },
+            "use_multipath": { "type": "bool", "required": true },
             "volume_defaults": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
Currently, mulitpath support is set by default in the cinder and
nova cookbooks, and both cookbooks force it to be true, but the
built package overrides nova's setting to false.

Remove that default support, and add a new option to cinder which allows
operators to enable or disable multipath support for both cinder
and nova.

Cherry picked from ab5df7ef6df1d84a33bd41f4473dd58fdd504542.