### PR TITLE
ec2-api: Remove deprecated "verbose" option

### DIFF
--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -186,7 +186,6 @@ template node[:nova]["ec2-api"][:config_file] do
   mode 0o640
   variables(
     debug: node[:nova][:debug],
-    verbose: node[:nova][:verbose],
     database_connection: database_connection,
     rabbit_settings: rabbit_settings,
     keystone_settings: keystone_settings,

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -1,6 +1,5 @@
 [DEFAULT]
 debug = <%= @debug ? "true" : "false" %>
-verbose = <%= @verbose ? "true" : "false" %>
 log_dir = /var/log/ec2-api
 use_stderr = false
 keystone_ec2_tokens_url = <%= @keystone_settings['public_auth_url'] %>/ec2tokens


### PR DESCRIPTION
The "verbose" option for ec2-api is deprecated, remove it. I don't think
it requires a migration since it was making use of the nova barclamp
setting directly.