### PR TITLE
Disable image_cache_manager_interval(bsc#1015324)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1326,6 +1326,7 @@ firewall_driver = nova.virt.firewall.NoopFirewallDriver
 # Number of seconds to wait between runs of the image cache manager. Set to -1
 # to disable. Setting this to 0 will run at the default rate. (integer value)
 #image_cache_manager_interval = 2400
+image_cache_manager_interval = -1
 
 # Where cached images are stored under $instances_path. This is NOT the full
 # path - just a folder name. For per-compute-host cached images, set to

--- a/chef/data_bags/crowbar/migrate/nova/048_add_cache_manager_interval.rb
+++ b/chef/data_bags/crowbar/migrate/nova/048_add_cache_manager_interval.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "image_cache_manager_interval"
+    a["image_cache_manager_interval"] = ta["image_cache_manager_interval"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "image_cache_manager_interval"
+    a.delete("image_cache_manager_interval")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -20,6 +20,7 @@
       "setup_shared_instance_storage": false,
       "use_shared_instance_storage": false,
       "use_migration": false,
+      "image_cache_manager_interval": -1,
       "migration": {
         "network": "admin"
       },
@@ -100,7 +101,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 47,
+      "schema-revision": 48,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -27,6 +27,7 @@
             "max_header_line": { "type": "int", "required": true },
             "trusted_flavors": { "type": "bool", "required": true },
             "use_migration": { "type": "bool", "required": true },
+            "image_cache_manager_interval": { "type": "int", "required": true },
             "migration": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
Disabling this option as a precaution to avoid the race wherin
the cache_manager removes the images which are actually in use.
This can be enabled by setting to a value greater than -1.