### PR TITLE
nova: Change name for docker compute_driver

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1460,7 +1460,7 @@ disk_allocation_ratio = <%= node[:nova][:scheduler][:disk_allocation_ratio] %>
 <% if @libvirt_type.eql?('vmware') -%>
 compute_driver = vmwareapi.VMwareVCDriver
 <% elsif @libvirt_type.eql?('docker') -%>
-compute_driver = novadocker.virt.docker.DockerDriver
+compute_driver = docker.DockerDriver
 <% elsif @libvirt_type.eql?('zvm') -%>
 compute_driver = nova.virt.zvm.ZVMDriver
 <% else -%>


### PR DESCRIPTION
Since nova does not support out-of-tree drivers anymore we introduced
this workaround https://review.openstack.org/#/c/408148/ in our package
so the config change is required.