### PR TITLE
neutron: Increase sync-mark timeout for DB sync

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -249,7 +249,13 @@ end
 
 ha_enabled = node[:neutron][:ha][:server][:enabled]
 
-crowbar_pacemaker_sync_mark "wait-neutron_db_sync"
+# use an increased timeout here because there are plenty of db syncs
+# inside of the sync mark and also a neutron-server start/stop
+crowbar_pacemaker_sync_mark "wait sync mark for neutron db sync" do
+  mark "neutron_db_sync"
+  action :wait
+  timeout 120
+end
 
 execute "neutron-db-manage migrate" do
   user node[:neutron][:user]


### PR DESCRIPTION
The default timeout of 60s seems to be not enough. The error msg is:

FATAL: Cluster founder didn't set neutron_db_sync to 5!

There are multiple reasons for that:
- neutron-server is started/stopped inside of the sync mark. We recently
  switched to systemd and use now Type=notify for the service. That means
  that starting the service blocks until the service is ready
- there are multiple db-syncs between the sync-mark. There is a sync
  for the main DB, but also for fwaas, lbaas and possibly for Cisco
  APIC.