### PR TITLE
database: Add ability to log slow queries in postgresql

### DIFF
--- a/chef/data_bags/crowbar/migrate/database/100_add_log_min_duration_statement.rb
+++ b/chef/data_bags/crowbar/migrate/database/100_add_log_min_duration_statement.rb
@@ -1,0 +1,14 @@
+def upgrade(ta, td, a, d)
+  unless a["postgresql"]["config"].key?("log_min_duration_statement")
+    a["postgresql"]["config"]["log_min_duration_statement"] = \
+      ta["postgresql"]["config"]["log_min_duration_statement"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["postgresql"]["config"].key?("log_min_duration_statement")
+    a["postgresql"]["config"].delete("log_min_duration_statement")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -11,7 +11,8 @@
         "config": {
           "max_connections": 1000,
           "log_filename": "postgresql.log-%Y%m%d%H%M",
-          "log_truncate_on_rotation": false
+          "log_truncate_on_rotation": false,
+          "log_min_duration_statement": -1
         }
       },
       "ha": {
@@ -33,7 +34,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 4,
+      "schema-revision": 100,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -34,7 +34,8 @@
                   "mapping": {
                     "max_connections": { "type": "int" },
                     "log_truncate_on_rotation": { "type": "bool" },
-                    "log_filename": {"type": "str" }
+                    "log_filename": {"type": "str" },
+                    "log_min_duration_statement": { "type": "int" }
                   }
                 }
               }


### PR DESCRIPTION
This is useful to understand why some OpenStack API calls may be slow,
if this turns out to be caused by the database.

The setting is in ms; -1 means that it's disabled.

Closes https://github.com/sap-oc/crowbar-openstack/issues/8