### PR TITLE
nova: increase sync mark timeout for compute HA

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -87,6 +87,7 @@ end
 # the corosync nodes to be part of the nova proposal.
 crowbar_pacemaker_sync_mark "sync-nova_compute_before_ha" do
   revision nova[:nova]["crowbar-revision"]
+  timeout 120
 end
 
 # Avoid races when creating pacemaker resources


### PR DESCRIPTION
For vitualized installations we need to increase the timeout
of the sync-nova_compute_before_ha synchronization point.