### PR TITLE
Fix neutron migrations for upgrade when F5 backport lands

### DIFF
--- a/chef/data_bags/crowbar/migrate/neutron/103_add_lbaasv2_driver.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/103_add_lbaasv2_driver.rb
@@ -1,9 +1,13 @@
 def upgrade(ta, td, a, d)
-  a["lbaasv2_driver"] = ta["lbaasv2_driver"]
+  unless a.key? "lbaasv2_driver"
+    a["lbaasv2_driver"] = ta["lbaasv2_driver"]
+  end
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  a.delete("lbaasv2_driver")
+  unless ta.key? "lbaasv2_driver"
+    a.delete("lbaasv2_driver")
+  end
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/neutron/103_remove_use_lbaasv2.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/103_remove_use_lbaasv2.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a.delete("use_lbaasv2")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta.key? "use_lbaasv2"
+    a["use_lbaasv2"] = ta["use_lbaasv2"]
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/neutron/104_add_f5_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/104_add_f5_attributes.rb
@@ -1,9 +1,13 @@
 def upgrade(ta, td, a, d)
-  a["f5"] = ta["f5"]
+  unless a.key? "f5"
+    a["f5"] = ta["f5"]
+  end
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  a.delete("f5")
+  unless ta.key? "f5"
+    a.delete("f5")
+  end
   return a, d
 end


### PR DESCRIPTION
The migrations related to lbaasv2 & F5 were assuming that the code would not hit 3.0.