### PR TITLE
tempest: Remove boto related options

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -213,7 +213,3 @@ vendor_name = <%= @vendor_name %>
 [volume-feature-enabled]
 multi_backend = <%= @cinder_multi_backend ? 'true' : 'false' %>
 backup = false
-
-[boto]
-s3_url = http://<%= @s3_host %>:<%= @s3_port %>/
-s3_materials_path = <%= @tempest_path %>/etc/cirros/


### PR DESCRIPTION
boto testing was dropped in tempest 10.0, so there is no point
in trying to set it. Also ec2api is now handled via a tempest
plugin