### PR TITLE
neutron: Additional fix for infoblox migration (bsc#1020121)

### DIFF
--- a/chef/data_bags/crowbar/migrate/neutron/049_infoblox_update.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/049_infoblox_update.rb
@@ -9,7 +9,7 @@ def upgrade(ta, td, a, d)
   # won't touch it. If, on the other hand, we are dealing with the Cloud 5
   # version from October 2015 we'll just overwrite it since the infoblox plugin
   # changed a great deal since then.
-  unless a.key?("infoblox") && a[:infoblox].key?("grid_defaults")
+  unless a.key?("infoblox") && a["infoblox"].key?("grid_defaults")
     a["infoblox"] = ta["infoblox"]
   end
   return a, d


### PR DESCRIPTION
We hit "undefined method `key?' for nil:NilClass", because it's a hash,
and using symbols don't work here.

Note that the fix is already in master...