### PR TITLE
trove: Fix config file path

### DIFF
--- a/chef/cookbooks/trove/attributes/default.rb
+++ b/chef/cookbooks/trove/attributes/default.rb
@@ -22,7 +22,7 @@ default[:trove][:debug] = false
 
 default[:trove][:user] = "trove"
 default[:trove][:group] = "trove"
-default[:trove][:api][:config_file] = "/etc/trove/trove-api.conf.d/100-trove-api.conf"
+default[:trove][:config_file] = "/etc/trove/trove.conf.d/100-trove.conf"
 default[:trove][:conductor][:config_file] = \
   "/etc/trove/trove-conductor.conf.d/100-trove-conductor.conf"
 default[:trove][:taskmanager][:config_file] = \

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -148,7 +148,7 @@ template "/etc/trove/api-paste.ini" do
   notifies :restart, "service[trove-api]"
 end
 
-template node[:trove][:api][:config_file] do
+template node[:trove][:config_file] do
   source "trove.conf.erb"
   owner node[:trove][:user]
   group node[:trove][:group]
@@ -169,7 +169,7 @@ template node[:trove][:api][:config_file] do
 end
 
 execute "trove-manage db sync" do
-  command "trove-manage --config-file #{node[:trove][:api][:config_file]} db_sync"
+  command "trove-manage db_sync"
   user node[:trove][:user]
   group node[:trove][:group]
   action :nothing


### PR DESCRIPTION
Commit dfb322935fca7 switched to the new config file paths but also
changed the common config file /etc/trove/trove.conf to
/etc/trove/trove-api.conf.d/100-trove-api.conf which seems not to work.