### PR TITLE
Deploy keystone wsgi mod with SSL

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -58,7 +58,6 @@ default[:keystone][:ssl][:certfile] = "/etc/keystone/ssl/certs/signing_cert.pem"
 default[:keystone][:ssl][:keyfile] = "/etc/keystone/ssl/private/signing_key.pem"
 default[:keystone][:ssl][:generate_certs] = false
 default[:keystone][:ssl][:insecure] = false
-default[:keystone][:ssl][:cert_required] = false
 default[:keystone][:ssl][:ca_certs] = "/etc/keystone/ssl/certs/ca.pem"
 
 default[:keystone][:ldap][:url] = "ldap://localhost"

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -157,6 +157,8 @@ elsif node[:keystone][:frontend] == "apache"
     "${APACHE_LOG_DIR}"
   end
 
+  apache_module "ssl" if node[:keystone][:api][:protocol] == "https"
+
   template "#{node[:apache][:dir]}/sites-available/keystone.conf" do
     path "#{node[:apache][:dir]}/vhosts.d/keystone.conf" if node[:platform_family] == "suse"
     source "apache_keystone.conf.erb"
@@ -166,6 +168,10 @@ elsif node[:keystone][:frontend] == "apache"
       bind_admin_host: bind_admin_host,
       bind_service_port: bind_service_port, # public port
       bind_service_host: bind_service_host,
+      ssl_enable: node[:keystone][:api][:protocol] == "https",
+      ssl_certfile: node[:keystone][:ssl][:certfile],
+      ssl_keyfile: node[:keystone][:ssl][:keyfile],
+      ssl_ca_certs: node[:keystone][:ssl][:ca_certs],
       processes: 3,
       threads: 10
     )
@@ -245,7 +251,6 @@ template "/etc/keystone/keystone.conf" do
       ssl_enable: (node[:keystone][:frontend] == "native" && node[:keystone][:api][:protocol] == "https"),
       ssl_certfile: node[:keystone][:ssl][:certfile],
       ssl_keyfile: node[:keystone][:ssl][:keyfile],
-      ssl_cert_required: node[:keystone][:ssl][:cert_required],
       ssl_ca_certs: node[:keystone][:ssl][:ca_certs],
       rabbit_settings: fetch_rabbitmq_settings
     )
@@ -403,7 +408,6 @@ if node[:keystone][:api][:protocol] == "https"
     keyfile node[:keystone][:ssl][:keyfile]
     group node[:keystone][:group]
     fqdn node[:fqdn]
-    cert_required node[:keystone][:ssl][:cert_required]
     ca_certs node[:keystone][:ssl][:ca_certs]
   end
 end

--- a/chef/cookbooks/keystone/templates/default/apache_keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/apache_keystone.conf.erb
@@ -7,6 +7,13 @@ Listen <%= @bind_service_host %>:<%= @bind_service_port %>
     WSGIPassAuthorization On
     LimitRequestBody 114688
 
+<% if @ssl_enable %>
+    SSLEngine on
+    SSLCertificateFile <%= @ssl_certfile %>
+    SSLCertificateKeyFile <%= @ssl_keyfile %>
+    SSLCACertificateFile <%= @ssl_ca_certs %>
+<% end %>
+
     <IfVersion >= 2.4>
       ErrorLogFormat "%M"
     </IfVersion>
@@ -36,6 +43,13 @@ Listen <%= @bind_admin_host %>:<%= @bind_admin_port %>
     WSGIApplicationGroup %{GLOBAL}
     WSGIPassAuthorization On
     LimitRequestBody 114688
+
+<% if @ssl_enable %>
+    SSLEngine on
+    SSLCertificateFile <%= @ssl_certfile %>
+    SSLCertificateKeyFile <%= @ssl_keyfile %>
+    SSLCACertificateFile <%= @ssl_ca_certs %>
+<% end %>
 
     <IfVersion >= 2.4>
       ErrorLogFormat "%M"

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -809,8 +809,6 @@ ca_certs = <%= @ssl_ca_certs %>
 # This option is deprecated for removal.
 # Its value may be silently ignored in the future.
 #cert_required = false
-cert_required = <%= @ssl_cert_required %>
-
 
 [federation]
 

--- a/chef/data_bags/crowbar/migrate/keystone/103_remove_cert_required.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/103_remove_cert_required.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ssl"].delete("cert_required")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["ssl"]["cert_required"] = ta["ssl"]["cert_required"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -25,7 +25,6 @@
         "keyfile": "/etc/keystone/ssl/private/signing_key.pem",
         "generate_certs": false,
         "insecure": false,
-        "cert_required": false,
         "ca_certs": "/etc/keystone/ssl/certs/ca.pem"
       },
       "api": {
@@ -118,7 +117,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 103,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -30,7 +30,6 @@
                       "keyfile": { "type" : "str", "required" : true },
                       "generate_certs": { "type" : "bool", "required" : true },
                       "insecure": { "type" : "bool", "required" : true },
-                      "cert_required": { "type" : "bool", "required" : true },
                       "ca_certs": { "type" : "str", "required" : true }
                     }},
                     "api": { "type": "map", "required": true, "mapping": {

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -30,12 +30,15 @@
       %legend
         = t(".ssl_header")
 
-      = select_field %w(api protocol), :collection => :api_protocols_for_keystone, "data-sslprefix" => "ssl", "data-sslcert" => "/etc/keystone/ssl/certs/signing_cert.pem", "data-sslkey" => "/etc/keystone/ssl/private/signing_key.pem"
+      = select_field %w(api protocol),
+        :collection => :api_protocols_for_keystone,
+        "data-sslprefix" => "ssl",
+        "data-sslcert" => "/etc/keystone/ssl/certs/signing_cert.pem",
+        "data-sslkey" => "/etc/keystone/ssl/private/signing_key.pem"
 
       #ssl_container
         = boolean_field %w(ssl generate_certs)
         = string_field %w(ssl certfile)
         = string_field %w(ssl keyfile)
         = boolean_field %w(ssl insecure)
-        = boolean_field %w(ssl cert_required), "data-enabler" => "true", "data-enabler-target" => "#ssl_ca_certs"
         = string_field %w(ssl ca_certs)

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -42,7 +42,6 @@ en:
           certfile: 'SSL Certificate File'
           keyfile: 'SSL (Private) Key File'
           insecure: 'SSL Certificate is insecure (for instance, self-signed)'
-          cert_required: 'Require Client Certificate'
           ca_certs: 'SSL CA Certificates File'
       validation:
         api_version: 'API version %{api_version} not recognized.'


### PR DESCRIPTION
When using the wsgi apache module we need to enable SSL for it not in
the `keystone.conf` but in apache.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crowbar/crowbar-openstack/576)

<!-- Reviewable:end -->
