### PR TITLE
upgrade: Do not start neutron-ha-tool for node in the upgrade state

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -169,6 +169,11 @@ pacemaker_transaction "neutron agents" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
+if CrowbarPacemakerHelper.being_upgraded?(node)
+  log "Skipping neutron-ha-tool resource creation during the upgrade"
+  use_l3_agent = false
+end
+
 if use_l3_agent
   # FIXME: neutron-ha-tool can't do keystone v3 currently
   os_auth_url_v2 = KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],


### PR DESCRIPTION
During the initial post-upgrade chef-client run, network routers
are still present on another node.
We do not want neutron-ha-tool to create new ones automatically, so
we prevent the creation of neutron-ha-tool primitive and hope to handle the situation
manually later.


