### PR TITLE
crowbar: remove dependency on ca.pem availability

### DIFF
--- a/chef/cookbooks/crowbar-openstack/templates/default/vhost-wsgi.conf.erb
+++ b/chef/cookbooks/crowbar-openstack/templates/default/vhost-wsgi.conf.erb
@@ -16,7 +16,9 @@ Listen <%= @bind_host %>:<%= @bind_port %>
     SSLEngine on
     SSLCertificateFile <%= @ssl_certfile %>
     SSLCertificateKeyFile <%= @ssl_keyfile %>
+    <% unless @ssl_cacert.nil? -%>
     SSLCACertificateFile <%= @ssl_cacert %>
+    <% end -%>
 <% end %>
 
     ErrorLogFormat "%{cu}t %M"


### PR DESCRIPTION
not all services have a ca.pem file. This PR makes the entry optional to the availability of the users set path