### PR TITLE
Fix ordering constraint for ha-compute

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -321,7 +321,7 @@ crowbar_pacemaker_order_only_existing "o-#{evacuate_primitive}" do
   #    the instance to get an IP address
   ordering "( " \
       "postgresql rabbitmq cl-keystone cl-swift-proxy cl-glance-api cl-cinder-api " \
-      "cl-neutron-server cl-neutron-dhcp-agent neutron-l3-agent cl-neutron-metadata-agent " \
+      "cl-neutron-server cl-neutron-dhcp-agent cl-neutron-l3-agent cl-neutron-metadata-agent " \
       "cl-nova-api " \
       ") #{evacuate_primitive}"
   score "Mandatory"


### PR DESCRIPTION
This gives

Constraint 'o-nova-evacuate': Invalid reference to 'neutron-l3-agent'

otherwise