### PR TITLE
tempest: Use "use_heat" also for the heat plugin tests

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -1377,6 +1377,8 @@ swift = <%= @use_swift %>
 # Whether or not Heat is expected to be available (boolean value)
 #heat = false
 heat = <%= @use_heat %>
+# heat_plugin contains the tests from the heat tempest plugin
+heat_plugin = <%= @use_heat %>
 
 # Whether or not Ceilometer is expected to be available (boolean
 # value)


### PR DESCRIPTION
Heat has currently 2 test sources. The tests from Tempest itself
and the tests from the Heat Tempest plugin. When running Tempest and
Heat is not deployed, also the tests from the Heat Tempest plugin must
be disabled.