### PR TITLE
ec2-api: Change listen ports if using HA

### DIFF
--- a/chef/cookbooks/ec2-api/attributes/default.rb
+++ b/chef/cookbooks/ec2-api/attributes/default.rb
@@ -21,6 +21,5 @@ default[:nova]["ec2-api"][:db][:password] = nil # must be set by wrapper
 default[:nova]["ec2-api"][:user] = "ec2-api"
 default[:nova]["ec2-api"][:group] = "ec2-api"
 default[:nova]["ec2-api"][:ha][:enabled] = false
-default[:nova]["ec2-api"][:api][:port] = 8788
 
 default[:nova]["ec2-api"][:config_file] = "/etc/ec2api/ec2api.conf.d/100-ec2api.conf"

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -213,3 +213,7 @@ service "openstack-ec2-api-s3" do
   action [:enable, :start]
   subscribes :restart, resources(template: node[:nova]["ec2-api"][:config_file])
 end
+
+if ha_enabled
+  include_recipe "ec2-api::ec2api_ha"
+end

--- a/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
@@ -13,13 +13,6 @@
 # limitations under the License.
 #
 
-unless node[:nova][:ha][:enabled]
-  log "HA support for ec2-api is disabled"
-  return
-end
-
-log "Setting up ec2-api HA support"
-
 include_recipe "crowbar-pacemaker::haproxy"
 
 haproxy_loadbalancer "ec2-api" do

--- a/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
@@ -42,6 +42,16 @@ haproxy_loadbalancer "ec2-metadata" do
   action :nothing
 end.run_action(:create)
 
+haproxy_loadbalancer "ec2-s3" do
+  address "0.0.0.0"
+  port node[:nova][:ports][:ec2_s3]
+  use_ssl false
+  servers CrowbarPacemakerHelper.haproxy_servers_for_service(
+    node, "nova", "ec2-api", "ec2_s3"
+  )
+  action :nothing
+end.run_action(:create)
+
 # Wait for all nodes to reach this point so we know that they will have
 # all the required packages installed and configuration files updated
 # before we create the pacemaker resources.

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -6,6 +6,12 @@ use_stderr = false
 keystone_ec2_tokens_url = <%= @keystone_settings['public_auth_url'] %>/ec2tokens
 ec2api_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 metadata_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
+ec2api_listen = <% @bind_host %>
+ec2api_listen_port = <% @bind_port_ec2api %>
+metadata_listen = <% @bind_host %>
+metadata_listen_port = <% @bind_port_metadata %>
+s3_listen = <% @bind_host %>
+s3_listen_port = <% @bind_port_s3 %>
 transport_url = <%= @rabbit_settings[:url] %>
 full_vpc_support = false
 

--- a/chef/cookbooks/nova/recipes/role_ec2_api.rb
+++ b/chef/cookbooks/nova/recipes/role_ec2_api.rb
@@ -16,5 +16,4 @@
 
 if CrowbarRoleRecipe.node_state_valid_for_role?(node, "nova", "ec2-api")
   include_recipe "ec2-api::ec2api"
-  include_recipe "ec2-api::ec2api_ha"
 end

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -272,6 +272,14 @@ class NovaService < PacemakerServiceObject
     dirty = prepare_role_for_ha_with_haproxy(role, ["nova", "ha", "enabled"], ha_enabled, controller_elements, vip_networks)
     role.save if dirty
 
+    ec2_controller_elements, ec2_controller_nodes, ec2_ha_enabled = role_expand_elements(role, "ec2-api")
+    reset_sync_marks_on_clusters_founders(ec2_controller_elements)
+    Openstack::HA.set_controller_role(ec2_controller_nodes) if ec2_ha_enabled
+
+    dirty = false
+    dirty = prepare_role_for_ha_with_haproxy(role, ["nova", "ec2-api", "ha", "enabled"], ec2_ha_enabled,  ec2_controller_elements, vip_networks)
+    role.save if dirty
+
     net_svc = NetworkService.new @logger
     # All nodes must have a public IP, even if part of a cluster; otherwise
     # the VIP can't be moved to the nodes


### PR DESCRIPTION
Since nothing was changing the listening ports for the ec2-api service,
when deploying in a HA environment, either haproxy would grab the port,
and then the service wouldn't start; or the service would, and then
haproxy would be sad. Change the listening ports if HA is enabled.