### PR TITLE
cinder: looplvm: avoid one level of indirection

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder-looplvm.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder-looplvm.erb
@@ -16,8 +16,7 @@ echo_status()
 
 find_associated_loopdev()
 {
-    loopdev=$(losetup -j $LOOP_LVM 2>/dev/null | head -n1 | cut -d: -f1)
-    echo $loopdev
+    losetup -j $LOOP_LVM 2>/dev/null | head -n1 | cut -d: -f1
 }
 
 case "$1" in


### PR DESCRIPTION
to simplify code and reduce sources of errors