### PR TITLE
keystone/swift: Hide unneeded options from proposal screen

### DIFF
--- a/crowbar_framework/app/helpers/barclamp/keystone_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/keystone_helper.rb
@@ -17,16 +17,6 @@
 
 module Barclamp
   module KeystoneHelper
-    def server_frontends_for_keystone(selected)
-      options_for_select(
-        [
-          ["apache", "apache"],
-          ["uwsgi", "uwsgi"]
-        ],
-        selected.to_s
-      )
-    end
-
     def token_formats_for_keystone(selected)
       options_for_select(
         [

--- a/crowbar_framework/app/helpers/barclamp/swift_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/swift_helper.rb
@@ -17,16 +17,6 @@
 
 module Barclamp
   module SwiftHelper
-    def frontends_for_swift(selected)
-      options_for_select(
-        [
-          ["uwsgi", "uwsgi"],
-          ["native", "native"]
-        ],
-        selected.to_s
-      )
-    end
-
     def ssl_protocols_for_swift(selected)
       options_for_select(
         [

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -5,7 +5,6 @@
   .panel-body
     = instance_field :database
     = instance_field :rabbitmq
-    = select_field %w(frontend), :collection => :server_frontends_for_keystone
     = select_field %w(signing token_format), :collection => :token_formats_for_keystone
     = string_field %w(api region)
 

--- a/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
@@ -6,14 +6,11 @@
     = instance_field :keystone
     = boolean_field :keystone_delay_auth_decision
     = boolean_field :allow_versions
-    = select_field :frontend, :collection => :frontends_for_swift
     = integer_field :zones
     = integer_field :partitions
     = integer_field :min_part_hours
     = integer_field :replicas
     = integer_field :replication_interval
-    = string_field :cluster_hash
-    = password_field :cluster_admin_pw
     = boolean_field :debug
 
     %fieldset

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -19,7 +19,6 @@ en:
   barclamp:
     keystone:
       edit_attributes:
-        frontend: 'Frontend'
         database_instance: 'Database Instance'
         rabbitmq_instance: 'RabbitMQ'
         signing:

--- a/crowbar_framework/config/locales/swift/en.yml
+++ b/crowbar_framework/config/locales/swift/en.yml
@@ -72,14 +72,11 @@ en:
         keystone_instance: 'Keystone instance'
         keystone_delay_auth_decision: 'Allow Public Containers (Anonymous access, performance penalty)'
         allow_versions: 'Enable Object Versioning'
-        frontend: 'Frontend'
         zones: 'Zones'
         partitions: 'Create 2^X Logical Partitions'
         min_part_hours: 'Minimum Hours before Partition is reassigned'
         replicas: 'Replicas'
         replication_interval: 'Replication interval (in seconds)'
-        cluster_hash: 'Cluster Hash'
-        cluster_admin_pw: 'Cluster Admin Password'
         debug: 'Debug'
         middlewares:
           s3:


### PR DESCRIPTION
This patch has been in our packages since more or less forever.
As it causes conflicts in the PR testing, upstreaming that patch
is easier.