### PR TITLE
cinder/nova: Allow setting a fixed-key for encrypted volumes

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -3187,6 +3187,9 @@ wsgi_keep_alive = false
 
 # Fixed key returned by key manager, specified in hex (string value)
 #fixed_key = <None>
+<% unless node[:cinder][:keymgr_fixed_key].empty? -%>
+fixed_key = <%= node[:cinder][:keymgr_fixed_key].each_byte.map { |b| b.to_s(16) }.join %>
+<% end -%>
 
 # Authentication url for encryption service. (string value)
 #encryption_auth_url = http://localhost:5000/v3

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -153,6 +153,7 @@ if cinder_servers.length > 0
   cinder_server = cinder_servers[0]
   cinder_insecure = cinder_server[:cinder][:api][:protocol] == "https" && cinder_server[:cinder][:ssl][:insecure]
   use_multipath = cinder_server[:cinder][:use_multipath]
+  keymgr_fixed_key = cinder_server[:cinder][:keymgr_fixed_key]
 
   if node.roles.include? "nova-compute-kvm"
     cinder_server[:cinder][:volumes].each do |volume|
@@ -161,6 +162,7 @@ if cinder_servers.length > 0
   end
 else
   cinder_insecure = false
+  keymgr_fixed_key = ""
 end
 
 if rbd_enabled
@@ -391,6 +393,7 @@ template "/etc/nova/nova.conf" do
     keystone_settings: keystone_settings,
     cinder_insecure: cinder_insecure || keystone_settings["insecure"],
     use_multipath: use_multipath,
+    keymgr_fixed_key: keymgr_fixed_key,
     ceph_user: ceph_user,
     ceph_uuid: ceph_uuid,
     ssl_enabled: api[:nova][:ssl][:enabled],

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -3908,6 +3908,9 @@ protocol = <%= @glance_server_protocol %>
 
 # Fixed key returned by key manager, specified in hex (string value)
 #fixed_key = <None>
+<% unless @keymgr_fixed_key.empty? -%>
+fixed_key = <%= @keymgr_fixed_key.each_byte.map { |b| b.to_s(16) }.join %>
+<% end -%>
 
 # The full class name of the key manager API class (string value)
 #api_class = nova.keymgr.conf_key_mgr.ConfKeyManager

--- a/chef/data_bags/crowbar/migrate/cinder/103_add_keymgr_fixed_key.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/103_add_keymgr_fixed_key.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "keymgr_fixed_key"
+    a["keymgr_fixed_key"] = ta["keymgr_fixed_key"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "keymgr_fixed_key"
+    del a["keymgr_fixed_key"]
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -19,6 +19,7 @@
       "rpc_response_timeout": 60,
       "use_multi_backend": true,
       "use_multipath": false,
+      "keymgr_fixed_key": "",
       "volume_defaults": {
         "raw": {
           "volume_name": "cinder-volumes",
@@ -161,7 +162,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 103,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -28,6 +28,7 @@
             "rpc_response_timeout": { "type": "int", "required": true },
             "use_multi_backend": { "type": "bool", "required": true },
             "use_multipath": { "type": "bool", "required": true },
+            "keymgr_fixed_key": { "type": "str", "required": true },
             "volume_defaults": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -81,6 +81,7 @@ class CinderService < PacemakerServiceObject
 
     base["attributes"][@bc_name]["service_password"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
+    base["attributes"][@bc_name]["keymgr_fixed_key"] = random_password
 
     @logger.debug("Cinder create_proposal: exiting")
     base


### PR DESCRIPTION
With this key set in the cinder proposal, volumes casn be encrypted.
Be careful: For *all* volumes the *same* key is used!