### PR TITLE
swift: Use correct slog_passwd key to drop during migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/swift/101_drop_slog.rb
+++ b/chef/data_bags/crowbar/migrate/swift/101_drop_slog.rb
@@ -1,12 +1,12 @@
 def upgrade(ta, td, a, d)
-  %w(use_slog slog_account slog_user slog_password).each do |attr|
+  %w(use_slog slog_account slog_user slog_passwd).each do |attr|
     a.delete(attr)
   end
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  %w(use_slog slog_account slog_user slog_password).each do |attr|
+  %w(use_slog slog_account slog_user slog_passwd).each do |attr|
     a[attr] = ta[attr]
   end
   return a, d


### PR DESCRIPTION
This was broken in https://github.com/crowbar/crowbar-openstack/pull/777