### PR TITLE
barbican: Add SSL support

### DIFF
--- a/chef/cookbooks/barbican/attributes/default.rb
+++ b/chef/cookbooks/barbican/attributes/default.rb
@@ -23,10 +23,16 @@ override[:barbican][:user] = "barbican"
 
 default[:barbican][:debug] = false
 default[:barbican][:api][:bind_host] = "*"
-default[:barbican][:api][:ssl] = false
 
 default[:barbican][:config_file] = "/etc/barbican/barbican.conf.d/100-barbican.conf"
 default[:barbican][:logfile] = "/var/log/barbican/barbican-api.log"
+
+default[:barbican][:ssl][:certfile] = "/etc/barbican/ssl/certs/signing_cert.pem"
+default[:barbican][:ssl][:keyfile] = "/etc/barbican/ssl/private/signing_key.pem"
+default[:barbican][:ssl][:generate_certs] = false
+default[:barbican][:ssl][:insecure] = false
+default[:barbican][:ssl][:cert_required] = false
+default[:barbican][:ssl][:ca_certs] = "/etc/barbican/ssl/certs/ca.pem"
 
 # HA attributes
 default[:barbican][:ha][:enabled] = false

--- a/chef/cookbooks/barbican/recipes/common.rb
+++ b/chef/cookbooks/barbican/recipes/common.rb
@@ -25,11 +25,11 @@ ha_enabled = node[:barbican][:ha][:enabled]
 db_settings = fetch_database_settings
 db_conn_scheme = db_settings[:url_scheme]
 
-public_host = CrowbarHelper.get_host_for_public_url(node,
-                                                    node[:barbican][:api][:ssl],
-                                                    node[:barbican][:ha][:enabled])
+barbican_protocol = node[:barbican][:api][:protocol]
 
-barbican_protocol = node[:barbican][:api][:ssl] ? "https" : "http"
+public_host = CrowbarHelper.get_host_for_public_url(node,
+                                                    barbican_protocol == "https",
+                                                    node[:barbican][:ha][:enabled])
 
 if db_settings[:backend_name] == "mysql"
   db_conn_scheme = "mysql+pymysql"

--- a/chef/data_bags/crowbar/migrate/barbican/101_add_ssl_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/barbican/101_add_ssl_attributes.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  a["ssl"] = ta["ssl"]
+  a["api"]["protocol"] = a["api"]["ssl"] ? "https" : "http"
+  a["api"].delete("ssl")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ssl")
+  a["api"]["ssl"] = a["api"]["protocol"] == "https" ? true : false
+  a["api"].delete("protocol")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-barbican.json
+++ b/chef/data_bags/crowbar/template-barbican.json
@@ -4,17 +4,25 @@
   "attributes": {
      "barbican" : {
         "api" : {
+           "protocol": "http",
            "bind_host" : "*",
            "bind_port" : 9311,
            "logfile" : "/var/log/barbican/barbican-api.log",
            "processes" : 3,
-           "ssl" : false,
            "threads" : 10
         },
         "db" : {
            "database" : "barbican",
            "password" : "",
            "user" : "barbican"
+        },
+        "ssl": {
+          "certfile": "/etc/barbican/ssl/certs/signing_cert.pem",
+          "keyfile": "/etc/barbican/ssl/private/signing_key.pem",
+          "generate_certs": false,
+          "insecure": false,
+          "cert_required": false,
+          "ca_certs": "/etc/barbican/ssl/certs/ca.pem"
         },
         "debug" : false,
         "enable_keystone_listener" : false,
@@ -32,7 +40,7 @@
     "barbican" : {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "barbican-controller": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-barbican.schema
+++ b/chef/data_bags/crowbar/template-barbican.schema
@@ -16,11 +16,11 @@
               "required": true,
               "type": "map",
               "mapping": {
+                  "protocol": { "required": true, "type": "str" },
                   "bind_host": { "required": true, "type": "str" },
                   "bind_port": { "required": true, "type": "int" },
                   "logfile": { "required": true, "type": "str" },
                   "processes": { "required": true, "type": "int" },
-                  "ssl": { "required": true, "type": "bool" },
                   "threads": { "required": true, "type": "int" }
                 }
               },
@@ -31,6 +31,16 @@
                   "database": { "required": true, "type": "str" },
                   "password": { "required": true, "type": "str" },
                   "user": { "required": true, "type": "str" }
+              }
+            },
+            "ssl": {
+              "type": "map", "required": true, "mapping": {
+                "certfile": { "type" : "str", "required" : true },
+                "keyfile": { "type" : "str", "required" : true },
+                "generate_certs": { "type" : "bool", "required" : true },
+                "insecure": { "type" : "bool", "required" : true },
+                "cert_required": { "type" : "bool", "required" : true },
+                "ca_certs": { "type" : "str", "required" : true }
               }
             },
             "debug": { "type": "bool" },

--- a/crowbar_framework/app/helpers/barclamp/barbican_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/barbican_helper.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2017, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Barclamp
+  module BarbicanHelper
+    def api_protocols_for_barbican(selected)
+      options_for_select(
+        [
+          ["HTTP", "http"],
+          ["HTTPS", "https"]
+        ],
+        selected.to_s
+      )
+    end
+  end
+end

--- a/crowbar_framework/app/views/barclamp/barbican/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/barbican/_edit_attributes.html.haml
@@ -1,3 +1,25 @@
 = attributes_for @proposal do
   .panel-sub
     = header show_raw_deployment?, true
+
+  .panel-body
+
+    %fieldset
+      %legend
+        = t(".ssl_header")
+
+      = select_field %w(api protocol),
+        :collection => :api_protocols_for_barbican,
+        "data-sslprefix" => "ssl",
+        "data-sslcert" => "/etc/barbican/ssl/certs/signing_cert.pem",
+        "data-sslkey" => "/etc/barbican/ssl/private/signing_key.pem"
+
+      #ssl_container
+        = boolean_field %w(ssl generate_certs)
+        = string_field %w(ssl certfile)
+        = string_field %w(ssl keyfile)
+        = boolean_field %w(ssl insecure)
+        = boolean_field %w(ssl cert_required),
+          "data-enabler" => "true",
+          "data-enabler-target" => "#ssl_ca_certs"
+        = string_field %w(ssl ca_certs)

--- a/crowbar_framework/config/locales/barbican/en.yml
+++ b/crowbar_framework/config/locales/barbican/en.yml
@@ -23,6 +23,7 @@ en:
         keystone_instance: 'Keystone'
         api_header: 'API Settings'
         api:
+          protocol: 'Protocol'
           bind_host: 'Address'
           bind_port: 'Port'
           processes: 'Number of processes'
@@ -35,3 +36,11 @@ en:
         enable_keystone_listener: "Enable Barbican's Keystone listener service"
         group: 'Group for Barbican services'
         user: 'User for Barbican services'
+        ssl_header: 'SSL Support'
+        ssl:
+          generate_certs: 'Generate (self-signed) certificates (implies insecure)'
+          certfile: 'SSL Certificate File'
+          keyfile: 'SSL (Private) Key File'
+          insecure: 'SSL Certificate is insecure (for instance, self-signed)'
+          cert_required: 'Require Client Certificate'
+          ca_certs: 'SSL CA Certificates File'


### PR DESCRIPTION
Add a "protocol" setting and "ssl" configuration options to the barbican
barclamp.

This patch also removes the "api" "ssl" config flag in favor of the "protocol"
string setting, as this was the only barclamp to use such a setting. This
brings it into conformance with other barclamps and makes it possible to test
the SSL scenario without any special treatment[1].

[1] https://github.com/SUSE-Cloud/automation/blob/93fac15bdaa15751362f5856fa348ba3c632e8dd/scripts/qa_crowbarsetup.sh#L2242