### PR TITLE
neutron: Reenable qos and dns extensions

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -191,7 +191,7 @@ when "ml2"
   os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
   mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
 
-  ml2_extension_drivers = ["port_security"]
+  ml2_extension_drivers = ["port_security", "qos", "dns"]
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv


### PR DESCRIPTION
Setting extension_drivers causes *only* those drivers to be loaded,
instead of a builtin default, so suddenly a lot of extensions
got disabled.

(cherry picked from commit 4316cf735f1e3785a12511ff1dbb5c0b8c570c67)
backport of #802