### PR TITLE
[stable/3.0] Provide .openrc for nodes with neutron-network role

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -36,6 +36,19 @@ if use_l3_agent
     #sensitive true
     action :create
   end
+
+  # We need .openrc present at network node so the node can use neutron-ha-tool even
+  # when located in separate cluster
+  template "/root/.openrc" do
+    source "openrc.erb"
+    cookbook "keystone"
+    owner "root"
+    group "root"
+    mode 0600
+    variables(
+      keystone_settings: keystone_settings
+    )
+  end
 end
 
 # Wait for all "neutron-network" nodes to reach this point so we know that they will


### PR DESCRIPTION
So we can execute neutron-ha-tool or nova commands if they
are in the different cluster than keystone.


OK, I'm not sure if this is correct, so it's rather initial proposal...