### PR TITLE
Ceilometer: add ssl support

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -62,6 +62,13 @@ default[:ceilometer][:database][:event_time_to_live] = -1
 
 default[:ceilometer][:mongodb][:port] = 27017
 
+default[:ceilometer][:ssl][:certfile] = "/etc/ceilometer/ssl/certs/signing_cert.pem"
+default[:ceilometer][:ssl][:keyfile] = "/etc/ceilometer/ssl/private/signing_key.pem"
+default[:ceilometer][:ssl][:generate_certs] = false
+default[:ceilometer][:ssl][:insecure] = false
+default[:ceilometer][:ssl][:cert_required] = false
+default[:ceilometer][:ssl][:ca_certs] = "/etc/ceilometer/ssl/certs/ca.pem"
+
 default[:ceilometer][:ha][:server][:enabled] = false
 
 # increase default timeout: ceilometer has to wait until mongodb is ready

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -322,6 +322,14 @@ else
   manila_insecure = false
 end
 
+ceilometers = search(:node, "roles:ceilometer-server") || []
+if !ceilometers.empty?
+  ceilometer = ceilometers[0][:ceilometer]
+  ceilometer_insecure = ceilometer[:api][:protocol] == "https" && ceilometer[:ssl][:insecure]
+else
+  ceilometer_insecure = false
+end
+
 # We're going to use memcached as a cache backend for Django
 
 # make sure our memcache only listens on the admin IP address
@@ -399,7 +407,8 @@ template local_settings do
     || neutron_insecure \
     || nova_insecure \
     || heat_insecure \
-    || manila_insecure,
+    || manila_insecure \
+    || ceilometer_insecure,
     db_settings: db_settings,
     enable_lb: neutron_use_lbaas,
     enable_vpn: neutron_use_vpnaas,

--- a/chef/data_bags/crowbar/migrate/ceilometer/104_add_ssl_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/104_add_ssl_attributes.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ssl"] = ta["ssl"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ssl")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -28,14 +28,22 @@
       "database": {
           "metering_time_to_live": 30,
           "event_time_to_live": 30
-      }
+      },
+      "ssl": {
+         "certfile": "/etc/ceilometer/ssl/certs/signing_cert.pem",
+         "keyfile": "/etc/ceilometer/ssl/private/signing_key.pem",
+         "generate_certs": false,
+         "insecure": false,
+         "cert_required": false,
+         "ca_certs": "/etc/ceilometer/ssl/certs/ca.pem"
+      }      
     }
   },
   "deployment": {
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 103,
+      "schema-revision": 104,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-central": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-ceilometer.schema
+++ b/chef/data_bags/crowbar/template-ceilometer.schema
@@ -49,7 +49,17 @@
                 "metering_time_to_live": { "type": "int", "required": true },
                 "event_time_to_live": { "type": "int", "required": true }
               }
-	    }
+	        },
+            "ssl": {
+              "type": "map", "required": true, "mapping": {
+                "certfile": { "type" : "str", "required" : true },
+                "keyfile": { "type" : "str", "required" : true },
+                "generate_certs": { "type" : "bool", "required" : true },
+                "insecure": { "type" : "bool", "required" : true },
+                "cert_required": { "type" : "bool", "required" : true },
+                "ca_certs": { "type" : "str", "required" : true }
+              }
+            }
           }
         }
       }

--- a/crowbar_framework/app/helpers/barclamp/ceilometer_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/ceilometer_helper.rb
@@ -17,5 +17,14 @@
 
 module Barclamp
   module CeilometerHelper
+    def api_protocols_for_ceilometer(selected)
+      options_for_select(
+        [
+          ["HTTP", "http"],
+          ["HTTPS", "https"]
+        ],
+        selected.to_s
+      )
+    end
   end
 end

--- a/crowbar_framework/app/views/barclamp/ceilometer/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ceilometer/_edit_attributes.html.haml
@@ -21,6 +21,27 @@
     %span.help-block
       = t(".database.event_time_to_live_hint")
 
+
+    %fieldset
+      %legend
+        = t(".ssl_header")
+
+      = select_field %w(api protocol),
+        :collection => :api_protocols_for_ceilometer,
+        "data-sslprefix" => "ssl",
+        "data-sslcert" => "/etc/ceilometer/ssl/certs/signing_cert.pem",
+        "data-sslkey" => "/etc/ceilometer/ssl/private/signing_key.pem"
+
+      #ssl_container
+        = boolean_field %w(ssl generate_certs)
+        = string_field %w(ssl certfile)
+        = string_field %w(ssl keyfile)
+        = boolean_field %w(ssl insecure)
+        = boolean_field %w(ssl cert_required),
+          "data-enabler" => "true",
+          "data-enabler-target" => "#ssl_ca_certs"
+        = string_field %w(ssl ca_certs)
+
     %fieldset
       %legend
         = t(".logging_header")

--- a/crowbar_framework/config/locales/ceilometer/en.yml
+++ b/crowbar_framework/config/locales/ceilometer/en.yml
@@ -24,6 +24,9 @@ en:
         database_instance: 'Database'
         keystone_instance: 'Keystone'
         rabbitmq_instance: 'RabbitMQ'
+        api_header: 'API Settings'
+        api:
+          protocol: 'Protocol'
         cpu_interval: 'Interval used for CPU meter updates (in seconds)'
         disk_interval: 'Interval used for disk meter updates (in seconds)'
         network_interval: 'Interval used for network meter updates (in seconds)'
@@ -36,6 +39,14 @@ en:
           metering_time_to_live_hint: '-1 means that samples are kept in the database forever'
           event_time_to_live: 'How long are event samples kept in the database (in days)'
           event_time_to_live_hint: '-1 means that samples are kept in the database forever'
+        ssl_header: 'SSL Support'
+        ssl:
+          generate_certs: 'Generate (self-signed) certificates (implies insecure)'
+          certfile: 'SSL Certificate File'
+          keyfile: 'SSL (Private) Key File'
+          insecure: 'SSL Certificate is insecure (for instance, self-signed)'
+          cert_required: 'Require Client Certificate'
+          ca_certs: 'SSL CA Certificates File'
       validation:
         hyper_v_support: 'Hyper-V support is not available.'
         swift_proxy: 'Nodes with the ceilometer-swift-proxy-middleware role must also have the swift-proxy role.'


### PR DESCRIPTION
Add ability to configure SSL to the ceilometer barclamp

- SSL parameters can be accessed through the UI 'protocol' attribute (aligned to other barclamps)
- chef cookbook support to generate and configure certificates for the ceilometer-api service
- modified horizon chef deployment to take note of the insecure ceilometer certificates

Side notes:
- the ceilometer global REST API will be [deprecated in Ocata](https://docs.openstack.org/releasenotes/ceilometer/ocata.html#deprecation-notes) and replaced with the individual REST APIs of its components (Aodh, Gnocci and Panko), which are already available in Newton