### PR TITLE
magnum: switch default cert store to x509keypair

### DIFF
--- a/chef/data_bags/crowbar/template-magnum.json
+++ b/chef/data_bags/crowbar/template-magnum.json
@@ -30,7 +30,7 @@
         "database": "magnum"
       },
       "cert": {
-        "cert_manager_type": "local"
+        "cert_manager_type": "x509keypair"
       }
     }
   },


### PR DESCRIPTION
the issue with "local" is that it stores on the local filesystem,
which is 100% not working for a HA deployment because there is no shared
filesystem. Also "local" is explictely marked as non-production ready
so it doesn't make a good default.
Storing in the database seems to be a saner default.