### PR TITLE
[stable/3.0] Add tunnel_csum attribute to neutron barclamp

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -223,6 +223,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
         use_l2pop: neutron[:neutron][:use_l2pop] &&
             (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
         dvr_enabled: neutron[:neutron][:use_dvr],
+        tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
         bridge_mappings: bridge_mappings
       )
     end

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -186,6 +186,9 @@ enable_distributed_routing = True
 # carrying GRE/VXLAN tunnel. The default value is False.
 #
 # tunnel_csum = False
+<% if @tunnel_csum -%>
+tunnel_csum = True
+<% end -%>
 
 # (StrOpt) agent_type to report.
 # This config entry allows configuration of the neutron agent type reported

--- a/chef/data_bags/crowbar/migrate/neutron/055_add_tunnel_csum.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/055_add_tunnel_csum.rb
@@ -1,0 +1,14 @@
+def upgrade(ta, td, a, d)
+  a["ovs"] ||= {}
+  a["ovs"]["tunnel_csum"] = ta["ovs"]["tunnel_csum"]
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if a.key?("ovs")
+    a["ovs"].delete("tunnel_csum")
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -32,6 +32,9 @@
         "vni_end": 99999,
         "multicast_group": "239.1.1.1"
       },
+      "ovs": {
+        "tunnel_csum": false
+      },
       "allow_overlapping_ips": true,
       "use_syslog": false,
       "database_instance": "none",
@@ -115,7 +118,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 54,
+      "schema-revision": 55,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -37,6 +37,9 @@
                       "vni_end": { "type" : "int", "required" : true },
                       "multicast_group": { "type" : "str", "required": true }
                     }},
+                    "ovs": { "type": "map", "required": true, "mapping": {
+                      "tunnel_csum": { "type": "bool", "required": true }
+                    }},
                     "allow_overlapping_ips": { "type": "bool", "required": true },
                     "cisco_switches": {
                       "type" : "map",


### PR DESCRIPTION
(cherry picked from commit eca6eb435189d1c63c431e7df4ae2af97d527d57)