### PR TITLE
neutron: Add attribute of choosing ovsdb/of interface (bsc#1022074)

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -227,6 +227,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
             (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
+        of_interface: neutron[:neutron][:ovs][:of_interface],
+        ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
         bridge_mappings: bridge_mappings
       )
     end

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -19,6 +19,8 @@ tunnel_csum = True
 <% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
 tunnel_bridge = br-tunnel
 <% end -%>
+ovsdb_interface = <%= @ovsdb_interface %>
+of_interface = <%= @of_interface %>
 <% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
 local_ip = <%= node.address("os_sdn").addr %>
 <% end -%>

--- a/chef/data_bags/crowbar/migrate/neutron/107_add_ovs_interface_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/107_add_ovs_interface_attributes.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  unless a["ovs"].key? "of_interface"
+    a["ovs"]["of_interface"] = ta["ovs"]["of_interface"]
+  end
+
+  unless a["ovs"].key? "ovsdb_interface"
+    a["ovs"]["ovsdb_interface"] = ta["ovs"]["ovsdb_interface"]
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta.key?("ovs") && a.key?("ovs")
+    unless ta["ovs"].key?("of_interface")
+      a["ovs"].delete("of_interface")
+    end
+    unless ta["ovs"].key?("ovsdb_interface")
+      a["ovs"].delete("ovsdb_interface")
+    end
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -32,7 +32,9 @@
         "multicast_group": "239.1.1.1"
       },
       "ovs": {
-        "tunnel_csum": false
+        "tunnel_csum": false,
+        "of_interface": "native",
+        "ovsdb_interface": "native"
       },
       "allow_overlapping_ips": true,
       "use_syslog": false,
@@ -119,7 +121,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 106,
+      "schema-revision": 107,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -37,7 +37,9 @@
                       "multicast_group": { "type" : "str", "required": true }
                     }},
                     "ovs": { "type": "map", "required": true, "mapping": {
-                      "tunnel_csum": { "type": "bool", "required": true }
+                      "tunnel_csum": { "type": "bool", "required": true },
+                      "ovsdb_interface": { "type": "str", "required": true },
+                      "of_interface": { "type": "str", "required": true }
                     }},
                     "allow_overlapping_ips": { "type": "bool", "required": true },
                     "cisco_switches": {


### PR DESCRIPTION
Neutron uses "native" by default now. Allow to switch back to the old
vsctl/ovs_ofctl based implementations.

Workaround for: https://bugzilla.suse.com/show_bug.cgi?id=1022074