### PR TITLE
crowbar_openstack_wsgi: reload apache configuration

### DIFF
--- a/chef/cookbooks/crowbar-openstack/providers/wsgi.rb
+++ b/chef/cookbooks/crowbar-openstack/providers/wsgi.rb
@@ -70,9 +70,7 @@ action :create do
         error_log: current_resource.error_log,
         apache_log_dir: node[:apache][:log_dir],
       )
-      # NOTE(aplanas) a :reload is not enough for apache, we need a
-      # full restart to read the new vhost files
-      notifies :restart, resources(service: "apache2")
+      notifies :reload, resources(service: "apache2"), :delayed
     end
     Chef::Log.info "#{@new_resource} created / updated"
   end
@@ -84,9 +82,7 @@ action :delete do
       file _get_vhost_name do
         action :delete
         only_if { File.exist?(_get_vhost_name) }
-        # NOTE(aplanas) a :reload is not enough for apache, we need a
-        # full restart to read the new vhost files
-        notifies :restart, resources(service: "apache2")
+        notifies :reload, resources(service: "apache2"), :delayed
       end
       Chef::Log.info "#{@new_resource} deleted"
     end


### PR DESCRIPTION
Instead of restarting the apache service when a new vhost is
created, try to reload the configuration.

This can resolve issues in HA when apache is restarted, but a
barclamp in a different node is making queries to a service that
is behing apache (like keystone)