### PR TITLE
Revert "dispersion: restart swift-proxy service to avoid bsc#1003366"

### DIFF
--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -105,14 +105,6 @@ template "/etc/swift/dispersion.conf" do
   #notifies :run, "execute[populate-dispersion]", :immediately
 end
 
-# FIXME(aplanas): extreme workaround to bsc#1003366. Python 2.7.9 and
-# greenlet 0.4.5 produce GIL deadlock in this service. A restart
-# usually resolves the issue in local testing. This needs to be
-# removed once the bug is fixed.
-service "swift-proxy" do
-  action :restart
-end
-
 # NOTE(aplanas): swift-dispersion-populate process can be slow, and
 # produce a timeout in the sync-marks in other HA recipes.  The more
 # correct approach is to create a one-shot service for this command.


### PR DESCRIPTION
This is an ultra brutal workaround of restarting proxy on every
chef run and completely destabilizes HA (as the restarts happen
on all nodes at the same time and pacemaker collapses as the services
disappear everywhere). If there is a problem this needs to be fixed
elsewhere.

This reverts commit 77ec11da5b7db42bedfdd3829234957af1c28011.

This reverts https://github.com/crowbar/crowbar-openstack/pull/544