### PR TITLE
fix undefined method [] for nil:NilClass (bsc#1013549)

### DIFF
--- a/crowbar_framework/lib/openstack/ha.rb
+++ b/crowbar_framework/lib/openstack/ha.rb
@@ -28,11 +28,13 @@ module Openstack
         end
 
         if role == "controller"
+          node[:pacemaker][:apache2] ||= {}
           unless node[:pacemaker][:apache2][:for_openstack]
             node[:pacemaker][:apache2][:for_openstack] = true
             save_it = true
           end
 
+          node[:pacemaker][:haproxy] ||= {}
           unless node[:pacemaker][:haproxy][:for_openstack]
             node[:pacemaker][:haproxy][:for_openstack] = true
             save_it = true


### PR DESCRIPTION
Fix this error:

    Failed to apply the proposal: exception before calling chef
    (undefined method `[]' for nil:NilClass)

which was seen when a customer added two new nodes to a network cluster (only running neutron agents and nothing else) and then re-applied the Pacemaker proposal.

https://bugzilla.suse.com/show_bug.cgi?id=1013549