### PR TITLE
neutron: Replace /etc/sysconfig/neutron usage with links

### DIFF
--- a/chef/cookbooks/neutron/templates/opensuse/sysconfig.neutron.erb
+++ b/chef/cookbooks/neutron/templates/opensuse/sysconfig.neutron.erb
@@ -1,1 +1,0 @@
-../suse/sysconfig.neutron.erb

--- a/chef/cookbooks/neutron/templates/suse/sysconfig.neutron.erb
+++ b/chef/cookbooks/neutron/templates/suse/sysconfig.neutron.erb
@@ -1,3 +1,0 @@
-# Managed by Crowbar
-# Do not edit.
-NEUTRON_PLUGIN_CONF="<%=@plugin_config_file%>"


### PR DESCRIPTION
/etc/sysconfig/neutron is no longer supported. Instead use symlinks
to enable/disable specific configs for the neutron-server.