### PR TITLE
nova: Always set live_migration_flag/block_migration_flag for kvm

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -2596,15 +2596,13 @@ live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_LIVE
 live_migration_uri = qemu+tcp://<%= @migration_host %>/system
 
   <% if @libvirt_migration -%>
-    <% if @shared_instances -%>
 # Migration flags to be set for live migration (string value)
 #live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_LIVE, VIR_MIGRATE_TUNNELLED
 live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_LIVE
-    <% else -%>
+
 # Migration flags to be set for block migration (string value)
 #block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_LIVE, VIR_MIGRATE_TUNNELLED, VIR_MIGRATE_NON_SHARED_INC
 block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_NON_SHARED_INC, VIR_MIGRATE_LIVE
-    <% end -%>
   <% end -%>
 <% end -%>
 


### PR DESCRIPTION
It's wrong to not set live_migration_flag when no shared storage is
used because it's actually still the flag used when volume-backed
instances are migrated.

This becomes visible since we now set live_migration_uri, and we get
this error:
  Live Migration failure: argument unsupported: migration URI is not supported by tunnelled migration

That's because the default value of live_migration_flag contains
VIR_MIGRATE_TUNNELLED.

(cherry picked from commit 096cb6f3c8df50857fe39b5f75745399dbe13e01)

Backport of https://github.com/crowbar/crowbar-openstack/pull/856