### PR TITLE
magnum: add x509keycert store option

### DIFF
--- a/crowbar_framework/app/helpers/barclamp/magnum_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/magnum_helper.rb
@@ -21,7 +21,8 @@ module Barclamp
       options_for_select(
         [
           ["Local", "local"],
-          ["Barbican", "barbican"]
+          ["Barbican", "barbican"],
+          ["Magnum Database (x509keypair)", "x509keypair"]
         ],
         selected.to_s
       )


### PR DESCRIPTION
Introduce a new certificate store called x509keypair to magnum.