### PR TITLE
neutron: make rpc_workers attribute configurable

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -27,6 +27,7 @@ default[:neutron][:config_file] = "/etc/neutron/neutron.conf.d/100-neutron.conf"
 default[:neutron][:lbaas_service_file] = "/etc/neutron/neutron-server.conf.d/100-neutron_service_lbaas.conf"
 default[:neutron][:lbaas_config_file] = "/etc/neutron/neutron.conf.d/110-neutron_lbaas.conf"
 default[:neutron][:l3_agent_config_file] = "/etc/neutron/neutron-l3-agent.conf.d/100-agent.conf"
+default[:neutron][:rpc_workers] = 1
 
 default[:neutron][:db][:database] = "neutron"
 default[:neutron][:db][:user] = "neutron"

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -151,7 +151,8 @@ template neutron[:neutron][:config_file] do
       dns_domain: neutron[:neutron][:dhcp_domain],
       mtu_value: mtu_value,
       infoblox: infoblox_settings,
-      ipam_driver: ipam_driver
+      ipam_driver: ipam_driver,
+      rpc_workers: neutron[:neutron][:rpc_workers]
     )
 end
 

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -12,7 +12,7 @@ ipam_driver = <%= @ipam_driver %>
 global_physnet_mtu = <%= @mtu_value %>
 use_ssl = <%= @ssl_enabled ? "True" : "False" %>
 api_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
-rpc_workers = 0
+rpc_workers = <%= @rpc_workers %>
 dhcp_agents_per_network = <%= @network_nodes_count %>
 <% if @dvr_enabled -%>
 router_distributed = True

--- a/chef/data_bags/crowbar/migrate/neutron/108_add_rpc_workers.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/108_add_rpc_workers.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["rpc_workers"] = ta["rpc_workers"] unless a.key?("rpc_workers")
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("rpc_workers")
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -11,6 +11,7 @@
       "verbose": true,
       "create_default_networks": true,
       "dhcp_domain": "openstack.local",
+      "rpc_workers": 1,
       "use_lbaas": true,
       "lbaasv2_driver": "haproxy",
       "use_l2pop": false,
@@ -121,7 +122,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 107,
+      "schema-revision": 108,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -16,6 +16,7 @@
                     "keystone_instance": { "type": "str", "required": true },
                     "create_default_networks": { "type": "bool", "required": true },
                     "dhcp_domain": { "type": "str", "required": true },
+                    "rpc_workers": { "type": "int", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
                     "lbaasv2_driver": { "type": "str", "required": true },
                     "use_l2pop": { "type": "bool", "required": true },


### PR DESCRIPTION
The rpc_workers neutron.conf configurable parameter was introduced in OpenStack Icehouse. It controls the number of RabbitMQ/ZeroMQ RPC listener processes spawned by neutron-server (one by default).

More info:
   * OS blueprint: https://blueprints.launchpad.net/neutron/+spec/multiple-rpc-workers
   * subsequent change in default value (from 0 to 1): https://bugs.launchpad.net/neutron/+bug/1463129
   * official Mitaka documentation: https://docs.openstack.org/mitaka/config-reference/networking/networking_options_reference.html#configure-messaging
