### PR TITLE
keystone: Enable caching

### DIFF
--- a/chef/cookbooks/keystone/metadata.rb
+++ b/chef/cookbooks/keystone/metadata.rb
@@ -8,6 +8,7 @@ version "1.0"
 
 depends "apache2"
 depends "database"
+depends "memcached"
 depends "nagios"
 depends "uwsgi"
 depends "crowbar-openstack"

--- a/chef/cookbooks/keystone/recipes/memcached.rb
+++ b/chef/cookbooks/keystone/recipes/memcached.rb
@@ -1,0 +1,13 @@
+package "memcached"
+
+case node[:platform_family]
+when "rhel"
+  package "python-memcached"
+when "suse"
+  package "python-python-memcached"
+end
+
+node.set[:memcached][:listen] =
+  Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+
+memcached_instance "keystone"

--- a/chef/cookbooks/keystone/recipes/role_keystone_server.rb
+++ b/chef/cookbooks/keystone/recipes/role_keystone_server.rb
@@ -15,6 +15,7 @@
 #
 
 if CrowbarRoleRecipe.node_state_valid_for_role?(node, "keystone", "keystone-server")
+  include_recipe "keystone::memcached"
   include_recipe "keystone::server"
   include_recipe "keystone::monitor"
 end

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -388,6 +388,7 @@ driver = <%= node[:keystone][:assignment][:driver] %>
 # production deployments.  Small workloads (single process) like devstack can
 # use the dogpile.cache.memory backend. (string value)
 #backend = dogpile.cache.null
+backend = dogpile.cache.memcached
 
 # Arguments supplied to the backend module. Specify this option once per
 # argument to be passed to the dogpile.cache backend. Example format:
@@ -401,6 +402,7 @@ driver = <%= node[:keystone][:assignment][:driver] %>
 
 # Global toggle for caching. (boolean value)
 #enabled = false
+enabled = True
 
 # Extra debugging from the cache backend (cache keys, get/set/delete/etc
 # calls). This is only really useful if you need to see the specific cache-
@@ -411,6 +413,7 @@ driver = <%= node[:keystone][:assignment][:driver] %>
 # Memcache servers in the format of "host:port". (dogpile.cache.memcache and
 # oslo_cache.memcache_pool backends only). (list value)
 #memcache_servers = localhost:11211
+memcache_servers = <%= @memcached_servers.join(',') %>
 
 # Number of seconds memcached server is considered dead before it is tried
 # again. (dogpile.cache.memcache and oslo_cache.memcache_pool backends only).


### PR DESCRIPTION
With the move to Apache2 the performance suffered greatly without
a cross-process caching layer. use memcached for this