### PR TITLE
cinder, nova: Use a tmpfiles.d config file for /var/run/openstack

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -113,11 +113,7 @@ if need_shared_lock_path
     members "cinder"
     append true
   end
-  directory "/var/run/openstack" do
-    owner "root"
-    group "openstack"
-    mode "0775"
-  end
+  include_recipe "crowbar-openstack::common"
 end
 
 template node[:cinder][:config_file] do

--- a/chef/cookbooks/crowbar-openstack/files/default/crowbar-openstack.tmpfiles
+++ b/chef/cookbooks/crowbar-openstack/files/default/crowbar-openstack.tmpfiles
@@ -1,0 +1,1 @@
+d /var/run/openstack 0775 root openstack -

--- a/chef/cookbooks/crowbar-openstack/recipes/common.rb
+++ b/chef/cookbooks/crowbar-openstack/recipes/common.rb
@@ -1,0 +1,28 @@
+# Copyright 2017 SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cookbook_file "/etc/tmpfiles.d/crowbar-openstack.conf" do
+  owner "root"
+  group "root"
+  mode "0644"
+  action :create
+  source "crowbar-openstack.tmpfiles"
+end
+
+bash "create tmpfiles.d files for crowbar-openstack" do
+  code "systemd-tmpfiles --create /etc/tmpfiles.d/crowbar-openstack.conf"
+  action :nothing
+  subscribes :run, resources("cookbook_file[/etc/tmpfiles.d/crowbar-openstack.conf]"), :immediately
+end

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -308,11 +308,7 @@ if need_shared_lock_path
     members "nova"
     append true
   end
-  directory "/var/run/openstack" do
-    owner "root"
-    group "openstack"
-    mode "0775"
-  end
+  include_recipe "crowbar-openstack::common"
 end
 
 template node[:nova][:config_file] do


### PR DESCRIPTION
Without this, we rely on chef-client for this directory to be created on
boot, which is undesired.

https://bugzilla.suse.com/show_bug.cgi?id=1021753