### PR TITLE
Adding reserved_host_memory_mb Parameter for nova

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -79,6 +79,7 @@ default[:nova][:vcenter][:interface] = ""
 default[:nova][:scheduler][:ram_allocation_ratio] = 1.0
 default[:nova][:scheduler][:cpu_allocation_ratio] = 16.0
 default[:nova][:scheduler][:disk_allocation_ratio] = 1.0
+default[:nova][:scheduler][:reserved_host_memory_mb] = 1024
 
 #
 # Shared Settings

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -649,7 +649,7 @@ block_device_allocate_retries_interval = <%= node[:nova][:block_device][:allocat
 #reserved_host_disk_mb = 0
 
 # Amount of memory in MB to reserve for the host (integer value)
-#reserved_host_memory_mb = 512
+reserved_host_memory_mb = 1024
 
 # DEPRECATED: Class that will manage stats for the local compute host (string
 # value)

--- a/chef/data_bags/crowbar/migrate/nova/108_add_host_mb_reserve.rb
+++ b/chef/data_bags/crowbar/migrate/nova/108_add_host_mb_reserve.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["scheduler"]["reserved_host_memory_mb"] = ta["scheduler"]["reserved_host_memory_mb"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["scheduler"].delete("reserved_host_memory_mb")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -31,7 +31,8 @@
       "scheduler": {
         "ram_allocation_ratio": 1.0,
         "cpu_allocation_ratio": 16.0,
-        "disk_allocation_ratio": 1.0
+        "disk_allocation_ratio": 1.0,
+        "reserved_host_memory_mb": 1024
       },
       "db": {
         "password": "",
@@ -137,7 +138,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 107,
+      "schema-revision": 108,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -48,7 +48,8 @@
               "mapping": {
                 "ram_allocation_ratio": { "type": "number" },
                 "cpu_allocation_ratio": { "type": "number" },
-                "disk_allocation_ratio": { "type": "number" }
+                "disk_allocation_ratio": { "type": "number" },
+                "reserved_host_memory_mb": { "type", "number" }
               }
             },
             "db": {

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -21,6 +21,7 @@
       = float_field %w(scheduler ram_allocation_ratio)
       = float_field %w(scheduler cpu_allocation_ratio)
       = float_field %w(scheduler disk_allocation_ratio)
+      = float_field %w(scheduler reserved_host_memory_mb)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -34,6 +34,7 @@ en:
           ram_allocation_ratio: 'Virtual RAM to Physical RAM allocation ratio'
           cpu_allocation_ratio: 'Virtual CPU to Physical CPU allocation ratio'
           disk_allocation_ratio: 'Virtual Disk to Physical Disk allocation ratio'
+          reserved_host_memory_mb: 'Reserved Memory for Nova Compute hosts'
         live_migration_header: 'Live Migration Support'
         setup_shared_instance_storage: 'Set up Shared Storage on nova-controller for Nova instances'
         use_shared_instance_storage: 'Shared Storage for Nova instances has been manually configured'


### PR DESCRIPTION
This commit should add the Nova Compute RAM/MB reservation. The specified reserved memory will be substracted from the total available memory in ompute hosts by the nova scheduler.