### PR TITLE
nova: Allocate IPs on compute nodes from the ceph_client network

### DIFF
--- a/crowbar_framework/config/locales/glance/en.yml
+++ b/crowbar_framework/config/locales/glance/en.yml
@@ -61,3 +61,4 @@ en:
         verbose: 'Verbose Logging'
       validation:
         default_store_no_cinder: 'Cannot set default store to Cinder without Cinder being active.'
+        ceph_client_network_not_available: "The ceph_client network '%{ceph_client}' is not available in the network proposal"

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -92,3 +92,4 @@ en:
         invalid_migration_network: 'Network "%{network}" configured for live migration is not defined in the configuration of the network barclamp.'
         invalid_zvm_xcat_network: 'Network "%{network}" configured for zvm xcat access is not defined in the configuration of the network barclamp.'
         vendor_data_invalid_json: "The provided vendordata for the metadata server is invalid JSON."
+        ceph_client_network_not_available: "The ceph_client network '%{ceph_client}' is not available in the network proposal"


### PR DESCRIPTION
crowbar-ceph got recently CephFS support. With that, the instances
running on compute nodes need access to the Ceph cluster to be able
to mount shares.
For that, the default network for ceph client traffic changed to
the public network (set via the "ceph_client" attribute).

See https://github.com/crowbar/crowbar-ceph/commit/4f893f6bbf6c3 for
details about the new ceph_client attribute.