### PR TITLE
nova: use `live_migration_inbound_addr`

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -274,10 +274,10 @@ template vendordata_jsonfile do
 end
 
 # Allow to use some specific NICs for live migration
-migration_host = if node[:nova][:migration][:network] == "admin"
-  "%s"
+live_migration_inbound_fqdn = if node[:nova][:migration][:network] == "admin"
+  node[:fqdn]
 else
-  "#{node[:nova][:migration][:network]}.%s"
+  "#{node[:nova][:migration][:network]}.#{node[:fqdn]}"
 end
 
 # Select libvirt compute flags for this particular compute node
@@ -338,7 +338,7 @@ template node[:nova][:config_file] do
     ec2_host: admin_api_host,
     ec2_dmz_host: public_api_host,
     libvirt_migration: node[:nova]["use_migration"],
-    migration_host: migration_host,
+    live_migration_inbound_fqdn: live_migration_inbound_fqdn,
     shared_instances: node[:nova]["use_shared_instance_storage"],
     force_config_drive: node[:nova]["force_config_drive"],
     glance_server_protocol: glance_server_protocol,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -161,13 +161,14 @@ user_domain_name = <%= @keystone_settings["admin_domain"] %>
 <% if %w(kvm lxc qemu uml xen parallels).include? @libvirt_type -%>
 virt_type = <%= @libvirt_type %>
 <% end -%>
+<% if (@libvirt_type.eql?('xen') and @libvirt_migration and @shared_instances) or @libvirt_type.eql?('kvm') -%>
+live_migration_inbound_addr = <%= @live_migration_inbound_fqdn %>
+<% end -%>
 <% if @libvirt_type.eql?('xen') -%>
   <% if @libvirt_migration and @shared_instances -%>
-live_migration_uri = xenmigr://<%= @migration_host %>/system
 live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_LIVE
   <% end %>
 <% elsif @libvirt_type.eql?('kvm') -%>
-live_migration_uri = qemu+tcp://<%= @migration_host %>/system
   <% if @libvirt_migration -%>
     <% if @shared_instances -%>
 live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_LIVE


### PR DESCRIPTION
Incase when using network other than admin, the said variable should
have the fqdn/ip of the migration interface.

`live_migration_uri` is no longer used for migration.