### PR TITLE
Disable image_cache_manager_interval(bsc#1015324)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -18,6 +18,7 @@ metadata_listen = <%= @metadata_bind_address %>
 metadata_listen_port = <%= @bind_port_metadata %>
 metadata_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 instance_usage_audit_period = hour
+image_cache_manager_interval = -1
 <% if @libvirt_type.eql?('kvm') -%>
 use_rootwrap_daemon = <%= @use_rootwrap_daemon %>
 <% end -%>

--- a/chef/data_bags/crowbar/migrate/nova/115_add_cache_manager_interval.rb
+++ b/chef/data_bags/crowbar/migrate/nova/115_add_cache_manager_interval.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "image_cache_manager_interval"
+    a["image_cache_manager_interval"] = ta["image_cache_manager_interval"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "image_cache_manager_interval"
+    a.delete("image_cache_manager_interval")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -23,6 +23,7 @@
       "use_migration": false,
       "cross_az_attach": true,
       "create_default_flavors": true,
+      "image_cache_manager_interval": -1,
       "migration": {
         "network": "admin"
       },
@@ -147,7 +148,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 114,
+      "schema-revision": 115,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-kvm": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -30,6 +30,7 @@
             "use_migration": { "type": "bool", "required": true },
             "cross_az_attach": { "type": "bool", "required": true },
             "create_default_flavors": { "type": "bool", "required": true },
+            "image_cache_manager_interval": { "type": "int", "required": true },
             "migration": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
Disabling this option as a precaution to avoid the race wherin
the cache_manager removes the images which are actually in use.
This can be enabled by setting to a value greater than -1.