### PR TITLE
cinder: set backups_enabled to false

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -307,3 +307,6 @@ lock_path = /var/run/cinder
 ca_file = <%= node[:cinder][:ssl][:ca_certs] if node[:cinder][:api][:protocol] == 'https' && node[:cinder][:ssl][:cert_required] %>
 cert_file = <%= node[:cinder][:ssl][:certfile] if node[:cinder][:api][:protocol] == 'https' %>
 key_file = <%= node[:cinder][:ssl][:keyfile] if node[:cinder][:api][:protocol] == 'https' %>
+
+[volumes]
+backups_enabled = false


### PR DESCRIPTION
Operators that do not have Cinder backup service deployed in their cloud should set this option to False.