### PR TITLE
monasca: Added skeleton for Monsasca barclamp

### DIFF
--- a/bin/crowbar_monasca
+++ b/bin/crowbar_monasca
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
+@barclamp = "monasca"
+@timeout = 3600
+
+main

--- a/chef/cookbooks/monasca/README.md
+++ b/chef/cookbooks/monasca/README.md
@@ -1,0 +1,30 @@
+DESCRIPTION
+===========
+
+Chef Cookbook to install and configure Monasca. This cookbook contains 2 roles:
+
+* monasca-agent: deploys monasca-agent on arbitrary nodes
+* monasca-server: deploys Monasca's backend services on dedicated Monasca nodes
+
+REQUIREMENTS
+============
+TBD
+
+
+License
+=======
+Author:: Johannes Grassler <johannes.grassler@suse.com>
+
+Copyright:: 2016 SUSE LINUX GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/chef/cookbooks/monasca/attributes/default.rb
+++ b/chef/cookbooks/monasca/attributes/default.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2016 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitation.
+
+default[:monasca][:db][:database] = "monasca"
+default[:monasca][:db][:user] = "monasca"
+default[:monasca][:db][:password] = nil # must be set by wrapper
+
+override[:monasca][:group] = "monasca"
+override[:monasca][:user] = "monasca"
+
+default[:monasca][:debug] = false
+default[:monasca][:ha_enabled] = false
+
+default[:monasca][:api][:bind_host] = "*"

--- a/chef/cookbooks/monasca/metadata.rb
+++ b/chef/cookbooks/monasca/metadata.rb
@@ -1,0 +1,13 @@
+name "monasca"
+maintainer "Crowbar project"
+maintainer_email "crowbar@googlegroups.com"
+license "Apache 2.0"
+description "Installs/Configures Monasca"
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
+version "0.1"
+
+depends "database"
+depends "keystone"
+depends "crowbar-openstack"
+depends "crowbar-pacemaker"
+depends "utils"

--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -1,0 +1,51 @@
+#
+# Copyright 2016 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+### TODO: uncomment this once there is a package.
+# package "openstack-monasca-agent"
+
+### FIXME: remove this once there is a package creating this directory
+
+directory "/etc/monasca/agent/" do
+  owner "root"
+  group "root"
+  mode 0o755
+  recursive true
+  notifies :create, "template[/etc/monasca/agent/agent.yaml]"
+end
+
+### TODO:
+# * populate agent_settings with useful values for monasca_url and keystone
+#   settings
+# * generate per-node keystone credentials in
+#   crowbar_framework/app/models/monasca_service.rb
+# * use credentials generated in the previous step to create a keystone account
+#   here (using keystone_register)
+
+agent_settings = node[:monasca][:agent][:config]
+
+template "/etc/monasca/agent/agent.yaml" do
+  source "agent.yaml.erb"
+  owner "root"
+  ### FIXME: Uncomment once we have a package that creates a monasca group
+  # group node[:monasca][:group]
+  mode 0o640
+  variables agent_settings
+  ### FIXME: Uncomment once we have a package that creates a monasca-agent service
+  # notifies :reload, resources(service: "openstack-monasca-agent")
+end
+
+node.save

--- a/chef/cookbooks/monasca/recipes/api.rb
+++ b/chef/cookbooks/monasca/recipes/api.rb
@@ -1,0 +1,148 @@
+#
+# Copyright 2016 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "apache2"
+include_recipe "apache2::mod_wsgi"
+include_recipe "apache2::mod_rewrite"
+
+apache_module "deflate" do
+  conf false
+  enable true
+end
+
+apache_site "000-default" do
+  enable false
+end
+
+### TODO: uncomment this once there is a package.
+# package "openstack-monasca-api"
+
+### FIXME: remove this once there is a package creating this directory
+
+directory "/etc/monasca/" do
+  owner "root"
+  group "root"
+  mode 0o755
+  recursive true
+  notifies :create, "template[/etc/monasca/api-config.conf]"
+end
+
+ha_enabled = node[:monasca][:ha][:enabled]
+
+db_settings = fetch_database_settings
+db_conn_scheme = db_settings[:url_scheme]
+
+db_settings[:backend_name] == "mysql" && db_conn_scheme = "mysql+pymysql"
+
+database_connection = "#{db_conn_scheme}://" \
+  "#{node[:monasca][:db][:user]}" \
+  ":#{node[:monasca][:db][:password]}" \
+  "@#{db_settings[:address]}" \
+  "/#{node[:monasca][:db][:database]}"
+
+crowbar_pacemaker_sync_mark "wait-monasca_database"
+
+# Create the Monasca Database
+database "create #{node[:monasca][:db][:database]} database" do
+  connection db_settings[:connection]
+  database_name node[:monasca][:db][:database]
+  provider db_settings[:provider]
+  action :create
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+database_user "create #{@cookbook_name} database user" do
+  connection db_settings[:connection]
+  database_name node[:monasca][:db][:database]
+  username node[:monasca][:db][:user]
+  password node[:monasca][:db][:password]
+  host "%"
+  provider db_settings[:user_provider]
+  action :create
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+database_user "grant database access for #{@cookbook_name} database user" do
+  connection db_settings[:connection]
+  database_name node[:monasca][:db][:database]
+  username node[:monasca][:db][:user]
+  password node[:monasca][:db][:password]
+  host "%"
+  privileges db_settings[:privs]
+  provider db_settings[:user_provider]
+  action :grant
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+### FIXME: uncomment this once we have a package that contains a monasca-manage
+### command.
+# execute "monasca-manage db upgrade" do
+#   user node[:monasca][:user]
+#   group node[:monasca][:group]
+#   command "monasca-manage db upgrade -d #{database_connection} -v head "
+#   # We only do the sync the first time, and only if we're not doing HA or if we
+#   # are the founder of the HA cluster (so that it's really only done once).
+#   only_if do
+#     !node[:monasca][:db_synced] &&
+#       (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node))
+#   end
+# end
+
+# We want to keep a note that we've done db_sync, so we don't do it again.
+# If we were doing that outside a ruby_block, we would add the note in the
+# compile phase, before the actual db_sync is done (which is wrong, since it
+# could possibly not be reached in case of errors).
+ruby_block "mark node for monasca db_sync" do
+  block do
+    node.set[:monasca][:db_synced] = true
+    node.save
+  end
+  action :nothing
+  subscribes :create, "execute[monasca-manage db upgrade]", :immediately
+end
+
+crowbar_pacemaker_sync_mark "create-monasca_database"
+
+template "/etc/monasca/api-config.conf" do
+  source "api-config.conf.erb"
+  owner "root"
+  ### FIXME: Uncomment once we have a package that creates a monasca group
+  # group node[:monasca][:group]
+  mode 0o0640
+  variables(
+    database_connection: database_connection,
+    keystone_settings: KeystoneHelper.keystone_settings(node, @cookbook_name)
+  )
+  notifies :reload, resources(service: "apache2")
+end
+
+### FIXME: Uncomment once we actually have a runnable WSGI app from a
+###        monasca-api package
+# crowbar_openstack_wsgi "WSGI entry for monasca-api" do
+#   bind_host bind_host
+#   bind_port bind_port
+#   daemon_process "monasca-api"
+#   user node[:monasca][:user]
+#   group node[:monasca][:group]
+#   processes node[:monasca][:api][:processes]
+#   threads node[:monasca][:api][:threads]
+# end
+#
+# apache_site "monasca-api.conf" do
+#   enable true
+# end
+
+node.save

--- a/chef/cookbooks/monasca/recipes/role_monasca_agent.rb
+++ b/chef/cookbooks/monasca/recipes/role_monasca_agent.rb
@@ -1,0 +1,19 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "monasca", "monasca-agent")
+  include_recipe "monasca::agent"
+end

--- a/chef/cookbooks/monasca/recipes/role_monasca_server.rb
+++ b/chef/cookbooks/monasca/recipes/role_monasca_server.rb
@@ -1,0 +1,20 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "monasca", "monasca-server")
+  include_recipe "monasca::server"
+  include_recipe "monasca::api"
+end

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -1,0 +1,32 @@
+# Copyright 2016 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# TODO: Fill this with code that deploys the Monasca backend services
+
+### Example code for retrieving a database URL and keystone settings:
+
+# keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name),
+
+# db_settings = fetch_database_settings
+# db_conn_scheme = db_settings[:url_scheme]
+
+# if db_settings[:backend_name] == "mysql"
+#  db_conn_scheme = "mysql+pymysql"
+# end
+
+# database_connection = "#{db_conn_scheme}://" \
+# "#{node[:monasca][:db][:user]}" \
+# ":#{node[:monasca][:db][:password]}" \
+#  "@#{db_settings[:address]}" \
+#  "/#{node[:monasca][:db][:database]}"

--- a/chef/cookbooks/monasca/templates/default/agent.yaml.erb
+++ b/chef/cookbooks/monasca/templates/default/agent.yaml.erb
@@ -1,0 +1,142 @@
+Api:
+  # To configure Keystone correctly, a project-scoped token must be acquired.
+  # To accomplish this, the configuration must be set up with one of the
+  # following scenarios:
+  #   Set username and password and you have a default project set in keystone.
+  #   Set username, password and project id.
+  #   Set username, password, project name and (domain id or domain name).
+  #
+  # Monitoring API URL: URL for the monitoring API, if undefined it will be pulled from the keystone service catalog
+  # Example: https://region-a.geo-1.monitoring.hpcloudsvc.com:8080/v2.0
+  url: <%= @monasca_url %>
+  # Keystone Username
+  username: <%= @username %>
+  # Keystone Password
+  password: "<%= @password %>"
+  # Keystone API URL: URL for the Keystone server to use
+  # Example: https://region-a.geo-1.identity.hpcloudsvc.com:35357/v3/
+  keystone_url: <%= @keystone_url %>
+  # Domain id to be used to resolve username
+  user_domain_id: <%= @user_domain_id %>
+  # Domain name to be used to resolve username
+  user_domain_name: <%= @user_domain_name %>
+  # Project name to be used by this agent
+  project_name: <%= @project_name %>
+  # Project domain id to be used by this agent
+  project_domain_id: <%= @project_domain_id %>
+  # Project domain id to be used by this agent
+  project_domain_name: <%= @project_domain_name %>
+  # Project id to be used by this agent
+  project_id: <%= @project_id %>
+  # Set whether certificates are used for Keystone
+  # *******************************************************************************************
+  # **** CAUTION ****: The insecure flag should NOT be set to True in a production environment!
+  # *******************************************************************************************
+  # If insecure is set to False, a ca_file name must be set to authenticate with Keystone
+  insecure: <%= @insecure %>
+  # Name of the ca certs file
+  ca_file: <%= @ca_file %>
+
+  # The following 3 options are for handling buffering and reconnection to the monasca-api
+  # If the agent forwarder is consuming too much memory, you may want to set
+  # max_measurement_buffer_size to a lower value. If you have a larger system with many agents,
+  # you may want to throttle the number of messages sent to the API by setting the
+  # backlog_send_rate to a lower number.
+
+  # DEPRECATED - please use max_measurement_buffer_size instead
+  # Maximum number of messages (batches of measurements) to buffer when unable to communicate
+  # with the monasca-api (-1 means no limit)
+  max_buffer_size: <%= @max_buffer_size %>
+  # Maximum number of measurements to buffer when unable to communicate with the monasca-api
+  # (-1 means no limit)
+  max_measurement_buffer_size: <%= @max_measurement_buffer_size %>
+  # Maximum number of messages to send at one time when communication with the monasca-api is restored
+  backlog_send_rate: <%= @backlog_send_rate %>
+
+  # Publish extra metrics to the API by adding this number of 'amplifier' dimensions.
+  # For load testing purposes only; set to 0 for production use.
+  amplifier: <%= @amplifier %>
+
+Main:
+  # Force the hostname to whatever you want.
+  hostname: <%= @hostname %>
+
+  # Optional dimensions to be sent with every metric from this node
+  # They should be in the format name: value
+  # Example of dimensions below
+  # dimensions:
+  #   service: nova
+  #   group: group_a
+  #   environment: production
+  <%- unless @dimensions.nil? or @dimension.empty? then -%>
+  dimensions: <%= @dimensions %>
+  <%- @dimensions.each_pair do |key, val| -%>
+    <%= key %>: <%= val %>
+  <%- end -%>
+  <%- end -%>
+
+  # Set the threshold for accepting points to allow anything
+  # with recent_point_threshold seconds
+  # Defaults to 30 seconds if no value is provided
+  #recent_point_threshold: 30
+
+  # time to wait between collection runs
+  check_freq: <%= @check_frequency %>
+
+  # Number of Collector Threads to run
+  num_collector_threads: <%= @num_collector_threads %>
+
+  # Maximum number of collection cycles where all of the threads in the pool are
+  # still running plugins before the collector will exit
+  pool_full_max_retries: <%= @pool_full_max_retries %>
+
+  # Threshold value for warning on collection time of each check (in seconds)
+  sub_collection_warn: <%= @plugin_collect_time_warn %>
+
+  # Collector restart interval (in hours)
+  collector_restart_interval: 24
+
+  # Change port the Agent is listening to
+  # listen_port: 17123
+
+  # Allow non-local traffic to this Agent
+  # This is required when using this Agent as a proxy for other Agents
+  # that might not have an internet connection
+  # For more information, please see
+  # https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
+  # non_local_traffic: no
+
+Statsd:
+  # ========================================================================== #
+  # Monasca Statsd configuration                                                    #
+  # ========================================================================== #
+  # Monasca Statsd is a small server that aggregates your custom app metrics.
+
+  #  Make sure your client is sending to the same port.
+  monasca_statsd_port : 8125
+
+  ## The monasca_statsd flush period.
+  # monasca_statsd_interval : 20
+
+  # If you want to forward every packet received by the monasca_statsd server
+  # to another statsd server, uncomment these lines.
+  # WARNING: Make sure that forwarded packets are regular statsd packets and not "monasca_statsd" packets,
+  # as your other statsd server might not be able to handle them.
+  # monasca_statsd_forward_host: address_of_own_statsd_server
+  # monasca_statsd_statsd_forward_port: 8125
+
+Logging:
+  # ========================================================================== #
+  # Logging
+  # ========================================================================== #
+  log_level: <%= @log_level %>
+  collector_log_file: /var/log/monasca/agent/collector.log
+  forwarder_log_file: /var/log/monasca/agent/forwarder.log
+  statsd_log_file: /var/log/monasca/agent/statsd.log
+
+  # if syslog is enabled but a host and port are not set, a local domain socket
+  # connection will be attempted
+  #
+  # log_to_syslog: yes
+  # syslog_host:
+  # syslog_port:

--- a/chef/cookbooks/monasca/templates/default/api-config.conf.erb
+++ b/chef/cookbooks/monasca/templates/default/api-config.conf.erb
@@ -1,0 +1,159 @@
+[DEFAULT]
+log_config_append=/etc/monasca/api-logging.conf
+
+# Identifies the region that the Monasca API is running in.
+region = useast
+
+# Dispatchers to be loaded to serve restful APIs
+[dispatcher]
+versions = monasca_api.v2.reference.versions:Versions
+version_2_0 = monasca_api.v2.reference.version_2_0:Version2
+metrics = monasca_api.v2.reference.metrics:Metrics
+metrics_measurements = monasca_api.v2.reference.metrics:MetricsMeasurements
+metrics_statistics = monasca_api.v2.reference.metrics:MetricsStatistics
+metrics_names = monasca_api.v2.reference.metrics:MetricsNames
+alarm_definitions = monasca_api.v2.reference.alarm_definitions:AlarmDefinitions
+alarms = monasca_api.v2.reference.alarms:Alarms
+alarms_count = monasca_api.v2.reference.alarms:AlarmsCount
+alarms_state_history = monasca_api.v2.reference.alarms:AlarmsStateHistory
+notification_methods = monasca_api.v2.reference.notifications:Notifications
+dimension_values = monasca_api.v2.reference.metrics:DimensionValues
+dimension_names = monasca_api.v2.reference.metrics:DimensionNames
+notification_method_types = monasca_api.v2.reference.notificationstype:NotificationsType
+
+[security]
+# The roles that are allowed full access to the API.
+default_authorized_roles = user, domainuser, domainadmin, monasca-user
+
+# The roles that are allowed to only POST metrics to the API. This role would be used by the Monasca Agent.
+agent_authorized_roles = monasca-agent
+
+# The roles that are allowed to only GET metrics from the API.
+read_only_authorized_roles = monasca-read-only-user
+
+# The roles that are allowed to access the API on behalf of another tenant.
+# For example, a service can POST metrics to another tenant if they are a member of the "delegate" role.
+delegate_authorized_roles = admin
+
+[messaging]
+# The message queue driver to use
+driver = monasca_api.common.messaging.kafka_publisher:KafkaPublisher
+
+[repositories]
+# The driver to use for the metrics repository
+# Switches depending on backend database in use. Influxdb or Cassandra.
+metrics_driver = monasca_api.common.repositories.influxdb.metrics_repository:MetricsRepository
+#metrics_driver = monasca_api.common.repositories.cassandra.metrics_repository:MetricsRepository
+
+# The driver to use for the alarm definitions repository
+alarm_definitions_driver = monasca_api.common.repositories.mysql.alarm_definitions_repository:AlarmDefinitionsRepository
+
+# The driver to use for the alarms repository
+alarms_driver = monasca_api.common.repositories.mysql.alarms_repository:AlarmsRepository
+
+# The driver to use for the notifications repository
+notifications_driver = monasca_api.common.repositories.mysql.notifications_repository:NotificationsRepository
+
+# The driver to use for the notification  method type repository
+notification_method_type_driver = monasca_api.common.repositories.sqla.notification_method_type_repository:NotificationMethodTypeRepository
+
+
+[dispatcher]
+driver = v2_reference
+
+[kafka]
+# The endpoint to the kafka server
+uri = 192.168.10.4:9092
+
+# The topic that metrics will be published too
+metrics_topic = metrics
+
+# consumer group name
+group = api
+
+# how many times to try when error occurs
+max_retry = 1
+
+# wait time between tries when kafka goes down
+wait_time = 1
+
+# use synchronous or asynchronous connection to kafka
+async = False
+
+# send messages in bulk or send messages one by one.
+compact = False
+
+# How many partitions this connection should listen messages on, this
+# parameter is for reading from kafka. If listens on multiple partitions,
+# For example, if the client should listen on partitions 1 and 3, then the
+# configuration should look like the following:
+#   partitions = 1
+#   partitions = 3
+# default to listen on partition 0.
+partitions = 0
+
+[influxdb]
+# Only needed if Influxdb database is used for backend.
+# The IP address of the InfluxDB service.
+ip_address = 192.168.10.4
+
+# The port number that the InfluxDB service is listening on.
+port = 8086
+
+# The username to authenticate with.
+user = mon_api
+
+# The password to authenticate with.
+password = password
+
+# The name of the InfluxDB database to use.
+database_name = mon
+
+[cassandra]
+# Only needed if Cassandra database is used for backend.
+# Comma separated list of Cassandra node IP addresses. No spaces.
+cluster_ip_addresses: 192.168.10.6
+keyspace: monasca
+
+# Below is configuration for database.
+# The order of reading configuration for database is:
+# 1) [mysql] section
+# 2) [database]
+#    url
+# 3) [database]
+#    host = 127.0.0.1
+#    username = monapi
+#    password = password
+#    drivername = mysq+pymysql
+#    port = 3306
+#    database = mon
+#    query = ""
+#[mysql]
+#database_name = mon
+#hostname = 192.168.10.4
+#username = monapi
+#password = password
+#
+# [database]
+# url = "mysql+pymysql://monapi:password@127.0.0.1/mon"
+# host = 127.0.0.1
+# username = monapi
+# password = password
+# drivername = mysq+pymysql
+# port = 3306
+# database = mon
+# query = ""
+
+[database]
+url = <%= @database_connection %>
+
+[keystone_authtoken]
+auth_type = password
+user_domain_id = default
+project_domain_id = default
+auth_url = <%= @keystone_settings['admin_auth_url'] %>
+auth_uri = <%= @keystone_settings['public_auth_url'] %>
+auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
+project_name = <%= @keystone_settings['service_tenant'] %>

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -1,0 +1,77 @@
+{
+  "id": "template-monasca",
+  "description": "Logging and Monitoring Service for OpenStack",
+  "attributes": {
+     "monasca" : {
+        "agent" : {
+           "monasca_url": "",
+           "username": "",
+           "password": "",
+           "keystone_url": "",
+           "user_domain_id": "",
+           "user_domain_name": "",
+           "project_name": "",
+           "project_domain_id": "",
+           "project_domain_name": "",
+           "project_id": "",
+           "insecure": true,
+           "ca_file": "",
+           "max_buffer_size": 1000,
+           "max_measurement_buffer_size": -1,
+           "backlog_send_rate": 5,
+           "amplifier": 0,
+           "hostname": "",
+           "check_frequency": 15,
+           "num_collector_threads": 1,
+           "pool_full_max_retries": 5,
+           "plugin_collect_time_warn": 6,
+           "log_level": "INFO"
+        },
+        "api" : {
+           "bind_host" : "*",
+           "bind_port" : 8070,
+           "processes" : 3,
+           "ssl" : false,
+           "threads" : 10
+        },
+        "db" : {
+           "database" : "monasca",
+           "password" : "",
+           "user" : "monasca"
+        },
+        "debug" : false,
+        "group" : "monasca",
+        "user" : "monasca",
+        "database_instance": "none",
+        "keystone_instance": "none",
+        "service_password": "none",
+        "service_user": "monasca"
+     }
+  },
+  "deployment": {
+    "monasca" : {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "schema-revision": 100,
+      "element_states": {
+        "monasca-server": [ "readying", "ready", "applying" ],
+        "monasca-agent": [ "readying", "ready", "applying" ]
+      },
+      "elements": {},
+      "element_order": [
+        [ "monasca-server" ],
+        [ "monasca-agent" ]
+      ],
+      "element_run_list_order": {
+        "monasca-server": 110,
+        "monasca-agent": 120
+      },
+      "config": {
+        "environment": "monasca-base-config",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": []
+      }
+    }
+  }
+}

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -1,0 +1,147 @@
+{
+  "required": true,
+  "type": "map",
+  "mapping": {
+    "id": { "type": "str", "required": true, "pattern": "/^monasca-|^template-monasca$/" },
+    "description": { "required": true, "type": "str" },
+    "attributes": {
+      "required": true,
+      "type": "map",
+      "mapping": {
+        "monasca": {
+          "required": true,
+          "type": "map",
+          "mapping": {
+            "agent": {
+              "required": true,
+              "type": "map",
+              "mapping": {
+                  "monasca_url": { "type": "str", required: true },
+                  "username": { "type": "str", required: true },
+                  "password": { "type": "str", required: true },
+                  "keystone_url": { "type": "str", required: true },
+                  "user_domain_id": { "type": "str", required: true },
+                  "user_domain_name": { "type": "str", required: true },
+                  "project_name": { "type": "str", required: true },
+                  "project_domain_id": { "type": "str", required: true },
+                  "project_domain_name": { "type": "str", required: true },
+                  "project_id": { "type": "str", required: true },
+                  "insecure": { "type": "bool", required: true },
+                  "ca_file": { "type": "str", required: true },
+                  "max_buffer_size": { "type": "int", required: true },
+                  "max_measurement_buffer_size": { "type": "int", required: true },
+                  "backlog_send_rate": { "type": "int", required: true },
+                  "amplifier": { "type": "int", required: true },
+                  "hostname": { "type": "str", required: true },
+                  "check_frequency": { "type": "int", required: true },
+                  "num_collector_threads": { "type": "int", required: true },
+                  "pool_full_max_retries": { "type": "int", required: true },
+                  "plugin_collect_time_warn": { "type": "int", required: true },
+                  "log_level": { "type": "str", required: true }
+                }
+              },
+            "api": {
+              "required": true,
+              "type": "map",
+              "mapping": {
+                  "bind_host": { "required": true, "type": "str" },
+                  "bind_port": { "required": true, "type": "int" },
+                  "processes": { "required": true, "type": "int" },
+                  "ssl": { "required": true, "type": "bool" },
+                  "threads": { "required": true, "type": "int" }
+                }
+              },
+            "db": {
+              "required": true,
+              "type": "map",
+              "mapping": {
+                  "database": { "required": true, "type": "str" },
+                  "password": { "required": true, "type": "str" },
+                  "user": { "required": true, "type": "str" }
+              }
+            },
+            "debug": { "type": "bool" },
+            "database_instance": { "type": "str", "required": true },
+            "keystone_instance": { "type": "str", "required": true },
+            "service_user": { "type": "str", "required": true },
+            "service_password": { "type": "str", "required": true },
+            "group": { "required": true, "type": "str" },
+            "user": { "required": true, "type": "str" }
+           }
+         }
+       }
+     },
+  "deployment": {
+    "type": "map",
+    "required": true,
+    "mapping": {
+      "monasca": {
+        "type": "map",
+        "required": true,
+        "mapping": {
+          "crowbar-revision": { "type": "int", "required": true },
+          "crowbar-committing": { "type": "bool" },
+          "crowbar-applied": { "type": "bool" },
+          "crowbar-status": { "type": "str" },
+          "crowbar-failed": { "type": "str" },
+          "crowbar-queued": { "type": "bool" },
+          "schema-revision": { "type": "int" },
+          "element_states": {
+            "type": "map",
+            "mapping": {
+              = : {
+                "type": "seq",
+                "required": true,
+                "sequence": [ { "type": "str" } ]
+              }
+            }
+          },
+          "elements": {
+            "type": "map",
+            "required": true,
+            "mapping": {
+              = : {
+                "type": "seq",
+                "required": true,
+                "sequence": [ { "type": "str" } ]
+              }
+            }
+          },
+          "element_order": {
+            "type": "seq",
+            "required": true,
+            "sequence": [ {
+              "type": "seq",
+              "sequence": [ { "type": "str" } ]
+            } ]
+          },
+          "element_run_list_order": {
+            "type": "map",
+            "required": false,
+            "mapping": {
+              = : {
+                "type": "int",
+                "required": true
+              }
+            }
+          },
+          "config": {
+            "type": "map",
+            "required": true,
+            "mapping": {
+              "environment": { "type": "str", "required": true },
+              "mode": { "type": "str", "required": true },
+              "transitions": { "type": "bool", "required": true },
+              "transition_list": {
+                "type": "seq",
+                "required": true,
+                "sequence": [ { "type": "str" } ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+ }
+}

--- a/chef/roles/monasca-agent.rb
+++ b/chef/roles/monasca-agent.rb
@@ -1,0 +1,5 @@
+name "monasca-agent"
+description "Monasca Agent Role"
+run_list("recipe[monasca::role_monasca_agent]")
+default_attributes
+override_attributes

--- a/chef/roles/monasca-server.rb
+++ b/chef/roles/monasca-server.rb
@@ -1,0 +1,5 @@
+name "monasca-server"
+description "Monasca Server Role"
+run_list("recipe[monasca::role_monasca_server]")
+default_attributes
+override_attributes

--- a/crowbar_framework/app/controllers/monasca_controller.rb
+++ b/crowbar_framework/app/controllers/monasca_controller.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class MonascaController < BarclampController
+  # Controller for Monasca barclamp
+
+  protected
+
+  def initialize_service
+    @service_object = MonascaService.new logger
+  end
+end

--- a/crowbar_framework/app/models/monasca_service.rb
+++ b/crowbar_framework/app/models/monasca_service.rb
@@ -1,0 +1,144 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class MonascaService < PacemakerServiceObject
+  def initialize(thelogger)
+    @bc_name = "monasca"
+    @logger = thelogger
+  end
+
+  class << self
+    # Turn off multi proposal support till it really works and people ask for it.
+    def self.allow_multiple_proposals?
+      false
+    end
+
+    def role_constraints
+      {
+        "monasca-agent" => {
+          "unique" => false,
+          "admin" => true,
+          "count" => -1,
+          "exclude_platform" => {
+            "suse" => "< 12.1",
+            "windows" => "/.*/"
+          }
+        },
+        "monasca-server" => {
+          "unique" => false,
+          "count" => 1,
+          "cluster" => true,
+          "admin" => false,
+          "exclude_platform" => {
+            "suse" => "< 12.1",
+            "windows" => "/.*/"
+          }
+        }
+      }
+    end
+  end
+
+  def proposal_dependencies(role)
+    answer = []
+    deps = ["database", "keystone"]
+    deps.each do |dep|
+      answer << {
+        "barclamp" => dep,
+        "inst" => role.default_attributes[@bc_name]["#{dep}_instance"]
+      }
+    end
+    answer
+  end
+
+  def create_proposal
+    @logger.debug("Monasca create_proposal: entering")
+    base = super
+
+    nodes = NodeObject.all
+    # FIXME: Putting the monasca backend services on the controller is
+    # temporary to allow for development right now. We will eventually want the
+    # commented line for server_roles, i.e. have a dedicated Monitoring node
+    # role in Crowbar. Adding that role will require changes to:
+    #
+    #  * https://github.com/crowbar/crowbar-core/blob/master/crowbar_framework/app/helpers/nodes_helper.rb#L366
+    #  * https://github.com/crowbar/crowbar-core/blob/master/bin/crowbar_machines#L362
+    #  * https://github.com/crowbar/crowbar-core/blob/master/crowbar_framework/config/locales/crowbar/en.yml
+    #
+    # at the very least.
+    server_nodes = nodes.select { |n| n.intended_role == "controller" }
+    ### server_nodes = nodes.select { |n| n.intended_role == "monitoring" }
+
+    server_nodes = [nodes.first] if server_nodes.empty?
+
+    # TODO: do we really want to have the agent on all nodes by
+    # default?
+    agent_nodes = nodes
+
+    base["deployment"][@bc_name]["elements"]["monasca-agent"] = agent_nodes
+    unless server_nodes.nil?
+      base["deployment"][@bc_name]["elements"] = {
+        "monasca-server" => [server_nodes.first.name]
+      }
+    end
+
+    base["attributes"][@bc_name]["database_instance"] =
+      find_dep_proposal("database")
+    base["attributes"][@bc_name]["keystone_instance"] =
+      find_dep_proposal("keystone")
+    base["attributes"][@bc_name]["service_password"] = random_password
+    base["attributes"][@bc_name][:db][:password] = random_password
+
+    @logger.debug("Monasca create_proposal: exiting")
+    base
+  end
+
+  def validate_proposal_after_save(proposal)
+    validate_one_for_role proposal, "monasca-server"
+
+    super
+  end
+
+  def apply_role_pre_chef_call(_old_role, role, all_nodes)
+    @logger.debug("Monasca apply_role_pre_chef_call: "\
+                  "entering #{all_nodes.inspect}")
+
+    server_elements,
+    server_nodes,
+    ha_enabled = role_expand_elements(role, "monasca-server")
+    reset_sync_marks_on_clusters_founders(server_elements)
+    Openstack::HA.set_controller_role(server_nodes) if ha_enabled
+
+    vip_networks = ["admin", "public"]
+
+    dirty = prepare_role_for_ha_with_haproxy(
+      role, ["monasca", "ha", "enabled"],
+      ha_enabled, server_elements, vip_networks
+    )
+    role.save if dirty
+
+    unless all_nodes.empty? || server_elements.empty?
+      net_svc = NetworkService.new @logger
+      # All nodes must have a public IP, even if part of a cluster; otherwise
+      # the VIP can't be moved to the nodes
+      server_nodes.each do |node|
+        net_svc.allocate_ip "default", "public", "host", node
+      end
+      allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(server_elements, vip_networks)
+    end
+
+    @logger.debug("Monasca apply_role_pre_chef_call: leaving")
+  end
+end

--- a/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
@@ -1,0 +1,3 @@
+= attributes_for @proposal do
+  .panel-sub
+    = header show_raw_deployment?, true

--- a/crowbar_framework/config/locales/monasca/en.yml
+++ b/crowbar_framework/config/locales/monasca/en.yml
@@ -1,0 +1,38 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+en:
+  barclamp:
+    monasca:
+      edit_attributes:
+        database_instance: 'Database Instance'
+        keystone_instance: 'Keystone'
+        api_header: 'API Settings'
+        api:
+          bind_host: 'Address'
+          bind_port: 'Port'
+          processes: 'Number of processes'
+          threads: 'Number of concurrent threads'
+        agent_header: 'Agent Settings'
+        agent:
+          url: 'Monasca URL'
+        db_header: 'Database settings'
+        db:
+          database: 'Database'
+          password: 'Password'
+          user: 'Username'
+        group: 'Group for Monasca services'
+        user: 'User for Monasca services'

--- a/monasca.yml
+++ b/monasca.yml
@@ -1,0 +1,45 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This file directs the installation of the barclamp by the Crowbar Framework
+# The major compoents are:
+#
+#   barclamp: detalis about the barclamp
+#   crowbar: installation instructions
+#   nav: (optional) injects items into the Crowbar UI menu
+#   debs/rpms/gems: components needs by the barclamp
+#
+
+barclamp:
+  name: 'monasca'
+  display: 'Monasca'
+  description: 'OpenStack Monasca: Logging and Monitoring service for OpenStack'
+  version: 0
+  user_managed: false
+  requires:
+    - '@crowbar'
+    - 'database'
+    - 'keystone'
+  member:
+    - 'openstack'
+
+crowbar:
+  layout: 1
+  order: 98
+  run_order: 98
+  chef_order: 98
+  proposal_schema_version: 1


### PR DESCRIPTION
This commit contains skeleton code for deploying OpenStack Monasca. It is meant
as a scaffold to add the actual code for deploying Monasca to. It is divided
into three roles:

* monasca-agent: for deploying a Monasca logging/monitoring agent to arbitrary
  nodes
* monasca-api: for deploying the Monasca API service to the OpenStack
  controller nodes.
* monasca-server: for deploying the Monasca backend services for receiving and
  storing logs and monitoring events to dedicated Monasca nodes.

There are some TODO and FIXME comments in the places where things still need to
be changed.