### PR TITLE
Revert "Revert "neutron: Disable l2pop mechanism unless DVR is enabled""

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -223,7 +223,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
-        use_l2pop: ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"),
+        use_l2pop: (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")) && neutron[:neutron][:use_dvr],
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
         bridge_mappings: bridge_mappings
@@ -248,7 +248,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         vxlan_mcast_group: neutron[:neutron][:vxlan][:multicast_group],
-        use_l2pop: ml2_type_drivers.include?("vxlan"),
+        use_l2pop: ml2_type_drivers.include?("vxlan") && neutron[:neutron][:use_dvr],
         interface_mappings: interface_mappings
        )
     end

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -158,7 +158,7 @@ when "ml2"
     ml2_mechanism_drivers.push("zvm")
   end
   if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
-    ml2_mechanism_drivers.push("l2population")
+    ml2_mechanism_drivers.push("l2population") if node[:neutron][:use_dvr]
   end
 
   ml2_mech_drivers = node[:neutron][:ml2_mechanism_drivers]


### PR DESCRIPTION
l2pop with HA/vxlan just doesn't seem to work at all. Only enable
what upstream does in devstack: when DVR is used.

This reverts commit 8ed94d918e0ba241e70a16d37d4d63177c2804cc.