### PR TITLE
rabbitmq: Add SSL support

### DIFF
--- a/chef/cookbooks/aodh/templates/default/aodh.conf.erb
+++ b/chef/cookbooks/aodh/templates/default/aodh.conf.erb
@@ -36,3 +36,9 @@ password = <%= @keystone_settings['service_password'] %>
 project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_type = password
+
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>

--- a/chef/cookbooks/barbican/templates/default/barbican.conf.erb
+++ b/chef/cookbooks/barbican/templates/default/barbican.conf.erb
@@ -12,6 +12,10 @@ rabbit_password =  <%= @rabbit_settings[:password] %>
 rabbit_virtual_host = <%= @rabbit_settings[:vhost] %>
 rabbit_port = <%= @rabbit_settings[:port] %>
 rabbit_hosts = <%= @rabbit_settings[:address] %>
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
 
 [queue]
 

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -67,3 +67,9 @@ ca_file = <%= node[:nova][:vcenter][:ca_file] -%>
 <% if @hypervisor_inspector == "vmware" && node[:nova][:vcenter][:insecure] -%>
 insecure = <%= node[:nova][:vcenter][:insecure] %>
 <% end -%>
+
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -303,6 +303,12 @@ lock_path = /var/run/openstack
 lock_path = /var/run/cinder
 <% end -%>
 
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
+
 [ssl]
 ca_file = <%= node[:cinder][:ssl][:ca_certs] if node[:cinder][:api][:protocol] == 'https' && node[:cinder][:ssl][:cert_required] %>
 cert_file = <%= node[:cinder][:ssl][:certfile] if node[:cinder][:api][:protocol] == 'https' %>

--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -123,15 +123,28 @@ class CrowbarOpenStackHelper
       if rabbit.nil?
         Chef::Log.warn("No RabbitMQ server found!")
       else
+        if rabbit[:rabbitmq][:ssl][:enabled]
+          port = rabbit[:rabbitmq][:ssl][:port]
+          use_ssl = true
+        else
+          port = rabbit[:rabbitmq][:port]
+          use_ssl = false
+        end
+        client_ca_certs = if rabbit[:rabbitmq][:ssl][:enabled] && \
+            !rabbit[:rabbitmq][:ssl][:insecure]
+          rabbit[:rabbitmq][:ssl][:client_ca_certs]
+        end
         @rabbitmq_settings[instance] = {
           address: rabbit[:rabbitmq][:address],
-          port: rabbit[:rabbitmq][:port],
+          port: port,
           user: rabbit[:rabbitmq][:user],
           password: rabbit[:rabbitmq][:password],
           vhost: rabbit[:rabbitmq][:vhost],
+          use_ssl: use_ssl,
+          client_ca_certs: client_ca_certs,
           url: "rabbit://#{rabbit[:rabbitmq][:user]}:" \
             "#{rabbit[:rabbitmq][:password]}@" \
-            "#{rabbit[:rabbitmq][:address]}:#{rabbit[:rabbitmq][:port]}/" \
+            "#{rabbit[:rabbitmq][:address]}:#{port}/" \
             "#{rabbit[:rabbitmq][:vhost]}"
         }
 

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -28,6 +28,11 @@ s3_use_ssl = true
 connection = <%= @database_connection %>
 [oslo_concurrency]
 lock_path = /var/run/ec2-api
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
 [keystone_authtoken]
 auth_type = password
 auth_uri = <%= @keystone_settings['public_auth_url'] %>

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -84,6 +84,12 @@ lock_path = /var/run/glance
 [oslo_messaging_notifications]
 driver = messaging
 
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
+
 [paste_deploy]
 <% if node[:glance][:enable_caching] and node[:glance][:use_cachemanagement] -%>
 flavor = keystone+cachemanagement

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -374,11 +374,7 @@ template "/etc/heat/heat.conf.d/100-heat.conf" do
   variables(
     debug: node[:heat][:debug],
     verbose: node[:heat][:verbose],
-    transport_url: "rabbit://#{rabbit_settings[:user]}:"\
-                            "#{rabbit_settings[:password]}@"\
-                            "#{rabbit_settings[:address]}:"\
-                            "#{rabbit_settings[:port]}/"\
-                            "#{rabbit_settings[:vhost]}",
+    rabbit_settings: rabbit_settings,
     keystone_settings: keystone_settings,
     database_connection: db_connection,
     bind_host: bind_host,

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -18,7 +18,7 @@ debug = <%= node[:heat][:debug] ? 'true' : 'false' %>
 verbose = <%= node[:heat][:verbose] ? 'true' : 'false' %>
 log_dir = /var/log/heat
 use_stderr = false
-transport_url = <%= @transport_url %>
+transport_url = <%= @rabbit_settings[:url] %>
 control_exchange = heat
 
 [clients]
@@ -168,3 +168,9 @@ auth_url = <%= @keystone_settings['internal_auth_url'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 username = <%= @keystone_settings['service_user'] %>
 password = <%= @keystone_settings['service_password'] %>
+
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -101,6 +101,10 @@ rabbit_host = <%= @rabbit_settings[:address] %>
 rabbit_userid = <%= @rabbit_settings[:user] %>
 rabbit_password = <%= @rabbit_settings[:password] %>
 rabbit_virtual_host = <%= @rabbit_settings[:vhost] %>
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
 
 [oslo_policy]
 policy_file = <%= node[:keystone][:policy_file] %>

--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -71,6 +71,12 @@ lock_path = /var/run/magnum
 [oslo_messaging_notifications]
 driver = messaging
 
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
+
 [oslo_policy]
 policy_file = /etc/magnum/policy.json
 

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -77,6 +77,12 @@ username=<%= @nova_admin_username %>
 [oslo_concurrency]
 lock_path = /var/run/manila
 
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
+
 #############################################################################
 #############################################################################
 ## BEGIN Manila backends (which are enabled with 'enabled_share_backends')

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -71,6 +71,12 @@ lock_path = /var/run/neutron
 [oslo_messaging_notifications]
 driver = neutron.openstack.common.notifier.rpc_notifier
 
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
+
 [ssl]
 <% if @ssl_cert_required -%>
 ca_file = <%= @ssl_ca_file %>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -210,6 +210,12 @@ lock_path = /var/run/nova
 [oslo_messaging_notifications]
 driver = messagingv2
 
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
+
 [serial_console]
 enabled = <%= @serial_enabled ? "True" : "False" %>
 base_url = ws://<%= @serialproxy_public_host %>:<%= node[:nova][:ports][:serialproxy] %>/

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -34,6 +34,18 @@ end
 
 include_recipe "rabbitmq::default"
 
+if node[:rabbitmq][:ssl][:enabled]
+  ssl_setup "setting up ssl for rabbitmq" do
+    generate_certs node[:rabbitmq][:ssl][:generate_certs]
+    certfile node[:rabbitmq][:ssl][:certfile]
+    keyfile node[:rabbitmq][:ssl][:keyfile]
+    group "rabbitmq"
+    fqdn node[:fqdn]
+    cert_required node[:rabbitmq][:ssl][:cert_required]
+    ca_certs node[:rabbitmq][:ssl][:ca_certs]
+  end
+end
+
 if ha_enabled
   log "HA support for rabbitmq is enabled"
   include_recipe "rabbitmq::ha"

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -4,9 +4,24 @@
    {tcp_listeners, [
                     <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:port]}}" }.join(", ") %>
                    ]},
+<% if node[:rabbitmq][:ssl][:enabled] -%>
+   {ssl_listeners, [
+                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:ssl][:port]}}" }.join(", ") %>
+                   ]},
+   {ssl_options, [
+   <% if node[:rabbitmq][:ssl][:cert_required] -%>
+                 {cacertfile, "<%= node[:rabbitmq][:ssl][:ca_certs] %>"},
+                 {verify, verify_peer},
+                 {fail_if_no_peer_cert, true},
+   <% else -%>
+                 {verify, verify_none},
+                 {fail_if_no_peer_cert, false},
+   <% end -%>
+                 {certfile, "<%= node[:rabbitmq][:ssl][:certfile] %>"},
+                 {keyfile, "<%= node[:rabbitmq][:ssl][:keyfile] %>"}]},
+<% end -%>
    {disk_free_limit, 50000000}
-  ]
- },
+ ]},
  {rabbitmq_management,
   [
    {listener, [{ip, "<%= node[:rabbitmq][:management_address] %>"}, {port, <%= node[:rabbitmq][:management_port] %>}]}

--- a/chef/cookbooks/sahara/templates/default/sahara.conf.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara.conf.erb
@@ -49,3 +49,9 @@ api_insecure = <%= @nova_insecure %>
 
 [oslo_concurrency]
 lock_path = "/var/run/sahara"
+
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -131,8 +131,15 @@ if node[:swift][:middlewares][:s3][:enabled]
 end
 
 # enable ceilometer middleware if ceilometer is configured
+# and rabbitmq is unsecured - lp#1673738
+ceilometermiddleware_enabled = node.roles.include? "ceilometer-swift-proxy-middleware"
+rabbitmq_ssl_enabled = node[:rabbitmq][:ssl][:enabled]
+if ceilometermiddleware_enabled && rabbitmq_ssl_enabled
+  Chef::Log.warn("Disabling ceilometer swift-proxy middleware because it cannot connect"\
+                 " to rabbitmq over SSL")
+end
 node.set[:swift][:middlewares]["ceilometer"] = {
-  "enabled" => (node.roles.include? "ceilometer-swift-proxy-middleware")
+  "enabled" => ceilometermiddleware_enabled && !rabbitmq_ssl_enabled
 }
 
 if node[:swift][:middlewares]["ceilometer"]["enabled"]

--- a/chef/cookbooks/trove/recipes/conductor.rb
+++ b/chef/cookbooks/trove/recipes/conductor.rb
@@ -30,7 +30,8 @@ template node[:trove][:conductor][:config_file] do
   variables(
     keystone_settings: KeystoneHelper.keystone_settings(node, :trove),
     sql_connection: sql_connection,
-    rabbit_trove_url: rabbit_trove_url
+    rabbit_trove_url: rabbit_trove_url,
+    rabbit_default_settings: fetch_rabbitmq_settings
   )
   notifies :restart, "service[trove-conductor]"
 end

--- a/chef/cookbooks/trove/recipes/taskmanager.rb
+++ b/chef/cookbooks/trove/recipes/taskmanager.rb
@@ -44,6 +44,7 @@ template node[:trove][:taskmanager][:config_file] do
     keystone_settings: keystone_settings,
     sql_connection: sql_connection,
     rabbit_trove_url: rabbit_trove_url,
+    rabbit_default_settings: fetch_rabbitmq_settings,
     nova_url: nova_url,
     nova_insecure: nova_insecure,
     cinder_url: cinder_url,

--- a/chef/cookbooks/trove/templates/default/trove-conductor.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove-conductor.conf.erb
@@ -16,3 +16,9 @@ log_dir = /var/log/trove
 
 [database]
 connection = <%= @sql_connection %>
+
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_default_settings[:use_ssl] %>
+<% if @rabbit_default_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_default_settings[:client_ca_certs] %>
+<% end -%>

--- a/chef/cookbooks/trove/templates/default/trove-taskmanager.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove-taskmanager.conf.erb
@@ -67,3 +67,9 @@ log_dir = /var/log/trove
 
 [database]
 connection = <%= @sql_connection %>
+
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_default_settings[:use_ssl] %>
+<% if @rabbit_default_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_default_settings[:client_ca_certs] %>
+<% end -%>

--- a/chef/cookbooks/trove/templates/default/trove.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove.conf.erb
@@ -65,3 +65,9 @@ identity_uri = <%= @keystone_settings['admin_auth_url'] %>
 admin_user = <%= @keystone_settings['service_user'] %>
 admin_password = <%= @keystone_settings['service_password'] %>
 admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
+
+[oslo_messaging_rabbit]
+rabbit_use_ssl = <%= @rabbit_default_settings[:use_ssl] %>
+<% if @rabbit_default_settings[:client_ca_certs] -%>
+kombu_ssl_ca_certs = <%= @rabbit_default_settings[:client_ca_certs] %>
+<% end -%>

--- a/chef/data_bags/crowbar/migrate/rabbitmq/012_ssl.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/012_ssl.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ssl"] = ta["ssl"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ssl")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -8,6 +8,17 @@
       "password": "",
       "user": "nova",
       "vhost": "/nova",
+      "ssl": {
+        "enabled": false,
+        "port": 5671,
+        "certfile": "/etc/rabbitmq/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/rabbitmq/ssl/private/signing_key.pem",
+        "insecure": false,
+        "generate_certs": false,
+        "cert_required": false,
+        "ca_certs": "/etc/rabbitmq/ssl/certs/ca.pem",
+        "client_ca_certs": "/etc/ssl/certs/rabbitca.pem"
+      },
       "ha": {
         "storage": {
           "mode": "shared",
@@ -33,7 +44,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 11,
+      "schema-revision": 12,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -17,6 +17,19 @@
             "password": { "type": "str", "required": true },
             "user": { "type": "str", "required": true },
             "vhost": { "type": "str", "required": true },
+            "ssl": {
+              "type": "map", "required": true, "mapping": {
+                "enabled": { "type": "bool", "required": true },
+                "port": { "type" : "int", "required" : true },
+                "certfile": { "type" : "str", "required" : true },
+                "keyfile": { "type" : "str", "required" : true },
+                "insecure": { "type": "bool", "required": true },
+                "generate_certs": { "type" : "bool", "required" : true },
+                "cert_required": { "type" : "bool", "required" : true },
+                "ca_certs": { "type" : "str", "required" : true },
+                "client_ca_certs": { "type" : "str", "required" : true }
+              }
+            },
             "ha" : {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
@@ -7,6 +7,29 @@
     = integer_field :port
     = string_field :user
 
+    %fieldset
+      %legend
+        = t(".ssl_header")
+
+      = boolean_field %w(ssl enabled),
+        "data-sslprefix" => "ssl",
+        "data-sslcert" => "/etc/rabbitmq/ssl/certs/signing_cert.pem",
+        "data-sslkey" => "/etc/rabbitmq/ssl/private/signing_key.pem"
+
+      #ssl_container
+        = integer_field %w(ssl port)
+        = boolean_field %w(ssl generate_certs)
+        = string_field %w(ssl certfile)
+        = string_field %w(ssl keyfile)
+        = boolean_field %w(ssl cert_required),
+          "data-enabler" => "true",
+          "data-enabler-target" => "#ssl_ca_certs"
+        = string_field %w(ssl ca_certs)
+        = boolean_field %w(ssl insecure),
+          "data-disabler" => "true",
+          "data-disabler-target" => "#ssl_client_ca_certs"
+        = string_field %w(ssl client_ca_certs)
+
     %fieldset#ha-setup{ "data-show-for-clusters-only" => "true", "data-elements-path" => "rabbitmq-server" }
       %legend
         = t('.ha_header')

--- a/crowbar_framework/config/locales/rabbitmq/en.yml
+++ b/crowbar_framework/config/locales/rabbitmq/en.yml
@@ -22,6 +22,17 @@ en:
         vhost: 'Virtual host'
         user: 'User'
         port: 'Port'
+        ssl_header: 'SSL Support'
+        ssl:
+          enabled: 'Enable SSL'
+          port: 'SSL Port'
+          generate_certs: 'Generate (self-signed) certificates (implies insecure)'
+          certfile: 'SSL Certificate File'
+          keyfile: 'SSL (Private) Key File'
+          insecure: 'SSL Certificate is insecure (for instance, self-signed)'
+          cert_required: 'Require Client Certificate'
+          ca_certs: 'SSL CA Certificates File'
+          client_ca_certs: 'SSL client CA file (used to validate rabbitmq server certificate)'
         ha_header: 'High Availability'
         ha:
           storage:


### PR DESCRIPTION
Add SSL support to rabbitmq barclamp

This patch adds the option to configure some of the SSL settings for
rabbitmq and ensure all OpenStack services are using the SSL-secured
port. There are some important notes regarding how this differs from
enabling SSL for the REST APIs:
    
- The SSL port is configurable, since typically rabbitmq has different
   ports designated for regular and SSL traffic and it would be confusing
   to only allow one port.
- The ceilometer pipeline for swift does not have the ability to read
   the oslo.messaging SSL-specific options from oslo.config[1]. Rather
   than send ceilometer traffic over an unsecured channel, we disable
   this pipeline when rabbitmq is enabled.
- Disabling the "insecure" option requires the client services to
   configure a CA to validate the rabbitmq server certificate, which must
   have the same path on all clients. There is no way to tell the client
   services to require a certificate be validated against the
   system-trusted CAs.
- The cert_required option is configurable, but it currently does not do
   the work of setting up client certs so it is somewhat toothless.
 
[1] https://bugs.launchpad.net/ceilometermiddleware/+bug/1673738