### PR TITLE
Re-add use_l2pop attribute

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -223,7 +223,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
-        use_l2pop: neutron[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
+        use_l2pop: neutron[:neutron][:use_l2pop] &&
+            (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
         bridge_mappings: bridge_mappings

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -223,7 +223,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
-        use_l2pop: ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"),
+        use_l2pop: neutron[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
         bridge_mappings: bridge_mappings
@@ -248,7 +248,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         ml2_type_drivers: ml2_type_drivers,
         vxlan_mcast_group: neutron[:neutron][:vxlan][:multicast_group],
-        use_l2pop: ml2_type_drivers.include?("vxlan"),
+        use_l2pop: neutron[:neutron][:use_l2pop] && ml2_type_drivers.include?("vxlan"),
         interface_mappings: interface_mappings
        )
     end

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -158,7 +158,8 @@ when "ml2"
   if use_zvm
     ml2_mechanism_drivers.push("zvm")
   end
-  if node[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"))
+  if node[:neutron][:use_l2pop] &&
+      (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"))
     ml2_mechanism_drivers.push("l2population")
   end
 

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -158,7 +158,7 @@ when "ml2"
   if use_zvm
     ml2_mechanism_drivers.push("zvm")
   end
-  if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
+  if node[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"))
     ml2_mechanism_drivers.push("l2population")
   end
 

--- a/chef/data_bags/crowbar/migrate/neutron/105_add_back_use_l2pop.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/105_add_back_use_l2pop.rb
@@ -1,0 +1,16 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "use_l2pop"
+    # Only enable it if DVR is used
+    a["use_l2pop"] = a["use_dvr"]
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "use_l2pop"
+    a.delete("use_l2pop")
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -13,6 +13,7 @@
       "dhcp_domain": "openstack.local",
       "use_lbaas": true,
       "lbaasv2_driver": "haproxy",
+      "use_l2pop": false,
       "use_dvr": false,
       "additional_external_networks": [],
       "networking_plugin": "ml2",
@@ -117,7 +118,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 104,
+      "schema-revision": 105,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -18,6 +18,7 @@
                     "dhcp_domain": { "type": "str", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
                     "lbaasv2_driver": { "type": "str", "required": true },
+                    "use_l2pop": { "type": "bool", "required": true },
                     "use_dvr": { "type": "bool", "required": true },
                     "additional_external_networks": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "networking_plugin": { "type": "str", "required": true },

--- a/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
@@ -253,6 +253,7 @@ function networking_plugin_check() {
     $('#ml2_type_drivers_container').show();
     $('#ml2_type_drivers_default_provider_network_container').show();
     $('#ml2_type_drivers_default_tenant_network_container').show();
+    $('#l2pop_container').show();
     $('#dvr_container').show();
     $('#lbaas_container').show();
     $('#lbaasv2_driver_container').show();
@@ -268,6 +269,7 @@ function networking_plugin_check() {
     $('#ml2_type_drivers_container').hide();
     $('#ml2_type_drivers_default_provider_network_container').hide();
     $('#ml2_type_drivers_default_tenant_network_container').hide();
+    $('#l2pop_container').hide();
     $('#dvr_container').hide();
     $('#lbaas_container').hide();
     $('#lbaasv2_driver_container').hide();
@@ -299,6 +301,13 @@ function ml2_type_drivers_check() {
     $('#vxlan_container').show();
   } else {
     $('#vxlan_container').hide();
+  }
+
+  // show/hide l2pop depending on gre/vxlan
+  if (values.indexOf("gre") >= 0 || values.indexOf("vxlan") >= 0) {
+    $('#l2pop_container').show();
+  } else {
+    $('#l2pop_container').hide();
   }
 
   // hide uneeded default type drivers if only one is set
@@ -338,6 +347,13 @@ function ml2_mechanism_drivers_check() {
     }
   } else {
     $('#cisco_switches').hide();
+  }
+
+  // show/hide l2pop depending on openvswitch/linuxbridge
+  if (values.indexOf("openvswitch") >= 0 || values.indexOf("linuxbridge") >= 0) {
+    $('#l2pop_container').show();
+  } else {
+    $('#l2pop_container').hide();
   }
 
   // show/hide DVR and GRE options depending on openvswitch

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -267,9 +267,11 @@ class NeutronService < PacemakerServiceObject
   def validate_dvr(proposal)
     plugin = proposal["attributes"]["neutron"]["networking_plugin"]
     ml2_mechanism_drivers = proposal["attributes"]["neutron"]["ml2_mechanism_drivers"]
+    ml2_type_drivers = proposal["attributes"]["neutron"]["ml2_type_drivers"]
 
     if proposal["attributes"]["neutron"]["use_dvr"]
-      if !proposal["attributes"]["neutron"]["use_l2pop"]
+      if (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")) &&
+          !proposal["attributes"]["neutron"]["use_l2pop"]
         validation_error I18n.t("barclamp.#{@bc_name}.validation.dvr_requires_l2")
       end
 

--- a/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
@@ -30,6 +30,9 @@
         %span.help-block
           = t('.ml2_type_drivers_default_tenant_network_hint')
 
+      #l2pop_container
+        = boolean_field :use_l2pop
+
       #dvr_container
         = boolean_field :use_dvr
 

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -59,6 +59,7 @@ en:
         switch_password: 'Password'
         add_switch: 'Add'
         remove_switch: 'Remove'
+        use_l2pop: 'Use L2 Population'
         use_dvr: 'Use Distributed Virtual Router setup'
         use_lbaas: 'Use Neutron LoadBalancer agent'
         lbaasv2_driver: 'Select LoadBalancer v2 driver'

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -130,5 +130,7 @@ en:
         cisco_nexus_vlan: 'The "cisco_nexus" mechanism driver needs the type driver "vlan"'
         cisco_nexus_ovs: 'The "cisco_nexus" mechanism driver needs also the "openvswitch" mechanism driver'
         openvswitch_linuxbridge: 'The "openvswitch" and "linuxbridge" mechanism drivers cannot be used in parallel. Only select one of them'
+        l2_population: 'L2 population requires GRE and/or VXLAN'
+        dvr_requires_l2: 'DVR requires L2 population'
         dvr_vmware: 'DVR is not compatible with VMware NSX plugin'
         dvr_linuxbridge: 'DVR is not compatible with Linux Bridge ML2 driver'

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -131,6 +131,6 @@ en:
         cisco_nexus_ovs: 'The "cisco_nexus" mechanism driver needs also the "openvswitch" mechanism driver'
         openvswitch_linuxbridge: 'The "openvswitch" and "linuxbridge" mechanism drivers cannot be used in parallel. Only select one of them'
         l2_population: 'L2 population requires GRE and/or VXLAN'
-        dvr_requires_l2: 'DVR requires L2 population'
+        dvr_requires_l2: 'DVR with GRE or VXLAN requires L2 population'
         dvr_vmware: 'DVR is not compatible with VMware NSX plugin'
         dvr_linuxbridge: 'DVR is not compatible with Linux Bridge ML2 driver'


### PR DESCRIPTION
Quoting @dirkmueller:

> l2pop with HA/vxlan just doesn't seem to work at all. Only enable what upstream does in devstack: when DVR is used.

This should replace https://github.com/crowbar/crowbar-openstack/pull/684