### PR TITLE
keystone: migrate value of token_format

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/106_pki_uuid_switch.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/106_pki_uuid_switch.rb
@@ -1,0 +1,14 @@
+def upgrade(ta, td, a, d)
+  # This migration is required to correctly update the attribute when migrating
+  # from a cloud with PKI option enabled to the new release without PKI support
+  if a["signing"]["token_format"] == "PKI"
+    a["signing"]["token_format"] = "UUID"
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no good way to roll back the above change since we
+  # don't know what was set before here.
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -122,7 +122,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 105,
+      "schema-revision": 106,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
As part of https://github.com/crowbar/crowbar-openstack/pull/702 while the behavior of 702 is correct, it leaves the value for the token_format incorrect in the attribute list, which is a bug. This PR migrates the value of the attribute since in the new release the PKI is not supported.