### PR TITLE
nova: Add back memcached_servers option

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -489,6 +489,7 @@ auth_strategy = keystone
 # This option is deprecated for removal.
 # Its value may be silently ignored in the future.
 #memcached_servers = <None>
+memcached_servers = <%= @memcached_servers.join(',') %>
 
 #
 # From nova.compute


### PR DESCRIPTION
It's deprecated, but actually still required in Mitaka. Without it, when
we do HA for nova, then the console doesn't work.