### PR TITLE
horizon: Increase Apache SSLCipherSuite forward secrecy

### DIFF
--- a/chef/cookbooks/horizon/templates/centos/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/centos/openstack-dashboard.conf.erb
@@ -8,7 +8,7 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
-    SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+    SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
     SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>

--- a/chef/cookbooks/horizon/templates/default/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/default/openstack-dashboard.conf.erb
@@ -8,7 +8,7 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
-    SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+    SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
     SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>

--- a/chef/cookbooks/horizon/templates/redhat/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/redhat/openstack-dashboard.conf.erb
@@ -8,7 +8,7 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
-    SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+    SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
     SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>

--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -26,7 +26,7 @@
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
-    SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+    SSLCipherSuite DEFAULT_SUSE
     SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>


### PR DESCRIPTION
The current SSLCipherSuite default is not anymore contemporary. The new
default is based on the latest recommendation from the Mozilla Foundation.

see: https://wiki.mozilla.org/Security/Server_Side_TLS