### PR TITLE
cookbooks: Add missing dependencies to cookbooks

### DIFF
--- a/chef/cookbooks/aodh/metadata.rb
+++ b/chef/cookbooks/aodh/metadata.rb
@@ -6,3 +6,8 @@ long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"
 
 depends "apache2"
+depends "database"
+depends "keystone"
+depends "crowbar-openstack"
+depends "crowbar-pacemaker"
+depends "utils"

--- a/chef/cookbooks/ec2-api/metadata.rb
+++ b/chef/cookbooks/ec2-api/metadata.rb
@@ -5,3 +5,9 @@ license "Apache 2.0"
 description "Installs/Configures EC2 API"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1"
+
+depends "database"
+depends "crowbar-openstack"
+depends "crowbar-pacemaker"
+depends "keystone"
+depends "utils"

--- a/chef/cookbooks/trove/metadata.rb
+++ b/chef/cookbooks/trove/metadata.rb
@@ -7,6 +7,8 @@ long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1.0"
 recipe "trove::default", "Troves"
 
+depends "crowbar-openstack"
+depends "crowbar-pacemaker"
 depends "database"
 depends "utils"
 depends "nova"


### PR DESCRIPTION
This matters if these services are installed on nodes where nothing else
is installed.