### PR TITLE
ec2api: Fix restart on config file change

### DIFF
--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -86,15 +86,15 @@ node.save
 
 service "openstack-ec2-api-api" do
   action [:enable, :start]
-  subscribes :restart, resources(template: node["ec2-api"][:config_file])
+  subscribes :restart, resources(template: node[:nova]["ec2-api"][:config_file])
 end
 
 service "openstack-ec2-api-metadata" do
   action [:enable, :start]
-  subscribes :restart, resources(template: node["ec2-api"][:config_file])
+  subscribes :restart, resources(template: node[:nova]["ec2-api"][:config_file])
 end
 
 service "openstack-ec2-api-s3" do
   action [:enable, :start]
-  subscribes :restart, resources(template: node["ec2-api"][:config_file])
+  subscribes :restart, resources(template: node[:nova]["ec2-api"][:config_file])
 end


### PR DESCRIPTION
Commit a7cc09d4156fcea8e changed the attribute with the
config_file name. This fixes:

undefined method `[]' for nil:NilClass