### PR TITLE
nova: Use rootwrap daemon mode only for kvm (bsc#1010553)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -366,7 +366,9 @@ instance_usage_audit_period = hour
 # root privileges. This option is usually enabled on nodes that run nova
 # compute processes (boolean value)
 #use_rootwrap_daemon = false
+<% if @libvirt_type.eql?('kvm') -%>
 use_rootwrap_daemon = <%= @use_rootwrap_daemon %>
+<% end -%>
 
 # Path to the rootwrap configuration file to use for running commands as root
 # (string value)


### PR DESCRIPTION
Using the daemon mode fails for Xen (see lp#1643457).
This is a workarround until the bug in oslo.rootwrap is fixed.

https://bugzilla.suse.com/show_bug.cgi?id=1010553