### PR TITLE
keystone: Enable domain specific configuration

### DIFF
--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -17,7 +17,8 @@
 # limitations under the License.
 #
 
-actions :add_service, :add_endpoint_template, :add_tenant, :add_user, :add_role, :add_access, :add_ec2, :wakeup
+actions :add_service, :add_endpoint_template, :add_tenant, :add_domain, :add_user, :add_role,
+        :add_access, :add_ec2, :wakeup
 
 attribute :protocol, kind_of: String
 attribute :insecure, kind_of: [TrueClass, FalseClass], default: false
@@ -44,6 +45,9 @@ attribute :endpoint_enabled, default: true
 
 # :add_tenant specific attributes
 attribute :tenant_name, kind_of: String
+
+# :add_domain specific attributes
+attribute :domain_name, kind_of: String
 
 # :add_user specific attributes
 attribute :user_name, kind_of: String

--- a/chef/cookbooks/keystone/templates/default/keystone.domain.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.domain.conf.erb
@@ -1,0 +1,52 @@
+[identity]
+driver = <%= node[:keystone][:domain_specific_config][@domain][:identity][:driver] %>
+
+[ldap]
+url = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:url] %>
+user = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user] %>
+password = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:password] %>
+suffix = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:suffix] %>
+query_scope = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:query_scope] %>
+page_size = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:page_size] %>
+alias_dereferencing = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:alias_dereferencing] %>
+user_tree_dn = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_tree_dn] %>
+user_filter = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_filter] %>
+user_objectclass = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_objectclass] %>
+user_id_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_id_attribute] %>
+user_name_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_name_attribute] %>
+user_description_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_description_attribute] %>
+user_mail_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_mail_attribute] %>
+user_pass_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_pass_attribute] %>
+user_enabled_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_enabled_attribute] %>
+user_enabled_invert = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_enabled_invert] %>
+user_enabled_mask = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_enabled_mask] %>
+user_enabled_default = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_enabled_default] %>
+user_attribute_ignore = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_attribute_ignore] %>
+user_default_project_id_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_default_project_id_attribute] %>
+user_enabled_emulation = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_enabled_emulation] %>
+user_enabled_emulation_dn = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_enabled_emulation_dn] %>
+user_enabled_emulation_use_group_config = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_enabled_emulation_use_group_config] %>
+user_additional_attribute_mapping = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_additional_attribute_mapping] %>
+group_tree_dn = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_tree_dn] %>
+group_filter = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_filter] %>
+group_objectclass = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_objectclass] %>
+group_id_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_id_attribute] %>
+group_name_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_name_attribute]%>
+group_member_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_member_attribute] %>
+group_members_are_ids = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_members_are_ids] %>
+group_desc_attribute = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_desc_attribute] %>
+group_additional_attribute_mapping = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_additional_attribute_mapping] %>
+group_ad_nesting = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:group_ad_nesting] %>
+tls_cacertfile = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:tls_cacertfile] %>
+tls_cacertdir = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:tls_cacertdir] %>
+use_tls = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:use_tls] %>
+tls_req_cert = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:tls_req_cert] %>
+use_pool = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:use_pool] %>
+pool_size = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:pool_size] %>
+pool_retry_max = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:pool_retry_max] %>
+pool_retry_delay = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:pool_retry_delay] %>
+pool_connection_timeout = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:pool_connection_timeout] %>
+pool_connection_lifetime = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:pool_connection_lifetime] %>
+use_auth_pool = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:use_auth_pool] %>
+auth_pool_size = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:auth_pool_size] %>
+auth_pool_connection_lifetime = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:auth_pool_connection_lifetime] %>

--- a/chef/data_bags/crowbar/migrate/keystone/109_add_domain_specific_configs.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/109_add_domain_specific_configs.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["domain_specific_config"] = ta["domain_specific_config"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("domain_specific_config")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -115,6 +115,63 @@
         "use_auth_pool": true,
         "auth_pool_size": 100,
         "auth_pool_connection_lifetime": 60
+      },
+      "domain_specific_config": {
+        "ldap_users": {
+          "identity": {
+            "driver": "ldap"
+          },
+          "ldap" : {
+            "url": "ldap://localhost",
+            "user": "dc=Manager,dc=example,dc=com",
+            "password": "",
+            "suffix": "cn=example,cn=com",
+            "page_size": 0,
+            "alias_dereferencing": "default",
+            "query_scope": "one",
+            "user_tree_dn": "",
+            "user_filter": "",
+            "user_objectclass": "inetOrgPerson",
+            "user_id_attribute": "cn",
+            "user_name_attribute": "sn",
+            "user_description_attribute": "description",
+            "user_mail_attribute": "mail",
+            "user_pass_attribute": "userPassword",
+            "user_enabled_attribute": "enabled",
+            "user_enabled_mask": 0,
+            "user_enabled_default": "True",
+            "user_attribute_ignore": "default_project_id",
+            "user_default_project_id_attribute": "",
+            "user_enabled_invert": false,
+            "user_enabled_emulation": false,
+            "user_enabled_emulation_dn": "",
+            "user_enabled_emulation_use_group_config": false,
+            "user_additional_attribute_mapping": "",
+            "group_tree_dn": "",
+            "group_filter": "",
+            "group_objectclass": "groupOfNames",
+            "group_id_attribute": "cn",
+            "group_name_attribute": "ou",
+            "group_member_attribute": "member",
+            "group_members_are_ids": false,
+            "group_desc_attribute": "description",
+            "group_additional_attribute_mapping": "",
+            "group_ad_nesting": false,
+            "tls_cacertfile": "",
+            "tls_cacertdir": "",
+            "use_tls": false,
+            "tls_req_cert": "demand",
+            "use_pool": true,
+            "pool_size": 10,
+            "pool_retry_max": 3,
+            "pool_retry_delay": 0.1,
+            "pool_connection_timeout": -1,
+            "pool_connection_lifetime": 600,
+            "use_auth_pool": true,
+            "auth_pool_size": 100,
+            "auth_pool_connection_lifetime": 60
+          }
+        }
       }
     }
   },
@@ -122,7 +179,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 108,
+      "schema-revision": 109,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -120,7 +120,67 @@
                       "use_auth_pool": { "type": "bool" },
                       "auth_pool_size": { "type": "int" },
                       "auth_pool_connection_lifetime": { "type": "int" }
-                    }}
+                    }},
+                    "domain_specific_config" : { "type": "map",
+                      "mapping": {
+                        = : {"type": "map", "mapping": {
+                          "identity": { "type": "map", "mapping": {
+                            "driver": { "type": "str" }
+                          }},
+                          "ldap": { "type": "map", "mapping": {
+                            "url": { "type": "str" },
+                            "user": { "type": "str" },
+                            "password": { "type": "str" },
+                            "suffix": { "type": "str" },
+                            "page_size": { "type": "int" },
+                            "alias_dereferencing": { "type": "str" },
+                            "query_scope": { "type": "str" },
+                            "user_tree_dn": { "type": "str" },
+                            "user_filter": { "type": "str" },
+                            "user_objectclass": { "type": "str" },
+                            "user_id_attribute": { "type": "str" },
+                            "user_name_attribute": { "type": "str" },
+                            "user_description_attribute": { "type": "str" },
+                            "user_mail_attribute": { "type": "str" },
+                            "user_pass_attribute": { "type": "str" },
+                            "user_enabled_attribute": { "type": "str" },
+                            "user_enabled_mask": { "type": "int" },
+                            "user_enabled_default": { "type": "str" },
+                            "user_attribute_ignore": { "type": "str" },
+                            "user_default_project_id_attribute": { "type": "str" },
+                            "user_enabled_invert": { "type": "bool" },
+                            "user_enabled_emulation": { "type": "bool" },
+                            "user_enabled_emulation_dn": { "type": "str" },
+                            "user_enabled_emulation_use_group_config": { "type": "bool" },
+                            "user_additional_attribute_mapping": { "type": "str" },
+                            "group_tree_dn": { "type": "str" },
+                            "group_filter": { "type": "str" },
+                            "group_objectclass": { "type": "str" },
+                            "group_id_attribute": { "type": "str" },
+                            "group_name_attribute": { "type": "str" },
+                            "group_member_attribute": { "type": "str" },
+                            "group_members_are_ids": { "type": "bool" },
+                            "group_desc_attribute": { "type": "str" },
+                            "group_attribute_ignore": { "type": "str" },
+                            "group_additional_attribute_mapping": { "type": "str" },
+                            "group_ad_nesting": { "type": "bool" },
+                            "tls_cacertfile": { "type": "str" },
+                            "tls_cacertdir": { "type": "str" },
+                            "use_tls": { "type": "bool" },
+                            "tls_req_cert": { "type": "str" },
+                            "use_pool": { "type": "bool" },
+                            "pool_size": { "type": "int" },
+                            "pool_retry_max": { "type": "int" },
+                            "pool_retry_delay": { "type": "number" },
+                            "pool_connection_timeout": { "type": "int" },
+                            "pool_connection_lifetime": { "type": "int" },
+                            "use_auth_pool": { "type": "bool" },
+                            "auth_pool_size": { "type": "int" },
+                            "auth_pool_connection_lifetime": { "type": "int" }
+                          }}
+                        }}
+                      }
+                    }
               }}
      }},
     "deployment": { "type": "map", "required": true,


### PR DESCRIPTION
In SOC6 we had the "hybrid" keystone identity and assignment backend
which allowed LDAP users to authenticate with keystone. Recent versions
of keystone allow domain-specific identity backends to be configured,
essentially providing the same functionality. This patch adds support
for domain specific configuration by adding the parameter
"domain_specific_config", which provides a mapping from domain names to
their [identity] and [ldap] settings, as well as adding a new add_domain
action to keystone_register. Instead of setting the identity and
assignment drivers to "hybrid" and setting LDAP parameters in the main
LDAP section, users should now leave the default drivers as "sql",
enable "domain_specific_drivers", and set the LDAP parameters under
"domain_specific_config" for a domain of their choosing (by default
named "ldap_users"). They also have to enable multi_domain_support in
the horizon barclamp.

LDAP parameters that were removed from keystone in Ocata[1] were not
transferred to the new domain_specific_config section.

This patch does not address migrating from the old "hybrid" backend to
using domain specific identity backends but this can be implemented in a
followup patch.

[1] https://review.openstack.org/#/c/423572/