### PR TITLE
Revert "neutron: Fix device_driver for Neutron Lbaas agent"

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -146,8 +146,7 @@ if node[:neutron][:use_lbaas] &&
       debug: node[:neutron][:debug],
       interface_driver: interface_driver,
       user_group: node[:neutron][:platform][:lbaas_haproxy_group],
-      device_driver: "neutron_lbaas.services.loadbalancer.drivers" \
-                     ".haproxy.namespace_driver.HaproxyNSDriver"
+      device_driver: "neutron_lbaas.drivers.haproxy.namespace_driver.HaproxyNSDriver"
     )
   end
 elsif node[:neutron][:use_lbaas] && node[:neutron][:use_lbaasv2] &&


### PR DESCRIPTION
This reverts commit 208ec23e473ac64a6603f50192254aa327c55c80.
It does not work with Newton. The error (neutron-lbaas.log) on Newton is:

Could not load neutron_lbaas.services.loadbalancer.drivers.haproxy.\
      namespace_driver.HaproxyNSDriver