### PR TITLE
Do not use pacemaker groups unless needed

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh_ha.rb
+++ b/chef/cookbooks/aodh/recipes/aodh_ha.rb
@@ -39,7 +39,7 @@ node[:aodh][:platform][:services].each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:aodh][:ha][service.to_sym][:agent]
     op node[:aodh][:ha][service.to_sym][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
+    order_only_existing "( postgresql rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/aodh/recipes/aodh_ha.rb
+++ b/chef/cookbooks/aodh/recipes/aodh_ha.rb
@@ -36,29 +36,15 @@ transaction_objects = []
 node[:aodh][:platform][:services].each do |service|
   primitive_name = "aodh-#{service}"
 
-  pacemaker_primitive primitive_name do
+  objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:aodh][:ha][service.to_sym][:agent]
     op node[:aodh][:ha][service.to_sym][:op]
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-
-  clone_name = "cl-#{primitive_name}"
-  pacemaker_clone clone_name do
-    rsc primitive_name
-    meta CrowbarPacemakerHelper.clone_meta(node)
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-  transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-  location_name = openstack_pacemaker_controller_only_location_for clone_name
-  transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects.push(objects)
 end
 
 pacemaker_transaction "aodh" do
-  cib_objects transaction_objects
+  cib_objects transaction_objects.flatten
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/aodh/recipes/aodh_ha.rb
+++ b/chef/cookbooks/aodh/recipes/aodh_ha.rb
@@ -59,7 +59,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/barbican/recipes/ha.rb
+++ b/chef/cookbooks/barbican/recipes/ha.rb
@@ -59,7 +59,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:barbican][:ha][service.to_sym][:agent]
     op node[:barbican][:ha][service.to_sym][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
+    order_only_existing "( postgresql rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/barbican/recipes/ha.rb
+++ b/chef/cookbooks/barbican/recipes/ha.rb
@@ -78,7 +78,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta("clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node))
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/ceilometer/recipes/central_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/central_ha.rb
@@ -43,7 +43,7 @@ pacemaker_transaction "ceilometer central" do
 end
 
 crowbar_pacemaker_order_only_existing "o-#{service_name}" do
-  ordering ["rabbitmq", "cl-keystone", service_name]
+  ordering "( rabbitmq cl-keystone ) #{service_name}"
   score "Optional"
   action :create
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/ceilometer/recipes/mongodb.rb
+++ b/chef/cookbooks/ceilometer/recipes/mongodb.rb
@@ -60,7 +60,7 @@ if ha_enabled
   clone_name = "cl-#{service_name}"
   pacemaker_clone clone_name do
     rsc service_name
-    meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+    meta CrowbarPacemakerHelper.clone_meta(node)
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -38,12 +38,12 @@ services.each do |service|
   primitive_name = "ceilometer-#{service}"
 
   if node[:ceilometer][:use_mongodb]
-    order_only_existing = ["rabbitmq", "cl-keystone"]
+    order_only_existing = "( rabbitmq cl-keystone )"
   else
     # we don't make the db mandatory if not mongodb; this is debatable, but
     # oslo.db is supposed to deal well with reconnections; it's less clear about
     # mongodb
-    order_only_existing = ["postgresql", "rabbitmq", "cl-keystone"]
+    order_only_existing = "( postgresql rabbitmq cl-keystone )"
   end
 
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -31,59 +31,42 @@ crowbar_pacemaker_sync_mark "sync-ceilometer_server_before_ha"
 # Avoid races when creating pacemaker resources
 crowbar_pacemaker_sync_mark "wait-ceilometer_server_ha_resources"
 
+services = ["collector", "agent_notification"]
 transaction_objects = []
-primitives = []
 
-["collector", "agent_notification"].each do |service|
+services.each do |service|
   primitive_name = "ceilometer-#{service}"
-
   pacemaker_primitive primitive_name do
     agent node[:ceilometer][:ha][service.to_sym][:agent]
     op node[:ceilometer][:ha][service.to_sym][:op]
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-
-  primitives << primitive_name
   transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-end
 
-group_name = "g-ceilometer-server"
-pacemaker_group group_name do
-  members primitives
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-transaction_objects << "pacemaker_group[#{group_name}]"
-
-clone_name = "cl-#{group_name}"
-pacemaker_clone clone_name do
-  rsc group_name
-  meta CrowbarPacemakerHelper.clone_meta(node)
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-order_only_existing = ["rabbitmq", "cl-keystone", clone_name]
-
-if node[:ceilometer][:use_mongodb]
-  pacemaker_order "o-ceilometer-mongo" do
-    score "Mandatory"
-    ordering "cl-mongodb #{clone_name}"
+  clone_name = "cl-#{primitive_name}"
+  pacemaker_clone clone_name do
+    rsc primitive_name
+    meta CrowbarPacemakerHelper.clone_meta(node)
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  transaction_objects << "pacemaker_order[o-ceilometer-mongo]"
-else
-  # we don't make the db mandatory if not mongodb; this is debatable, but
-  # oslo.db is supposed to deal well with reconnections; it's less clear about
-  # mongodb
-  order_only_existing.unshift "postgresql"
-end
+  transaction_objects << "pacemaker_clone[#{clone_name}]"
 
-location_name = openstack_pacemaker_controller_only_location_for clone_name
-transaction_objects << "pacemaker_location[#{location_name}]"
+  location_name = openstack_pacemaker_controller_only_location_for clone_name
+  transaction_objects << "pacemaker_location[#{location_name}]"
+
+  if node[:ceilometer][:use_mongodb]
+    order_name = "o-#{clone_name}-mongo"
+    pacemaker_order order_name do
+      score "Mandatory"
+      ordering "cl-mongodb #{clone_name}"
+      action :update
+      only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+    end
+    transaction_objects << "pacemaker_order[#{order_name}]"
+  end
+end
 
 pacemaker_transaction "ceilometer server" do
   cib_objects transaction_objects
@@ -92,11 +75,25 @@ pacemaker_transaction "ceilometer server" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-  ordering order_only_existing
-  score "Optional"
-  action :create
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+services.each do |service|
+  primitive_name = "ceilometer-#{service}"
+  clone_name = "cl-#{primitive_name}"
+
+  if node[:ceilometer][:use_mongodb]
+    order_only_existing = ["rabbitmq", "cl-keystone", clone_name]
+  else
+    # we don't make the db mandatory if not mongodb; this is debatable, but
+    # oslo.db is supposed to deal well with reconnections; it's less clear about
+    # mongodb
+    order_only_existing = ["postgresql", "rabbitmq", "cl-keystone", clone_name]
+  end
+
+  crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
+    ordering order_only_existing
+    score "Optional"
+    action :create
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
 end
 
 crowbar_pacemaker_sync_mark "create-ceilometer_server_ha_resources"

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -59,7 +59,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -36,27 +36,15 @@ transaction_objects = []
 
 services.each do |service|
   primitive_name = "ceilometer-#{service}"
-  pacemaker_primitive primitive_name do
+
+  objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:ceilometer][:ha][service.to_sym][:agent]
     op node[:ceilometer][:ha][service.to_sym][:op]
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-
-  clone_name = "cl-#{primitive_name}"
-  pacemaker_clone clone_name do
-    rsc primitive_name
-    meta CrowbarPacemakerHelper.clone_meta(node)
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-  transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-  location_name = openstack_pacemaker_controller_only_location_for clone_name
-  transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects.push(objects)
 
   if node[:ceilometer][:use_mongodb]
+    clone_name = "cl-#{primitive_name}"
     order_name = "o-#{clone_name}-mongo"
     pacemaker_order order_name do
       score "Mandatory"
@@ -69,7 +57,7 @@ services.each do |service|
 end
 
 pacemaker_transaction "ceilometer server" do
-  cib_objects transaction_objects
+  cib_objects transaction_objects.flatten
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -37,9 +37,19 @@ transaction_objects = []
 services.each do |service|
   primitive_name = "ceilometer-#{service}"
 
+  if node[:ceilometer][:use_mongodb]
+    order_only_existing = ["rabbitmq", "cl-keystone"]
+  else
+    # we don't make the db mandatory if not mongodb; this is debatable, but
+    # oslo.db is supposed to deal well with reconnections; it's less clear about
+    # mongodb
+    order_only_existing = ["postgresql", "rabbitmq", "cl-keystone"]
+  end
+
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:ceilometer][:ha][service.to_sym][:agent]
     op node[:ceilometer][:ha][service.to_sym][:op]
+    order_only_existing order_only_existing
   end
   transaction_objects.push(objects)
 
@@ -61,27 +71,6 @@ pacemaker_transaction "ceilometer server" do
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-
-services.each do |service|
-  primitive_name = "ceilometer-#{service}"
-  clone_name = "cl-#{primitive_name}"
-
-  if node[:ceilometer][:use_mongodb]
-    order_only_existing = ["rabbitmq", "cl-keystone", clone_name]
-  else
-    # we don't make the db mandatory if not mongodb; this is debatable, but
-    # oslo.db is supposed to deal well with reconnections; it's less clear about
-    # mongodb
-    order_only_existing = ["postgresql", "rabbitmq", "cl-keystone", clone_name]
-  end
-
-  crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-    ordering order_only_existing
-    score "Optional"
-    action :create
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
 end
 
 crowbar_pacemaker_sync_mark "create-ceilometer_server_ha_resources"

--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -45,29 +45,16 @@ transaction_objects = []
 
 services.each do |service|
   primitive_name = "cinder-#{service}"
-  pacemaker_primitive primitive_name do
+
+  objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:cinder][:ha]["#{service}_ra"]
     op node[:cinder][:ha][:op]
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-
-  clone_name = "cl-#{primitive_name}"
-  pacemaker_clone clone_name do
-    rsc primitive_name
-    meta CrowbarPacemakerHelper.clone_meta(node)
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-  transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-  location_name = openstack_pacemaker_controller_only_location_for clone_name
-  transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects.push(objects)
 end
 
 pacemaker_transaction "cinder controller" do
-  cib_objects transaction_objects
+  cib_objects transaction_objects.flatten
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -71,7 +71,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -49,7 +49,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:cinder][:ha]["#{service}_ra"]
     op node[:cinder][:ha][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
+    order_only_existing "( postgresql rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_clone_for_transaction.rb
+++ b/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_clone_for_transaction.rb
@@ -1,0 +1,48 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+define :openstack_pacemaker_controller_clone_for_transaction,
+    agent: nil,
+    op: {} do
+  primitive_name = params[:name]
+  agent = params[:agent]
+  op = params[:op]
+
+  raise "No agent specified for #{primitive_name}!" if agent.nil?
+
+  pacemaker_primitive primitive_name do
+    agent agent
+    op op
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  clone_name = "cl-#{primitive_name}"
+  pacemaker_clone clone_name do
+    rsc primitive_name
+    meta CrowbarPacemakerHelper.clone_meta(node)
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  location_name = openstack_pacemaker_controller_only_location_for clone_name
+
+  [
+    "pacemaker_primitive[#{primitive_name}]",
+    "pacemaker_clone[#{clone_name}]",
+    "pacemaker_location[#{location_name}]"
+  ]
+end

--- a/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_clone_for_transaction.rb
+++ b/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_clone_for_transaction.rb
@@ -25,9 +25,14 @@ define :openstack_pacemaker_controller_clone_for_transaction,
 
   raise "No agent specified for #{primitive_name}!" if agent.nil?
 
+  fake_params = {}
+
   pacemaker_primitive primitive_name do
     agent agent
     op op
+    # do not inherit params from the definition; yes, they get inherited if not
+    # explicitly specified
+    params fake_params
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
@@ -65,6 +65,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent primitive_ra
     op node[:nova][:ha][:op]
+    order_only_existing ["rabbitmq", "cl-keystone"]
   end
   transaction_objects.push(objects)
 end
@@ -74,20 +75,6 @@ pacemaker_transaction "ec2-api" do
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-
-services.each do |service|
-  primitive_name = "ec2-api-#{service}"
-  clone_name = "cl-#{primitive_name}"
-
-  order_only_existing = ["rabbitmq", "cl-keystone", clone_name]
-
-  crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-    ordering order_only_existing
-    score "Optional"
-    action :create
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
 end
 
 crowbar_pacemaker_sync_mark "create-ec2_api_ha_resources"

--- a/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
@@ -65,7 +65,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent primitive_ra
     op node[:nova][:ha][:op]
-    order_only_existing ["rabbitmq", "cl-keystone"]
+    order_only_existing "( rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
@@ -83,7 +83,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
@@ -65,7 +65,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent primitive_ra
     op node[:nova][:ha][:op]
-    order_only_existing "( rabbitmq cl-keystone )"
+    order_only_existing "( postgresql rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -57,7 +57,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:glance][:ha][service.to_sym][:agent]
     op node[:glance][:ha][service.to_sym][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
+    order_only_existing "( postgresql rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -48,42 +48,31 @@ crowbar_pacemaker_sync_mark "sync-glance_before_ha"
 # Avoid races when creating pacemaker resources
 crowbar_pacemaker_sync_mark "wait-glance_ha_resources"
 
-primitives = []
+services = ["registry", "api"]
 transaction_objects = []
 
-["registry", "api"].each do |service|
+services.each do |service|
   primitive_name = "glance-#{service}"
-
   pacemaker_primitive primitive_name do
     agent node[:glance][:ha][service.to_sym][:agent]
     op node[:glance][:ha][service.to_sym][:op]
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  primitives << primitive_name
   transaction_objects << "pacemaker_primitive[#{primitive_name}]"
+
+  clone_name = "cl-#{primitive_name}"
+  pacemaker_clone clone_name do
+    rsc primitive_name
+    meta CrowbarPacemakerHelper.clone_meta(node)
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+  transaction_objects << "pacemaker_clone[#{clone_name}]"
+
+  location_name = openstack_pacemaker_controller_only_location_for clone_name
+  transaction_objects << "pacemaker_location[#{location_name}]"
 end
-
-group_name = "g-glance"
-
-pacemaker_group group_name do
-  members primitives
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-transaction_objects << "pacemaker_group[#{group_name}]"
-
-clone_name = "cl-#{group_name}"
-pacemaker_clone clone_name do
-  rsc group_name
-  meta CrowbarPacemakerHelper.clone_meta(node)
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-location_name = openstack_pacemaker_controller_only_location_for clone_name
-transaction_objects << "pacemaker_location[#{location_name}]"
 
 pacemaker_transaction "glance server" do
   cib_objects transaction_objects
@@ -92,11 +81,16 @@ pacemaker_transaction "glance server" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-  ordering ["postgresql", "rabbitmq", "cl-keystone", clone_name]
-  score "Optional"
-  action :create
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+services.each do |service|
+  primitive_name = "glance-#{service}"
+  clone_name = "cl-#{primitive_name}"
+
+  crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
+    ordering ["postgresql", "rabbitmq", "cl-keystone", clone_name]
+    score "Optional"
+    action :create
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
 end
 
 crowbar_pacemaker_sync_mark "create-glance_ha_resources"

--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -57,6 +57,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:glance][:ha][service.to_sym][:agent]
     op node[:glance][:ha][service.to_sym][:op]
+    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
   end
   transaction_objects.push(objects)
 end
@@ -66,18 +67,6 @@ pacemaker_transaction "glance server" do
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-
-services.each do |service|
-  primitive_name = "glance-#{service}"
-  clone_name = "cl-#{primitive_name}"
-
-  crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-    ordering ["postgresql", "rabbitmq", "cl-keystone", clone_name]
-    score "Optional"
-    action :create
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
 end
 
 crowbar_pacemaker_sync_mark "create-glance_ha_resources"

--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -76,7 +76,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -52,29 +52,16 @@ transaction_objects = []
 
 services.each do |service|
   primitive_name = "heat-#{service}".gsub("_","-")
-  pacemaker_primitive primitive_name do
+
+  objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:heat][:ha][service.to_sym][:agent]
     op node[:heat][:ha][service.to_sym][:op]
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-
-  clone_name = "cl-#{primitive_name}"
-  pacemaker_clone clone_name do
-    rsc primitive_name
-    meta CrowbarPacemakerHelper.clone_meta(node)
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-  transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-  location_name = openstack_pacemaker_controller_only_location_for clone_name
-  transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects.push(objects)
 end
 
 pacemaker_transaction "heat server" do
-  cib_objects transaction_objects
+  cib_objects transaction_objects.flatten
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -74,7 +74,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -56,7 +56,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:heat][:ha][service.to_sym][:agent]
     op node[:heat][:ha][service.to_sym][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-g-nova-controller"]
+    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-nova-api"]
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -56,7 +56,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:heat][:ha][service.to_sym][:agent]
     op node[:heat][:ha][service.to_sym][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-nova-api"]
+    order_only_existing "( postgresql rabbitmq cl-keystone cl-nova-api )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -56,6 +56,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:heat][:ha][service.to_sym][:agent]
     op node[:heat][:ha][service.to_sym][:op]
+    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-g-nova-controller"]
   end
   transaction_objects.push(objects)
 end
@@ -65,18 +66,6 @@ pacemaker_transaction "heat server" do
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-
-services.each do |service|
-  primitive_name = "heat-#{service}".gsub("_","-")
-  clone_name = "cl-#{primitive_name}"
-
-  crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-    ordering ["postgresql", "rabbitmq", "cl-keystone", "cl-g-nova-controller", clone_name]
-    score "Optional"
-    action :create
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
 end
 
 crowbar_pacemaker_sync_mark "create-heat_ha_resources"

--- a/chef/cookbooks/magnum/recipes/ha.rb
+++ b/chef/cookbooks/magnum/recipes/ha.rb
@@ -51,7 +51,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:magnum][:ha][service.to_sym][:agent]
     op node[:magnum][:ha][service.to_sym][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-heat"]
+    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-heat-api"]
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/magnum/recipes/ha.rb
+++ b/chef/cookbooks/magnum/recipes/ha.rb
@@ -51,7 +51,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:magnum][:ha][service.to_sym][:agent]
     op node[:magnum][:ha][service.to_sym][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-heat-api"]
+    order_only_existing "( postgresql rabbitmq cl-keystone cl-heat-api )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/magnum/recipes/ha.rb
+++ b/chef/cookbooks/magnum/recipes/ha.rb
@@ -47,29 +47,16 @@ transaction_objects = []
 
 services.each do |service|
   primitive_name = "magnum-#{service}"
-  pacemaker_primitive primitive_name do
+
+  objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:magnum][:ha][service.to_sym][:agent]
     op node[:magnum][:ha][service.to_sym][:op]
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-
-  clone_name = "cl-#{primitive_name}"
-  pacemaker_clone clone_name do
-    rsc primitive_name
-    meta CrowbarPacemakerHelper.clone_meta(node)
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-  transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-  location_name = openstack_pacemaker_controller_only_location_for clone_name
-  transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects.push(objects)
 end
 
 pacemaker_transaction "magnum server" do
-  cib_objects transaction_objects
+  cib_objects transaction_objects.flatten
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/magnum/recipes/ha.rb
+++ b/chef/cookbooks/magnum/recipes/ha.rb
@@ -70,7 +70,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta("clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node))
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/magnum/recipes/ha.rb
+++ b/chef/cookbooks/magnum/recipes/ha.rb
@@ -42,42 +42,31 @@ crowbar_pacemaker_sync_mark "sync-magnum_before_ha"
 # Avoid races when creating pacemaker resources
 crowbar_pacemaker_sync_mark "wait-magnum_ha_resources"
 
-primitives = []
+services = ["conductor", "api"]
 transaction_objects = []
 
-["conductor", "api"].each do |service|
+services.each do |service|
   primitive_name = "magnum-#{service}"
-
   pacemaker_primitive primitive_name do
     agent node[:magnum][:ha][service.to_sym][:agent]
     op node[:magnum][:ha][service.to_sym][:op]
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  primitives << primitive_name
   transaction_objects << "pacemaker_primitive[#{primitive_name}]"
+
+  clone_name = "cl-#{primitive_name}"
+  pacemaker_clone clone_name do
+    rsc primitive_name
+    meta CrowbarPacemakerHelper.clone_meta(node)
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+  transaction_objects << "pacemaker_clone[#{clone_name}]"
+
+  location_name = openstack_pacemaker_controller_only_location_for clone_name
+  transaction_objects << "pacemaker_location[#{location_name}]"
 end
-
-group_name = "g-magnum"
-
-pacemaker_group group_name do
-  members primitives
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-transaction_objects << "pacemaker_group[#{group_name}]"
-
-clone_name = "cl-#{group_name}"
-pacemaker_clone clone_name do
-  rsc group_name
-  meta CrowbarPacemakerHelper.clone_meta(node)
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-location_name = openstack_pacemaker_controller_only_location_for clone_name
-transaction_objects << "pacemaker_location[#{location_name}]"
 
 pacemaker_transaction "magnum server" do
   cib_objects transaction_objects
@@ -86,11 +75,16 @@ pacemaker_transaction "magnum server" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-  ordering ["postgresql", "rabbitmq", "cl-keystone", "cl-heat", clone_name]
-  score "Optional"
-  action :create
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+services.each do |service|
+  primitive_name = "magnum-#{service}"
+  clone_name = "cl-#{primitive_name}"
+
+  crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
+    ordering ["postgresql", "rabbitmq", "cl-keystone", "cl-heat", clone_name]
+    score "Optional"
+    action :create
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
 end
 
 crowbar_pacemaker_sync_mark "create-magnum_ha_resources"

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -51,29 +51,16 @@ transaction_objects = []
 
 services.each do |service|
   primitive_name = "manila-#{service}"
-  pacemaker_primitive primitive_name do
-    agent node[:cinder][:ha]["#{service}_ra"]
+
+  objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
+    agent node[:manila][:ha]["#{service}_ra"]
     op node[:manila][:ha][:op]
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-
-  clone_name = "cl-#{primitive_name}"
-  pacemaker_clone clone_name do
-    rsc primitive_name
-    meta CrowbarPacemakerHelper.clone_meta(node)
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-  transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-  location_name = openstack_pacemaker_controller_only_location_for clone_name
-  transaction_objects << "pacemaker_location[#{location_name}]"
+  transaction_objects.push(objects)
 end
 
 pacemaker_transaction "manila controller" do
-  cib_objects transaction_objects
+  cib_objects transaction_objects.flatten
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -55,8 +55,8 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:manila][:ha]["#{service}_ra"]
     op node[:manila][:ha][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-glance-api", "cl-cinder-api",
-                         "cl-neutron-server", "cl-nova-api"]
+    order_only_existing "( postgresql rabbitmq cl-keystone cl-glance-api cl-cinder-api " \
+        "cl-neutron-server cl-nova-api )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -77,7 +77,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -55,8 +55,8 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent node[:manila][:ha]["#{service}_ra"]
     op node[:manila][:ha][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-glance", "cl-cinder",
-                         "cl-neutron", "cl-nova"]
+    order_only_existing ["postgresql", "rabbitmq", "cl-keystone", "cl-glance-api", "cl-cinder-api",
+                         "cl-neutron-server", "cl-nova-api"]
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -156,7 +156,7 @@ transaction_objects << "pacemaker_group[#{agents_group_name}]"
 agents_clone_name = "cl-#{agents_group_name}"
 pacemaker_clone agents_clone_name do
   rsc agents_group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
@@ -180,7 +180,7 @@ if use_lbaas_agent && node[:neutron][:lbaasv2_driver] == "f5"
   f5_clone_name = "cl-#{f5_agent_primitive}"
   pacemaker_clone f5_clone_name do
     rsc f5_agent_primitive
-    meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+    meta CrowbarPacemakerHelper.clone_meta(node)
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/neutron/recipes/server_ha.rb
+++ b/chef/cookbooks/neutron/recipes/server_ha.rb
@@ -67,7 +67,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta({"clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node)})
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/neutron/recipes/server_ha.rb
+++ b/chef/cookbooks/neutron/recipes/server_ha.rb
@@ -38,7 +38,7 @@ server_primitive_name = "neutron-server"
 objects = openstack_pacemaker_controller_clone_for_transaction server_primitive_name do
   agent node[:neutron][:ha][:server][:server_ra]
   op node[:neutron][:ha][:server][:op]
-  order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
+  order_only_existing "( postgresql rabbitmq cl-keystone )"
 end
 transaction_objects.push(objects)
 
@@ -48,7 +48,7 @@ if node[:neutron][:use_infoblox]
   objects = openstack_pacemaker_controller_clone_for_transaction infoblox_primitive_name do
     agent node[:neutron][:ha][:infoblox][:infoblox_ra]
     op node[:neutron][:ha][:infoblox][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
+    order_only_existing "( postgresql rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -319,7 +319,11 @@ crowbar_pacemaker_order_only_existing "o-#{evacuate_primitive}" do
   #  - cinder is used in case of boot from volume
   #  - neutron agents are used even with DVR, if only to have a DHCP server for
   #    the instance to get an IP address
-  ordering "( postgresql rabbitmq cl-keystone cl-swift-proxy cl-g-glance cl-g-cinder-controller cl-neutron-server cl-g-neutron-agents cl-g-nova-controller ) #{evacuate_primitive}"
+  ordering "( " \
+      "postgresql rabbitmq cl-keystone cl-swift-proxy cl-glance-api cl-cinder-api " \
+      "cl-neutron-server cl-neutron-dhcp-agent neutron-l3-agent cl-neutron-metadata-agent " \
+      "cl-nova-api " \
+      ") #{evacuate_primitive}"
   score "Mandatory"
   action :create
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -186,7 +186,7 @@ compute_transaction_objects << "pacemaker_group[#{compute_group_name}]"
 compute_clone_name = "cl-#{compute_group_name}"
 pacemaker_clone compute_clone_name do
   rsc compute_group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_remote_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node, remote: true)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -94,7 +94,8 @@ crowbar_pacemaker_sync_mark "wait-nova_compute_ha_resources" do
   revision nova[:nova]["crowbar-revision"]
 end
 
-compute_primitives = []
+compute_primitives_for_group = []
+compute_primitives_to_clone = []
 compute_transaction_objects = []
 
 if node[:platform_family] == "suse" && node[:platform_version].to_f > 12.1
@@ -105,7 +106,7 @@ if node[:platform_family] == "suse" && node[:platform_version].to_f > 12.1
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  compute_primitives << virtlogd_primitive
+  compute_primitives_for_group << virtlogd_primitive
   compute_transaction_objects << "pacemaker_primitive[#{virtlogd_primitive}]"
 end
 
@@ -116,7 +117,7 @@ pacemaker_primitive libvirtd_primitive do
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
-compute_primitives << libvirtd_primitive
+compute_primitives_for_group << libvirtd_primitive
 compute_transaction_objects << "pacemaker_primitive[#{libvirtd_primitive}]"
 
 case neutron[:neutron][:networking_plugin]
@@ -128,7 +129,7 @@ when "ml2"
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  compute_primitives << neutron_agent_primitive
+  compute_primitives_to_clone << neutron_agent_primitive
   compute_transaction_objects << "pacemaker_primitive[#{neutron_agent_primitive}]"
 end
 
@@ -140,7 +141,7 @@ if neutron[:neutron][:use_dvr]
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  compute_primitives << l3_agent_primitive
+  compute_primitives_to_clone << l3_agent_primitive
   compute_transaction_objects << "pacemaker_primitive[#{l3_agent_primitive}]"
 
   metadata_agent_primitive = "neutron-metadata-agent-compute"
@@ -150,7 +151,7 @@ if neutron[:neutron][:use_dvr]
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  compute_primitives << metadata_agent_primitive
+  compute_primitives_to_clone << metadata_agent_primitive
   compute_transaction_objects << "pacemaker_primitive[#{metadata_agent_primitive}]"
 end
 
@@ -172,33 +173,38 @@ pacemaker_primitive nova_primitive do
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
-compute_primitives << nova_primitive
+compute_primitives_for_group << nova_primitive
 compute_transaction_objects << "pacemaker_primitive[#{nova_primitive}]"
 
 compute_group_name = "g-#{nova_primitive}"
 pacemaker_group compute_group_name do
-  members compute_primitives
+  members compute_primitives_for_group
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
+compute_primitives_to_clone << compute_group_name
 compute_transaction_objects << "pacemaker_group[#{compute_group_name}]"
 
-compute_clone_name = "cl-#{compute_group_name}"
-pacemaker_clone compute_clone_name do
-  rsc compute_group_name
-  meta CrowbarPacemakerHelper.clone_meta(node, remote: true)
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-compute_transaction_objects << "pacemaker_clone[#{compute_clone_name}]"
+compute_primitives_to_clone.each do |compute_primitive_to_clone|
+  clone_name = "cl-#{compute_primitive_to_clone}"
+  pacemaker_clone clone_name do
+    rsc compute_primitive_to_clone
+    meta CrowbarPacemakerHelper.clone_meta(node, remote: true)
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+  compute_transaction_objects << "pacemaker_clone[#{clone_name}]"
 
-compute_location_name = "l-#{compute_clone_name}-compute"
-pacemaker_location compute_location_name do
-  definition OpenStackHAHelper.compute_only_location(compute_location_name, compute_clone_name)
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  location_name = "l-#{clone_name}-compute"
+  definition = OpenStackHAHelper.compute_only_location(location_name, clone_name)
+  pacemaker_location location_name do
+    definition definition
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+  compute_transaction_objects << "pacemaker_location[#{location_name}]"
 end
-compute_transaction_objects << "pacemaker_location[#{compute_location_name}]"
+compute_clone_name = "cl-#{compute_group_name}"
 
 pacemaker_transaction "nova compute" do
   cib_objects compute_transaction_objects

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -91,7 +91,7 @@ services.each do |service|
   objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent primitive_ra
     op node[:nova][:ha][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
+    order_only_existing "( postgresql rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -70,7 +70,6 @@ crowbar_pacemaker_sync_mark "sync-nova_before_ha"
 crowbar_pacemaker_sync_mark "wait-nova_ha_resources"
 
 transaction_objects = []
-primitives = []
 
 services = %w(api cert conductor consoleauth scheduler)
 if node[:nova][:use_novnc]
@@ -81,43 +80,34 @@ if node[:nova][:use_serial]
 end
 
 services.each do |service|
-  primitive_name = "nova-#{service}"
   if %w(rhel suse).include?(node[:platform_family])
     primitive_ra = "systemd:openstack-nova-#{service}"
   else
     primitive_ra = "systemd:nova-#{service}"
   end
 
+  primitive_name = "nova-#{service}"
   pacemaker_primitive primitive_name do
     agent primitive_ra
     op node[:nova][:ha][:op]
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-
-  primitives << primitive_name
   transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-end
 
-group_name = "g-nova-controller"
-pacemaker_group group_name do
-  members primitives
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-transaction_objects << "pacemaker_group[#{group_name}]"
+  clone_name = "cl-#{primitive_name}"
+  pacemaker_clone clone_name do
+    rsc primitive_name
+    meta CrowbarPacemakerHelper.clone_meta(node)
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+  transaction_objects << "pacemaker_clone[#{clone_name}]"
 
-clone_name = "cl-#{group_name}"
-pacemaker_clone clone_name do
-  rsc group_name
-  meta CrowbarPacemakerHelper.clone_meta(node)
-  action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-end
-transaction_objects << "pacemaker_clone[#{clone_name}]"
+  location_name = openstack_pacemaker_controller_only_location_for clone_name
+  transaction_objects << "pacemaker_location[#{location_name}]"
 
-location_name = openstack_pacemaker_controller_only_location_for clone_name
-transaction_objects << "pacemaker_location[#{location_name}]"
+end
 
 pacemaker_transaction "nova controller" do
   cib_objects transaction_objects
@@ -126,11 +116,16 @@ pacemaker_transaction "nova controller" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-  ordering ["postgresql", "rabbitmq", "cl-keystone", clone_name]
-  score "Optional"
-  action :create
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+services.each do |service|
+  primitive_name = "nova-#{service}"
+  clone_name = "cl-#{primitive_name}"
+
+  crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
+    ordering ["postgresql", "rabbitmq", "cl-keystone", clone_name]
+    score "Optional"
+    action :create
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
 end
 
 crowbar_pacemaker_sync_mark "create-nova_ha_resources"

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -110,7 +110,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -87,30 +87,16 @@ services.each do |service|
   end
 
   primitive_name = "nova-#{service}"
-  pacemaker_primitive primitive_name do
+
+  objects = openstack_pacemaker_controller_clone_for_transaction primitive_name do
     agent primitive_ra
     op node[:nova][:ha][:op]
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  transaction_objects << "pacemaker_primitive[#{primitive_name}]"
-
-  clone_name = "cl-#{primitive_name}"
-  pacemaker_clone clone_name do
-    rsc primitive_name
-    meta CrowbarPacemakerHelper.clone_meta(node)
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-  transaction_objects << "pacemaker_clone[#{clone_name}]"
-
-  location_name = openstack_pacemaker_controller_only_location_for clone_name
-  transaction_objects << "pacemaker_location[#{location_name}]"
-
+  transaction_objects.push(objects)
 end
 
 pacemaker_transaction "nova controller" do
-  cib_objects transaction_objects
+  cib_objects transaction_objects.flatten
   # note that this will also automatically start the resources
   action :commit_new
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/sahara/recipes/ha.rb
+++ b/chef/cookbooks/sahara/recipes/ha.rb
@@ -65,7 +65,7 @@ transaction_objects << "pacemaker_group[#{group_name}]"
 clone_name = "cl-#{group_name}"
 pacemaker_clone clone_name do
   rsc group_name
-  meta "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node)
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/sahara/recipes/ha.rb
+++ b/chef/cookbooks/sahara/recipes/ha.rb
@@ -47,6 +47,7 @@ transaction_objects = []
   objects = openstack_pacemaker_controller_clone_for_transaction primitive do
     agent node[:sahara][:ha][service.to_sym][:ra]
     op node[:sahara][:ha][:op]
+    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/sahara/recipes/ha.rb
+++ b/chef/cookbooks/sahara/recipes/ha.rb
@@ -47,7 +47,7 @@ transaction_objects = []
   objects = openstack_pacemaker_controller_clone_for_transaction primitive do
     agent node[:sahara][:ha][service.to_sym][:ra]
     op node[:sahara][:ha][:op]
-    order_only_existing ["postgresql", "rabbitmq", "cl-keystone"]
+    order_only_existing "( postgresql rabbitmq cl-keystone )"
   end
   transaction_objects.push(objects)
 end

--- a/chef/cookbooks/swift/recipes/proxy_ha.rb
+++ b/chef/cookbooks/swift/recipes/proxy_ha.rb
@@ -40,6 +40,7 @@ service_name = "swift-proxy"
 objects = openstack_pacemaker_controller_clone_for_transaction service_name do
   agent node[:swift][:ha]["proxy"][:agent]
   op node[:swift][:ha]["proxy"][:op]
+  order_only_existing ["cl-keystone"]
 end
 transaction_objects.push(objects)
 
@@ -48,13 +49,6 @@ pacemaker_transaction "swift proxy" do
   # note that this will also automatically start the resources
   action :commit_new
   # Do not even try to start the daemon if we don't have the ring yet
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) && ::File.exist?("/etc/swift/object.ring.gz") }
-end
-
-crowbar_pacemaker_order_only_existing "o-#{clone_name}" do
-  ordering ["cl-keystone", clone_name]
-  score "Optional"
-  action :create
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) && ::File.exist?("/etc/swift/object.ring.gz") }
 end
 

--- a/chef/cookbooks/swift/recipes/proxy_ha.rb
+++ b/chef/cookbooks/swift/recipes/proxy_ha.rb
@@ -40,7 +40,7 @@ service_name = "swift-proxy"
 objects = openstack_pacemaker_controller_clone_for_transaction service_name do
   agent node[:swift][:ha]["proxy"][:agent]
   op node[:swift][:ha]["proxy"][:op]
-  order_only_existing ["cl-keystone"]
+  order_only_existing "cl-keystone"
 end
 transaction_objects.push(objects)
 

--- a/chef/cookbooks/swift/recipes/proxy_ha.rb
+++ b/chef/cookbooks/swift/recipes/proxy_ha.rb
@@ -48,7 +48,7 @@ transaction_objects << "pacemaker_primitive[#{service_name}]"
 clone_name = "cl-#{service_name}"
 pacemaker_clone clone_name do
   rsc service_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+  meta CrowbarPacemakerHelper.clone_meta(node)
   action :update
   # Do not even try to start the daemon if we don't have the ring yet
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) && ::File.exist?("/etc/swift/object.ring.gz") }


### PR DESCRIPTION
The downside of groups is that this creates ordering constraints within
a group, and in nearly all cases, these ordering constraints are not
reflecting real dependencies.

This is then causing issues when restarting an individual resource,
because all later resources in the group are also restarted, possibly
leading to temporary failures that were not wanted.

On top of that, a helper was created to significantly reduce code duplication.

This depends on https://github.com/crowbar/crowbar-ha/pull/178 and contains https://github.com/crowbar/crowbar-openstack/pull/330.