### PR TITLE
neutron: add port_security to ml2 extension_drivers

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -191,6 +191,7 @@ when "ml2"
   os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
   mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
 
+  ml2_extension_drivers = ["port_security"]
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv
@@ -216,6 +217,7 @@ when "ml2"
     mode "0640"
     variables(
       ml2_mechanism_drivers: ml2_mechanism_drivers,
+      ml2_extension_drivers: ml2_extension_drivers,
       ml2_type_drivers: ml2_type_drivers,
       tenant_network_types: tenant_network_types,
       vlan_start: vlan_start,

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -28,6 +28,7 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # to be loaded from the neutron.ml2.extension_drivers namespace.
 # extension_drivers =
 # Example: extension_drivers = anewextensiondriver
+extension_drivers = <%= @ml2_extension_drivers.join(",") %>
 
 # =========== items for MTU selection and advertisement =============
 # (IntOpt) Path MTU.  The maximum permissible size of an unfragmented


### PR DESCRIPTION
as per
http://specs.openstack.org/openstack/neutron-specs/specs/kilo/ml2-ovs-portsecurity.html
https://wiki.openstack.org/wiki/Neutron/ML2PortSecurityExtensionDriver

this should allow us to run our own routers and DHCP-servers within the cloud
that would allow us to test SOC within OpenStack

using
neutron net-update ournet --port-security-enabled=False
or neutron port-update
to override the defaults (default is to filter as before)

cherry-picked-from 3fa8ae148dadad66d1da2b2be28aca0d1a3b5967

backport of #676