### PR TITLE
aodh/ceilometer: put behind apache2

### DIFF
--- a/chef/cookbooks/aodh/attributes/default.rb
+++ b/chef/cookbooks/aodh/attributes/default.rb
@@ -29,7 +29,7 @@ when "debian"
       "aodh-notifier",
       "python-ceilometerclient"
     ],
-    services: ["api", "evaluator", "notifier", "listener"]
+    services: ["evaluator", "notifier", "listener"]
   }
 when "rhel", "suse"
   default[:aodh][:platform] = {
@@ -42,7 +42,7 @@ when "rhel", "suse"
       "openstack-aodh-notifier",
       "python-aodhclient"
     ],
-    services: ["api", "evaluator", "notifier", "listener"]
+    services: ["evaluator", "notifier", "listener"]
   }
   api_service_name = "openstack-aodh-api"
   evaluator_service_name = "openstack-aodh-evaluator"
@@ -72,8 +72,6 @@ default[:aodh][:db][:database] = "aodh"
 default[:aodh][:db][:user] = "aodh"
 default[:aodh][:db][:password] = ""
 
-default[:aodh][:ha][:api][:agent] = "systemd:#{api_service_name}"
-default[:aodh][:ha][:api][:op][:monitor][:interval] = "10s"
 default[:aodh][:ha][:evaluator][:agent] = "systemd:#{evaluator_service_name}"
 default[:aodh][:ha][:evaluator][:op][:monitor][:interval] = "10s"
 default[:aodh][:ha][:notifier][:agent] = "systemd:#{notifier_service_name}"

--- a/chef/cookbooks/aodh/metadata.rb
+++ b/chef/cookbooks/aodh/metadata.rb
@@ -4,3 +4,5 @@ license "Apache 2.0"
 description "Installs/Configures Aodh"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"
+
+depends "apache2"

--- a/chef/cookbooks/aodh/templates/default/apache_aodh.conf.erb
+++ b/chef/cookbooks/aodh/templates/default/apache_aodh.conf.erb
@@ -1,0 +1,21 @@
+
+Listen <%= @bind_host %>:<%= @bind_port %>
+
+<VirtualHost <%= @bind_host %>:<%= @bind_port %>>
+    WSGIDaemonProcess aodh-api user=aodh group=aodh processes=<%= @processes %> threads=<%= @threads %> user=aodh group=aodh display-name=%{GROUP}
+    WSGIProcessGroup aodh-api
+    WSGIScriptAlias / /srv/www/aodh-api/app.wsgi
+    WSGIApplicationGroup %{GLOBAL}
+    ErrorLogFormat "%{cu}t %M"
+    ErrorLog <%= @apache_log_dir %>/aodh_error.log
+    CustomLog <%= @apache_log_dir %>/aodh_access.log combined
+    <Directory /srv/www/aodh-api>
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
+        <IfVersion < 2.4>
+            Order allow,deny
+            Allow from all
+        </IfVersion>
+    </Directory>
+</VirtualHost>

--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -69,8 +69,6 @@ default[:ceilometer][:mongodb][:port] = 27017
 
 default[:ceilometer][:ha][:server][:enabled] = false
 
-default[:ceilometer][:ha][:api][:agent] = "systemd:#{api_service_name}"
-default[:ceilometer][:ha][:api][:op][:monitor][:interval] = "10s"
 # increase default timeout: ceilometer has to wait until mongodb is ready
 default[:ceilometer][:ha][:api][:op][:start][:timeout] = "60s"
 default[:ceilometer][:ha][:collector][:agent] = "systemd:#{collector_service_name}"

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -32,7 +32,7 @@ crowbar_pacemaker_sync_mark "wait-ceilometer_server_ha_resources"
 transaction_objects = []
 primitives = []
 
-["collector", "agent_notification", "api"].each do |service|
+["collector", "agent_notification"].each do |service|
   primitive_name = "ceilometer-#{service}"
 
   pacemaker_primitive primitive_name do

--- a/chef/cookbooks/ceilometer/templates/default/apache_ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/apache_ceilometer.conf.erb
@@ -1,0 +1,21 @@
+
+Listen <%= @bind_host %>:<%= @bind_port %>
+
+<VirtualHost <%= @bind_host %>:<%= @bind_port %>>
+    WSGIDaemonProcess ceilometer-api user=ceilometer group=ceilometer processes=<%= @processes %> threads=<%= @threads %> user=ceilometer group=ceilometer display-name=%{GROUP}
+    WSGIProcessGroup ceilometer-api
+    WSGIScriptAlias / /srv/www/ceilometer-api/app.wsgi
+    WSGIApplicationGroup %{GLOBAL}
+    ErrorLogFormat "%{cu}t %M"
+    ErrorLog <%= @apache_log_dir %>/ceilometer_error.log
+    CustomLog <%= @apache_log_dir %>/ceilometer_access.log combined
+    <Directory /srv/www/ceilometer-api>
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
+        <IfVersion < 2.4>
+            Order allow,deny
+            Allow from all
+        </IfVersion>
+    </Directory>
+</VirtualHost>


### PR DESCRIPTION
The builtin wsgi server in Newton does not read the port setting
from the config file anymore, so any attempt at setting that (which
is needed to be customized for HA) is failing.