### PR TITLE
keystone: Do not bootstrap keystone after upgrade

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -447,7 +447,9 @@ execute "keystone-manage bootstrap" do
   action :run
   only_if do
     !node[:keystone][:bootstrap] &&
-      (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node))
+      (!ha_enabled || (CrowbarPacemakerHelper.is_cluster_founder?(node) &&
+        !CrowbarPacemakerHelper.being_upgraded?(node))
+      )
   end
 end
 


### PR DESCRIPTION
This may be wrong. Also, we need to take care for non-HA case as well, I assume