### PR TITLE
manila: Fix haproxy config when ssl is enabled

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh_ha.rb
+++ b/chef/cookbooks/aodh/recipes/aodh_ha.rb
@@ -18,7 +18,7 @@ include_recipe "crowbar-pacemaker::haproxy"
 haproxy_loadbalancer "aodh-api" do
   address "0.0.0.0"
   port node[:aodh][:api][:port]
-  use_ssl(node[:aodh][:api][:protocol] == "https")
+  use_ssl (node[:aodh][:api][:protocol] == "https")
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "aodh", "aodh-server", "api")
   action :nothing
 end.run_action(:create)

--- a/chef/cookbooks/manila/recipes/controller_ha.rb
+++ b/chef/cookbooks/manila/recipes/controller_ha.rb
@@ -28,9 +28,7 @@ haproxy_loadbalancer "manila-api" do
   address node[:manila][:api][:bind_open_address] ?
     "0.0.0.0" : cluster_admin_ip
   port node[:manila][:api][:bind_port]
-  # FIXME(toabctl): implement SSL support
-  # use_ssl (node[:manila][:api][:protocol] == "https")
-  use_ssl false
+  use_ssl (node[:manila][:api][:protocol] == "https")
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node,
                                                              "manila",
                                                              "manila-server",


### PR DESCRIPTION
ssl was always marked as disabled.