### PR TITLE
nova: Add attribute to configure default_schedule_zone

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -56,6 +56,9 @@ config_drive_format = vfat
 <% if @force_config_drive || @libvirt_type.eql?('zvm') %>
 force_config_drive = True
 <% end %>
+<% unless node[:nova][:default_schedule_zone].empty? -%>
+default_schedule_zone = <%= node[:nova][:default_schedule_zone] %>
+<% end %>
 debug = <%= node[:nova][:debug] %>
 log_dir = /var/log/nova
 use_syslog = <%= node[:nova][:use_syslog] ? 'True' : 'False' %>

--- a/chef/data_bags/crowbar/migrate/nova/206_add_default_schedule_zone.rb
+++ b/chef/data_bags/crowbar/migrate/nova/206_add_default_schedule_zone.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "default_schedule_zone"
+    a["default_schedule_zone"] = ta["default_schedule_zone"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("default_schedule_zone") unless ta.key?("default_schedule_zone")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -22,6 +22,7 @@
       "use_shared_instance_storage": false,
       "use_migration": false,
       "cross_az_attach": true,
+      "default_schedule_zone": "",
       "create_default_flavors": true,
       "image_cache_manager_interval": 0,
       "migration": {
@@ -171,7 +172,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 205,
+      "schema-revision": 206,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -30,6 +30,7 @@
             "trusted_flavors": { "type": "bool", "required": true },
             "use_migration": { "type": "bool", "required": true },
             "cross_az_attach": { "type": "bool", "required": true },
+            "default_schedule_zone": { "type": "str", "required": true },
             "create_default_flavors": { "type": "bool", "required": true },
             "image_cache_manager_interval": { "type": "int", "required": true },
             "migration": {


### PR DESCRIPTION
Quoting the doc:

> Availability zone to use when user doesn't specify one.
>
> This option is used by the scheduler to determine which availability
> zone to place a new VM instance into if the user did not specify one
> at the time of VM boot request.
>
> Possible values:
>
> * Any string representing an availability zone name
> * Default value is None.
>  (string value)

We don't set it by default, to keep the current behavior.

Closes https://github.com/sap-oc/crowbar-openstack/issues/12