### PR TITLE
[TEST] nova: use lazy for not_if check on flavor creation

### DIFF
--- a/chef/cookbooks/nova/recipes/flavors.rb
+++ b/chef/cookbooks/nova/recipes/flavors.rb
@@ -101,7 +101,7 @@ if node[:nova][:trusted_flavors]
   #{flavors[id]["disk"]} #{flavors[id]["vcpu"]}
   #{novacmd} flavor-key #{flavors[id]["name"]} set trust:trusted_host=trusted
   EOF
-      not_if { system("#{novacmd} flavor-show #{flavors[id]["name"]}", out: File::NULL) }
+      not_if lazy { system("#{novacmd} flavor-show #{flavors[id]["name"]}", out: File::NULL) }
       action :nothing
       subscribes :run, "execute[trigger-flavor-creation]", :delayed
     end
@@ -116,7 +116,7 @@ if node[:nova][:create_default_flavors]
   #{novacmd} flavor-create #{flavors[id]["name"]} #{id} #{flavors[id]["mem"]} \
   #{flavors[id]["disk"]} #{flavors[id]["vcpu"]}
   EOF
-      not_if { system("#{novacmd} flavor-show #{flavors[id]["name"]}", out: File::NULL) }
+      not_if lazy { system("#{novacmd} flavor-show #{flavors[id]["name"]}", out: File::NULL) }
       action :nothing
       subscribes :run, "execute[trigger-flavor-creation]", :delayed
     end


### PR DESCRIPTION
I have a feeling that the delay of the flavor creation
is not syncyng with the check on the not_if code block.
Use lazy to delay the not_if evaluation until the
execution phase.


* Im not even sure if chef allows using lazy on the not_if part, it should but who knows. test PR!