### PR TITLE
api: replace (tenant_id) with (project_id) in service endpoint registration urls

### DIFF
--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -90,9 +90,12 @@ keystone_register "register cinder endpoint" do
   auth register_auth_hash
   endpoint_service "cinder"
   endpoint_region keystone_settings["endpoint_region"]
-  endpoint_publicURL "#{cinder_protocol}://#{my_public_host}:#{cinder_port}/v1/$(tenant_id)s"
-  endpoint_adminURL "#{cinder_protocol}://#{my_admin_host}:#{cinder_port}/v1/$(tenant_id)s"
-  endpoint_internalURL "#{cinder_protocol}://#{my_admin_host}:#{cinder_port}/v1/$(tenant_id)s"
+  endpoint_publicURL "#{cinder_protocol}://"\
+                     "#{my_public_host}:#{cinder_port}/v1/$(project_id)s"
+  endpoint_adminURL "#{cinder_protocol}://"\
+                    "#{my_admin_host}:#{cinder_port}/v1/$(project_id)s"
+  endpoint_internalURL "#{cinder_protocol}://"\
+                       "#{my_admin_host}:#{cinder_port}/v1/$(project_id)s"
 #  endpoint_global true
 #  endpoint_enabled true
   action :add_endpoint_template
@@ -118,9 +121,12 @@ keystone_register "register cinder endpoint v2" do
   auth register_auth_hash
   endpoint_service "cinderv2"
   endpoint_region keystone_settings["endpoint_region"]
-  endpoint_publicURL "#{cinder_protocol}://#{my_public_host}:#{cinder_port}/v2/$(tenant_id)s"
-  endpoint_adminURL "#{cinder_protocol}://#{my_admin_host}:#{cinder_port}/v2/$(tenant_id)s"
-  endpoint_internalURL "#{cinder_protocol}://#{my_admin_host}:#{cinder_port}/v2/$(tenant_id)s"
+  endpoint_publicURL "#{cinder_protocol}://"\
+                     "#{my_public_host}:#{cinder_port}/v2/$(project_id)s"
+  endpoint_adminURL "#{cinder_protocol}://"\
+                    "#{my_admin_host}:#{cinder_port}/v2/$(project_id)s"
+  endpoint_internalURL "#{cinder_protocol}://"\
+                       "#{my_admin_host}:#{cinder_port}/v2/$(project_id)s"
   action :add_endpoint_template
 end
 

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -336,9 +336,15 @@ keystone_register "register heat endpoint" do
   auth register_auth_hash
   endpoint_service "heat"
   endpoint_region keystone_settings["endpoint_region"]
-  endpoint_publicURL "#{node[:heat][:api][:protocol]}://#{my_public_host}:#{node[:heat][:api][:port]}/v1/$(tenant_id)s"
-  endpoint_adminURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:port]}/v1/$(tenant_id)s"
-  endpoint_internalURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:port]}/v1/$(tenant_id)s"
+  endpoint_publicURL "#{node[:heat][:api][:protocol]}://"\
+                     "#{my_public_host}:"\
+                     "#{node[:heat][:api][:port]}/v1/$(project_id)s"
+  endpoint_adminURL "#{node[:heat][:api][:protocol]}://"\
+                    "#{my_admin_host}:"\
+                    "#{node[:heat][:api][:port]}/v1/$(project_id)s"
+  endpoint_internalURL "#{node[:heat][:api][:protocol]}://"\
+                       "#{my_admin_host}:"\
+                       "#{node[:heat][:api][:port]}/v1/$(project_id)s"
   #  endpoint_global true
   #  endpoint_enabled true
   action :add_endpoint_template

--- a/chef/cookbooks/manila/recipes/api.rb
+++ b/chef/cookbooks/manila/recipes/api.rb
@@ -91,11 +91,11 @@ keystone_register "register manila endpoint" do
   endpoint_service "manila"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{manila_protocol}://"\
-                     "#{my_public_host}:#{manila_port}/v1/$(tenant_id)s"
+                     "#{my_public_host}:#{manila_port}/v1/$(project_id)s"
   endpoint_adminURL "#{manila_protocol}://"\
-                    "#{my_admin_host}:#{manila_port}/v1/$(tenant_id)s"
+                    "#{my_admin_host}:#{manila_port}/v1/$(project_id)s"
   endpoint_internalURL "#{manila_protocol}://"\
-                       "#{my_admin_host}:#{manila_port}/v1/$(tenant_id)s"
+                       "#{my_admin_host}:#{manila_port}/v1/$(project_id)s"
   #  endpoint_global true
   #  endpoint_enabled true
   action :add_endpoint_template
@@ -123,11 +123,11 @@ keystone_register "register manila endpoint v2" do
   endpoint_service "manilav2"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{manila_protocol}://"\
-                     "#{my_public_host}:#{manila_port}/v2/$(tenant_id)s"
+                     "#{my_public_host}:#{manila_port}/v2/$(project_id)s"
   endpoint_adminURL "#{manila_protocol}://"\
-                    "#{my_admin_host}:#{manila_port}/v2/$(tenant_id)s"
+                    "#{my_admin_host}:#{manila_port}/v2/$(project_id)s"
   endpoint_internalURL "#{manila_protocol}://"\
-                       "#{my_admin_host}:#{manila_port}/v2/$(tenant_id)s"
+                       "#{my_admin_host}:#{manila_port}/v2/$(project_id)s"
   action :add_endpoint_template
 end
 

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -124,9 +124,12 @@ keystone_register "register nova endpoint" do
   auth register_auth_hash
   endpoint_service "nova"
   endpoint_region keystone_settings["endpoint_region"]
-  endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v2.1/$(tenant_id)s"
-  endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v2.1/$(tenant_id)s"
-  endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v2.1/$(tenant_id)s"
+  endpoint_publicURL "#{api_protocol}://"\
+                     "#{public_api_host}:#{api_port}/v2.1/$(project_id)s"
+  endpoint_adminURL "#{api_protocol}://"\
+                    "#{admin_api_host}:#{api_port}/v2.1/$(project_id)s"
+  endpoint_internalURL "#{api_protocol}://"\
+                       "#{admin_api_host}:#{api_port}/v2.1/$(project_id)s"
 #  endpoint_global true
 #  endpoint_enabled true
   action :add_endpoint_template
@@ -156,9 +159,12 @@ keystone_register "register nova_legacy endpoint" do
   auth register_auth_hash
   endpoint_service "nova_legacy"
   endpoint_region keystone_settings["endpoint_region"]
-  endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}/v2/$(tenant_id)s"
-  endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v2/$(tenant_id)s"
-  endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}/v2/$(tenant_id)s"
+  endpoint_publicURL "#{api_protocol}://"\
+                     "#{public_api_host}:#{api_port}/v2/$(project_id)s"
+  endpoint_adminURL "#{api_protocol}://"\
+                    "#{admin_api_host}:#{api_port}/v2/$(project_id)s"
+  endpoint_internalURL "#{api_protocol}://"\
+                       "#{admin_api_host}:#{api_port}/v2/$(project_id)s"
   action :add_endpoint_template
 end
 

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -225,9 +225,14 @@ case proxy_config[:auth_method]
          port keystone_settings["admin_port"]
          endpoint_service "swift"
          endpoint_region keystone_settings["endpoint_region"]
-         endpoint_publicURL "#{swift_protocol}://#{public_host}:#{node[:swift][:ports][:proxy]}/v1/#{node[:swift][:reseller_prefix]}$(tenant_id)s"
-         endpoint_adminURL "#{swift_protocol}://#{admin_host}:#{node[:swift][:ports][:proxy]}/v1/"
-         endpoint_internalURL "#{swift_protocol}://#{admin_host}:#{node[:swift][:ports][:proxy]}/v1/#{node[:swift][:reseller_prefix]}$(tenant_id)s"
+         endpoint_publicURL "#{swift_protocol}://#{public_host}:"\
+                            "#{node[:swift][:ports][:proxy]}/v1/"\
+                            "#{node[:swift][:reseller_prefix]}$(project_id)s"
+         endpoint_adminURL "#{swift_protocol}://#{admin_host}:"\
+                           "#{node[:swift][:ports][:proxy]}/v1/"
+         endpoint_internalURL "#{swift_protocol}://#{admin_host}:"\
+                              "#{node[:swift][:ports][:proxy]}/v1/"\
+                              "#{node[:swift][:reseller_prefix]}$(project_id)s"
          #  endpoint_global true
          #  endpoint_enabled true
         action :add_endpoint_template

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -104,11 +104,11 @@ keystone_register "register trove endpoint" do
   endpoint_service "trove"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{trove_protocol}://"\
-                     "#{my_public_host}:#{trove_port}/v1.0/$(tenant_id)s"
+                     "#{my_public_host}:#{trove_port}/v1.0/$(project_id)s"
   endpoint_adminURL "#{trove_protocol}://"\
-                    "#{my_admin_host}:#{trove_port}/v1.0/$(tenant_id)s"
+                    "#{my_admin_host}:#{trove_port}/v1.0/$(project_id)s"
   endpoint_internalURL "#{trove_protocol}://"\
-                       "#{my_admin_host}:#{trove_port}/v1.0/$(tenant_id)s"
+                       "#{my_admin_host}:#{trove_port}/v1.0/$(project_id)s"
   #  endpoint_global true
   #  endpoint_enabled true
   action :add_endpoint_template


### PR DESCRIPTION
Keystone supports $(project_id)s in the catalog. It works the same as $(tenant_id)s. Use of $(tenant_id)s is deprecated and catalog endpoints should be updated to use $(project_id)s.