### PR TITLE
tempest: Add missing heat_plugin config section

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -41,6 +41,9 @@ tempest_manila_settings = node[:tempest][:manila]
 # magnum (container)
 tempest_magnum_settings = node[:tempest][:magnum]
 
+# heat (orchestration)
+tempest_heat_settings = node[:tempest][:heat]
+
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
                        tenant: keystone_settings["admin_tenant"] }
@@ -552,7 +555,9 @@ template "/etc/tempest/tempest.conf" do
     # manila (share) settings
     manila_settings: tempest_manila_settings,
     # magnum (container) settings
-    magnum_settings: tempest_magnum_settings
+    magnum_settings: tempest_magnum_settings,
+    # heat (orchestration) settings
+    heat_settings: tempest_heat_settings
   )
 end
 

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -634,6 +634,165 @@ endpoint_type = internalURL
 #trace_requests =
 
 
+[heat_plugin]
+
+#
+# From tempest.config
+#
+
+# Catalog type of the orchestration service. (string value)
+#catalog_type = orchestration
+
+# Username to use for non admin API requests. (string value)
+#username = <None>
+username = <%= @comp_user %>
+
+# Non admin API key to use when authenticating. (string value)
+#password = <None>
+password = <%= @comp_pass %>
+
+# Username to use for admin API requests. (string value)
+#admin_username = <None>
+admin_username = <%= @keystone_settings['admin_user'] %>
+
+# Admin API key to use when authentication. (string value)
+#admin_password = <None>
+admin_password = <%= @keystone_settings['admin_password'] %>
+
+# Tenant name to use for API requests. (string value)
+#tenant_name = <None>
+tenant_name = <%= @comp_tenant %>
+
+# Admin tenant name to use for admin API requests. (string value)
+#admin_tenant_name = admin
+admin_tenant_name = <%= @keystone_settings['default_tenant'] %>
+
+# Full URI of the OpenStack Identity API (Keystone) (string value)
+#auth_url = <None>
+auth_url = <%= @keystone_settings['internal_auth_url'].chomp('/') %>
+
+# User domain name, if keystone v3 auth_urlis used (string value)
+#user_domain_name = <None>
+user_domain_name = Default
+
+# Project domain name, if keystone v3 auth_urlis used (string value)
+#project_domain_name = <None>
+project_domain_name = Default
+
+# The region name to use (string value)
+#region = <None>
+region = <%= @keystone_settings['endpoint_region'] %>
+
+# Instance type for tests. Needs to be big enough for a full OS plus
+# the test workload (string value)
+#instance_type = <None>
+instance_type = <%= @heat_flavor_ref %>
+
+# Instance type enough for simplest cases. (string value)
+#minimal_instance_type = <None>
+minimal_instance_type = tempest-stuff
+
+# Name of image to use for tests which boot servers. (string value)
+#image_ref = <None>
+<% unless @heat_settings['image_ref'].empty? -%>
+image_ref = <%= @heat_settings['image_ref'] %>
+<% end -%>
+
+# Name of existing keypair to launch servers with. (string value)
+#keypair_name = <None>
+
+# Name of minimal (e.g cirros) image to use when launching test
+# instances. (string value)
+#minimal_image_ref = <None>
+minimal_image_ref = <%= `cat #{@machine_id_file}`.strip %>
+
+# Set to True if using self-signed SSL certificates. (boolean value)
+#disable_ssl_certificate_validation = false
+
+# CA certificate to pass for servers that have https endpoint. (string
+# value)
+#ca_file = <None>
+
+# Time in seconds between build status checks. (integer value)
+#build_interval = 4
+
+# Timeout in seconds to wait for a stack to build. (integer value)
+#build_timeout = 1200
+build_timeout = 2000
+
+# Network used for SSH connections. (string value)
+#network_for_ssh = heat-net
+
+# Visible fixed network name  (string value)
+#fixed_network_name = heat-net
+fixed_network_name = fixed
+
+# Visible floating network name  (string value)
+#floating_network_name = public
+floating_network_name = floating
+
+# Path to environment file which defines the resource type
+# Heat::InstallConfigAgent. Needs to be appropriate for the image_ref.
+# (string value)
+#boot_config_env = heat_integrationtests/scenario/templates/boot_config_none_env.yaml
+
+# Visible fixed sub-network name  (string value)
+#fixed_subnet_name = heat-subnet
+
+# Timeout in seconds to wait for authentication to succeed. (integer
+# value)
+#ssh_timeout = 300
+
+# IP version used for SSH connections. (integer value)
+#ip_version_for_ssh = 4
+
+# Timeout in seconds to wait for output from ssh channel. (integer
+# value)
+#ssh_channel_timeout = 60
+
+# The mask bits for tenant ipv4 subnets (integer value)
+#tenant_network_mask_bits = 28
+
+# Skip all scenario tests (boolean value)
+#skip_scenario_tests = false
+
+# Skip all functional tests (boolean value)
+#skip_functional_tests = false
+
+# List of functional test class or class.method names to skip ex.
+# AutoscalingGroupTest,InstanceGroupBasicTest.test_size_updates_work
+# (list value)
+#skip_functional_test_list = <None>
+
+# List of scenario test class or class.method names to skip ex.
+# NeutronLoadBalancerTest, AodhAlarmTest.test_alarm (list value)
+#skip_scenario_test_list = <None>
+
+# List of stack actions in tests to skip ex. ABANDON, ADOPT, SUSPEND,
+# RESUME (list value)
+#skip_test_stack_action_list = <None>
+
+# Default size in GB for volumes created by volumes tests (integer
+# value)
+#volume_size = 1
+
+# Timeout in seconds to wait for connectivity to server. (integer
+# value)
+#connectivity_timeout = 120
+
+# Timeout in seconds to wait for adding or removing childprocess after
+# receiving of sighup signal (integer value)
+#sighup_timeout = 120
+
+# Count of retries to edit config file during sighup. If another
+# worker already edit config file, file can be busy, so need to wait
+# and try edit file again. (integer value)
+#sighup_config_edit_retries = 10
+
+# Path to the script heat-config-notify (string value)
+#heat_config_notify_script = heat-config-notify
+
+
 [identity]
 
 #

--- a/chef/data_bags/crowbar/migrate/tempest/103_add_heat_options.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/103_add_heat_options.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["heat"] = ta["heat"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("heat")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -31,6 +31,9 @@
         "image_id": "magnum-service-image",
         "flavor_id": "m1.small",
         "master_flavor_id": "m1.medium"
+      },
+      "heat": {
+        "image_ref": "heat-cfntools-image"
       }
     }
   },
@@ -38,7 +41,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 103,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -49,6 +49,12 @@
                 "flavor_id": { "type": "str", "required": true },
                 "master_flavor_id": { "type": "str", "required": true }
               }
+            },
+            "heat": {
+              "type": "map",
+              "mapping": {
+                "image_ref": { "type": "str", "required": true }
+              }
             }
           }
         }


### PR DESCRIPTION
The heat tempest plugin does not use the [orchestration] section.
Instead it uses its own config section called [heat_plugin].
So add that section with the needed parameters to the tempest config
template.