### PR TITLE
magnum: Use correct values for keystone authentication

### DIFF
--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -46,12 +46,14 @@ insecure = <%= @keystone_settings['insecure'] %>
 auth_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
+project_name = <%= @keystone_settings['service_tenant'] %>
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
 insecure = <%= @keystone_settings['insecure'] %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
-identity_uri = <%= @keystone_settings['admin_auth_url'] %>
-admin_user = <%= @keystone_settings['service_user'] %>
-admin_password = <%= @keystone_settings['service_password'] %>
-admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
+project_domain_name = <%= @keystone_settings["admin_domain"]%>
+user_domain_name = <%= @keystone_settings["admin_domain"] %>
+auth_type = password
 
 [magnum_client]
 region_name = <%= @keystone_settings['endpoint_region'] %>


### PR DESCRIPTION
This removes the deprecation warning

WARNING keystonemiddleware.auth_token [-] Use of the auth_admin_prefix, \
        auth_host, auth_port, auth_protocol, identity_uri, admin_token, \
        admin_user, admin_password, and admin_tenant_name configuration \
        options was deprecated in the Mitaka release in favor of an \
        auth_plugin and its related options. This class may be removed in \
        a future release.

when starting the magnum-api service.