### PR TITLE
glance: add uid and gid check

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -142,6 +142,50 @@ class CrowbarOpenStackHelper
     @rabbitmq_settings[instance]
   end
 
+  # Verify uid for user.
+  def self.check_user(node, expected_username, expected_uid)
+    node["etc"]["passwd"].each do |username, attrs|
+      if username == expected_username
+        if attrs["uid"] != expected_uid
+          message = "user #{username} has uid #{attrs["uid"]} but " \
+            "expected #{expected_uid}"
+          Chef::Log.fatal(message)
+          raise message
+        else
+          break
+        end
+      end
+
+      next unless attrs["uid"] == expected_uid
+
+      message = "#{expected_uid} already in use by user #{username}"
+      Chef::Log.fatal(message)
+      raise message
+    end
+  end
+
+  # Verify gid for group.
+  def self.check_group(node, expected_groupname, expected_gid)
+    node["etc"]["group"].each do |groupname, attrs|
+      if groupname == expected_groupname
+        if attrs["gid"] != expected_gid
+          message = "group #{username} has gid #{attrs["gid"]} but " \
+            "expected #{expected_gid}"
+          Chef::Log.fatal(message)
+          raise message
+        else
+          break
+        end
+      end
+
+      next unless attrs["gid"] == expected_gid
+
+      message = "#{expected_gid} already in use by group #{groupname}"
+      Chef::Log.fatal(message)
+      raise message
+    end
+  end
+
   private
 
   def self.get_node(node, role, barclamp, instance)

--- a/chef/cookbooks/glance/attributes/default.rb
+++ b/chef/cookbooks/glance/attributes/default.rb
@@ -21,8 +21,8 @@
 
 override[:glance][:user] = "glance"
 override[:glance][:group] = "glance"
-override[:glance][:uid] = 483
-override[:glance][:gid] = 483
+override[:glance][:uid] = 200
+override[:glance][:gid] = 200
 
 default[:glance][:verbose] = "False"
 default[:glance][:debug] = "False"

--- a/chef/cookbooks/glance/attributes/default.rb
+++ b/chef/cookbooks/glance/attributes/default.rb
@@ -19,8 +19,10 @@
 # limitations under the License.
 #
 
-override[:glance][:user]="glance"
-override[:glance][:group]="glance"
+override[:glance][:user] = "glance"
+override[:glance][:group] = "glance"
+override[:glance][:uid] = 483
+override[:glance][:gid] = 483
 
 default[:glance][:verbose] = "False"
 default[:glance][:debug] = "False"

--- a/chef/cookbooks/glance/libraries/helpers.rb
+++ b/chef/cookbooks/glance/libraries/helpers.rb
@@ -28,52 +28,9 @@ module GlanceHelper
     end
   end
 
-  def self.check_user(node, expected_username, expected_uid)
-    node["etc"]["passwd"].each do |username, attrs|
-      if username == expected_username
-        if attrs["uid"] != expected_uid
-          message = "#{username} user exists on the system, "\
-                    "but it's uid is different from #{expected_uid}"
-          Chef::Log.fatal(message)
-          raise message
-        else
-          break
-        end
-      end
-
-      if attrs["uid"] == expected_uid
-        message = "#{expected_uid} already in use by user #{username}"
-        Chef::Log.fatal(message)
-        raise message
-      end
-    end
-  end
-
-  def self.check_group(node, expected_groupname, expected_gid)
-    node["etc"]["group"].each do |groupname, attrs|
-      if groupname == expected_groupname
-        if attrs["gid"] != expected_gid
-          message = "#{groupname} group exists on the system, "\
-                    "but it's gid is different from #{expected_gid}"
-          Chef::Log.fatal(message)
-          raise message
-        else
-          break
-        end
-      end
-
-      if attrs["gid"] == expected_gid
-        message = "#{expected_gid} already in use by user #{groupname}"
-        Chef::Log.fatal(message)
-        raise message
-      end
-    end
-  end
-
   def self.verify_user_and_group_ids(node)
-    Chef::Log.info("verifying user and group ids")
-    check_user(node, node[:glance][:user], node[:glance][:uid])
-    check_group(node, node[:glance][:group], node[:glance][:gid])
+    Chef::Log.info("Verifying user and group ids")
+    CrowbarOpenStackHelper.check_user(node, node[:glance][:user], node[:glance][:uid])
+    CrowbarOpenStackHelper.check_group(node, node[:glance][:group], node[:glance][:gid])
   end
-
 end

--- a/chef/cookbooks/glance/libraries/helpers.rb
+++ b/chef/cookbooks/glance/libraries/helpers.rb
@@ -27,4 +27,53 @@ module GlanceHelper
       }
     end
   end
+
+  def self.check_user(node, expected_username, expected_uid)
+    node["etc"]["passwd"].each do |username, attrs|
+      if username == expected_username
+        if attrs["uid"] != expected_uid
+          message = "#{username} user exists on the system, "\
+                    "but it's uid is different from #{expected_uid}"
+          Chef::Log.fatal(message)
+          raise message
+        else
+          break
+        end
+      end
+
+      if attrs["uid"] == expected_uid
+        message = "#{expected_uid} already in use by user #{username}"
+        Chef::Log.fatal(message)
+        raise message
+      end
+    end
+  end
+
+  def self.check_group(node, expected_groupname, expected_gid)
+    node["etc"]["group"].each do |groupname, attrs|
+      if groupname == expected_groupname
+        if attrs["gid"] != expected_gid
+          message = "#{groupname} group exists on the system, "\
+                    "but it's gid is different from #{expected_gid}"
+          Chef::Log.fatal(message)
+          raise message
+        else
+          break
+        end
+      end
+
+      if attrs["gid"] == expected_gid
+        message = "#{expected_gid} already in use by user #{groupname}"
+        Chef::Log.fatal(message)
+        raise message
+      end
+    end
+  end
+
+  def self.verify_user_and_group_ids(node)
+    Chef::Log.info("verifying user and group ids")
+    check_user(node, node[:glance][:user], node[:glance][:uid])
+    check_group(node, node[:glance][:group], node[:glance][:gid])
+  end
+
 end

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -22,7 +22,28 @@ package "glance" do
   package_name "openstack-glance" if %w(rhel suse).include?(node[:platform_family])
 end
 
-GlanceHelper.verify_user_and_group_ids(node)
+ruby_block "Adjust glance uid/gid" do
+  block do
+    Chef::Log.info("Verifying uid/gid for glance")
+
+    cmdline = "groupmod -g #{node[:glance][:gid]} #{node[:glance][:group]}"
+    Chef::Log.info("running #{cmdline}")
+    cmd = Chef::ShellOut.new(cmdline).run_command
+    if cmd.exitstatus.nonzero?
+      Chef::Log.error("Failed to update glance uid/gid")
+    end
+
+    cmdline = "usermod -u #{node[:glance][:uid]} -g #{node[:glance][:gid]} #{node[:glance][:user]}"
+    Chef::Log.info("running #{cmdline}")
+    cmd = Chef::ShellOut.new(cmdline).run_command
+    if cmd.exitstatus.nonzero?
+      Chef::Log.error("Failed to update glance uid/gid")
+    end
+
+  end
+  notifies :stop, "service[#{node[:glance][:api][:service_name]}]", :before
+  notifies :start, "service[#{node[:glance][:api][:service_name]}]"
+end
 
 ha_enabled = node[:glance][:ha][:enabled]
 

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -22,6 +22,8 @@ package "glance" do
   package_name "openstack-glance" if %w(rhel suse).include?(node[:platform_family])
 end
 
+GlanceHelper.verify_user_and_group_ids(node)
+
 ha_enabled = node[:glance][:ha][:enabled]
 
 db_settings = fetch_database_settings


### PR DESCRIPTION
Make the recipe fail if the node is not compatible with hardwired
uid/gid/username/groupname constraints.