### PR TITLE
keystone: revert back certificate attributes setup

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -287,12 +287,11 @@ end
 crowbar_pacemaker_sync_mark "create-keystone_db_sync"
 
 ruby_block "synchronize signing keys for founder and remember them for non-HA case" do
-  only_if { (!ha_enabled || (ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node))) &&
-            (node[:platform_family] == "suse") }
+  only_if { (!ha_enabled || (ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node))) }
   block do
-    ca = File.open("/etc/keystone/ssl/certs/ca.pem", "rb") { |io| io.read } rescue ""
-    signing_cert = File.open("/etc/keystone/ssl/certs/signing_cert.pem", "rb") { |io| io.read } rescue ""
-    signing_key = File.open("/etc/keystone/ssl/private/signing_key.pem", "rb") { |io| io.read } rescue ""
+    ca = File.open("/etc/keystone/ssl/certs/ca.pem", "rb", &:read)
+    signing_cert = File.open("/etc/keystone/ssl/certs/signing_cert.pem", "rb", &:read)
+    signing_key = File.open("/etc/keystone/ssl/private/signing_key.pem", "rb", &:read)
 
     node[:keystone][:certificates] ||= {}
     node[:keystone][:certificates][:content] ||= {}
@@ -317,11 +316,11 @@ ruby_block "synchronize signing keys for founder and remember them for non-HA ca
 end
 
 ruby_block "synchronize signing keys for non-founder" do
-  only_if { ha_enabled && !CrowbarPacemakerHelper.is_cluster_founder?(node) && (node[:platform_family] == "suse") }
+  only_if { ha_enabled && !CrowbarPacemakerHelper.is_cluster_founder?(node) }
   block do
-    ca = File.open("/etc/keystone/ssl/certs/ca.pem", "rb") { |io| io.read } rescue ""
-    signing_cert = File.open("/etc/keystone/ssl/certs/signing_cert.pem", "rb") { |io| io.read } rescue ""
-    signing_key = File.open("/etc/keystone/ssl/private/signing_key.pem", "rb") { |io| io.read } rescue ""
+    ca = File.open("/etc/keystone/ssl/certs/ca.pem", "rb", &:read)
+    signing_cert = File.open("/etc/keystone/ssl/certs/signing_cert.pem", "rb", &:read)
+    signing_key = File.open("/etc/keystone/ssl/private/signing_key.pem", "rb", &:read)
 
     founder = CrowbarPacemakerHelper.cluster_founder(node)
 
@@ -333,15 +332,21 @@ ruby_block "synchronize signing keys for non-founder" do
     # the code below
     dirty = false
     if ca != cluster_ca
-      File.open("/etc/keystone/ssl/certs/ca.pem", "w") { |f| f.write(cluster_ca) }
+      File.open("/etc/keystone/ssl/certs/ca.pem", "w") { |f|
+        f.write(cluster_ca)
+      }
       dirty = true
     end
     if signing_cert != cluster_signing_cert
-      File.open("/etc/keystone/ssl/certs/signing_cert.pem", "w") { |f| f.write(cluster_signing_cert) }
+      File.open("/etc/keystone/ssl/certs/signing_cert.pem", "w") { |f|
+        f.write(cluster_signing_cert)
+      }
       dirty = true
     end
     if signing_key != cluster_signing_key
-      File.open("/etc/keystone/ssl/private/signing_key.pem", "w") { |f| f.write(cluster_signing_key) }
+      File.open("/etc/keystone/ssl/private/signing_key.pem", "w") { |f|
+        f.write(cluster_signing_key)
+      }
       dirty = true
     end
 

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -286,6 +286,11 @@ end
 
 crowbar_pacemaker_sync_mark "create-keystone_db_sync"
 
+# Make sure the certificates code is run on the founder first
+crowbar_pacemaker_sync_mark "wait-keystone_certificates" do
+  fatal true
+end
+
 ruby_block "synchronize signing keys for founder and remember them for non-HA case" do
   only_if { (!ha_enabled || (ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node))) }
   block do


### PR DESCRIPTION
Due to the fact that Ceph depends on Keystone signing certificates for communication with Keystone we need to have the right code to set up the attributes and related content.

relates to this https://github.com/crowbar/crowbar-ceph/pull/83