### PR TITLE
horizon: fix KIBANA_HOST setting

### DIFF
--- a/chef/cookbooks/horizon/templates/default/_80_monasca_ui_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/_80_monasca_ui_settings.py.erb
@@ -60,7 +60,7 @@ DASHBOARDS = getattr(settings, 'GRAFANA_LINKS', GRAFANA_LINKS)
 #]
 
 ENABLE_KIBANA_BUTTON = getattr(settings, 'ENABLE_KIBANA_BUTTON', <%= @kibana_enabled ? "True" : "False" %>)
-KIBANA_HOST = getattr(settings, 'KIBANA_HOST', '<%= @kibana_host %>')
+KIBANA_HOST = getattr(settings, 'KIBANA_HOST', 'http://<%= @kibana_host %>:5601/')
 
 OPENSTACK_SSL_NO_VERIFY = getattr(settings, 'OPENSTACK_SSL_NO_VERIFY', False)
 OPENSTACK_SSL_CACERT = getattr(settings, 'OPENSTACK_SSL_CACERT', None)


### PR DESCRIPTION
The monasca plugin expects a URL in this field so we need to prefix
the IP address we are currently putting in there with an 'http://'.

See also: https://gitlab.com/monasca-installer/ansible-monasca-ui/blob/master/templates/local_settings.py.j2#L55 - the monasca-installer puts a URL in there as well.