### PR TITLE
nova: Always set live_migration_flag/block_migration_flag for kvm

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -164,15 +164,11 @@ virt_type = <%= @libvirt_type %>
 <% if (@libvirt_type.eql?('xen') and @libvirt_migration and @shared_instances) or @libvirt_type.eql?('kvm') -%>
 live_migration_inbound_addr = <%= @live_migration_inbound_fqdn %>
 <% end -%>
-<% if @libvirt_type.eql?('xen') -%>
-  <% if @libvirt_migration and @shared_instances -%>
+<% if @libvirt_type.eql?('xen') and @libvirt_migration and @shared_instances -%>
 live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_LIVE
-  <% end %>
-<% elsif @libvirt_type.eql?('kvm') -%>
-  <% if @libvirt_migration -%>
+<% elsif @libvirt_type.eql?('kvm') and @libvirt_migration -%>
 live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_LIVE
 block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_NON_SHARED_INC, VIR_MIGRATE_LIVE
-  <% end -%>
 <% end -%>
 <%= "disk_prefix = xvd" if @libvirt_type.eql?('xen') %>
 <%= "cpu_mode = #{@cpu_mode}" unless @cpu_mode.empty? -%>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -170,11 +170,8 @@ live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_LIVE
   <% end %>
 <% elsif @libvirt_type.eql?('kvm') -%>
   <% if @libvirt_migration -%>
-    <% if @shared_instances -%>
 live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_LIVE
-    <% else -%>
 block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_NON_SHARED_INC, VIR_MIGRATE_LIVE
-    <% end -%>
   <% end -%>
 <% end -%>
 <%= "disk_prefix = xvd" if @libvirt_type.eql?('xen') %>


### PR DESCRIPTION
It's wrong to not set live_migration_flag when no shared storage is
used because it's actually still the flag used when volume-backed
instances are migrated.

This becomes visible since we now set live_migration_uri, and we get
this error:
  Live Migration failure: argument unsupported: migration URI is not supported by tunnelled migration

That's because the default value of live_migration_flag contains
VIR_MIGRATE_TUNNELLED.