### PR TITLE
[3.0] nova: Add attribute to configure default_schedule_zone

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -668,6 +668,9 @@ keystone_ec2_insecure = <%= @keystone_settings['insecure'] %>
 
 # Availability zone to use when user doesn't specify one (string value)
 #default_schedule_zone = <None>
+<% unless node[:nova][:default_schedule_zone].empty? -%>
+default_schedule_zone = <%= node[:nova][:default_schedule_zone] %>
+<% end -%>
 
 # These are image properties which a snapshot should not inherit from an
 # instance (list value)

--- a/chef/data_bags/crowbar/migrate/nova/048_add_default_schedule_zone.rb
+++ b/chef/data_bags/crowbar/migrate/nova/048_add_default_schedule_zone.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "default_schedule_zone"
+    a["default_schedule_zone"] = ta["default_schedule_zone"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("default_schedule_zone") unless ta.key?("default_schedule_zone")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -24,6 +24,7 @@
         "network": "admin"
       },
       "cross_az_attach": true,
+      "default_schedule_zone": "",
       "use_syslog": false,
       "neutron_url_timeout": 30,
       "force_config_drive": false,
@@ -100,7 +101,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 47,
+      "schema-revision": 48,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -35,6 +35,7 @@
               }
             },
             "cross_az_attach": { "type": "bool", "required": true },
+            "default_schedule_zone": { "type": "str", "required": true },
             "setup_shared_instance_storage": { "type": "bool", "required": true },
             "use_shared_instance_storage": { "type": "bool", "required": true },
             "use_syslog": { "type": "bool", "required": true },


### PR DESCRIPTION
Quoting the doc:

> Availability zone to use when user doesn't specify one.
>
> This option is used by the scheduler to determine which availability
> zone to place a new VM instance into if the user did not specify one
> at the time of VM boot request.
>
> Possible values:
>
> * Any string representing an availability zone name
> * Default value is None.
>  (string value)

We don't set it by default, to keep the current behavior.

Closes https://github.com/sap-oc/crowbar-openstack/issues/12

(cherry picked from commit fa0ad588f1fba630a0858e61ac57e0482a95f207)

Backport of https://github.com/crowbar/crowbar-openstack/pull/851