### PR TITLE
upgrade: Check for run_list_map when searching for ceph nodes.

### DIFF
--- a/chef/cookbooks/cinder/recipes/ceph.rb
+++ b/chef/cookbooks/cinder/recipes/ceph.rb
@@ -33,7 +33,7 @@ end
 
 if has_internal
   ceph_env_filter = " AND ceph_config_environment:ceph-config-default"
-  ceph_servers = search(:node, "roles:ceph-osd#{ceph_env_filter}") || []
+  ceph_servers = search(:node, "run_list_map:ceph-osd#{ceph_env_filter}") || []
   if ceph_servers.length > 0
     include_recipe "ceph::keyring"
   else

--- a/chef/cookbooks/glance/recipes/ceph.rb
+++ b/chef/cookbooks/glance/recipes/ceph.rb
@@ -18,7 +18,7 @@
 #
 
 ceph_env_filter = " AND ceph_config_environment:ceph-config-default"
-ceph_servers = search(:node, "roles:ceph-osd#{ceph_env_filter}") || []
+ceph_servers = search(:node, "run_list_map:ceph-osd#{ceph_env_filter}") || []
 if ceph_servers.length > 0
   include_recipe "ceph::keyring"
 

--- a/chef/cookbooks/nova/recipes/ceph.rb
+++ b/chef/cookbooks/nova/recipes/ceph.rb
@@ -33,7 +33,7 @@ end
 
 if has_internal
   ceph_env_filter = " AND ceph_config_environment:ceph-config-default"
-  ceph_servers = search(:node, "roles:ceph-osd#{ceph_env_filter}") || []
+  ceph_servers = search(:node, "run_list_map:ceph-osd#{ceph_env_filter}") || []
   if ceph_servers.length > 0
     include_recipe "ceph::keyring"
   else


### PR DESCRIPTION
When ceph node is prepared for the upgrade, it cannot be find by
the search for roles, but search for run_list_map still works.

This is actually consistent with the (upgrade unrelated) search method
that is already used in ceph recipes.