### PR TITLE
neutron: add port_security to ml2 extension_drivers

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -149,6 +149,7 @@ when "ml2"
   os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
   mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
 
+  ml2_extension_drivers = ["port_security"]
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv
@@ -173,6 +174,7 @@ when "ml2"
     mode "0640"
     variables(
       ml2_mechanism_drivers: ml2_mechanism_drivers,
+      ml2_extension_drivers: ml2_extension_drivers,
       ml2_type_drivers: ml2_type_drivers,
       tenant_network_types: tenant_network_types,
       vlan_start: vlan_start,

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -121,7 +121,7 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # An ordered list of extension driver entrypoints to be loaded from the
 # neutron.ml2.extension_drivers namespace. For example: extension_drivers =
 # port_security,qos (list value)
-#extension_drivers =
+extension_drivers = <%= @ml2_extension_drivers.join(",") %>
 
 # Maximum size of an IP packet (MTU) that can traverse the underlying physical
 # network infrastructure without fragmentation for overlay/tunnel networks. In


### PR DESCRIPTION
as per
http://specs.openstack.org/openstack/neutron-specs/specs/kilo/ml2-ovs-portsecurity.html
https://wiki.openstack.org/wiki/Neutron/ML2PortSecurityExtensionDriver

this should allow us to run our own routers and DHCP-servers within the cloud
that would allow us to test SOC within OpenStack

using
neutron net-update ournet --port-security-enabled=False
or neutron port-update
to override the defaults (default is to filter as before)