### PR TITLE
ha: Re-order rabbitmq UID/GID and pacemaker resource creation

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -18,6 +18,23 @@
 # limitations under the License.
 #
 
+# Create rabbitmq user with fixed UID/GID values to allow for HA.
+group "rabbitmq" do
+  gid node[:rabbitmq][:gid]
+  action :create
+  not_if "grep -q rabbitmq:x /etc/group"
+end
+
+user "rabbitmq" do
+  comment "user for RabbitMQ messaging server"
+  uid node[:rabbitmq][:uid]
+  gid node[:rabbitmq][:gid]
+  home "/var/lib/rabbitmq"
+  shell "/sbin/nologin"
+  action :create
+  not_if "grep -q rabbitmq:x /etc/passwd"
+end
+
 package "rabbitmq-server"
 package "rabbitmq-server-plugins" if node[:platform_family] == "suse"
 
@@ -26,6 +43,19 @@ directory "/etc/rabbitmq/" do
   group "root"
   mode 0755
   action :create
+  recursive true
+end
+
+# Update ownerships
+["/var/lib/rabbitmq", "/var/run/rabbitmq", "/var/log/rabbitmq",
+ "/var/log/rabbitmq"].each do |d|
+  directory d do
+    owner "rabbitmq"
+    group "rabbitmq"
+    action :create
+    recursive true
+    notifies :restart, "service[rabbitmq-server]"
+  end
 end
 
 template "/etc/rabbitmq/rabbitmq-env.conf" do
@@ -68,5 +98,3 @@ service "rabbitmq-server" do
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if node[:rabbitmq][:ha][:enabled]
 end
-
-

--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -137,37 +137,6 @@ end
 
 crowbar_pacemaker_sync_mark "create-rabbitmq_ha_storage"
 
-# Ensure that uid/gid are the same on all nodes
-#
-# This is really hacky!!!
-#
-# We need to have the uid/gid be the same accross all nodes, but rabbitmq
-# packages don't use a static uid/gid. So we pick one (91) which doesn't seem
-# to be in use:
-#  - see base-passwd package for Debian: http://sources.debian.net/src/base-passwd/3.5.32/passwd.master
-#  - see wiki page for Fedora: https://fedoraproject.org/wiki/PackageUserRegistry
-# We could use the chef user/group LWRP to do the change, but we also need to
-# run other commands (to change ownership of existing files), so we might as
-# well do a big script.
-# We also stop rabbitmq in case it was running before, so we can change the uid
-# without any impact. Pacemaker will start the process on one other node later
-# on anyway.
-static_uid = 91
-static_gid = 91
-bash "assign static uid to rabbitmq" do
- code <<EOC
- service rabbitmq-server stop > /dev/null;
- groupmod -g #{static_gid} rabbitmq;
- usermod -u #{static_uid} -g #{static_gid} rabbitmq;
- chown -R rabbitmq:rabbitmq /var/lib/rabbitmq;
- chown rabbitmq:rabbitmq /var/run/rabbitmq /var/log/rabbitmq;
- chown rabbitmq:rabbitmq /var/run/rabbitmq/pid /var/log/rabbitmq/*.log* || :;
-EOC
- # Make any error in the commands fatal
- flags "-e"
- only_if "test \"$(id -u rabbitmq 2> /dev/null)\" != \"#{static_uid}\" -a \"$(id -g rabbitmq 2> /dev/null)\" != \"#{static_gid}\""
-end
-
 # wait for fs primitive to be active, and for the directory to be actually
 # mounted; this is needed so we can change its ownership
 ruby_block "wait for #{fs_primitive} to be started" do

--- a/chef/data_bags/crowbar/migrate/rabbitmq/100_add_uid_gid.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/100_add_uid_gid.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["uid"] = ta["uid"]
+  a["gid"] = ta["gid"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("uid")
+  a.delete("gid")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -7,6 +7,8 @@
       "port": 5672,
       "password": "",
       "user": "nova",
+      "uid": 91,
+      "gid": 91,
       "vhost": "/nova",
       "ha": {
         "storage": {
@@ -33,7 +35,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 11,
+      "schema-revision": 100,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -16,6 +16,8 @@
             "port": { "type": "int", "required": true },
             "password": { "type": "str", "required": true },
             "user": { "type": "str", "required": true },
+            "uid": { "type": "int", "required": true },
+            "gid": { "type": "int", "required": true },
             "vhost": { "type": "str", "required": true },
             "ha" : {
               "type": "map",


### PR DESCRIPTION
We reset the UID/GID of rabbitmq to `91` to make it consistent across
the cluster. This change has to happen before we create the fs-rabbitmq
pacemaker resource, otherwise rabbitmq can not be started due to
potentially wrong ownership values on its home directory. This patch
re-orders the two relevant Chef resources so that the UID/GID is changed
before pacemaker creates the new resource.