### PR TITLE
Do not execute dispersion recipe in readying state.

### DIFF
--- a/chef/data_bags/crowbar/migrate/swift/100_dispersion_states.rb
+++ b/chef/data_bags/crowbar/migrate/swift/100_dispersion_states.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-swift.json
+++ b/chef/data_bags/crowbar/template-swift.json
@@ -100,9 +100,9 @@
     "swift": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 22,
+      "schema-revision": 100,
       "element_states": {
-        "swift-dispersion": [ "readying", "ready", "applying" ],
+        "swift-dispersion": [ "ready", "applying" ],
         "swift-storage": [ "readying", "ready", "applying" ],
         "swift-proxy": [ "readying", "ready", "applying" ],
         "swift-ring-compute": [ "readying", "ready", "applying" ]


### PR DESCRIPTION
Restart of swift-proxy from dispersion recipe during readying
(introduced by commit 77ec11da5b7db42bedfdd3829234957af1c28011)
could break pacemaker cluster setup.