### PR TITLE
sahara: remove UI widgets

### DIFF
--- a/crowbar_framework/app/views/barclamp/sahara/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/sahara/_edit_attributes.html.haml
@@ -15,5 +15,3 @@
       %legend
         = t(".logging_header")
       = boolean_field :verbose
-      = boolean_field :debug
-      = boolean_field :use_syslog

--- a/crowbar_framework/config/locales/sahara/en.yml
+++ b/crowbar_framework/config/locales/sahara/en.yml
@@ -28,5 +28,3 @@ en:
         cinder_instance: 'Cinder'
         logging_header: 'Logging'
         verbose: 'Verbose'
-        debug: 'Debug'
-        use_syslog: 'Use syslog'


### PR DESCRIPTION
To be consistent with the rest of the barclamps, let's not expose debug
and use_syslog on the UI
