### PR TITLE
nova: Expose `use_serial` to UI

### DIFF
--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -99,5 +99,14 @@
 
     %fieldset
       %legend
+        = t(".serial_console_header")
+
+      .alert.alert-warning
+        = t(".serial_console_hint")
+
+      = boolean_field :use_serial
+
+    %fieldset
+      %legend
         = t(".logging_header")
       = boolean_field :verbose

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -80,6 +80,9 @@ en:
             enabled: 'NoVNC Protocol'
             certfile: 'SSL Certificate File'
             keyfile: 'SSL (Private) Key File'
+        serial_console_header: 'Serial Console Settings'
+        serial_console_hint: 'Please note the following limitations: (1) NoVNC needs to be disabled when the serial console is enabled. (2) Access via serial console is unprotected. (3) Only one client can connect via serial console at a time.'
+        use_serial: 'Use serial console'
         logging_header: 'Logging'
         verbose: 'Verbose Logging'
       validation:


### PR DESCRIPTION
Right now the `use_serial` switch is hidden in the raw view but it's
useful enough to expose it in the UI.