### PR TITLE
don't break whole cluster when not upgrading

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/ha_helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/ha_helpers.rb
@@ -32,7 +32,7 @@
 module OpenStackHAHelper
   def self.controller_only_location(location, service)
     "location #{location} #{service} resource-discovery=exclusive " \
-      "rule 0: OpenStack-role eq controller and pre-upgrade eq false"
+      "rule 0: OpenStack-role eq controller and pre-upgrade ne true"
   end
 
   def self.no_compute_location(location, service)


### PR DESCRIPTION
https://github.com/crowbar/crowbar-openstack/pull/562 totally broke HA cluster setup, because when the pre-upgrade node attribute is not present, the location constraints generated by this helper prevent anything useful from running.

So instead we reverse the

    pre-upgrade eq false

logic to

    pre-upgrade ne true

so that the constraints will *only* prevent resources from running when pre-upgrade is set to true, and not when it isn't set at all.