### PR TITLE
magnum: expose trust/cluster_user_trust.

### DIFF
--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -75,6 +75,7 @@ driver = messaging
 policy_file = /etc/magnum/policy.json
 
 [trust]
+cluster_user_trust = <%= @trustee["cluster_user_trust"] %>
 trustee_domain_id = <%= @trustee["domain_id"] %>
 trustee_domain_admin_id = <%= @trustee["domain_admin_id"] %>
 trustee_domain_admin_password = <%= @trustee["domain_admin_password"] %>

--- a/chef/data_bags/crowbar/migrate/magnum/101_add_cluster_user_trust.rb
+++ b/chef/data_bags/crowbar/migrate/magnum/101_add_cluster_user_trust.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a["trust"].key? "cluster_user_trust"
+    a["trust"]["cluster_user_trust"] = ta["trust"]["cluster_user_trust"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta["trust"].key? "cluster_user_trust"
+    a["trust"].delete("cluster_user_trust")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-magnum.json
+++ b/chef/data_bags/crowbar/template-magnum.json
@@ -15,6 +15,7 @@
       "service_user": "magnum",
       "service_password": "",
       "trustee": {
+          "cluster_user_trust": false,
           "domain_name": "magnum",
           "domain_admin_name": "magnum_domain_admin",
           "domain_admin_password": ""
@@ -38,7 +39,7 @@
     "magnum": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "magnum-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-magnum.schema
+++ b/chef/data_bags/crowbar/template-magnum.schema
@@ -25,6 +25,7 @@
             "service_password": { "type": "str", "required": true },
             "trustee": {
               "type": "map", "required": true, "mapping": {
+                "cluster_user_trust": { "type" : "bool", "required" : true },
                 "domain_name": { "type" : "str", "required" : true },
                 "domain_admin_name": { "type": "str", "required": true },
                 "domain_admin_password": { "type": "str", "required": true }

--- a/crowbar_framework/app/views/barclamp/magnum/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/magnum/_edit_attributes.html.haml
@@ -11,6 +11,7 @@
     %fieldset
       %legend
         = t('.trustee_header')
+      = boolean_field %w(trustee cluster_user_trust)
       = string_field %w(trustee domain_name)
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/magnum/en.yml
+++ b/crowbar_framework/config/locales/magnum/en.yml
@@ -27,6 +27,7 @@ en:
         heat_instance: 'Heat Instance'
         trustee_header: 'Trustee Domain'
         trustee:
+          cluster_user_trust: 'Delegate trust to cluster users if required'
           domain_name: 'Domain Name'
         cert_header: 'Certificate Manager'
         cert:


### PR DESCRIPTION
[This upstream commit](https://github.com/openstack/magnum/commit/2d4e617a529ea12ab5330f12631f44172a623a14) in Magnum introduced the setting `cluster_user_trust` which defaults to `False` (the secure choice) but must be set to `True` for some clusters that run their own registry and/or the `rexray` volume drivers. In order to allow users (and functional tests that test the problematic cluster types) to make that choice we need to expose this setting in Crowbar.