### PR TITLE
ceilometer/nova: Hide references to Hyper-V

### DIFF
--- a/chef/data_bags/crowbar/migrate/ceilometer/103_remove_hyperv.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/103_remove_hyperv.rb
@@ -1,0 +1,28 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  if d["elements"]["ceilometer-agent-hyperv"]
+    d["elements"].delete("ceilometer-agent-hyperv")
+  end
+  if d.fetch("elements_expanded", {}).key? "ceilometer-agent-hyperv"
+    d["elements_expanded"].delete("ceilometer-agent-hyperv")
+  end
+
+  nodes = NodeObject.find("run_list_map:ceilometer-agent-hyperv")
+  nodes.each do |node|
+    node.delete_from_run_list("ceilometer-agent-hyperv")
+    node.save
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/nova/113_remove_hyperv.rb
+++ b/chef/data_bags/crowbar/migrate/nova/113_remove_hyperv.rb
@@ -1,0 +1,28 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  if d["elements"]["nova-compute-hyperv"]
+    d["elements"].delete("nova-compute-hyperv")
+  end
+  if d.fetch("elements_expanded", {}).key? "nova-compute-hyperv"
+    d["elements_expanded"].delete("nova-compute-hyperv")
+  end
+
+  nodes = NodeObject.find("run_list_map:nova-compute-hyperv")
+  nodes.each do |node|
+    node.delete_from_run_list("nova-compute-hyperv")
+    node.save
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -35,12 +35,11 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 103,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-central": [ "readying", "ready", "applying" ],
         "ceilometer-agent": [ "readying", "ready", "applying" ],
-        "ceilometer-agent-hyperv": [ "readying", "ready", "applying" ],
         "ceilometer-swift-proxy-middleware": [ "readying", "ready", "applying" ]
       },
       "elements": {},
@@ -48,14 +47,12 @@
         [ "ceilometer-server" ],
         [ "ceilometer-central" ],
         [ "ceilometer-agent" ],
-        [ "ceilometer-agent-hyperv" ],
         [ "ceilometer-swift-proxy-middleware" ]
       ],
       "element_run_list_order": {
         "ceilometer-server": 101,
         "ceilometer-central": 102,
         "ceilometer-agent": 103,
-        "ceilometer-agent-hyperv": 104,
         "ceilometer-swift-proxy-middleware" : 80
       },
       "config": {

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -146,10 +146,9 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 112,
+      "schema-revision": 113,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
-        "nova-compute-hyperv": [ "readying", "ready", "applying" ],
         "nova-compute-kvm": [ "readying", "ready", "applying" ],
         "nova-compute-qemu": [ "readying", "ready", "applying" ],
         "nova-compute-vmware": [ "readying", "ready", "applying" ],
@@ -165,7 +164,6 @@
           "ec2-api"
         ],
         [
-          "nova-compute-hyperv",
           "nova-compute-kvm",
           "nova-compute-qemu",
           "nova-compute-vmware",
@@ -176,7 +174,6 @@
       "element_run_list_order": {
         "nova-controller": 95,
         "ec2-api": 96,
-        "nova-compute-hyperv": 97,
         "nova-compute-kvm": 97,
         "nova-compute-qemu": 97,
         "nova-compute-vmware": 97,

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -97,7 +97,7 @@ class CeilometerService < PacemakerServiceObject
       NodeObject.find("roles:nova-compute-vmware") +
       NodeObject.find("roles:nova-compute-xen")
 
-    hyperv_agent_nodes = NodeObject.find("roles:nova-compute-hyperv")
+    # hyperv_agent_nodes = NodeObject.find("roles:nova-compute-hyperv")
 
     nodes       = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }
@@ -107,9 +107,10 @@ class CeilometerService < PacemakerServiceObject
 
     swift_proxy_nodes = NodeObject.find("roles:swift-proxy")
 
+    # (2017-01-30): Hyper-V is hidden for now
+    # "ceilometer-agent-hyperv" => hyperv_agent_nodes.map { |x| x.name },
     base["deployment"]["ceilometer"]["elements"] = {
         "ceilometer-agent" => agent_nodes.map { |x| x.name },
-        "ceilometer-agent-hyperv" => hyperv_agent_nodes.map { |x| x.name },
         "ceilometer-central" => [server_nodes.first.name],
         "ceilometer-server" => [server_nodes.first.name],
         "ceilometer-swift-proxy-middleware" => swift_proxy_nodes.map { |x| x.name }
@@ -129,9 +130,9 @@ class CeilometerService < PacemakerServiceObject
 
     validate_minimum_three_nodes_in_cluster(proposal)
 
-    unless (proposal["deployment"]["ceilometer"]["elements"]["ceilometer-agent-hyperv"] || []).empty? || hyperv_available?
-      validation_error I18n.t("barclamp.#{@bc_name}.validation.hyper_v_support")
-    end
+    # unless (proposal["deployment"]["ceilometer"]["elements"]["ceilometer-agent-hyperv"] || []).empty? || hyperv_available?
+    #   validation_error I18n.t("barclamp.#{@bc_name}.validation.hyper_v_support")
+    # end
 
     swift_proxy_nodes = NodeObject.find("roles:swift-proxy").map { |x| x.name }
     if proposal["deployment"]["ceilometer"]["elements"]["ceilometer-swift-proxy-middleware"]

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -159,9 +159,10 @@ class NovaService < PacemakerServiceObject
 
     # do not use zvm by default
     #   TODO add it here once a compute node can run inside z/VM
+    # (2017-01-30) Hyper-V is hidden for now
+    # "nova-compute-hyperv" => hyperv.map(&:name),
     base["deployment"]["nova"]["elements"] = {
       "nova-controller" => [controller.name],
-      "nova-compute-hyperv" => hyperv.map(&:name),
       "nova-compute-kvm" => kvm.map(&:name),
       "nova-compute-qemu" => qemu.map(&:name),
       "nova-compute-xen" => xen.map(&:name)
@@ -367,9 +368,9 @@ class NovaService < PacemakerServiceObject
       end
     end
 
-    unless elements["nova-compute-hyperv"].empty? || hyperv_available?
-      validation_error I18n.t("barclamp.#{@bc_name}.validation.hyperv_support")
-    end
+    # unless elements["nova-compute-hyperv"].empty? || hyperv_available?
+    #   validation_error I18n.t("barclamp.#{@bc_name}.validation.hyperv_support")
+    # end
 
     unless elements["nova-compute-zvm"].nil? || elements["nova-compute-zvm"].empty?
       unless network_present? proposal["attributes"][@bc_name]["zvm"]["zvm_xcat_network"]
@@ -380,9 +381,6 @@ class NovaService < PacemakerServiceObject
       end
     end
 
-    elements["nova-compute-hyperv"].each do |n|
-      nodes[n] += 1
-    end unless elements["nova-compute-hyperv"].nil?
     elements["nova-compute-kvm"].each do |n|
       nodes[n] += 1
     end unless elements["nova-compute-kvm"].nil?


### PR DESCRIPTION
This only removes the minimal things needed, in case Hyper-V support
gets staffed with ressources again.