### PR TITLE
Make cinder volume HA work again

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder-volume.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder-volume.conf.erb
@@ -3,4 +3,4 @@
 [DEFAULT]
 # Name of this node.  This can be an opaque identifier. It is not necessarily a
 # host name, FQDN, or IP address. (string value)
-backend_host = <%= @host %>
+host = <%= @host %>


### PR DESCRIPTION
Unfortunately as part of the Hyper Agile Super config rediffing effort the feature was accidentally disabled. Revert the incorrect change and switch to a more robust implementation that does not suffer from deprecation warnings .