### PR TITLE
ec2-api: Add SSL support

### DIFF
--- a/chef/cookbooks/ec2-api/attributes/default.rb
+++ b/chef/cookbooks/ec2-api/attributes/default.rb
@@ -23,3 +23,11 @@ default[:nova]["ec2-api"][:group] = "ec2-api"
 default[:nova]["ec2-api"][:ha][:enabled] = false
 
 default[:nova]["ec2-api"][:config_file] = "/etc/ec2api/ec2api.conf.d/100-ec2api.conf"
+
+default[:nova]["ec2-api"][:ssl][:enabled] = false
+default[:nova]["ec2-api"][:ssl][:certfile] = "/etc/ec2api/ssl/certs/signing_cert.pem"
+default[:nova]["ec2-api"][:ssl][:keyfile] = "/etc/ec2api/ssl/private/signing_key.pem"
+default[:nova]["ec2-api"][:ssl][:generate_certs] = false
+default[:nova]["ec2-api"][:ssl][:insecure] = false
+default[:nova]["ec2-api"][:ssl][:cert_required] = false
+default[:nova]["ec2-api"][:ssl][:ca_certs] = "/etc/ec2api/ssl/certs/ca.pem"

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -23,10 +23,9 @@ package "openstack-ec2-api-s3"
 
 # NOTE: ec2 is deployed via the nova barclamp
 ha_enabled  = node[:nova]["ec2-api"][:ha][:enabled]
-# SSL support is for the entire barclamp
-ssl_enabled = node[:nova][:ssl][:enabled]
+ssl_enabled = node[:nova]["ec2-api"][:ssl][:enabled]
+api_protocol = ssl_enabled ? "https" : "http"
 db_settings = fetch_database_settings "nova"
-api_protocol = node[:nova][:ssl][:enabled] ? "https" : "http"
 ec2_api_port = node[:nova][:ports][:ec2_api]
 ec2_metadata_port = node[:nova][:ports][:ec2_metadata]
 if ha_enabled
@@ -180,6 +179,19 @@ keystone_register "register ec2-metadata endpoint" do
 end
 
 crowbar_pacemaker_sync_mark "create-ec2_api_register"
+
+# ec2-api ssl
+if node[:nova]["ec2-api"][:ssl][:enabled]
+  ssl_setup "setting up ssl for ec2-api" do
+    generate_certs node[:nova]["ec2-api"][:ssl][:generate_certs]
+    certfile node[:nova]["ec2-api"][:ssl][:certfile]
+    keyfile node[:nova]["ec2-api"][:ssl][:keyfile]
+    group node[:nova]["ec2-api"][:group]
+    fqdn node[:fqdn]
+    cert_required node[:nova]["ec2-api"][:ssl][:cert_required]
+    ca_certs node[:nova]["ec2-api"][:ssl][:ca_cert]
+  end
+end
 
 template node[:nova]["ec2-api"][:config_file] do
   source "ec2api.conf.erb"

--- a/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
@@ -18,7 +18,7 @@ include_recipe "crowbar-pacemaker::haproxy"
 haproxy_loadbalancer "ec2-api" do
   address "0.0.0.0"
   port node[:nova][:ports][:ec2_api]
-  use_ssl false
+  use_ssl node[:nova]["ec2-api"][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(
     node, "nova", "ec2-api", "ec2_api"
   )
@@ -28,7 +28,7 @@ end.run_action(:create)
 haproxy_loadbalancer "ec2-metadata" do
   address "0.0.0.0"
   port node[:nova][:ports][:ec2_metadata]
-  use_ssl false
+  use_ssl node[:nova]["ec2-api"][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(
     node, "nova", "ec2-api", "ec2_metadata"
   )
@@ -38,7 +38,7 @@ end.run_action(:create)
 haproxy_loadbalancer "ec2-s3" do
   address "0.0.0.0"
   port node[:nova][:ports][:ec2_s3]
-  use_ssl false
+  use_ssl node[:nova]["ec2-api"][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(
     node, "nova", "ec2-api", "ec2_s3"
   )

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -13,6 +13,16 @@ s3_listen = <%= @bind_host %>
 s3_listen_port = <%= @bind_port_s3 %>
 transport_url = <%= @rabbit_settings[:url] %>
 full_vpc_support = false
+<% if node[:nova]["ec2-api"][:ssl][:enabled] %>
+ec2api_use_ssl = true
+metadata_use_ssl = true
+ssl_cert_file = <%= node[:nova]["ec2-api"][:ssl][:certfile] %>
+ssl_key_file = <%= node[:nova]["ec2-api"][:ssl][:keyfile] %>
+<% if node[:nova]["ec2-api"][:ssl][:cert_required] %>
+ssl_ca_file = <%= node[:nova]["ec2-api"][:ssl][:ca_certs] %>
+<% end %>
+s3_use_ssl = true
+<% end %>
 
 [database]
 connection = <%= @database_connection %>

--- a/chef/data_bags/crowbar/migrate/nova/116_add_ec2_ssl.rb
+++ b/chef/data_bags/crowbar/migrate/nova/116_add_ec2_ssl.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ec2-api"]["ssl"] = ta["ec2-api"]["ssl"]
+  return a, d
+end
+
+def downgrage(ta, td, a, d)
+  a["ec2-api"].delete("ssl")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -42,6 +42,15 @@
           "password": "",
           "user": "ec2",
           "database": "ec2"
+        },
+        "ssl": {
+          "enabled": false,
+          "certfile": "/etc/ec2api/ssl/certs/signing_cert.pem",
+          "keyfile": "/etc/ec2api/ssl/certs/signing_key.pem",
+          "generate_certs": false,
+          "insecure": false,
+          "cert_required": false,
+          "ca_certs": "/etc/ec2api/ssl/certs/ca.pem"
         }
       },
       "db": {
@@ -148,7 +157,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 115,
+      "schema-revision": 116,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-kvm": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -67,6 +67,19 @@
                     "user": { "type": "str", "required": true },
                     "database": { "type": "str", "required": true }
                   }
+                },
+                "ssl": {
+                  "type": "map",
+                  "required": true,
+                  "mapping": {
+                    "enabled": { "type" : "bool", "required" : true },
+                    "certfile": { "type" : "str", "required" : true },
+                    "keyfile": { "type" : "str", "required" : true },
+                    "generate_certs": { "type" : "bool", "required" : true },
+                    "insecure": { "type" : "bool", "required" : true },
+                    "cert_required": { "type" : "bool", "required" : true },
+                    "ca_certs": { "type" : "str", "required" : true }
+                  }
                 }
               }
             },

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -84,6 +84,26 @@
 
     %fieldset
       %legend
+        = t('.ec2-api_header')
+
+      = boolean_field %w(ec2-api ssl enabled),
+        :collection => :ssl_protocols_for_nova,
+        'data-sslprefix' => 'ec2-api_ssl',
+        'data-sslcert' => '/etc/ec2api/ssl/certs/signing_cert.pem',
+        'data-sslkey' => '/etc/ec2api/ssl/private/signing_key.pem'
+
+      #ec2-api_ssl_container
+        = boolean_field %w(ec2-api ssl generate_certs)
+        = string_field %w(ec2-api ssl certfile)
+        = string_field %w(ec2-api ssl keyfile)
+        = boolean_field %w(ec2-api ssl insecure)
+        = boolean_field %w(ec2-api ssl cert_required),
+          "data-enabler" => "true",
+          "data-enabler-target" => "#ssl_ca_certs"
+        = string_field %w(ssl ca_certs)
+
+    %fieldset
+      %legend
         = t(".vnc_header")
 
       = string_field :vnc_keymap

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -82,6 +82,17 @@ en:
             keyfile: 'SSL (Private) Key File'
         logging_header: 'Logging'
         verbose: 'Verbose Logging'
+        ec2-api_header: 'EC2API Configuration'
+        ec2-api:
+          ssl_header: 'SSL Support'
+          ssl:
+            enabled: 'Protocol'
+            insecure: 'SSL Certificate is insecure (for instance, self-signed)'
+            certfile: 'SSL Certificate File'
+            keyfile: 'SSL (Private) Key File'
+            generate_certs: 'Generate (self-signed) certificates (implies insecure)'
+            cert_required: 'Require Client Certificate'
+            ca_certs: 'SSL CA Certificates File'
       validation:
         no_shared_storage_cluster: 'Shared storage cannot be automatically setup when a cluster has the nova-controller role. Please consider using the NFS Client barclamp instead.'
         setup_use_shared_storage: 'When automatically setting up shared storage, it must also be used.'


### PR DESCRIPTION
Add support to deploy ec2-api with SSL enabled endpoints, optionally
generating self-signed certificates.

Co-Authored-By: Steve Kowalik <steven@wedontsleep.org>

This replaces https://github.com/crowbar/crowbar-openstack/pull/773 .