### PR TITLE
bsc_1023522: Synchronize on rsync install

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -420,8 +420,9 @@ if node[:keystone][:signing][:token_format] == "fernet"
     cluster_nodes.map do |n|
       next if node.name == n.name
       node_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
-      rsync_command += "rsync -a --delete-after /etc/keystone/fernet-keys " \
-                                "#{node_address}:/etc/keystone/;"
+      rsync_command += \
+        "rsync -a --timeout=300 --delete-after /etc/keystone/fernet-keys " \
+        "#{node_address}:/etc/keystone/; "
     end
     raise "No other cluster members found" if rsync_command.empty?
   end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -413,7 +413,7 @@ end
 if node[:keystone][:signing][:token_format] == "fernet"
   # To be sure that rsync package is installed
   package "rsync"
-
+  crowbar_pacemaker_sync_mark "sync-keystone_install_rsync"
   rsync_command = ""
   if ha_enabled
     cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)


### PR DESCRIPTION
To ensure that all cluster nodes have the `rsync` package installed,
insert a sync mark after the `package` call.

Co-Authored-By: Roman Arcea <rarcea@suse.com>
Co-Authored-By: Nicolas Bock <nicolas.bock@suse.com>