### PR TITLE
magnum: Rename service_type from "container" to "container-infra" bsc#1010673

### DIFF
--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -75,8 +75,8 @@ keystone_register "register magnum service" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   service_name "magnum"
-  service_type "container"
-  service_description "Openstack Magnum - Containers as a Service"
+  service_type "container-infra"
+  service_description "Container Infrastructure Management Service"
   action :add_service
 end
 


### PR DESCRIPTION
OpenStack Magnum changed service_type name from "container" to "container-infra".
It was done in upstream bug https://bugs.launchpad.net/magnum/+bug/1584251