### PR TITLE
manila: Add NetApp driver for managed mode

### DIFF
--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -2598,6 +2598,20 @@ netapp_transport_type=<%= share['netapp']['netapp_transport_type'] %>
 netapp_aggregate_name_search_pattern=<%= share['netapp']['netapp_aggregate_name_search_pattern'] %>
 <% end -%>
 <% end -%> <%# netapp driver %>
+<% if share['backend_driver'] == 'netapp-managed' -%>
+share_driver=manila.share.drivers.netapp.common.NetAppDriver
+share_backend_name=<%= share['backend_name'] %>
+driver_handles_share_servers=True
+netapp_storage_family=<%= share['netapp-managed']['netapp_storage_family'] %>
+netapp_server_hostname=<%= share['netapp-managed']['netapp_server_hostname'] %>
+netapp_server_port=<%= share['netapp-managed']['netapp_server_port'] %>
+netapp_login=<%= share['netapp-managed']['netapp_login'] %>
+netapp_password=<%= share['netapp-managed']['netapp_password'] %>
+netapp_transport_type=<%= share['netapp-managed']['netapp_transport_type'] %>
+netapp_root_volume_aggregate=<%= share['netapp-managed']['netapp_root_volume_aggregate'] %>
+netapp_aggregate_name_search_pattern=<%= share['netapp-managed']['netapp_aggregate_name_search_pattern'] %>
+netapp_port_name_search_pattern=<%= share['netapp-managed']['netapp_port_name_search_pattern'] %>
+<% end -%> <%# netapp-managed driver %>
 <% if share['backend_driver'] == 'hitachi' -%>
 share_backend_name=<%= share['backend_name'] %>
 share_driver = manila.share.drivers.hitachi.hds_hnas.HDSHNASDriver

--- a/chef/data_bags/crowbar/migrate/manila/101_add_netapp_managed_config.rb
+++ b/chef/data_bags/crowbar/migrate/manila/101_add_netapp_managed_config.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a["share_defaults"].key? "netapp-managed"
+    a["share_defaults"]["netapp-managed"] = ta["share_defaults"]["netapp-managed"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["share_defaults"].key? "netapp-managed"
+    a["share_defaults"].delete("netapp-managed")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-manila.json
+++ b/chef/data_bags/crowbar/template-manila.json
@@ -53,6 +53,17 @@
           "netapp_vserver": "",
           "netapp_transport_type": "https"
         },
+        "netapp-managed": {
+          "netapp_storage_family": "ontap_cluster",
+          "netapp_server_hostname": "",
+          "netapp_server_port": "",
+          "netapp_login": "admin",
+          "netapp_password": "",
+          "netapp_transport_type": "https",
+          "netapp_root_volume_aggregate": "",
+          "netapp_aggregate_name_search_pattern": "(.*)",
+          "netapp_port_name_search_pattern": "(.*)"
+        },
         "hitachi": {
           "hds_hnas_cluster_admin_ip0": "None",
           "hds_hnas_evs_id": "None",
@@ -90,7 +101,7 @@
     "manila": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "manila-server": [ "readying", "ready", "applying" ],
         "manila-share": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-manila.schema
+++ b/chef/data_bags/crowbar/template-manila.schema
@@ -69,6 +69,19 @@
                     "netapp_aggregate_name_search_pattern": { "type": "str", "required": false }
                   }
                 },
+                "netapp-managed": {
+                  "type": "map", "mapping": {
+                    "netapp_storage_family": { "type": "str", "required": true },
+                    "netapp_server_hostname": { "type": "str", "required": true },
+                    "netapp_server_port": { "type": "str", "required": true },
+                    "netapp_login": { "type": "str", "required": true },
+                    "netapp_password": { "type": "str", "required": true },
+                    "netapp_transport_type": { "type": "str", "required": true },
+                    "netapp_root_volume_aggregate": { "type": "str", "required": true },
+                    "netapp_aggregate_name_search_pattern": { "type": "str", "required": false },
+                    "netapp_port_name_search_pattern": { "type": "str", "required": true }
+                  }
+                },
                 "hitachi": {
                    "type": "map", "mapping": {
                      "hds_hnas_cluster_admin_ip0": { "type": "str", "required": true },
@@ -116,6 +129,19 @@
                       "netapp_vserver": { "type": "str", "required": true },
                       "netapp_transport_type": { "type": "str", "required": true },
                       "netapp_aggregate_name_search_pattern": { "type": "str", "required": false }
+                    }
+                  },
+                  "netapp-managed": {
+                    "type": "map", "mapping": {
+                      "netapp_storage_family": { "type": "str", "required": true },
+                      "netapp_server_hostname": { "type": "str", "required": true },
+                      "netapp_server_port": { "type": "str", "required": true },
+                      "netapp_login": { "type": "str", "required": true },
+                      "netapp_password": { "type": "str", "required": true },
+                      "netapp_transport_type": { "type": "str", "required": true },
+                      "netapp_root_volume_aggregate": { "type": "str", "required": true },
+                      "netapp_aggregate_name_search_pattern": { "type": "str", "required": false },
+                      "netapp_port_name_search_pattern": { "type": "str", "required": true }
                     }
                   },
                   "hitachi": {

--- a/crowbar_framework/app/helpers/manila_barclamp_helper.rb
+++ b/crowbar_framework/app/helpers/manila_barclamp_helper.rb
@@ -31,6 +31,7 @@ module ManilaBarclampHelper
         [t(".shares.generic_share_driver"), "generic"],
         [t(".shares.hitachi_share_driver"), "hitachi"],
         [t(".shares.netapp_share_driver"), "netapp"],
+        [t(".shares.netapp_managed_share_driver"), "netapp-managed"],
         [t(".shares.manual_share_driver"), "manual"]
       ],
       selected.to_s

--- a/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
@@ -48,6 +48,21 @@
               = password_field %w(shares {{@index}} netapp netapp_password)
               = select_field %w(shares {{@index}} netapp netapp_transport_type), :collection => :netapp_transports_for_manila
           {{/if_eq}}
+          {{#if_eq backend_driver 'netapp-managed'}}
+          %li.list-group-item
+            %fieldset
+              %legend
+                = t('.shares.netapp_managed_parameters')
+
+              = string_field %w(shares {{@index}} netapp-managed netapp_server_hostname)
+              = string_field %w(shares {{@index}} netapp-managed netapp_server_port)
+              = string_field %w(shares {{@index}} netapp-managed netapp_login)
+              = password_field %w(shares {{@index}} netapp-managed netapp_password)
+              = select_field %w(shares {{@index}} netapp-managed netapp_transport_type), :collection => :netapp_transports_for_manila
+              = string_field %w(shares {{@index}} netapp-managed netapp_root_volume_aggregate)
+              = string_field %w(shares {{@index}} netapp-managed netapp_aggregate_name_search_pattern)
+              = string_field %w(shares {{@index}} netapp-managed netapp_port_name_search_pattern)
+          {{/if_eq}}
           {{#if_eq backend_driver 'hitachi'}}
           %li.list-group-item
             %fieldset

--- a/crowbar_framework/config/locales/manila/en.yml
+++ b/crowbar_framework/config/locales/manila/en.yml
@@ -33,10 +33,12 @@ en:
           loading_text: 'Loading Backends...'
           generic_parameters: 'Generic backend parameters'
           netapp_parameters: "NetApp parameters"
+          netapp_managed_parameters: "NetApp parameters (managed mode)"
           hitachi_parameters: "Hitachi parameters"
           manual_parameters: 'Other driver parameters'
           generic_share_driver: 'Generic driver'
           netapp_share_driver: 'NetApp driver'
+          netapp_managed_share_driver: 'NetApp driver (managed)'
           hitachi_share_driver: 'Hitachi driver'
           manual_share_driver: 'Other driver'
           generic:
@@ -60,6 +62,9 @@ en:
               netapp_server_hostname: 'Server host name'
               netapp_server_port: 'Server port'
               netapp_transport_type: 'Transport Type'
+              netapp_root_volume_aggregate: 'Root volume aggregate'
+              netapp_aggregate_name_search_pattern: 'Aggregate name search pattern'
+              netapp_port_name_search_pattern: 'Port name search pattern'
             hitachi:
               hds_hnas_cluster_admin_ip0: 'The IP of the clusters admin node. Only set in HNAS multinode clusters.'
               hds_hnas_evs_id: 'Specify which EVS this backend is assigned to.'


### PR DESCRIPTION
Manila has for some drivers different modes. DHSS=True means
in the NetApp case, that the vserver creation in handled by the Manila
driver. Support this mode in addition to the DHSS=False case.
