### PR TITLE
nova: set cache.enabled in nova.conf

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2609,6 +2609,7 @@ os_region_name=<%= @keystone_settings['endpoint_region'] %>
 # production deployments.  Small workloads (single process) like devstack can
 # use the dogpile.cache.memory backend. (string value)
 #backend = dogpile.cache.null
+backend = dogpile.cache.memcached
 
 # Arguments supplied to the backend module. Specify this option once per
 # argument to be passed to the dogpile.cache backend. Example format:
@@ -2622,6 +2623,7 @@ os_region_name=<%= @keystone_settings['endpoint_region'] %>
 
 # Global toggle for caching. (boolean value)
 #enabled = false
+enabled = true
 
 # Extra debugging from the cache backend (cache keys, get/set/delete/etc
 # calls). This is only really useful if you need to see the specific cache-


### PR DESCRIPTION
Option memcached_servers is deprecated in Mitaka. Operators should use oslo.cache configuration instead. Specifically enabled option under [cache] section should be set to True and the url(s) for the memcached servers should be in [cache]/memcache_servers option.

memcached was already enabled. This PR sets the cache to enabled