### PR TITLE
Revert "Use SSL to talk to nova-metadata when SSL is enabled for nova"

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -325,9 +325,6 @@ if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
     nova = node
   end
   metadata_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:enabled] rescue false))
-  metadata_port = nova[:nova][:ports][:metadata] rescue 8775
-  metadata_protocol = (nova[:nova][:ssl][:enabled] ? "https" : "http") rescue "http"
-  metadata_insecure = (nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]) rescue false
   metadata_proxy_shared_secret = (nova[:nova][:neutron_metadata_proxy_shared_secret] rescue "")
 
   keystone_settings = KeystoneHelper.keystone_settings(neutron, @cookbook_name)
@@ -340,9 +337,6 @@ if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
     variables(
       debug: neutron[:neutron][:debug],
       nova_metadata_host: metadata_host,
-      nova_metadata_port: metadata_port,
-      nova_metadata_protocol: metadata_protocol,
-      nova_metadata_insecure: metadata_insecure,
       metadata_proxy_shared_secret: metadata_proxy_shared_secret
     )
   end

--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -1,8 +1,6 @@
 [DEFAULT]
 nova_metadata_ip = <%= @nova_metadata_host %>
 metadata_proxy_shared_secret = <%= @metadata_proxy_shared_secret %>
-nova_metadata_protocol = <%= @nova_metadata_protocol %>
-nova_metadata_insecure = <%= @nova_metadata_insecure ? "True" : "False" %>
 metadata_workers = <%= [node["cpu"]["total"]/2, 4].min %>
 debug = <%= @debug ? "True" : "False" %>
 [AGENT]


### PR DESCRIPTION
The settings here specify the SSL settings used for the metadata proxy,
which causes in a ssl environment guests to require metadata to
be served via https://169.254.169.264:80/, which is highly unusual.
Go back to http.

This reverts commit 4a55e9117b65a9fabbb01f2bbe6a1d2d4a9cae46.