### PR TITLE
Call crowbar_pacemaker_sync_mark only when HA is enabled for component

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -11,7 +11,7 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-crowbar_pacemaker_sync_mark "wait-aodh_database"
+crowbar_pacemaker_sync_mark "wait-aodh_database" if ha_enabled
 
 # Create the Aodh Database
 database "create #{node[:aodh][:db][:database]} database" do
@@ -44,7 +44,7 @@ database_user "grant database access for aodh database user" do
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_sync_mark "create-aodh_database"
+crowbar_pacemaker_sync_mark "create-aodh_database" if ha_enabled
 
 directory "/var/cache/aodh" do
   owner node[:aodh][:user]
@@ -167,7 +167,7 @@ template node[:aodh][:config_file] do
   notifies :reload, resources(service: "apache2")
 end
 
-crowbar_pacemaker_sync_mark "wait-aodh_db_sync"
+crowbar_pacemaker_sync_mark "wait-aodh_db_sync" if ha_enabled
 
 execute "aodh-dbsync" do
   command "aodh-dbsync"
@@ -192,7 +192,7 @@ ruby_block "mark node for aodh db_sync" do
   subscribes :create, "execute[aodh-dbsync]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-aodh_db_sync"
+crowbar_pacemaker_sync_mark "create-aodh_db_sync" if ha_enabled
 
 service "aodh-api" do
   service_name node[:aodh][:api][:service_name]

--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -22,6 +22,8 @@ include_recipe "#{@cookbook_name}::common"
 application_path = "/srv/www/barbican-api"
 application_exec_path = "#{application_path}/app.wsgi"
 
+ha_enabled = node[:barbican][:ha][:enabled]
+
 package "openstack-barbican-api"
 
 apache_module "deflate" do
@@ -59,7 +61,7 @@ register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
                        tenant: keystone_settings["admin_tenant"] }
 
-crowbar_pacemaker_sync_mark "wait-barbican_register"
+crowbar_pacemaker_sync_mark "wait-barbican_register" if ha_enabled
 
 keystone_register "barbican api wakeup keystone" do
   protocol keystone_settings["protocol"]
@@ -122,7 +124,7 @@ keystone_register "give barbican user access" do
   action :add_access
 end
 
-crowbar_pacemaker_sync_mark "create-barbican_register"
+crowbar_pacemaker_sync_mark "create-barbican_register" if ha_enabled
 
 if node[:barbican][:ha][:enabled]
   admin_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address

--- a/chef/cookbooks/barbican/recipes/common.rb
+++ b/chef/cookbooks/barbican/recipes/common.rb
@@ -41,7 +41,7 @@ database_connection = "#{db_conn_scheme}://" \
   "@#{db_settings[:address]}" \
   "/#{node[:barbican][:db][:database]}"
 
-crowbar_pacemaker_sync_mark "wait-barbican_database"
+crowbar_pacemaker_sync_mark "wait-barbican_database" if ha_enabled
 
 # Create the Barbican Database
 database "create #{node[:barbican][:db][:database]} database" do
@@ -100,7 +100,7 @@ ruby_block "mark node for barbican db_sync" do
   subscribes :create, "execute[barbican-manage db upgrade]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-barbican_database"
+crowbar_pacemaker_sync_mark "create-barbican_database" if ha_enabled
 
 template node[:barbican][:config_file] do
   source "barbican.conf.erb"

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -66,7 +66,7 @@ else
   include_recipe "#{db_settings[:backend_name]}::client"
   include_recipe "#{db_settings[:backend_name]}::python-client"
 
-  crowbar_pacemaker_sync_mark "wait-ceilometer_database"
+  crowbar_pacemaker_sync_mark "wait-ceilometer_database" if ha_enabled
 
   # Create the Ceilometer Database
   database "create #{node[:ceilometer][:db][:database]} database" do
@@ -99,7 +99,7 @@ else
       only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
-  crowbar_pacemaker_sync_mark "create-ceilometer_database"
+  crowbar_pacemaker_sync_mark "create-ceilometer_database" if ha_enabled
 end
 
 case node[:platform_family]
@@ -137,7 +137,7 @@ my_public_host = CrowbarHelper.get_host_for_public_url(node,
                                                        ceilometer_protocol == "https",
                                                        ha_enabled)
 
-crowbar_pacemaker_sync_mark "wait-ceilometer_db_sync"
+crowbar_pacemaker_sync_mark "wait-ceilometer_db_sync" if ha_enabled
 
 execute "ceilometer-dbsync" do
   command "ceilometer-dbsync"
@@ -162,7 +162,7 @@ ruby_block "mark node for ceilometer db_sync" do
   subscribes :create, "execute[ceilometer-dbsync]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-ceilometer_db_sync"
+crowbar_pacemaker_sync_mark "create-ceilometer_db_sync" if ha_enabled
 
 service "ceilometer-collector" do
   service_name node[:ceilometer][:collector][:service_name]
@@ -238,7 +238,7 @@ else
   log "HA support for ceilometer is disabled"
 end
 
-crowbar_pacemaker_sync_mark "wait-ceilometer_register"
+crowbar_pacemaker_sync_mark "wait-ceilometer_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
@@ -351,6 +351,6 @@ else
   end
 end
 
-crowbar_pacemaker_sync_mark "create-ceilometer_register"
+crowbar_pacemaker_sync_mark "create-ceilometer_register" if ha_enabled
 
 node.save

--- a/chef/cookbooks/cinder/recipes/sql.rb
+++ b/chef/cookbooks/cinder/recipes/sql.rb
@@ -27,7 +27,7 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-crowbar_pacemaker_sync_mark "wait-cinder_database"
+crowbar_pacemaker_sync_mark "wait-cinder_database" if ha_enabled
 
 # Create the Cinder Database
 database "create #{node[:cinder][:db][:database]} database" do
@@ -82,7 +82,7 @@ ruby_block "mark node for cinder db_sync" do
   subscribes :create, "execute[cinder-manage db sync]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-cinder_database"
+crowbar_pacemaker_sync_mark "create-cinder_database" if ha_enabled
 
 # save data so it can be found by search
 node.save

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -46,7 +46,7 @@ if db_settings[:backend_name] == "mysql"
   db_conn_scheme = "mysql+pymysql"
 end
 
-crowbar_pacemaker_sync_mark "wait-ec2_api_database"
+crowbar_pacemaker_sync_mark "wait-ec2_api_database" if ha_enabled
 
 database_connection = "#{db_conn_scheme}://" \
   "#{node[:nova]["ec2-api"][:db][:user]}" \
@@ -86,7 +86,7 @@ database_user "grant database access for #{@cookbook_name} database user" do
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_sync_mark "create-ec2_api_database"
+crowbar_pacemaker_sync_mark "create-ec2_api_database" if ha_enabled
 
 rabbit_settings = fetch_rabbitmq_settings "nova"
 keystone_settings = KeystoneHelper.keystone_settings(node, "nova")
@@ -98,7 +98,7 @@ register_auth_hash = { user: keystone_settings["admin_user"],
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(node, ssl_enabled, ha_enabled)
 
-crowbar_pacemaker_sync_mark "wait-ec2_api_register"
+crowbar_pacemaker_sync_mark "wait-ec2_api_register" if ha_enabled
 
 keystone_register "register ec2 user" do
   protocol keystone_settings["protocol"]
@@ -178,7 +178,7 @@ keystone_register "register ec2-metadata endpoint" do
   action :add_endpoint_template
 end
 
-crowbar_pacemaker_sync_mark "create-ec2_api_register"
+crowbar_pacemaker_sync_mark "create-ec2_api_register" if ha_enabled
 
 # ec2-api ssl
 if node[:nova]["ec2-api"][:ssl][:enabled]

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -112,7 +112,7 @@ end
 api_port = node["glance"]["api"]["bind_port"]
 glance_protocol = node[:glance][:api][:protocol]
 
-crowbar_pacemaker_sync_mark "wait-glance_register_service"
+crowbar_pacemaker_sync_mark "wait-glance_register_service" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
@@ -146,6 +146,6 @@ keystone_register "register glance endpoint" do
   action :add_endpoint_template
 end
 
-crowbar_pacemaker_sync_mark "create-glance_register_service"
+crowbar_pacemaker_sync_mark "create-glance_register_service" if ha_enabled
 
 glance_service "api"

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -29,7 +29,7 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-crowbar_pacemaker_sync_mark "wait-glance_database"
+crowbar_pacemaker_sync_mark "wait-glance_database" if ha_enabled
 
 # Create the Glance Database
 database "create #{node[:glance][:db][:database]} database" do
@@ -62,7 +62,7 @@ database_user "grant database access for glance database user" do
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_sync_mark "create-glance_database"
+crowbar_pacemaker_sync_mark "create-glance_database" if ha_enabled
 
 node.set[:glance][:sql_connection] = "#{db_settings[:url_scheme]}://#{node[:glance][:db][:user]}:#{node[:glance][:db][:password]}@#{db_settings[:address]}/#{node[:glance][:db][:database]}"
 
@@ -72,7 +72,7 @@ node.save
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-crowbar_pacemaker_sync_mark "wait-glance_register_user"
+crowbar_pacemaker_sync_mark "wait-glance_register_user" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
@@ -111,6 +111,6 @@ keystone_register "give glance user access" do
   action :add_access
 end
 
-crowbar_pacemaker_sync_mark "create-glance_register_user"
+crowbar_pacemaker_sync_mark "create-glance_register_user" if ha_enabled
 
 include_recipe "glance::ceph"

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -33,7 +33,9 @@ template node[:glance][:registry][:config_file] do
   )
 end
 
-crowbar_pacemaker_sync_mark "wait-glance_db_sync"
+ha_enabled = node[:glance][:ha][:enabled]
+
+crowbar_pacemaker_sync_mark "wait-glance_db_sync" if ha_enabled
 
 execute "glance-manage db sync" do
   user node[:glance][:user]
@@ -58,6 +60,6 @@ ruby_block "mark node for glance db_sync" do
   subscribes :create, "execute[glance-manage db sync]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-glance_db_sync"
+crowbar_pacemaker_sync_mark "create-glance_db_sync" if ha_enabled
 
 glance_service "registry"

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -251,7 +251,7 @@ when "postgresql"
     django_db_backend = "'django.db.backends.postgresql_psycopg2'"
 end
 
-crowbar_pacemaker_sync_mark "wait-horizon_database"
+crowbar_pacemaker_sync_mark "wait-horizon_database" if ha_enabled
 
 # Create the Dashboard Database
 database "create #{node[:horizon][:db][:database]} database" do
@@ -285,7 +285,7 @@ database_user "grant database access for dashboard database user" do
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-crowbar_pacemaker_sync_mark "create-horizon_database"
+crowbar_pacemaker_sync_mark "create-horizon_database" if ha_enabled
 
 db_settings = {
   "ENGINE" => django_db_backend,
@@ -390,7 +390,7 @@ when "rhel"
   package "python-memcached"
 end
 
-crowbar_pacemaker_sync_mark "wait-horizon_config"
+crowbar_pacemaker_sync_mark "wait-horizon_config" if ha_enabled
 
 local_settings = "#{dashboard_path}/openstack_dashboard/local/" \
                  "local_settings.d/_100_local_settings.py"
@@ -464,7 +464,7 @@ template local_settings do
   action :create
 end
 
-crowbar_pacemaker_sync_mark "create-horizon_config"
+crowbar_pacemaker_sync_mark "create-horizon_config" if ha_enabled
 
 if ha_enabled
   log "HA support for horizon is enabled"

--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -29,7 +29,7 @@ my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(
   node, node[:magnum][:api][:protocol] == "https", ha_enabled)
 
-crowbar_pacemaker_sync_mark "wait-magnum_register"
+crowbar_pacemaker_sync_mark "wait-magnum_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
@@ -97,7 +97,7 @@ keystone_register "register magnum endpoint" do
   action :add_endpoint_template
 end
 
-crowbar_pacemaker_sync_mark "create-magnum_register"
+crowbar_pacemaker_sync_mark "create-magnum_register" if ha_enabled
 
 magnum_service "api" do
   use_pacemaker_provider ha_enabled

--- a/chef/cookbooks/magnum/recipes/setup.rb
+++ b/chef/cookbooks/magnum/recipes/setup.rb
@@ -37,7 +37,9 @@ openstack_command << " --os-password #{keystone_settings["admin_password"]}"
 openstack_command << " --os-tenant-name #{keystone_settings["admin_tenant"]}"
 openstack_command << " --os-auth-url #{auth_url} #{insecure}"
 
-crowbar_pacemaker_sync_mark "wait-magnum_setup_domain"
+ha_enabled = node[:magnum][:ha][:enabled]
+
+crowbar_pacemaker_sync_mark "wait-magnum_setup_domain" if ha_enabled
 
 create_magnum_domain = "#{openstack_command} domain create -f value -c id"
 create_magnum_domain << " --description 'Owns users and projects created by magnum'"
@@ -74,4 +76,4 @@ unless node["magnum"]["trustee"]["domain_id"] && node["magnum"]["trustee"]["doma
   end
 end
 
-crowbar_pacemaker_sync_mark "create-magnum_setup_domain"
+crowbar_pacemaker_sync_mark "create-magnum_setup_domain" if ha_enabled

--- a/chef/cookbooks/magnum/recipes/sql.rb
+++ b/chef/cookbooks/magnum/recipes/sql.rb
@@ -24,7 +24,7 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-crowbar_pacemaker_sync_mark "wait-magnum_database"
+crowbar_pacemaker_sync_mark "wait-magnum_database" if ha_enabled
 
 is_cluster_founder = CrowbarPacemakerHelper.is_cluster_founder?(node)
 # Create the Magnum Database
@@ -83,4 +83,4 @@ ruby_block "mark node for magnum db_sync" do
   subscribes :create, "execute[magnum-manage db sync]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-magnum_database"
+crowbar_pacemaker_sync_mark "create-magnum_database" if ha_enabled

--- a/chef/cookbooks/manila/recipes/sql.rb
+++ b/chef/cookbooks/manila/recipes/sql.rb
@@ -7,7 +7,7 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-crowbar_pacemaker_sync_mark "wait-manila_database"
+crowbar_pacemaker_sync_mark "wait-manila_database" if ha_enabled
 
 # Create the Manila Database
 database "create #{node[:manila][:db][:database]} database" do
@@ -62,4 +62,4 @@ ruby_block "mark node for manila db_sync" do
   subscribes :create, "execute[manila-manage db sync]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-manila_database"
+crowbar_pacemaker_sync_mark "create-manila_database" if ha_enabled

--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -23,7 +23,7 @@ neutron_protocol = node["neutron"]["api"]["protocol"]
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-crowbar_pacemaker_sync_mark "wait-neutron_register"
+crowbar_pacemaker_sync_mark "wait-neutron_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
@@ -90,4 +90,4 @@ keystone_register "register neutron endpoint" do
   action :add_endpoint_template
 end
 
-crowbar_pacemaker_sync_mark "create-neutron_register"
+crowbar_pacemaker_sync_mark "create-neutron_register" if ha_enabled

--- a/chef/cookbooks/neutron/recipes/database.rb
+++ b/chef/cookbooks/neutron/recipes/database.rb
@@ -26,7 +26,7 @@ props = [{"db_name" => node[:neutron][:db][:database],
           "db_conn_name" => "sql_connection"  }
         ]
 
-crowbar_pacemaker_sync_mark "wait-neutron_database"
+crowbar_pacemaker_sync_mark "wait-neutron_database" if ha_enabled
 
 # Create the Neutron Databases
 props.each do |prop|
@@ -72,6 +72,6 @@ props.each do |prop|
   end
 end
 
-crowbar_pacemaker_sync_mark "create-neutron_database"
+crowbar_pacemaker_sync_mark "create-neutron_database" if ha_enabled
 
 node.save

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -243,6 +243,7 @@ crowbar_pacemaker_sync_mark "wait sync mark for neutron db sync" do
   mark "neutron_db_sync"
   action :wait
   timeout 120
+  only_if { ha_enabled }
 end
 
 execute "neutron-db-manage migrate" do
@@ -369,7 +370,7 @@ if node[:neutron][:networking_plugin] == "ml2"
   end
 end
 
-crowbar_pacemaker_sync_mark "create-neutron_db_sync"
+crowbar_pacemaker_sync_mark "create-neutron_db_sync" if ha_enabled
 
 service node[:neutron][:platform][:service_name] do
   supports status: true, restart: true

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -32,7 +32,7 @@ api_port = node[:nova][:ports][:api]
 
 api_protocol = node[:nova][:ssl][:enabled] ? "https" : "http"
 
-crowbar_pacemaker_sync_mark "wait-nova_register"
+crowbar_pacemaker_sync_mark "wait-nova_register" if api_ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
@@ -131,4 +131,4 @@ keystone_register "register nova_legacy endpoint" do
   action :add_endpoint_template
 end
 
-crowbar_pacemaker_sync_mark "create-nova_register"
+crowbar_pacemaker_sync_mark "create-nova_register" if api_ha_enabled

--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -28,6 +28,7 @@ db_settings = fetch_database_settings
 crowbar_pacemaker_sync_mark "wait-nova_database" do
   # the db sync is very slow for nova
   timeout 120
+  only_if { ha_enabled }
 end
 
 [node[:nova][:db], node[:nova][:api_db]].each do |d|
@@ -152,7 +153,7 @@ ruby_block "mark node for nova api_db_sync" do
   subscribes :create, "execute[nova-manage api_db sync]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-nova_database"
+crowbar_pacemaker_sync_mark "create-nova_database" if ha_enabled
 
 # save data so it can be found by search
 node.save

--- a/chef/cookbooks/sahara/recipes/api.rb
+++ b/chef/cookbooks/sahara/recipes/api.rb
@@ -32,7 +32,7 @@ register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
                        tenant: keystone_settings["admin_tenant"] }
 
-crowbar_pacemaker_sync_mark "wait-sahara_register"
+crowbar_pacemaker_sync_mark "wait-sahara_register" if ha_enabled
 
 keystone_register "sahara api wakeup keystone" do
   protocol keystone_settings["protocol"]
@@ -93,6 +93,6 @@ keystone_register "register sahara endpoint" do
   action :add_endpoint_template
 end
 
-crowbar_pacemaker_sync_mark "create-sahara_register"
+crowbar_pacemaker_sync_mark "create-sahara_register" if ha_enabled
 
 sahara_service "api"

--- a/chef/cookbooks/sahara/recipes/sql.rb
+++ b/chef/cookbooks/sahara/recipes/sql.rb
@@ -23,7 +23,7 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-crowbar_pacemaker_sync_mark "wait-sahara_database"
+crowbar_pacemaker_sync_mark "wait-sahara_database" if ha_enabled
 
 # Create the sahara Database
 database "create #{node[:sahara][:db][:database]} database" do
@@ -80,4 +80,4 @@ ruby_block "mark node for sahara db_sync" do
   subscribes :create, "execute[sahara-manage db sync]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-sahara_database"
+crowbar_pacemaker_sync_mark "create-sahara_database" if ha_enabled

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -161,7 +161,7 @@ case proxy_config[:auth_method]
      proxy_config[:reseller_prefix] = node[:swift][:reseller_prefix]
      proxy_config[:keystone_delay_auth_decision] = node["swift"]["keystone_delay_auth_decision"]
 
-     crowbar_pacemaker_sync_mark "wait-swift_register"
+     crowbar_pacemaker_sync_mark "wait-swift_register" if ha_enabled
 
      register_auth_hash = { user: keystone_settings["admin_user"],
                             password: keystone_settings["admin_password"],
@@ -245,7 +245,7 @@ case proxy_config[:auth_method]
         action :add_endpoint_template
      end
 
-     crowbar_pacemaker_sync_mark "create-swift_register"
+     crowbar_pacemaker_sync_mark "create-swift_register" if ha_enabled
 
    when "tempauth"
      ## uses defaults...

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -61,7 +61,7 @@ object_store_url, object_store_insecure =
   TroveHelper.get_objectstore_details swift_proxies, ceph_radosgws
 
 
-crowbar_pacemaker_sync_mark "wait-trove_register"
+crowbar_pacemaker_sync_mark "wait-trove_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
@@ -131,7 +131,7 @@ keystone_register "register trove endpoint" do
   action :add_endpoint_template
 end
 
-crowbar_pacemaker_sync_mark "create-trove_register"
+crowbar_pacemaker_sync_mark "create-trove_register" if ha_enabled
 
 
 template node[:trove][:api][:config_file] do


### PR DESCRIPTION
CrowbarPacemakerSynchronization (that implements crowbar_pacemaker_sync_mark)
has a generic check for node being part of a cluster.
However, if a node is part of a cluster, but certain component is not
deployed as Higly Available, sync marks should not be used at all.

It's possible that such setup is not supported, however failing with missing sync mark is probably not the right way of pointing that out.