### PR TITLE
heat,manila,trove: Switch to new keystone settings

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -23,88 +23,60 @@ control_exchange = heat
 
 [clients]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_barbican]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_ceilometer]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_cinder]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_glance]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_heat]
 endpoint_type = publicURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_keystone]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 auth_uri = <%= @keystone_settings['public_auth_url'] %>
 
 [clients_magnum]
 endpoint_type = publicURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_manila]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_neutron]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_nova]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_sahara]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_swift]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [clients_trove]
 endpoint_type = internalURL
-<% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 
 [database]
 connection = <%= @database_connection %>
@@ -144,15 +116,16 @@ max_header_line = <%= node[:heat][:max_header_line] %>
 
 [keystone_authtoken]
 auth_uri = <%= @keystone_settings['public_auth_url'] %>
+auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
-<% if @keystone_settings['insecure'] -%>
+project_name = <%= @keystone_settings['service_tenant'] %>
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
 insecure = <%= @keystone_settings['insecure'] %>
-<% end -%>
 region_name = <%= @keystone_settings['endpoint_region'] %>
-identity_uri = <%= @keystone_settings['admin_auth_url'] %>
-admin_user = <%= @keystone_settings['service_user'] %>
-admin_password = <%= @keystone_settings['service_password'] %>
-admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
+project_domain_name = <%= @keystone_settings['admin_domain']%>
+user_domain_name = <%= @keystone_settings['admin_domain'] %>
+auth_type = password
 
 <% if node[:heat][:api][:protocol] == "https" %>
 [ssl]

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -42,13 +42,16 @@ connection=<%= @sql_connection %>
 
 [keystone_authtoken]
 auth_uri = <%= @keystone_settings['public_auth_url'] %>
+auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version= <%= @keystone_settings['api_version_for_middleware'] %>
+project_name = <%= @keystone_settings['service_tenant'] %>
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
 insecure = <%= @keystone_settings['insecure'] %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
-identity_uri = <%= @keystone_settings['admin_auth_url'] %>
-admin_user = <%= @keystone_settings['service_user'] %>
-admin_password = <%= @keystone_settings['service_password'] %>
-admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
+project_domain_name = <%= @keystone_settings['admin_domain']%>
+user_domain_name = <%= @keystone_settings['admin_domain'] %>
+auth_type = password
 
 [neutron]
 url=<%= @neutron_protocol%>://<%= @neutron_server_host%>:<%= @neutron_server_port%>

--- a/chef/cookbooks/trove/templates/default/trove.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove.conf.erb
@@ -58,13 +58,16 @@ ignore_dbs = lost+found, mysql, information_schema
 
 [keystone_authtoken]
 auth_uri = <%= @keystone_settings['public_auth_url'] %>
+auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version= <%= @keystone_settings['api_version_for_middleware'] %>
+project_name = <%= @keystone_settings['service_tenant'] %>
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
 insecure = <%= @keystone_settings['insecure'] %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
-identity_uri = <%= @keystone_settings['admin_auth_url'] %>
-admin_user = <%= @keystone_settings['service_user'] %>
-admin_password = <%= @keystone_settings['service_password'] %>
-admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
+project_domain_name = <%= @keystone_settings['admin_domain']%>
+user_domain_name = <%= @keystone_settings['admin_domain'] %>
+auth_type = password
 
 [oslo_messaging_rabbit]
 rabbit_use_ssl = <%= @rabbit_default_settings[:use_ssl] %>


### PR DESCRIPTION
Building on an earlier commit that fixed Magnum, fix Heat, Manila
and Trove configuration templates to use the New World Order of
Keystone settings. As a drive-by, remove the lots of lines checking
the insecure setting in the heat template.

Builds on the work started in https://github.com/crowbar/crowbar-openstack/pull/867, but doesn't require it.