### PR TITLE
crowbar: remove barclamp order overlap

### DIFF
--- a/barbican.yml
+++ b/barbican.yml
@@ -39,7 +39,7 @@ barclamp:
 
 crowbar:
   layout: 1
-  order: 98
-  run_order: 98
-  chef_order: 98
+  order: 100
+  run_order: 100
+  chef_order: 100
   proposal_schema_version: 1

--- a/manila.yml
+++ b/manila.yml
@@ -44,8 +44,7 @@ barclamp:
 
 crowbar:
   layout: 1
-  order: 98
-  run_order: 98
-  chef_order: 98
+  order: 101
+  run_order: 101
+  chef_order: 101
   proposal_schema_version: 3
-


### PR DESCRIPTION
for barbican, manila and ceilometer so that aodh can be listed in the right order