### PR TITLE
horizon: Do not require other openstack proposals for deployment

### DIFF
--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -298,8 +298,13 @@ else
   neutron_use_vpnaas = false
 end
 
-nova = get_instance("roles:nova-controller")
-nova_insecure = (nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]) rescue false
+novas = search(:node, "roles:nova-controller") || []
+if !novas.empty?
+  nova = novas[0]
+  nova_insecure = nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]
+else
+  nova_insecure = false
+end
 
 heats = search(:node, "roles:heat-server") || []
 if !heats.empty?

--- a/chef/data_bags/crowbar/migrate/horizon/101_remove_nova_instance.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/101_remove_nova_instance.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("nova_instance")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["nova_instance"] = ta["nova_instance"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -4,7 +4,6 @@
   "attributes": {
     "horizon": {
       "debug": false,
-      "nova_instance": "none",
       "keystone_instance": "none",
       "database_instance": "none",
       "site_branding": "OpenStack Dashboard",
@@ -49,7 +48,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -13,7 +13,6 @@
           "required": true,
           "mapping": {
             "debug": { "type": "bool", "required": true },
-            "nova_instance": { "type": "str", "required": true },
             "keystone_instance": { "type": "str", "required": true },
             "database_instance": { "type": "str", "required": true },
             "site_branding": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -46,7 +46,6 @@ class HorizonService < PacemakerServiceObject
     answer = []
     answer << { "barclamp" => "database", "inst" => role.default_attributes["horizon"]["database_instance"] }
     answer << { "barclamp" => "keystone", "inst" => role.default_attributes["horizon"]["keystone_instance"] }
-    answer << { "barclamp" => "nova", "inst" => role.default_attributes["horizon"]["nova_instance"] }
     answer
   end
 
@@ -65,7 +64,6 @@ class HorizonService < PacemakerServiceObject
 
     base["attributes"][@bc_name]["database_instance"] = find_dep_proposal("database")
     base["attributes"][@bc_name]["keystone_instance"] = find_dep_proposal("keystone")
-    base["attributes"][@bc_name]["nova_instance"] = find_dep_proposal("nova")
 
     base["attributes"][@bc_name][:db][:password] = random_password
 
@@ -177,4 +175,3 @@ class HorizonService < PacemakerServiceObject
     @logger.debug("Horizon apply_role_pre_chef_call: leaving")
   end
 end
-

--- a/horizon.yml
+++ b/horizon.yml
@@ -24,8 +24,7 @@ barclamp:
   requires:
     - 'pacemaker'
     - 'database'
-    - 'keystone'
-    - 'nova'
+    - 'keystone'    
   member:
     - 'openstack'
 


### PR DESCRIPTION
Horizon no longer requires Nova (or Glance) to function; it will run as long as keystone is present (for instance, swift-only deployments).