### PR TITLE
Fix unversioned internal auth url for the HA case

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -56,7 +56,6 @@ module KeystoneHelper
       has_default_user = node["keystone"]["default"]["create_user"]
       default_domain = "Default"
       default_domain_id = "default"
-
       @keystone_settings ||= Hash.new
       @keystone_settings[instance] = {
         "api_version" => node[:keystone][:api][:version],

--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -31,8 +31,8 @@ end.run_action(:create)
 
 ## Pacemaker is only used with native frontend
 if node[:keystone][:frontend] == "native"
-  proposal_name = node[:keystone][:config][:environment]
-  monitor_creds = node[:keystone][:admin]
+  # proposal_name = node[:keystone][:config][:environment]
+  # monitor_creds = node[:keystone][:admin]
 
   # Wait for all nodes to reach this point so we know that all nodes will have
   # all the required packages installed before we create the pacemaker

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -81,6 +81,10 @@ node.set[:keystone][:api][:versioned_internal_URL] = \
                                        my_admin_host,
                                        node[:keystone][:api][:service_port],
                                        node[:keystone][:api][:version])
+node.set[:keystone][:api][:unversioned_internal_URL] = \
+  KeystoneHelper.service_URL(node[:keystone][:api][:protocol],
+                             my_admin_host,
+                             node[:keystone][:api][:service_port])
 
 # Other barclamps need to know the hostname to reach keystone
 node.set[:keystone][:api][:public_URL_host] = my_public_host


### PR DESCRIPTION
Since the attribute was never set, it fell back to the non-HA case
and pointed to the non-VIP endpoint, which tentantivel might not work.