### PR TITLE
tempest: Allow more settings for Manila tests

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -1300,10 +1300,12 @@ multitenancy_enabled = False
 # First value of list is protocol by default, items of list show
 # enabled protocols at all. (list value)
 #enable_protocols = nfs,cifs
+enable_protocols = <%= @manila_settings['enable_protocols'] %>
 
 # Selection of protocols, that should be covered with ip rule tests
 # (list value)
 #enable_ip_rules_for_protocols = nfs,cifs
+enable_ip_rules_for_protocols = <%= @manila_settings['enable_ip_rules_for_protocols'] %>
 
 # Selection of protocols, that should be covered with user rule tests
 # (list value)
@@ -1311,6 +1313,7 @@ multitenancy_enabled = False
 
 # Protocols that should be covered with cert rule tests. (list value)
 #enable_cert_rules_for_protocols = glusterfs
+enable_cert_rules_for_protocols = <%= @manila_settings['enable_cert_rules_for_protocols'] %>
 
 # Protocols to be covered with cephx rule tests. (list value)
 #enable_cephx_rules_for_protocols = cephfs
@@ -1384,10 +1387,12 @@ suppress_errors_in_cleanup = true
 # Disable this feature if used driver doesn't support it. (boolean
 # value)
 #run_snapshot_tests = true
+run_snapshot_tests =<%= @manila_settings['run_snapshot_tests'] %>
 
 # Defines whether to run consistency group tests or not. Disable this
 # feature if used driver doesn't support it. (boolean value)
 #run_consistency_group_tests = true
+run_consistency_group_tests =<%= @manila_settings['run_consistency_group_tests'] %>
 
 # Defines whether to run replication tests or not. Enable this feature
 # if the driver is configured for replication. (boolean value)

--- a/chef/data_bags/crowbar/migrate/tempest/102_add_more_manila_options.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/102_add_more_manila_options.rb
@@ -1,0 +1,25 @@
+def upgrade(ta, td, a, d)
+  [
+    "enable_cert_rules_for_protocols",
+    "enable_ip_rules_for_protocols",
+    "run_consistency_group_tests",
+    "run_snapshot_tests",
+    "enable_protocols"
+  ].each do |key|
+    a["manila"][key] = ta["manila"][key]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  [
+    "enable_cert_rules_for_protocols",
+    "enable_ip_rules_for_protocols",
+    "run_consistency_group_tests",
+    "run_snapshot_tests",
+    "enable_protocols"
+  ].each do |key|
+    a["manila"].delete(key)
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -20,7 +20,12 @@
         "image_with_share_tools": "manila-service-image",
         "image_username": "root",
         "image_password": "",
-        "default_share_type_name": "default"
+        "default_share_type_name": "default",
+        "enable_cert_rules_for_protocols": "glusterfs",
+        "enable_ip_rules_for_protocols": "nfs,cifs",
+        "run_consistency_group_tests": true,
+        "run_snapshot_tests": true,
+        "enable_protocols": "nfs,cifs"
       },
       "magnum": {
         "image_id": "magnum-service-image",
@@ -33,7 +38,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },
@@ -50,4 +55,3 @@
     }
   }
 }
-

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -34,7 +34,12 @@
                 "image_with_share_tools": { "type": "str", "required": true },
                 "image_username": { "type": "str", "required": true },
                 "image_password": { "type": "str", "required": true },
-                "default_share_type_name": { "type": "str", "required": true }
+                "default_share_type_name": { "type": "str", "required": true },
+                "enable_cert_rules_for_protocols": { "type": "str", "required": true },
+                "enable_ip_rules_for_protocols": { "type": "str", "required": true },
+                "run_consistency_group_tests": { "type": "bool", "required": true },
+                "run_snapshot_tests": { "type": "bool", "required": true },
+                "enable_protocols": { "type": "str", "required": true }
               }
             },
             "magnum": {


### PR DESCRIPTION
This is needed to be able to run Manila tempest tests when a
CephFS backend is used.