### PR TITLE
ec2-api: Disable VPC support

### DIFF
--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -7,6 +7,8 @@ keystone_ec2_tokens_url = <%= @keystone_settings['public_auth_url'] %>/ec2tokens
 ec2api_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 metadata_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 transport_url = <%= @rabbit_settings[:url] %>
+full_vpc_support = false
+
 [database]
 connection = <%= @database_connection %>
 [oslo_concurrency]

--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -34,6 +34,8 @@ default[:neutron][:db][:password] = "" # Set by Recipe
 default[:neutron][:network][:fixed_router] = "127.0.0.1" # Set by Recipe
 default[:neutron][:network][:private_networks] = [] # Set by Recipe
 
+default[:neutron][:use_vpnaas] = false
+
 default[:neutron][:gre][:tunnel_id_start] = 1
 default[:neutron][:gre][:tunnel_id_stop] = 1000
 


### PR DESCRIPTION
This depends on Neutron VPNaaS which we have not implemented