### PR TITLE
tempest: Add storage_protocol option for Manila

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -169,6 +169,7 @@ region = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internalURL
 multitenancy_enabled = False
 enable_protocols = <%= @manila_settings['enable_protocols'] %>
+storage_protocol = <%= @manila_settings['storage_protocol'] %>
 enable_ip_rules_for_protocols = <%= @manila_settings['enable_ip_rules_for_protocols'] %>
 enable_cert_rules_for_protocols = <%= @manila_settings['enable_cert_rules_for_protocols'] %>
 suppress_errors_in_cleanup = true

--- a/chef/data_bags/crowbar/migrate/tempest/105_manila_add_storage_protocol.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/105_manila_add_storage_protocol.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["manila"]["storage_protocol"] = ta["manila"]["storage_protocol"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["manila"].delete("storage_protocol")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -24,7 +24,8 @@
         "enable_ip_rules_for_protocols": "nfs, cifs",
         "run_consistency_group_tests": false,
         "run_snapshot_tests": true,
-        "enable_protocols": "nfs, cifs"
+        "enable_protocols": "nfs, cifs",
+        "storage_protocol": "NFS_CIFS"
       },
       "magnum": {
         "image_id": "magnum-service-image",
@@ -40,7 +41,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 104,
+      "schema-revision": 105,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -38,7 +38,8 @@
                 "enable_ip_rules_for_protocols": { "type": "str", "required": true },
                 "run_consistency_group_tests": { "type": "bool", "required": true },
                 "run_snapshot_tests": { "type": "bool", "required": true },
-                "enable_protocols": { "type": "str", "required": true }
+                "enable_protocols": { "type": "str", "required": true },
+                "storage_protocol": { "type": "str", "required": true }
               }
             },
             "magnum": {


### PR DESCRIPTION
storage_protocol needs to be set to "CEPHFS" when only cephfs is available
as manila backend.
Otherwise tests like "test_get_share_with_share_type" fail with:

Failed to schedule create_share: No valid host was found.