### PR TITLE
monasca: Re-execute installer on variables change

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -19,7 +19,9 @@ monasca_hosts = MonascaHelper.monasca_hosts(monasca_servers)
 raise "no nodes with monasca-server role found" if monasca_hosts.nil? || monasca_hosts.empty?
 
 package "ansible"
-package "monasca-installer"
+package "monasca-installer" do
+  notifies :run, "execute[force running ansible]", :delayed
+end
 
 cookbook_file "/etc/ansible/ansible.cfg" do
   source "ansible.cfg"
@@ -50,87 +52,57 @@ template "/opt/monasca-installer/monasca-hosts" do
   notifies :run, "execute[run ansible]", :delayed
 end
 
-# This file is used to mark that ansible installer run successfully.
-# Without this, it could happen that the installer was not re-tried
-# after a failed run.
-file "/opt/monasca-installer/.installed" do
-  content "monasca installed"
-  owner "root"
-  group "root"
-  mode "0644"
-  notifies :run, "execute[run ansible]", :delayed
-  action :create_if_missing
-end
-
 monasca_node = monasca_servers[0]
 monasca_net_ip = MonascaHelper.get_host_for_monitoring_url(monasca_node)
 pub_net_ip = CrowbarHelper.get_host_for_public_url(monasca_node, false, false)
 
-ansible_vars = {
-  influxdb_mon_api_password: node[:monasca][:master][:influxdb_mon_api_password],
-  influxdb_mon_persister_password: node[:monasca][:master][:influxdb_mon_persister_password],
-  database_notification_password: node[:monasca][:master][:database_notification_password],
-  database_monapi_password: node[:monasca][:master][:database_monapi_password],
-  database_thresh_password: node[:monasca][:master][:database_thresh_password],
-  database_logapi_password: node[:monasca][:master][:database_logapi_password],
-  keystone_monasca_operator_password:
-    node[:monasca][:master][:keystone_monasca_operator_password],
-  keystone_monasca_agent_password: node[:monasca][:master][:keystone_monasca_agent_password],
-  keystone_admin_agent_password: node[:monasca][:master][:keystone_admin_agent_password],
-  keystone_admin_password: keystone_settings["admin_password"],
-  api_region: keystone_settings["endpoint_region"],
-  database_grafana_password: node[:monasca][:master][:database_grafana_password],
+template "/opt/monasca-installer/crowbar_vars.yml" do
+  source "crowbar_vars.yml.erb"
+  owner "root"
+  group "root"
+  mode "0400"
+  variables(
+    master_settings: node[:monasca][:master],
+    keystone_settings: keystone_settings,
+    monasca_net_ip: monasca_net_ip,
+    pub_net_ip: pub_net_ip,
+    api_settings: node[:monasca][:api],
+    log_api_settings: node[:monasca][:log_api]
+  )
+  notifies :run, "execute[force running ansible]", :delayed
+end
 
-  notification_enable_email: node[:monasca][:master][:notification_enable_email],
-  smtp_host: node[:monasca][:master][:smtp_host],
-  smtp_port: node[:monasca][:master][:smtp_port],
-  smtp_user: node[:monasca][:master][:smtp_user],
-  smtp_password: node[:monasca][:master][:smtp_password],
-  smtp_from_address: node[:monasca][:master][:smtp_from_address],
+# This file is used to mark that ansible installer run successfully.
+# Without this, it could happen that the installer was not re-tried
+# after a failed run.
+# It will contain installed versions of crowbar-openstack
+# and monasca-installer. If they change re-execute ansible installer.
+lock_file = "/opt/monasca-installer/.installed"
 
-  keystone_version: keystone_settings["api_version"],
-  keystone_url: keystone_settings["public_auth_url"],
-  keystone_admin_token: keystone_settings["admin_token"],
-  keystone_admin: keystone_settings["admin_user"],
-  keystone_admin_project: keystone_settings["admin_tenant"],
+previous_versions = if Pathname.new(lock_file).file?
+                      File.read(lock_file).gsub(/^$\n/, "")
+                    else
+                      ""
+                    end
 
-  memcached_listen_ip: monasca_net_ip,
-  kafka_host: monasca_net_ip,
-  kibana_host: pub_net_ip,
-  kibana_plugins: {
-    "monasca-kibana-plugin" => {
-      "url" => "file:///usr/share/monasca-kibana-plugin/monasca-kibana-plugin.tar.gz",
-      "configuration" => {
-        "monasca-kibana-plugin.enabled" => true,
-        "monasca-kibana-plugin.auth_uri" => keystone_settings["public_auth_url"],
-        "monasca-kibana-plugin.cookie.isSecure" => false
-      }
-    }
-  },
-  log_api_bind_host: "*",
-  influxdb_bind_address: monasca_net_ip,
-  influxdb_host: monasca_net_ip,
-  monasca_api_bind_host: "*",
-  elasticsearch_host: monasca_net_ip,
-  nimbus_host: monasca_net_ip,
-  zookeeper_hosts: monasca_net_ip,
-  kafka_hosts: "#{monasca_net_ip}:9092",
-  mariadb_bind_address: monasca_net_ip,
-  database_host: monasca_net_ip,
-  monasca_api_url: "http://#{pub_net_ip}:#{node[:monasca][:api][:bind_port]}/v2.0",
-  monasca_log_api_url: "http://#{pub_net_ip}:#{node[:monasca][:log_api][:bind_port]}/v2.0",
-  memcached_nodes: ["#{monasca_net_ip}:11211"],
-  influxdb_url: "http://#{monasca_net_ip}:8086",
-  elasticsearch_nodes: "[#{monasca_net_ip}]",
-  elasticsearch_hosts: monasca_net_ip,
-  monasca_api_log_level: node[:monasca][:api][:log_level],
-  log_api_log_level: node[:monasca][:log_api][:log_level]
-}.to_json
+get_versions = "rpm -qa | grep -e crowbar-openstack -e monasca-installer | sort"
+actual_versions = IO.popen(get_versions, &:read).gsub(/^$\n/, "")
+
+ansible_cmd =
+  "rm -f #{lock_file} " \
+  "&& ansible-playbook " \
+    "-i monasca-hosts -e '@/opt/monasca-installer/crowbar_vars.yml' " \
+    "monasca.yml " \
+  "&& echo '#{actual_versions}' > #{lock_file}"
 
 execute "run ansible" do
-  command "rm -f /opt/monasca-installer/.installed " \
-          "&& ansible-playbook -i monasca-hosts -e '#{ansible_vars}' monasca.yml " \
-          "&& touch /opt/monasca-installer/.installed"
+  command ansible_cmd
+  cwd "/opt/monasca-installer"
+  only_if { actual_versions != previous_versions }
+end
+
+execute "force running ansible" do
+  command ansible_cmd
   cwd "/opt/monasca-installer"
   action :nothing
 end

--- a/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
@@ -1,0 +1,49 @@
+influxdb_mon_api_password: <%= @master_settings['influxdb_mon_api_password'] %>
+influxdb_mon_persister_password: <%= @master_settings['influxdb_mon_persister_password'] %>
+database_notification_password: <%= @master_settings['database_notification_password'] %>
+database_monapi_password: <%= @master_settings['database_monapi_password'] %>
+database_thresh_password: <%= @master_settings['database_thresh_password'] %>
+database_logapi_password: <%= @master_settings['database_logapi_password'] %>
+keystone_monasca_operator_password: <%= @master_settings['keystone_monasca_operator_password'] %>
+keystone_monasca_agent_password: <%= @master_settings['keystone_monasca_agent_password'] %>
+keystone_admin_agent_password: <%= @master_settings['keystone_admin_agent_password'] %>
+keystone_admin_password: <%= @keystone_settings['admin_password'] %>
+api_region: <%= @keystone_settings['endpoint_region'] %>
+database_grafana_password: <%= @master_settings['database_grafana_password'] %>
+
+notification_enable_email: <%= @master_settings['notification_enable_email'] %>
+smtp_host: <%= @master_settings['smtp_host'] %>
+smtp_port: <%= @master_settings['smtp_port'] %>
+smtp_user: <%= @master_settings['smtp_user'] %>
+smtp_password: <%= @master_settings['smtp_password'] %>
+smtp_from_address: <%= @master_settings['smtp_from_address'] %>
+
+memcached_listen_ip: <%= @monasca_net_ip %>
+kafka_host: <%= @monasca_net_ip %>
+kibana_host: <%= @pub_net_ip %>
+kibana_plugins:
+  monasca-kibana-plugin:
+    url: "file:///usr/share/monasca-kibana-plugin/monasca-kibana-plugin.tar.gz"
+    configuration:
+      monasca-kibana-plugin.enabled: true
+      monasca-kibana-plugin.auth_uri: <%= @keystone_settings['public_auth_url'] %>
+      monasca-kibana-plugin.cookie.isSecure: false
+
+log_api_bind_host: "*"
+influxdb_bind_address: <%= @monasca_net_ip %>
+influxdb_host: <%= @monasca_net_ip %>
+monasca_api_bind_host: "*"
+elasticsearch_host: <%= @monasca_net_ip %>
+nimbus_host: <%= @monasca_net_ip %>
+zookeeper_hosts: <%= @monasca_net_ip %>
+kafka_hosts: "<%= @monasca_net_ip %>:9092"
+mariadb_bind_address: <%= @monasca_net_ip %>
+database_host: <%= @monasca_net_ip %>
+monasca_api_url: "http://<%= @pub_net_ip %>:<%= @api_settings['bind_port'] %>/v2.0"
+monasca_log_api_url: "http://<%= @pub_net_ip %>:<%= @log_api_settings['bind_port'] %>/v2.0"
+memcached_nodes: ["<%= @monasca_net_ip %>:11211"]
+influxdb_url: "http://<%= @monasca_net_ip %>:8086"
+elasticsearch_nodes: "[<%= @monasca_net_ip %>]"
+elasticsearch_hosts: <%= @monasca_net_ip %>
+monasca_api_log_level: <%= @api_settings['log_level'] %>
+log_api_log_level: <%= @log_api_settings['log_level'] %>


### PR DESCRIPTION
Save MD5 of variables for Ansible to lock file and compare it on every
Chef run.