### PR TITLE
Fix BSC#1029442

### DIFF
--- a/chef/cookbooks/horizon/templates/default/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/default/openstack-dashboard.conf.erb
@@ -19,7 +19,7 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 <% else %>
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
 <% end %>
-    WSGIDaemonProcess horizon user=<%= @user %> group=<%= @group %> processes=3 threads=10 home=<%= @horizon_dir %> 
+    WSGIDaemonProcess horizon user=<%= @user %> group=<%= @group %> processes=3 threads=10 home=<%= @horizon_dir %>  display-name=%{GROUP}
     WSGIScriptAlias / <%= @horizon_dir %>/openstack_dashboard/wsgi/django.wsgi
     SetEnv APACHE_RUN_USER  <%= @user %>
     SetEnv APACHE_RUN_GROUP <%= @group %>

--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -38,7 +38,7 @@
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
 <% end %>
     WSGIScriptAlias / <%= @horizon_dir %>/openstack_dashboard/wsgi/django.wsgi
-    WSGIDaemonProcess horizon user=<%= @user %> group=<%= @group %> processes=3 threads=10
+    WSGIDaemonProcess horizon user=<%= @user %> group=<%= @group %> processes=3 threads=10 display-name=%{GROUP}
     SetEnv APACHE_RUN_USER  <%= @user %>
     SetEnv APACHE_RUN_GROUP <%= @group %>
     WSGIProcessGroup horizon


### PR DESCRIPTION
horizon: create a dummy service for reload (bsc#1029442)

Apache reload (graceful) will signal the apache process, that will
restart the child process (WSGI).  This can cause a race, were an
OpenStack client try to contact to one of the WSGI services, and
the old WSGI process can answer.  This process will fail because
the WSGI socket is not anymore in the file system.

The aproach here is to create a dummy service for 'horizon', what
will SIGUSR1 the wsgi:horizon childs from apache, signaling the
reload of the configuration file.