### PR TITLE
Do not require crowbar-pacemaker cookbook to run when we configure HA in openstack

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh_ha.rb
+++ b/chef/cookbooks/aodh/recipes/aodh_ha.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "aodh-api" do
   address "0.0.0.0"
   port node[:aodh][:api][:port]

--- a/chef/cookbooks/barbican/recipes/ha.rb
+++ b/chef/cookbooks/barbican/recipes/ha.rb
@@ -24,6 +24,8 @@ network_settings = BarbicanHelper.network_settings(node)
 
 ssl_enabled = node[:barbican][:api][:ssl]
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "barbican-api" do
   address network_settings[:api][:ha_bind_host]
   port network_settings[:api][:ha_bind_port]

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "ceilometer-api" do
   address "0.0.0.0"
   port node[:ceilometer][:api][:port]

--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -22,6 +22,8 @@ log "HA support for cinder is enabled"
 
 cluster_admin_ip = CrowbarPacemakerHelper.cluster_vip(node, "admin")
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "cinder-api" do
   address node[:cinder][:api][:bind_open_address] ? "0.0.0.0" : cluster_admin_ip
   port node[:cinder][:api][:bind_port]

--- a/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_only_location_for.rb
+++ b/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_only_location_for.rb
@@ -15,6 +15,9 @@
 #
 
 define :openstack_pacemaker_controller_only_location_for do
+  # ensure attributes are set
+  include_recipe "crowbar-pacemaker::attributes"
+
   resource = params[:name]
   location_name = "l-#{resource}-controller"
   pacemaker_location location_name do

--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -22,6 +22,8 @@ log "Setting up glance HA support"
 
 network_settings = GlanceHelper.network_settings(node)
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "glance-api" do
   address network_settings[:api][:ha_bind_host]
   port network_settings[:api][:ha_bind_port]

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "heat-api" do
   address "0.0.0.0"
   port node[:heat][:api][:port]

--- a/chef/cookbooks/horizon/recipes/ha.rb
+++ b/chef/cookbooks/horizon/recipes/ha.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "horizon" do
   address "0.0.0.0"
   port 80

--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "keystone-service" do
   address node[:keystone][:api][:api_host]
   port node[:keystone][:api][:service_port]

--- a/chef/cookbooks/magnum/recipes/ha.rb
+++ b/chef/cookbooks/magnum/recipes/ha.rb
@@ -24,6 +24,8 @@ network_settings = MagnumHelper.network_settings(node)
 
 ssl_enabled = (node[:magnum][:api][:protocol] == "https")
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "magnum-api" do
   address network_settings[:api][:ha_bind_host]
   port network_settings[:api][:ha_bind_port]

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -22,6 +22,8 @@ log "HA support for manila is enabled"
 
 cluster_admin_ip = CrowbarPacemakerHelper.cluster_vip(node, "admin")
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "manila-api" do
   address node[:manila][:api][:bind_open_address] ?
     "0.0.0.0" : cluster_admin_ip

--- a/chef/cookbooks/neutron/recipes/server_ha.rb
+++ b/chef/cookbooks/neutron/recipes/server_ha.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "neutron-server" do
   address node[:neutron][:api][:service_host]
   port node[:neutron][:api][:service_port]

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -31,6 +31,10 @@ unless nova[:nova][:ha][:compute][:setup]
   return
 end
 
+# ensure attributes are set
+include_recipe "crowbar-pacemaker::attributes"
+include_recipe "crowbar-pacemaker::remote_attributes"
+
 keystone_settings = KeystoneHelper.keystone_settings(nova, @cookbook_name)
 internal_auth_url_v2 = \
   "#{keystone_settings["protocol"]}://" \

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -22,6 +22,8 @@ log "HA support for nova is enabled"
 
 cluster_admin_ip = CrowbarPacemakerHelper.cluster_vip(node, "admin")
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "nova-api" do
   address "0.0.0.0"
   port node[:nova][:ports][:api]

--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -38,6 +38,8 @@ fs_params = {}
 fs_params["directory"] = "/var/lib/pgsql"
 
 if node[:database][:ha][:storage][:mode] == "drbd"
+  include_recipe "crowbar-pacemaker::drbd"
+
   crowbar_pacemaker_drbd drbd_resource do
     size "#{node[:database][:ha][:storage][:drbd][:size]}G"
     action :nothing

--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -33,6 +33,8 @@ end
 fs_params = {}
 fs_params["directory"] = "/var/lib/rabbitmq"
 if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
+  include_recipe "crowbar-pacemaker::drbd"
+
   crowbar_pacemaker_drbd drbd_resource do
     size "#{node[:rabbitmq][:ha][:storage][:drbd][:size]}G"
     action :nothing

--- a/chef/cookbooks/sahara/recipes/ha.rb
+++ b/chef/cookbooks/sahara/recipes/ha.rb
@@ -20,6 +20,8 @@ end
 
 network_settings = SaharaHelper.network_settings(node)
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "sahara-api" do
   address network_settings[:api][:ha_bind_host]
   port network_settings[:api][:ha_bind_port]

--- a/chef/cookbooks/swift/recipes/proxy_ha.rb
+++ b/chef/cookbooks/swift/recipes/proxy_ha.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+include_recipe "crowbar-pacemaker::haproxy"
+
 haproxy_loadbalancer "swift-proxy" do
   address "0.0.0.0"
   port node[:swift][:ports][:proxy]


### PR DESCRIPTION
We make it possible to not run the crowbar-pacemaker cookbook when we run some OpenStack cookbook that use HA and require some specific setup (for drbd or haproxy, for instance).

This depends on and needs to be merged at the same time as: https://github.com/crowbar/crowbar-ha/pull/164