### PR TITLE
keystone: drop the use of 'use_syslog' as its deprecated in newton

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -247,7 +247,6 @@ template node[:keystone][:config_file] do
       bind_service_port: bind_service_port,
       admin_endpoint: node[:keystone][:api][:admin_URL],
       memcached_servers: memcached_servers,
-      use_syslog: node[:keystone][:use_syslog],
       signing_token_format: node[:keystone][:signing][:token_format],
       signing_certfile: node[:keystone][:signing][:certfile],
       signing_keyfile: node[:keystone][:signing][:keyfile],

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -4,7 +4,6 @@ debug = <%= @debug ? "True" : "False" %>
 verbose = <%= @verbose ? "True" : "False" %>
 log_file = keystone.log
 log_dir = /var/log/keystone
-use_syslog = <%= @use_syslog ? "True" : "False" %>
 
 [assignment]
 

--- a/chef/data_bags/crowbar/migrate/keystone/104_remove_use_syslog.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/104_remove_use_syslog.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("use_syslog")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["use_syslog"] = ta["use_syslog"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -116,7 +116,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 103,
+      "schema-revision": 104,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -6,7 +6,6 @@
       "debug": false,
       "frontend": "apache",
       "verbose": true,
-      "use_syslog": false,
       "policy_file": "policy.json",
       "database_instance": "none",
       "rabbitmq_instance": "none",

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -10,7 +10,6 @@
                     "verbose": { "type": "bool", "required": true },
                     "debug": { "type": "bool", "required": true },
                     "frontend": { "type": "str", "required": true },
-                    "use_syslog": { "type": "bool", "required": true },
                     "policy_file": { "type": "str", "required": true },
                     "database_instance": { "type": "str", "required": true },
                     "rabbitmq_instance": { "type": "str", "required": true },


### PR DESCRIPTION
http://docs.openstack.org/newton/config-reference/tables/conf-changes/keystone.html