### PR TITLE
rabbitmq: Fix ordering of ssl setup

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -34,6 +34,17 @@ end
 
 include_recipe "rabbitmq::default"
 
+if ha_enabled
+  log "HA support for rabbitmq is enabled"
+  include_recipe "rabbitmq::ha"
+  # All the rabbitmqctl commands are local, and can only be run if rabbitmq is
+  # local
+  service_name = "rabbitmq"
+  only_if_command = "crm resource show #{service_name} | grep -q \" #{node.hostname} *$\""
+else
+  log "HA support for rabbitmq is disabled"
+end
+
 if node[:rabbitmq][:ssl][:enabled]
   ssl_setup "setting up ssl for rabbitmq" do
     generate_certs node[:rabbitmq][:ssl][:generate_certs]
@@ -44,17 +55,6 @@ if node[:rabbitmq][:ssl][:enabled]
     cert_required node[:rabbitmq][:ssl][:cert_required]
     ca_certs node[:rabbitmq][:ssl][:ca_certs]
   end
-end
-
-if ha_enabled
-  log "HA support for rabbitmq is enabled"
-  include_recipe "rabbitmq::ha"
-  # All the rabbitmqctl commands are local, and can only be run if rabbitmq is
-  # local
-  service_name = "rabbitmq"
-  only_if_command = "crm resource show #{service_name} | grep -q \" #{node.hostname} *$\""
-else
-  log "HA support for rabbitmq is disabled"
 end
 
 # remove guest user


### PR DESCRIPTION
The ha recipe of the rabbitmq cookbook forcibly changes the IDs of the
rabbitmq user and group after rabbitmq is installed. If we try to change
group ownership of a file after rabbitmq is installed but before the
rabbitmq group's gid is changed, the file will be left with just an
apparently-random gid as its group. This was happening to the rabbitmq
crowbar-generated private SSL key, which caused rabbitmq to be unable to
read its own key.  Subsequently, the memcached package was installed
which scooped up the gid and the SSL key then became apparently owned by
the memcached group.

This patch simply delays generation of the SSL key pair until after the
ha recipe has been able to muck with the rabbitmq user and group.