### PR TITLE
horizon: stop deleting grafana.conf

### DIFF
--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -33,11 +33,6 @@ package "grafana-apache" do
   notifies :reload, resources(service: "apache2")
 end
 
-file "/etc/apache2/vhost.d/grafana.conf" do
-  action :delete
-  notifies :reload, resources(service: "apache2")
-end
-
 template "/srv/www/grafana/config.js" do
   source "grafana-config.js"
   variables(


### PR DESCRIPTION
This file should not be installed by the package, as we don't want
package installation to activate new services. so the attempt
at deleting it is obsolete and this needs to be fixed in packaging
instead.