### PR TITLE
glance: reintroduce vSphere insecure API option (bsc#1027791)

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -43,6 +43,7 @@ vmware_server_password = <%= node[:glance][:vsphere][:password] %>
 <% node[:glance][:vsphere][:datastores].each do |datastore| -%>
 vmware_datastores ="<%= datastore %>"
 <% end -%>
+vmware_api_insecure = <% node[:glance][:vsphere][:insecure] ? "True" : "False" %>
 cinder_catalog_info = volumev2:cinderv2:internalURL
 cinder_os_region_name = <%= @keystone_settings['endpoint_region'] %>
 cinder_api_insecure = <%= @cinder_api_insecure ? 'True' : 'False' %>

--- a/chef/data_bags/crowbar/migrate/glance/104_add_vsphere_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/glance/104_add_vsphere_insecure.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["vsphere"]["insecure"] = ta["vsphere"]["insecure"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["vsphere"].delete("insecure")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -54,6 +54,7 @@
         "user": "",
         "password": "",
         "datastores": [],
+        "insecure": false,
         "store_image_dir": "/openstack_glance"
       },
       "crossdomain": {
@@ -71,7 +72,7 @@
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 103,
+      "schema-revision": 104,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-glance.schema
+++ b/chef/data_bags/crowbar/template-glance.schema
@@ -82,7 +82,8 @@
                 "user": { "type": "str", "required": true },
                 "password": { "type": "str", "required": true },
                 "datastores": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
-                "store_image_dir": { "type": "str", "required": true }
+                "store_image_dir": { "type": "str", "required": true },
+                "insecure": { "type" : "bool", "required" : true }
               }
             },
             "crossdomain": {

--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -42,6 +42,7 @@
       %span.help-block
         = t('.vsphere.datastores_hint')
       = string_field %w(vsphere store_image_dir)
+      = boolean_field %w(vsphere insecure)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/glance/en.yml
+++ b/crowbar_framework/config/locales/glance/en.yml
@@ -44,6 +44,7 @@ en:
           datastores: 'Datastores for Storing Images'
           datastores_hint: 'A comma-separated list of datastores specified in the following format: <datacenter_name>:<datastore_name>'
           store_image_dir: 'Path on the datastore, where the glance images will be stored'
+          insecure: 'vCenter SSL Certificate is insecure (for instance, self-signed)'
         api:
           protocol: 'Protocol'
         ssl_header: 'SSL Support'


### PR DESCRIPTION
This is the switch for vmware_api_insecture.

It reverts a23290463630d89df893cac2ee81193ffb5ca47c, but using "insecure"
in the barclamp to match cinder and nova barclamp options.