### PR TITLE
crowbar: remove slash after port in rabbit settings

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -131,7 +131,7 @@ class CrowbarOpenStackHelper
           vhost: rabbit[:rabbitmq][:vhost],
           url: "rabbit://#{rabbit[:rabbitmq][:user]}:" \
             "#{rabbit[:rabbitmq][:password]}@" \
-            "#{rabbit[:rabbitmq][:address]}:#{rabbit[:rabbitmq][:port]}/" \
+            "#{rabbit[:rabbitmq][:address]}:#{rabbit[:rabbitmq][:port]}" \
             "#{rabbit[:rabbitmq][:vhost]}"
         }
 

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -16,7 +16,7 @@
             "port": { "type": "int", "required": true },
             "password": { "type": "str", "required": true },
             "user": { "type": "str", "required": true },
-            "vhost": { "type": "str", "required": true },
+            "vhost": { "type": "str", "required": true, "pattern": "/^\//" },
             "ha" : {
               "type": "map",
               "required": true,


### PR DESCRIPTION
the rabbit[:rabbitmq][:vhost] attribute already has a slash in its value for the vhost. The extra slash in the helpers library generates a string that contains two slashes as a result, such as ip_add:port//vhost. This PR removes the extra slash