### PR TITLE
keystone: Add admin/Member roles on Default domain to fix domain management in Horizon

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -204,6 +204,36 @@ action :add_access do
   end
 end
 
+# :add_domain_access specific attributes
+# attribute :domain_name, :kind_of => String
+# attribute :user_name, :kind_of => String
+# attribute :role_name, :kind_of => String
+action :add_domain_access do
+  http, headers = _build_connection(new_resource)
+
+  # Lets verify that the item does not exist yet
+  domain = new_resource.domain_name
+  user = new_resource.user_name
+  role = new_resource.role_name
+  user_id, uerror = _find_id(http, headers, user, "/v3/users", "users")
+  domain_id, terror = _find_id(http, headers, domain, "/v3/domains", "domains")
+  role_id, rerror = _find_id(http, headers, role, "/v3/roles", "roles")
+
+  path = "/v3/domains/#{domain_id}/users/#{user_id}/roles"
+  t_role_id, aerror = _find_id(http, headers, role, path, "roles")
+
+  error = (aerror or rerror or uerror or terror)
+  unless role_id == t_role_id or error
+    # Service does not exist yet
+    ret = _update_item(http, headers, "#{path}/#{role_id}", nil, new_resource.role_name)
+    new_resource.updated_by_last_action(ret)
+  else
+    raise "Failed to talk to keystone in add_access" if error
+    Chef::Log.info "Domain access '#{domain}:#{user} -> #{role}}' already exists. Not creating." unless error
+    new_resource.updated_by_last_action(false)
+  end
+end
+
 # :add_ec2 specific attributes
 # attribute :user_name, :kind_of => String
 # attribute :tenant_name, :kind_of => String
@@ -346,6 +376,9 @@ def _update_item(http, headers, path, body, name)
     return true
   elsif resp.is_a?(Net::HTTPCreated)
     Chef::Log.info("Created keystone item '#{name}'")
+    return true
+  elsif resp.is_a?(Net::HTTPNoContent)
+    Chef::Log.info("Updates keystone item '#{name}'")
     return true
   else
     Chef::Log.error("Unable to updated item '#{name}'")

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -595,6 +595,7 @@ end
 # Create Access info
 user_roles = [
   [node[:keystone][:admin][:username], "admin", node[:keystone][:admin][:tenant]],
+  [node[:keystone][:admin][:username], "Member", node[:keystone][:admin][:tenant]],
   [node[:keystone][:admin][:username], "admin", node[:keystone][:default][:tenant]]
 ]
 if node[:keystone][:default][:create_user]
@@ -611,6 +612,25 @@ user_roles.each do |args|
     role_name args[1]
     tenant_name args[2]
     action :add_access
+  end
+end
+
+# Add roles on Default domain
+user_roles = [
+  [node[:keystone][:admin][:username], "admin", "Default"],
+  [node[:keystone][:admin][:username], "Member", "Default"],
+]
+user_roles.each do |args|
+  keystone_register "add 'Default' domain role" do
+    protocol node[:keystone][:api][:protocol]
+    insecure keystone_insecure
+    host my_admin_host
+    port node[:keystone][:api][:admin_port]
+    auth register_auth_hash
+    user_name args[0]
+    role_name args[1]
+    domain_name args[2]
+    action :add_domain_access
   end
 end
 

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -18,7 +18,7 @@
 #
 
 actions :add_service, :add_endpoint_template, :add_tenant, :add_domain, :add_user, :add_role,
-        :add_access, :add_ec2, :wakeup
+        :add_access, :add_domain_access, :add_ec2, :wakeup
 
 attribute :protocol, kind_of: String
 attribute :insecure, kind_of: [TrueClass, FalseClass], default: false
@@ -60,6 +60,11 @@ attribute :role_name, kind_of: String
 attribute :user_name, kind_of: String
 attribute :role_name, kind_of: String
 attribute :tenant_name, kind_of: String
+
+# :add_domain_access specific attributes
+attribute :user_name, kind_of: String
+attribute :role_name, kind_of: String
+attribute :domain_name, kind_of: String
 
 # :add_ec2 specific attributes
 attribute :user_name, kind_of: String


### PR DESCRIPTION
In the current default configuration, if we enable multi-domain support in Horizon, the admin user can not manage the "Default" domain nor create new domains from Horizon, it has to be done from the CLI
The domain management from Horizon doesn't work because the "admin" user is not assigned any role on the "Default" domain. To fix it, we need to assign "admin" and "Member" role over the "Default" domain using the CLI. After this role assignment, everything works from Horizon

This branch modifies the keystone cookbook to assign "admin" and "Member" roles over the "Default" domain to the "admin" user

Since the cookbook uses the v2 api, it can not manage domains, so I added a new action "add_domain_access" that uses api v3 to manage roles on domains
It will probably be cleaner to refactor the cookbook to use v3 api everywhere and use only one "add_access" action to manage roles on both domains and projects, but it would be more intrusive

This branch also adds "Member" role on "admin" project to "admin" user, because without this role, the "admin" user can not create Heat stacks on the "admin" project, and this error can be quite confusing...
