### PR TITLE
horizon:  add unversioned keystone endpoint url

### DIFF
--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -185,7 +185,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 #]
 
 OPENSTACK_HOST = "<%= @keystone_settings['internal_url_host'] %>"
-OPENSTACK_KEYSTONE_URL = "<%= @keystone_settings['internal_auth_url'] %>"
+OPENSTACK_KEYSTONE_URL = "<%= @keystone_settings['unversioned_internal_auth_url'] %>"
 OPENSTACK_KEYSTONE_DEFAULT_ROLE = "Member"
 
 # Enables keystone web single-sign-on if set to True.

--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -46,6 +46,9 @@ module KeystoneHelper
                                                 node[:fqdn],
                                                 node[:keystone][:api][:service_port],
                                                 node[:keystone][:api][:version])
+      unversioned_internal_auth_url = service_URL(node[:keystone][:api][:protocol],
+                                                  node[:fqdn],
+                                                  node[:keystone][:api][:service_port])
 
       has_default_user = node["keystone"]["default"]["create_user"]
       default_domain = "Default"
@@ -61,6 +64,8 @@ module KeystoneHelper
         "admin_auth_url" => node[:keystone][:api][:admin_URL] || admin_auth_url,
         "public_auth_url" => node[:keystone][:api][:versioned_public_URL] || public_auth_url,
         "internal_auth_url" => node[:keystone][:api][:versioned_internal_URL] || internal_auth_url,
+        "unversioned_internal_auth_url" => node[:keystone][:api][:unversioned_internal_URL] || \
+          unversioned_internal_auth_url,
         "use_ssl" => use_ssl,
         "endpoint_region" => node["keystone"]["api"]["region"],
         "insecure" => use_ssl && node[:keystone][:ssl][:insecure],


### PR DESCRIPTION
It is no longer necessary to include the version suffix into OPENSTACK_KEYSTONE_URL setting. Thanks to a recent update of django-openstack-auth library as of 2.3.0 release, Horizon will append the proper version suffix to the URL based on the value stored inside OPENSTACK_API_VERSIONS[‘identity’] setting.