### PR TITLE
keystone: Start fernet-rotate HA resource

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -443,7 +443,7 @@ if node[:keystone][:signing][:token_format] == "fernet"
       "backup_suffix" => ".orig"
     })
     op node[:keystone][:ha][:fernet][:op]
-    action :create
+    action [:create, :start]
     only_if { ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -435,6 +435,8 @@ if node[:keystone][:signing][:token_format] == "fernet"
     )
   end
 
+  crowbar_pacemaker_sync_mark "wait-keystone_fernet_rotate"
+
   pacemaker_primitive "keystone-fernet-rotate" do
     agent node[:keystone][:ha][:fernet][:agent]
     params({
@@ -446,6 +448,8 @@ if node[:keystone][:signing][:token_format] == "fernet"
     action [:create, :start]
     only_if { ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
+
+  crowbar_pacemaker_sync_mark "create-keystone_fernet_rotate"
 end
 
 crowbar_pacemaker_sync_mark "wait-keystone_register"


### PR DESCRIPTION
Otherwise there is no symlink to execute the cronjob and
the tokens are not rotated.