### PR TITLE
keystone: Allow updating the admin pass after barclamp deployment

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -514,6 +514,36 @@ register_auth_hash = { user: node[:keystone][:admin][:username],
                        password: node[:keystone][:admin][:password],
                        tenant: node[:keystone][:admin][:tenant] }
 
+updated_password = node[:keystone][:admin][:updated_password]
+
+unless updated_password.empty? ||
+    updated_password.nil? ||
+    updated_password == node[:keystone][:admin][:password]
+
+  if !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)
+    keystone_register "update admin password" do
+      protocol node[:keystone][:api][:protocol]
+      insecure keystone_insecure
+      host my_admin_host
+      port node[:keystone][:api][:admin_port]
+      auth register_auth_hash
+      user_name node[:keystone][:admin][:username]
+      user_password updated_password
+      tenant_name node[:keystone][:admin][:tenant]
+      action :nothing
+    end.run_action(:add_user)
+  end
+
+  ruby_block "update admin password on node attributes" do
+    block do
+      node.set[:keystone][:admin][:password] = updated_password
+      node.save
+      register_auth_hash[:password] = updated_password
+    end
+    action :nothing
+  end.run_action(:create)
+end
+
 # Silly wake-up call - this is a hack; we use retries because the server was
 # just (re)started, and might not answer on the first try
 keystone_register "wakeup keystone" do

--- a/chef/data_bags/crowbar/migrate/keystone/110_add_updated_password.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/110_add_updated_password.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["admin"]["updated_password"] = ta["admin"]["updated_password"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["admin"].delete("updated_password")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -38,7 +38,8 @@
       "admin": {
         "tenant": "admin",
         "username": "admin",
-        "password": "crowbar"
+        "password": "crowbar",
+        "updated_password": ""
       },
       "service": {
         "tenant": "service",
@@ -179,7 +180,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 109,
+      "schema-revision": 110,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -43,7 +43,8 @@
                     "admin": { "type": "map", "required": true, "mapping": {
                       "tenant": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required" : true },
-                      "password": { "type" : "str", "required" : true }
+                      "password": { "type" : "str", "required" : true },
+                      "updated_password": { "type" : "str", "required" : false }
                     }},
                     "service": { "type": "map", "required": true, "mapping": {
                       "tenant": { "type" : "str", "required" : true },

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -131,5 +131,25 @@ class KeystoneService < PacemakerServiceObject
 
     @logger.debug("Keystone apply_role_pre_chef_call: leaving")
   end
+
+  def update_proposal_status(inst, status, message, bc = @bc_name)
+    @logger.debug("update_proposal_status: enter #{inst} #{bc} #{status} #{message}")
+
+    prop = Proposal.where(barclamp: bc, name: inst).first
+    unless prop.nil?
+      prop["deployment"][bc]["crowbar-status"] = status
+      prop["deployment"][bc]["crowbar-failed"] = message
+      # save the updated_password into the password field to update the raw_view
+      if status == "success" && !prop["attributes"][bc]["admin"]["updated_password"].blank?
+        prop["attributes"][bc]["admin"]["password"] = prop["attributes"][bc]["admin"]["updated_password"]
+      end
+      res = prop.save
+    else
+      res = true
+    end
+
+    @logger.debug("update_proposal_status: exit #{inst} #{bc} #{status} #{message}")
+    res
+  end
 end
 

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -14,7 +14,12 @@
 
       = string_field %w(default tenant)
       = string_field %w(admin username)
-      = password_field %w(admin password)
+      - if @proposal.active?
+        = password_field %w(admin updated_password)
+        .alert.alert-info
+          = t('.admin.updated_password_hint')
+      - else
+        = password_field %w(admin password)
 
       = boolean_field %w(default create_user),
         "data-showit" => "true",

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -32,6 +32,8 @@ en:
         admin:
           username: 'Administrator Username'
           password: 'Administrator Password'
+          updated_password: 'Update Administrator Password'
+          updated_password_hint: 'Changing the admin password directly in OpenStack its not supported. You can change the admin password directly using this field.'
         ssl_header: 'SSL Support'
         api:
           protocol: 'Protocol'


### PR DESCRIPTION
Before this, we could not update the password of the admin user in keystone
due using the same var for auth and the new password.