### PR TITLE
Complete renaming of READMEs

### DIFF
--- a/chef/cookbooks/aodh/metadata.rb
+++ b/chef/cookbooks/aodh/metadata.rb
@@ -2,5 +2,5 @@ maintainer "Crowbar project"
 maintainer_email "crowbar@googlegroups.com"
 license "Apache 2.0"
 description "Installs/Configures Aodh"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.me"))
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"

--- a/chef/cookbooks/barbican/metadata.rb
+++ b/chef/cookbooks/barbican/metadata.rb
@@ -3,7 +3,7 @@ maintainer "Crowbar project"
 maintainer_email "crowbar@googlegroups.com"
 license "Apache 2.0"
 description "Installs/Configures Barbican"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.me"))
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"
 
 depends "apache2"

--- a/chef/cookbooks/ceilometer/metadata.rb
+++ b/chef/cookbooks/ceilometer/metadata.rb
@@ -2,7 +2,7 @@ maintainer "User Unknown"
 maintainer_email "Unknown@Sample.com"
 license "Apache 2.0"
 description "Installs/Configures Ceilometer"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.me"))
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"
 
 depends "nagios"

--- a/chef/cookbooks/cinder/metadata.rb
+++ b/chef/cookbooks/cinder/metadata.rb
@@ -3,7 +3,7 @@ maintainer "Crowbar project"
 maintainer_email "crowbar@googlegroups.com"
 license "Apache 2.0"
 description "Installs/Configures Cinder"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.me"))
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"
 
 depends "nagios"

--- a/chef/cookbooks/heat/metadata.rb
+++ b/chef/cookbooks/heat/metadata.rb
@@ -2,7 +2,7 @@ maintainer "User Unknown"
 maintainer_email "crowbar@dell.com"
 license "Apache 2.0"
 description "Installs/Configures Heat"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.me"))
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"
 
 depends "nagios"

--- a/chef/cookbooks/horizon/metadata.rb
+++ b/chef/cookbooks/horizon/metadata.rb
@@ -2,7 +2,7 @@ maintainer "User Unknown"
 maintainer_email "Unknown@Sample.com"
 license "Apache 2.0"
 description "Installs/Configures Nova Dashboard"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.me"))
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.0"
 
 depends "apache2"

--- a/chef/cookbooks/manila/metadata.rb
+++ b/chef/cookbooks/manila/metadata.rb
@@ -3,7 +3,7 @@ maintainer "Crowbar project"
 maintainer_email "crowbar@googlegroups.com"
 license "Apache 2.0"
 description "Installs/Configures Manila"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.me"))
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"
 
 depends "nagios"


### PR DESCRIPTION
Commit 4c24cb3d010e8ec392cfba57ac3c2bd7f087462a was missing updates in
the metadata of the affect cookbooks.