### PR TITLE
neutron: Only put sql credentials in neutron.conf on neutron-server node

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+is_neutron_server = node.roles.include?("neutron-server")
+
 neutron = nil
 if node.attribute?(:cookbook) and node[:cookbook] == "nova"
   neutrons = search(:node, "roles:neutron-server AND roles:neutron-config-#{node[:nova][:neutron_instance]}")
@@ -126,7 +128,7 @@ template "/etc/neutron/neutron.conf" do
     owner "root"
     group neutron[:neutron][:platform][:group]
     variables(
-      sql_connection: neutron[:neutron][:db][:sql_connection],
+      sql_connection: is_neutron_server ? neutron[:neutron][:db][:sql_connection] : nil,
       sql_min_pool_size: neutron[:neutron][:sql][:min_pool_size],
       sql_max_pool_overflow: neutron[:neutron][:sql][:max_pool_overflow],
       sql_pool_timeout: neutron[:neutron][:sql][:pool_timeout],


### PR DESCRIPTION
Other nodes (neutron-network, compute) don't need that.