### PR TITLE
monasca: Rename metric-agent to agent

### DIFF
--- a/chef/cookbooks/monasca/attributes/default.rb
+++ b/chef/cookbooks/monasca/attributes/default.rb
@@ -26,12 +26,12 @@ default[:monasca][:api][:bind_port] = 8070
 
 default[:monasca][:log_api][:bind_port] = 5607
 
-# metric-agent default service settings
-default[:monasca][:metric_agent]["user"] = "monasca-agent"
-default[:monasca][:metric_agent][:group] = "monasca"
-default[:monasca][:metric_agent][:debug] = false
-default[:monasca][:metric_agent]["log_dir"] = "/var/log/monasca-metric-agent"
-default[:monasca][:metric_agent]["agent_service_name"] = "openstack-monasca-metric-agent"
+# agent default service settings
+default[:monasca][:agent]["user"] = "monasca-agent"
+default[:monasca][:agent][:group] = "monasca"
+default[:monasca][:agent][:debug] = false
+default[:monasca][:agent]["log_dir"] = "/var/log/monasca-agent"
+default[:monasca][:agent]["agent_service_name"] = "openstack-monasca-agent"
 
 # log-agent default service settings
 default[:monasca][:log_agent][:service_name] = "openstack-monasca-log-agent"

--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -16,7 +16,7 @@
 
 package "openstack-monasca-agent"
 
-agent_settings = node[:monasca][:metric_agent]
+agent_settings = node[:monasca][:agent]
 agent_keystone = agent_settings[:keystone]
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
@@ -55,7 +55,7 @@ execute "monasca-setup detect services" do
   action :nothing
 end
 
-service "monasca-metric-agent" do
+service "monasca-agent" do
   service_name agent_settings[:service_name]
   supports status: true, restart: true, start: true, stop: true
   action [:enable, :start]

--- a/chef/cookbooks/monasca/recipes/role_monasca_agent.rb
+++ b/chef/cookbooks/monasca/recipes/role_monasca_agent.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-if CrowbarRoleRecipe.node_state_valid_for_role?(node, "monasca", "monasca-metric-agent")
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "monasca", "monasca-agent")
   include_recipe "#{@cookbook_name}::common"
-  include_recipe "#{@cookbook_name}::metric_agent"
+  include_recipe "#{@cookbook_name}::agent"
 end

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -125,7 +125,7 @@ end
 
 agents_settings = []
 
-agents_settings.push(node[:monasca][:metric_agent][:keystone])
+agents_settings.push(node[:monasca][:agent][:keystone])
 la_keystone = node[:monasca][:log_agent][:keystone]
 agents_settings.push(la_keystone)
 

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -3,7 +3,7 @@
   "description": "Logging and Monitoring Service for OpenStack",
   "attributes": {
     "monasca" : {
-      "metric_agent" : {
+      "agent" : {
         "password": "",
         "user_domain_id": "",
         "user_domain_name": "",
@@ -24,7 +24,7 @@
         "plugin_collect_time_warn": 6,
         "log_level": "INFO",
         "keystone": {
-          "service_user": "monasca-metrics-agent",
+          "service_user": "monasca-agent",
           "service_password": "",
           "service_tenant": "monasca",
           "service_role": "monasca-agent"
@@ -88,20 +88,20 @@
       "schema-revision": 100,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
-        "monasca-metric-agent": [ "readying", "ready", "applying" ],
+        "monasca-agent": [ "readying", "ready", "applying" ],
         "monasca-master": [ "readying", "ready", "applying" ],
         "monasca-log-agent": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
         [ "monasca-server" ],
-        [ "monasca-metric-agent" ],
+        [ "monasca-agent" ],
         [ "monasca-master" ],
         [ "monasca-log-agent" ]
       ],
       "element_run_list_order": {
         "monasca-server": 110,
-        "monasca-metric-agent": 120,
+        "monasca-agent": 120,
         "monasca-master": 115,
         "monasca-log-agent": 120
       },

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -12,7 +12,7 @@
           "required": true,
           "type": "map",
           "mapping": {
-            "metric_agent": {
+            "agent": {
               "required": true,
               "type": "map",
               "mapping": {

--- a/chef/roles/monasca-agent.rb
+++ b/chef/roles/monasca-agent.rb
@@ -1,0 +1,5 @@
+name "monasca-agent"
+description "Monasca Agent Role"
+run_list("recipe[monasca::role_monasca_agent]")
+default_attributes
+override_attributes

--- a/chef/roles/monasca-metric-agent.rb
+++ b/chef/roles/monasca-metric-agent.rb
@@ -1,5 +1,0 @@
-name "monasca-metric-agent"
-description "Monasca Metric Agent Role"
-run_list("recipe[monasca::role_monasca_metric_agent]")
-default_attributes
-override_attributes

--- a/crowbar_framework/app/helpers/barclamp/monasca_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/monasca_helper.rb
@@ -16,7 +16,7 @@
 
 module Barclamp
   module MonascaHelper
-    def metric_agent_log_levels(selected)
+    def agent_log_levels(selected)
       options_for_select(
         [
           ["ERROR", "ERROR"],

--- a/crowbar_framework/app/models/monasca_service.rb
+++ b/crowbar_framework/app/models/monasca_service.rb
@@ -29,7 +29,7 @@ class MonascaService < PacemakerServiceObject
 
     def role_constraints
       {
-        "monasca-metric-agent" => {
+        "monasca-agent" => {
           "unique" => false,
           "admin" => false,
           "count" => -1,
@@ -94,7 +94,7 @@ class MonascaService < PacemakerServiceObject
 
     monasca_server = select_nodes_for_role(nodes, "monasca-server", "monitoring") || []
     log_agent_nodes = select_nodes_for_role(nodes, "monasca-log-agent", "compute") || []
-    metric_agent_nodes = select_nodes_for_role(nodes, "monasca-metric-agent", "compute") || []
+    agent_nodes = select_nodes_for_role(nodes, "monasca-agent", "compute") || []
 
     master_nodes = nodes.select { |n| n.intended_role == "admin" || n.name.start_with?("crowbar.") }
     master_node = master_nodes.empty? ? nodes.first : master_nodes.first
@@ -102,7 +102,7 @@ class MonascaService < PacemakerServiceObject
     base["deployment"][@bc_name]["elements"] = {
       "monasca-master" => [master_node.name],
       "monasca-server" => monasca_server.empty? ? [] : [monasca_server.first.name],
-      # "monasca-metric-agent" => metric_agent_nodes.map { |x| x.name },
+      # "monasca-agent" => agent_nodes.map { |x| x.name },
       "monasca-log-agent" => log_agent_nodes.map { |x| x.name }
     }
 
@@ -113,7 +113,7 @@ class MonascaService < PacemakerServiceObject
 
     base["attributes"][@bc_name]["service_password"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
-    base["attributes"][@bc_name][:metric_agent][:keystone][:service_password] = random_password
+    base["attributes"][@bc_name][:agent][:keystone][:service_password] = random_password
     base["attributes"][@bc_name][:log_agent][:keystone][:service_password] = random_password
     base["attributes"][@bc_name][:master][:influxdb_mon_api_password] = random_password
     base["attributes"][@bc_name][:master][:influxdb_mon_persister_password] = random_password

--- a/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
@@ -5,19 +5,19 @@
   .panel-body
     %fieldset
       %legend
-        = t(".metric_agent_header")
+        = t(".agent_header")
 
-      = boolean_field %w(metric_agent system_only)
-      = select_field %w(metric_agent log_level), :collection => :metric_agent_log_levels
-      = integer_field %w(metric_agent statsd_port)
-      = integer_field %w(metric_agent check_frequency)
-      = integer_field %w(metric_agent num_collector_threads)
-      = integer_field %w(metric_agent pool_full_max_retries)
-      = integer_field %w(metric_agent plugin_collect_time_warn)
-      = integer_field %w(metric_agent max_buffer_size)
-      = integer_field %w(metric_agent max_measurement_buffer_size)
-      = integer_field %w(metric_agent backlog_send_rate)
-      = integer_field %w(metric_agent amplifier)
+      = boolean_field %w(agent system_only)
+      = select_field %w(agent log_level), :collection => :agent_log_levels
+      = integer_field %w(agent statsd_port)
+      = integer_field %w(agent check_frequency)
+      = integer_field %w(agent num_collector_threads)
+      = integer_field %w(agent pool_full_max_retries)
+      = integer_field %w(agent plugin_collect_time_warn)
+      = integer_field %w(agent max_buffer_size)
+      = integer_field %w(agent max_measurement_buffer_size)
+      = integer_field %w(agent backlog_send_rate)
+      = integer_field %w(agent amplifier)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/monasca/en.yml
+++ b/crowbar_framework/config/locales/monasca/en.yml
@@ -33,8 +33,8 @@ en:
         log_api_header: 'Log API settings'
         log_api:
           log_level: 'Log level'
-        metric_agent_header: 'Metrics Agent Settings'
-        metric_agent:
+        agent_header: 'Agent Settings'
+        agent:
           monasca_url: 'Monasca URL'
           system_only: 'Setting to true will cause Monasca setup to run in `system_only` mode only, configure the base config and system metrics (cpu, disk, load, memory, network)'
           insecure: 'Do you want insecure connection?'


### PR DESCRIPTION
monasca-agent is the upstream project name. It is confusing to have

- monasca-agent
- monasca-log-agent
- monasca-metric-agent

In fact there are only 2 (the 2 first ones).