### PR TITLE
Heat: Change clients endpoints on publicURL

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -569,7 +569,7 @@ insecure = <%= @keystone_settings['insecure'] %>
 # Type of endpoint in Identity service catalog to use for communication with
 # the OpenStack service. (string value)
 #endpoint_type = <None>
-endpoint_type=internalURL
+endpoint_type=publicURL
 
 # Optional CA cert file to use in SSL connections. (string value)
 #ca_file = <None>


### PR DESCRIPTION
We would like to change endpoints on publicURL for Heat
and Magnum clients. This will be used by OS::Heat::WaitCondition
resource and wc_notify.

(cherry picked from commit 74611f7e49911eba0e13b8e020d5af3f12194229)

As part of the cherry-pick, we only take the Heat part (as Magnum
support is not in this branch).

Backport of https://github.com/crowbar/crowbar-openstack/pull/519