### PR TITLE
keep DRBD running during upgrade

### DIFF
--- a/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_location_ignoring_upgrade_for.rb
+++ b/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_location_ignoring_upgrade_for.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2016, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+define :openstack_pacemaker_controller_location_ignoring_upgrade_for do
+  resource = params[:name]
+  location_name = "l-#{resource}-controller"
+  pacemaker_location location_name do
+    definition OpenStackHAHelper.controller_only_location_ignoring_upgrade(location_name, resource)
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+  location_name
+end

--- a/chef/cookbooks/crowbar-openstack/libraries/ha_helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/ha_helpers.rb
@@ -35,6 +35,11 @@ module OpenStackHAHelper
       "rule 0: OpenStack-role eq controller and pre-upgrade ne true"
   end
 
+  def self.controller_only_location_ignoring_upgrade(location, service)
+    "location #{location} #{service} resource-discovery=exclusive " \
+      "rule 0: OpenStack-role eq controller"
+  end
+
   def self.no_compute_location(location, service)
     "location #{location} #{service} resource-discovery=exclusive " \
       "rule 0: OpenStack-role ne compute"

--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -96,7 +96,7 @@ if node[:database][:ha][:storage][:mode] == "drbd"
   end
   transaction_objects << "pacemaker_ms[#{ms_name}]"
 
-  location_name = openstack_pacemaker_controller_only_location_for ms_name
+  location_name = openstack_pacemaker_controller_location_ignoring_upgrade_for ms_name
   transaction_objects << "pacemaker_location[#{location_name}]"
 end
 

--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -92,7 +92,7 @@ if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
   end
   storage_transaction_objects << "pacemaker_ms[#{ms_name}]"
 
-  ms_location_name = openstack_pacemaker_controller_only_location_for ms_name
+  ms_location_name = openstack_pacemaker_controller_location_ignoring_upgrade_for ms_name
   storage_transaction_objects << "pacemaker_location[#{ms_location_name}]"
 end
 


### PR DESCRIPTION
DRBD resources need to be running on both (upgraded AND not upgraded) nodes during the upgrade, so DRBD data can be synchronized correctly.
