### PR TITLE
glance: remove conversion task api support from glance

### DIFF
--- a/chef/cookbooks/glance/attributes/default.rb
+++ b/chef/cookbooks/glance/attributes/default.rb
@@ -30,10 +30,6 @@ default[:glance][:config_dir] = "/etc/glance"
 default[:glance][:enable_v3_api] = false
 default[:glance][:max_header_line] = 16384
 
-default[:glance][:conversion][:enabled] = false
-default[:glance][:conversion][:conversion_format] = "raw"
-default[:glance][:conversion][:work_dir] = "/var/lib/glance/taskflow"
-
 default[:glance][:db][:password] = "" # set by wrapper
 default[:glance][:db][:user] = "glance"
 default[:glance][:db][:database] = "glance"

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -1861,8 +1861,7 @@ flavor = keystone
 # estimations and you should do them based on the worst case scenario
 # and be prepared to act in case they were wrong. (string value)
 #work_dir = <None>
-work_dir = <%= node[:glance][:conversion][:work_dir] %>
-
+work_dir = /var/lib/glance/taskflow
 
 [taskflow_executor]
 
@@ -1885,6 +1884,3 @@ work_dir = <%= node[:glance][:conversion][:work_dir] %>
 # using the RBD backend, this should be set to 'raw' (string value)
 # Allowed values: qcow2, raw, vmdk
 #conversion_format = <None>
-<% if node[:glance][:conversion][:enabled] -%>
-conversion_format = <%= node[:glance][:conversion][:conversion_format] %>
-<% end -%>

--- a/chef/data_bags/crowbar/migrate/glance/101_remove_conversion_task_api.rb
+++ b/chef/data_bags/crowbar/migrate/glance/101_remove_conversion_task_api.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("conversion")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["conversion"] = ta["conversion"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -38,11 +38,6 @@
       "use_syslog": false,
       "default_store": "file",
       "filesystem_store_datadir": "/var/lib/glance/images",
-      "conversion": {
-        "enabled": false,
-        "conversion_format": "raw",
-        "work_dir": "/var/lib/glance/taskflow"
-      },
       "swift": {
         "store_container": "glance",
         "store_create_container_on_put": true
@@ -71,7 +66,7 @@
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-glance.schema
+++ b/chef/data_bags/crowbar/template-glance.schema
@@ -61,13 +61,6 @@
             "use_syslog": { "type": "bool", "required": true },
             "default_store": { "type": "str", "required": true, "pattern": "/^(file|cinder|rbd|swift|vsphere)$/"  },
             "filesystem_store_datadir": { "type": "str", "required": true },
-            "conversion": {
-              "type": "map", "required": true, "mapping": {
-                "enabled": { "type": "bool", "required": true },
-                "conversion_format": { "type": "str", "required": true },
-                "work_dir": { "type": "str", "required": true }
-              }
-            },
             "swift": {
               "type": "map", "required": true, "mapping": {
                 "store_container": { "type": "str", "required": true },


### PR DESCRIPTION
The conversion task API for glance is being deprecated. The PR removes the attributes and tasks related to this service, effectively reverting this PR https://github.com/crowbar/crowbar-openstack/commit/2123499b53c7820c8cb8850a99dfe9d171dfc3a1 as well as migrates the schema