### PR TITLE
cinder: netapp: add max_over_subscription_ratio

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -269,6 +269,10 @@ iscsi_write_cache = off
 image_upload_use_cinder_backend = true
   <% end -%>
 
+  <% if volume[volume['backend_driver']] && volume[volume['backend_driver']]['max_over_subscription_ratio'] -%>
+max_over_subscription_ratio = <%= volume[volume['backend_driver']]['max_over_subscription_ratio'] %>
+  <% end -%>
+
   <% break unless @use_multi_backend -%>
 <% end -%>
 

--- a/chef/data_bags/crowbar/migrate/cinder/106_add_max_over_subscription_ratio.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/106_add_max_over_subscription_ratio.rb
@@ -1,0 +1,26 @@
+def upgrade(ta, td, a, d)
+  unless a["volume_defaults"]["netapp"].key? "max_over_subscription_ratio"
+    a["volume_defaults"]["netapp"]["max_over_subscription_ratio"] = \
+      ta["volume_defaults"]["netapp"]["max_over_subscription_ratio"]
+
+    a["volumes"].each do |volume|
+      next if volume["backend_driver"] != "netapp"
+      volume["netapp"]["max_over_subscription_ratio"] = \
+        ta["volume_defaults"]["netapp"]["max_over_subscription_ratio"]
+    end
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["volume_defaults"]["netapp"].key? "max_over_subscription_ratio"
+    a["volume_defaults"]["netapp"].delete("max_over_subscription_ratio")
+    a["volumes"].each do |volume|
+      next if volume["backend_driver"] != "netapp"
+      volume["netapp"].delete("max_over_subscription_ratio")
+    end
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -52,7 +52,8 @@
           "netapp_password": "",
           "netapp_vfiler": "",
           "netapp_transport_type": "https",
-          "netapp_volume_list": ""
+          "netapp_volume_list": "",
+          "max_over_subscription_ratio": 20
         },
         "emc": {
           "ecom_server_ip": "192.168.124.11",
@@ -161,7 +162,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 105,
+      "schema-revision": 106,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -71,7 +71,8 @@
                     "netapp_password": { "type": "str", "required": true },
                     "netapp_vfiler": { "type": "str", "required": true },
                     "netapp_transport_type": { "type": "str", "required": true },
-                    "netapp_volume_list": { "type": "str", "required": true }
+                    "netapp_volume_list": { "type": "str", "required": true },
+                    "max_over_subscription_ratio": { "type": "int", "required": true }
                 }
                 },
                 "emc": {
@@ -207,7 +208,8 @@
                       "netapp_password": { "type": "str", "required": true },
                       "netapp_vfiler": { "type": "str", "required": true },
                       "netapp_transport_type": { "type": "str", "required": true },
-                      "netapp_volume_list": { "type": "str", "required": true }
+                      "netapp_volume_list": { "type": "str", "required": true },
+                      "max_over_subscription_ratio": { "type": "int", "required": true }
                     }
                   },
                   "emc": {

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -56,6 +56,7 @@
               = integer_field %w(volumes {{@index}} netapp netapp_server_port)
               = string_field %w(volumes {{@index}} netapp netapp_login)
               = password_field %w(volumes {{@index}} netapp netapp_password)
+              = integer_field %w(volumes {{@index}} netapp max_over_subscription_ratio)
 
               %div{ :id => "netapp_7mode_container_{{@index}}" }
                 = string_field %w(volumes {{@index}} netapp netapp_vfiler)

--- a/crowbar_framework/config/locales/cinder/en.yml
+++ b/crowbar_framework/config/locales/cinder/en.yml
@@ -105,6 +105,7 @@ en:
               netapp_password: 'Password for accessing NetApp'
               netapp_server_hostname: 'Server host name'
               netapp_server_port: 'Server port'
+              max_over_subscription_ratio: 'Maximum Oversubscription Ratio'
               netapp_transport_type: 'Transport Type'
               netapp_volume_list: 'Restrict provisioning on iSCSI to these volumes (netapp_volume_list)'
               netapp_vfiler: 'The vFiler unit name for provisioning OpenStack volumes (netapp_vfiler)'


### PR DESCRIPTION
Enable users to specify the max_over_subscription_ratio when using
netapp driver. If other drivers needed this configuration value they
would add max_over_subscription_ratio to their configuration and the
template will render the value to the configuration file. So if for a
specific volume

    volume[volume['backend_driver']]['max_over_subscription_ratio']

exists, then it's value will be included.

Please note that an integer is used for this number whereas OpenStack
will interpret this as a float.