### PR TITLE
trove: Fix wrong db_sync resource action

### DIFF
--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -172,7 +172,6 @@ execute "trove-manage db sync" do
   command "trove-manage --config-file #{node[:trove][:api][:config_file]} db_sync"
   user node[:trove][:user]
   group node[:trove][:group]
-  action :nothing
   only_if { !node[:trove][:db_synced] }
 end
 


### PR DESCRIPTION
action :nothing is a leftover of a more complicated setup to be triggered that I experimented on while doing https://github.com/crowbar/crowbar-openstack/commit/dfb322935fca75f6e2b6887fad77c27f90d9c380 and blocks the database for trove to be created+synced, breaking the tempest run for all jobs in the CI