### PR TITLE
[3.0] neutron: make rpc_workers attribute configurable

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -23,6 +23,7 @@ default[:neutron][:max_header_line] = 16384
 default[:neutron][:dhcp_domain] = "openstack.local"
 default[:neutron][:networking_plugin] = "ml2"
 default[:neutron][:additional_external_networks] = []
+default[:neutron][:rpc_workers] = 1
 
 default[:neutron][:db][:database] = "neutron"
 default[:neutron][:db][:user] = "neutron"

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -171,7 +171,8 @@ template "/etc/neutron/neutron.conf" do
       network_nodes_count: network_nodes_count,
       dns_domain: neutron[:neutron][:dhcp_domain],
       infoblox: infoblox_settings,
-      ipam_driver: ipam_driver
+      ipam_driver: ipam_driver,
+      rpc_workers: neutron[:neutron][:rpc_workers]
     }.merge(nova_notify))
 end
 

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -345,7 +345,7 @@ api_workers = 0
 # Number of separate RPC worker processes to spawn. If not specified or < 1,
 # a single RPC worker process is spawned by the parent process.
 # rpc_workers = 1
-rpc_workers = 0
+rpc_workers = <%= @rpc_workers %>
 
 # Timeout for client connections socket operations. If an
 # incoming connection is idle for this number of seconds it

--- a/chef/data_bags/crowbar/migrate/neutron/056_add_rpc_workers.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/056_add_rpc_workers.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["rpc_workers"] = ta["rpc_workers"] unless a.key?("rpc_workers")
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("rpc_workers")
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -11,6 +11,7 @@
       "verbose": true,
       "create_default_networks": true,
       "dhcp_domain": "openstack.local",
+      "rpc_workers": 1,
       "use_lbaas": true,
       "use_lbaasv2": false,
       "lbaasv2_driver": "haproxy",
@@ -119,7 +120,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 55,
+      "schema-revision": 56,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -16,6 +16,7 @@
                     "keystone_instance": { "type": "str", "required": true },
                     "create_default_networks": { "type": "bool", "required": true },
                     "dhcp_domain": { "type": "str", "required": true },
+                    "rpc_workers": { "type": "int", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
                     "use_lbaasv2": { "type": "bool", "required": true },
                     "lbaasv2_driver": { "type": "str", "required": true },


### PR DESCRIPTION
Backport for #863:

> The rpc_workers neutron.conf configurable parameter was introduced in OpenStack Icehouse. It controls the number of RabbitMQ/ZeroMQ RPC listener processes spawned by neutron-server (one by default).
> 
> More info:
> 
> OS blueprint: https://blueprints.launchpad.net/neutron/+spec/multiple-rpc-workers
> subsequent change in default value (from 0 to 1): https://bugs.launchpad.net/neutron/+bug/1463129
> official Mitaka documentation: https://docs.openstack.org/mitaka/config-reference/networking/networking_options_reference.html#configure-messaging