### PR TITLE
keystone: Remove unused options

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -61,8 +61,6 @@ url = <%= node[:keystone][:ldap][:url] %>
 user = <%= node[:keystone][:ldap][:user] %>
 password = <%= node[:keystone][:ldap][:password] %>
 suffix = <%= node[:keystone][:ldap][:suffix] %>
-use_dumb_member = <%= node[:keystone][:ldap][:use_dumb_member] %>
-dumb_member = <%= node[:keystone][:ldap][:dumb_member] %>
 allow_subtree_delete = <%= node[:keystone][:ldap][:allow_subtree_delete] %>
 query_scope = <%= node[:keystone][:ldap][:query_scope] %>
 page_size = <%= node[:keystone][:ldap][:page_size] %>


### PR DESCRIPTION
We are not using '.*dumb_member' in the template anymore so remove it
from the conf file. Also sorted the ldap keys in the template and schema
files to make comparisons between the two easier.