### PR TITLE
Cache keystone settings per instance not per barclamp

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -79,19 +79,16 @@ module KeystoneHelper
         "admin_port" => node["keystone"]["api"]["admin_port"],
         "admin_token" => node["keystone"]["service"]["token"],
         "admin_tenant" => node["keystone"]["admin"]["tenant"],
-        "admin_tenant_id" => node["keystone"]["admin"]["tenant_id"],
         "admin_user" => node["keystone"]["admin"]["username"],
         "admin_domain" => default_domain,
         "admin_domain_id" => default_domain_id,
         "admin_password" => node["keystone"]["admin"]["password"],
         "default_tenant" => node["keystone"]["default"]["tenant"],
-        "default_tenant_id" => node["keystone"]["default"]["tenant_id"],
         "default_user" => has_default_user ? node["keystone"]["default"]["username"] : nil,
         "default_user_domain" => has_default_user ? default_domain : nil,
         "default_user_domain_id" => has_default_user ? default_domain_id : nil,
         "default_password" => has_default_user ? node["keystone"]["default"]["password"] : nil,
         "service_tenant" => node["keystone"]["service"]["tenant"],
-        "service_tenant_id" => node["keystone"]["service"]["tenant_id"]
       }
     end
 

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -494,19 +494,6 @@ ruby_block "mark node for keystone bootstrap" do
   subscribes :create, "execute[keystone-manage bootstrap]", :immediately
 end
 
-# Create tenants
-openstack_command = "openstack \
---os-username \"#{node[:keystone][:admin][:username]}\" \
---os-password \"#{node[:keystone][:admin][:password]}\" \
---os-project-name \"#{node[:keystone][:admin][:tenant]}\" \
---os-auth-url \"#{node[:keystone][:api][:versioned_admin_URL]}\" \
---os-region \"#{node[:keystone][:api][:region]}\""
-if node[:keystone][:api][:version] != "2.0"
-  openstack_command <<  " --os-identity-api-version #{node[:keystone][:api][:version]} --os-project-domain-id default --os-user-domain-id default"
-end
-
-openstack_command << " --insecure" if keystone_insecure
-
 [:service, :default].each do |tenant_type|
   tenant = node[:keystone][tenant_type][:tenant]
 
@@ -518,16 +505,6 @@ openstack_command << " --insecure" if keystone_insecure
     auth register_auth_hash
     tenant_name tenant
     action :add_tenant
-  end
-
-  ruby_block "saving id for default #{tenant} tenant" do
-    block do
-      tenant_id = `#{openstack_command} project show -f value -c id #{tenant}`.chomp
-      if !tenant_id.empty? && node[:keystone][tenant_type][:tenant_id] != tenant_id
-        node.set[:keystone][tenant_type][:tenant_id] = tenant_id
-        node.save
-      end
-    end
   end
 end
 

--- a/chef/cookbooks/trove/templates/default/trove-conductor.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove-conductor.conf.erb
@@ -11,7 +11,6 @@ os_region_name= <%= @keystone_settings['endpoint_region'] %>
 nova_proxy_admin_user = <%= @keystone_settings["admin_user"] %>
 nova_proxy_admin_pass = <%= @keystone_settings["admin_password"] %>
 nova_proxy_admin_tenant_name = <%= @keystone_settings["admin_tenant"] %>
-nova_proxy_admin_tenant_id = <%= @keystone_settings["admin_tenant_id"] %>
 sql_connection = <%= @sql_connection %>
 
 # AMQP Connection info

--- a/chef/cookbooks/trove/templates/default/trove-taskmanager.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove-taskmanager.conf.erb
@@ -88,7 +88,6 @@ use_nova_server_config_drive = true
 nova_proxy_admin_user = <%= @keystone_settings["admin_user"] %>
 nova_proxy_admin_pass = <%= @keystone_settings["admin_password"] %>
 nova_proxy_admin_tenant_name = <%= @keystone_settings["admin_tenant"] %>
-nova_proxy_admin_tenant_id = <%= @keystone_settings["admin_tenant_id"] %>
 
 # Manager impl for the taskmanager
 taskmanager_manager=trove.taskmanager.manager.Manager


### PR DESCRIPTION
per barclamp is actually unnecessarily conservative, per keystone
instance is enough. even in the dumb nova-compute node case this
reduces cache misses by factor two.