### PR TITLE
horizon: Fix pkill process search (bsc#1035270)

### DIFF
--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -33,10 +33,9 @@ end
 service "horizon" do
   service_name "apache2"
   if node[:platform_family] == "suse"
-    reload_command "pkill --signal SIGUSR1 -f '(wsgi:horizon)' && sleep 1"
+    reload_command 'sleep 1 && pkill --signal SIGUSR1 -f "^\(wsgi:horizon\)" && sleep 1'
   end
   supports reload: true, restart: true, status: true
-  ignore_failure true
 end
 
 case node[:platform_family]


### PR DESCRIPTION
Without this patch, the horizon service reload produces strange
non-fatal errors in the chef logs:

```
  ERROR: service[horizon] (horizon::server line 33) had an error: Expected process to exit with [0], but received ''
```

This happens because while pkill is smart enough not to include its own
PID in its matching processes, it is not smart enough not to include its
parent process. When chef executes a command, it shells out using 'sh
-c', then because the command includes a '&&' it must fork and exec the
pkill command rather than simply execing, so the command "sh -c pkill
--signal SIGUSR1 '(wsgi:horizon)' && sleep 1" is in the process table
and gets caught by pkill. You can see this in action by comparing these
commands:

```
  $ sh -c "pgrep -alf foobar && true"
  586 sh -c pgrep -alf foobar && true
  $ sh -c "pgrep -alf foobar"
  $
```

The sh -c then terminates because SIGUSR1's default action is "Term".
Chef uses Process.waitpid2 to get the exit code of the command, but
because it was terminated by a signal rather than exiting normally, the
status return value gets populated by the signal code rather than the
exit code (see si_status of the waitpid man page[1]). Chef doesn't
handle this properly and ends up setting the exit code to nil, which is
why it reports '' as the exit code.

We can fix this by narrowing down pkill's matches. pkill accepts regexes
and the wsgi process group is known to come at the beginning of the
process's command string, so we just alter the pkill command to look
only for matches at the beginning of the string, which will exclude
processes matching 'sh -c pgrep ...'.

We also add another sleep to the beginning of the command because on the
first chef run the installation of the horizon vhost, the apache reload,
and the horizon reload happen in quick succession and the wsgi workers
may not have had time to start between apache being refreshed and the
horizon reload happening. This way we can remove the ignore_failure
setting and start treating failures as fatal.

[1] https://linux.die.net/man/2/waitpid