### PR TITLE
upgrade: Do not reboot XEN node from the first chef-client run

### DIFF
--- a/chef/cookbooks/nova/libraries/boot_kernel.rb
+++ b/chef/cookbooks/nova/libraries/boot_kernel.rb
@@ -27,7 +27,11 @@ module NovaBootKernel
     # running
     unless Dir.exist?("/proc/xen") && flavor == "xen" ||
         !Dir.exist?("/proc/xen") && flavor == "default"
-      node.run_state[:reboot] = true
+      if node["crowbar_upgrade_step"] == "done_os_upgrade"
+        Chef::Log.info("Skipping reboot in the initial run after upgrade")
+      else
+        node.run_state[:reboot] = true
+      end
     end
   end
 


### PR DESCRIPTION
During node upgrade, we're executing chef-client from crowbar_join.
If node reboots in this stage, upgrade script that executed this
crowbar_join will be interrupted and cannot finish.

The reboot is indeed needed, but it could be delayed to the next regular chef-client run, I hope.