### PR TITLE
[nova] Assure that libvirtd is restarted before nova-compute (bsc#101…

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -93,7 +93,7 @@ case node[:nova][:libvirt_type]
           libvirtd_listen_addr: listen_addr,
           libvirtd_auth_tcp: node[:nova]["use_migration"] ? "none" : "sasl"
         )
-        notifies :restart, "service[libvirtd]", :delayed
+        notifies :create, "ruby_block[restart_libvirtd]", :immediately
       end
 
       case node[:nova][:libvirt_type]
@@ -197,7 +197,25 @@ case node[:nova][:libvirt_type]
             user: libvirt_user,
             group: libvirt_group
         )
-        notifies :restart, "service[libvirtd]"
+        notifies :create, "ruby_block[restart_libvirtd]", :immediately
+      end
+
+      # This block is here to allow to restart libvirtd as soon as possible
+      # after configuration changes (notified from the qemu.conf and libvirtd.conf
+      # templates above), while avoiding it to restart multiple times, like it would
+      # when we'd sent an :immediate restart notification directly to the service.
+      # We need a (somewhat) immediate restart of libvirtd to avoid race conditions
+      # and ordering issues with the delayed restart of nova-compute
+      # See: https://bugzilla.suse.com/show_bug.cgi?id=1016302
+      ruby_block "restart_libvirtd" do
+        block do
+          r = resources(service: "libvirtd")
+          a = Array.new(r.action)
+          a << :restart unless a.include?(:restart)
+          a.delete(:start) if a.include?(:restart)
+          r.action(a)
+        end
+        action :nothing
       end
 
       service "libvirtd" do


### PR DESCRIPTION
…6302)

nova-compute is currently suffering from race conditions when libvirtd
is being restarted during the startup of nova-compute. (For details see:
https://bugs.launchpad.net/nova/+bug/1654207

Our recipes currently are implemented in a way that makes that race
condition trigger pretty often on the initial deploymented and
especially on the crowbar_join run during the upgrade from an older
release. One reason for this is, that the libvirtd restart happens
after/during the restart of nova-compute.

This patch adds a workaround so that libvirtd is restarted before
nova-compute, by utilizing immediate notifications.

(cherry picked from commit 8c44da82f835c81e2377e38be5e1146a456e532d)