### PR TITLE
keystone: fernet token sanity fixes

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -440,6 +440,12 @@ if node[:keystone][:signing][:token_format] == "fernet"
     )
   end
 
+  unless ha_enabled
+    link "/etc/cron.hourly/openstack-keystone-fernet" do
+      to "/var/lib/keystone/keystone-fernet-rotate"
+    end
+  end
+
   crowbar_pacemaker_sync_mark "wait-keystone_fernet_rotate" if ha_enabled
 
   unless File.exist?("/etc/keystone/fernet-keys/0")

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -58,7 +58,7 @@
         "driver": "sql"
       },
       "signing": {
-        "token_format": "uuid",
+        "token_format": "fernet",
         "certfile": "/etc/keystone/ssl/certs/signing_cert.pem",
         "keyfile": "/etc/keystone/ssl/private/signing_key.pem",
         "ca_certs": "/etc/keystone/ssl/certs/ca.pem"


### PR DESCRIPTION
Move the pacemaker sync mark more up and make sure the cluster_nodes are only queried on 2nd phase, as on 1st phase it might be empty (???). also add a sanity check to see if it actually happens.