### PR TITLE
tempest: temporarily disable heat tests

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -85,7 +85,8 @@ openstackcli_adm << " --os-project-name #{tempest_comp_tenant}"
 openstackcli_adm << " --os-auth-url #{auth_url}"
 
 `#{openstackcli_adm} service show orchestration &> /dev/null`
-use_heat = $?.success?
+# Heat integration tests still need some work to pass
+use_heat = false && $?.success?
 
 users = [
           {"name" => tempest_comp_user, "pass" => tempest_comp_pass, "role" => "Member"},


### PR DESCRIPTION
They eat > 6 hours and fail since most of the functionality
that they depend on isn't there. disable it for now until
it is properly fixed