### PR TITLE
Transition swift to systemd

### DIFF
--- a/chef/cookbooks/swift/attributes/default.rb
+++ b/chef/cookbooks/swift/attributes/default.rb
@@ -95,5 +95,5 @@ default[:swift][:ha][:enabled] = false
 # Ports to bind to when haproxy is used for the real ports
 default[:swift][:ha][:ports][:proxy] = 5540
 # pacemaker part
-default[:swift][:ha][:proxy][:agent] = "service:#{default[:swift][:proxy][:service_name]}"
+default[:swift][:ha][:proxy][:agent] = "systemd:#{default[:swift][:proxy][:service_name]}"
 default[:swift][:ha][:proxy][:op][:monitor][:interval] = "10s"


### PR DESCRIPTION
With the move of swift from init scripts to systemd units, change
to the systemd: resource.