### PR TITLE
Make logger parameter optional

### DIFF
--- a/crowbar_framework/app/models/aodh_service.rb
+++ b/crowbar_framework/app/models/aodh_service.rb
@@ -15,7 +15,7 @@
 #
 
 class AodhService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "aodh"
   end

--- a/crowbar_framework/app/models/barbican_service.rb
+++ b/crowbar_framework/app/models/barbican_service.rb
@@ -15,7 +15,7 @@
 #
 
 class BarbicanService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     @bc_name = "barbican"
     @logger = thelogger
   end

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -16,7 +16,7 @@
 #
 
 class CeilometerService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "ceilometer"
   end

--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -16,7 +16,7 @@
 #
 
 class CinderService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "cinder"
   end

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -16,7 +16,7 @@
 #
 
 class DatabaseService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "database"
   end

--- a/crowbar_framework/app/models/glance_service.rb
+++ b/crowbar_framework/app/models/glance_service.rb
@@ -16,7 +16,7 @@
 #
 
 class GlanceService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "glance"
   end

--- a/crowbar_framework/app/models/heat_service.rb
+++ b/crowbar_framework/app/models/heat_service.rb
@@ -16,7 +16,7 @@
 #
 
 class HeatService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "heat"
   end

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -16,7 +16,7 @@
 #
 
 class HorizonService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "horizon"
   end

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -16,7 +16,7 @@
 #
 
 class KeystoneService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "keystone"
   end

--- a/crowbar_framework/app/models/magnum_service.rb
+++ b/crowbar_framework/app/models/magnum_service.rb
@@ -17,7 +17,7 @@
 #
 
 class MagnumService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     @bc_name = "magnum"
     @logger = thelogger
   end

--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -15,7 +15,7 @@
 #
 
 class ManilaService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     @bc_name = "manila"
     @logger = thelogger
   end

--- a/crowbar_framework/app/models/monasca_service.rb
+++ b/crowbar_framework/app/models/monasca_service.rb
@@ -16,7 +16,7 @@
 #
 
 class MonascaService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     @bc_name = "monasca"
     @logger = thelogger
   end

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -18,7 +18,7 @@
 require "ipaddr"
 
 class NeutronService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "neutron"
   end

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -16,7 +16,7 @@
 #
 
 class NovaService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "nova"
   end

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -16,7 +16,7 @@
 #
 
 class RabbitmqService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "rabbitmq"
   end

--- a/crowbar_framework/app/models/sahara_service.rb
+++ b/crowbar_framework/app/models/sahara_service.rb
@@ -14,7 +14,7 @@
 #
 
 class SaharaService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "sahara"
   end

--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -21,7 +21,7 @@ class SwiftService < PacemakerServiceObject
   class ServiceError < StandardError
   end
 
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "swift"
   end

--- a/crowbar_framework/app/models/tempest_service.rb
+++ b/crowbar_framework/app/models/tempest_service.rb
@@ -19,7 +19,7 @@ class TempestService < ServiceObject
   class ServiceError < StandardError
   end
 
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     @bc_name = "tempest"
     @logger = thelogger
   end

--- a/crowbar_framework/app/models/trove_service.rb
+++ b/crowbar_framework/app/models/trove_service.rb
@@ -15,7 +15,7 @@
 #
 
 class TroveService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "trove"
   end


### PR DESCRIPTION
Since the logger parameter became optional for ServiceObjects[1],
deactivating a proposal has been broken, producing a cryptic error in
the UI:

  wrong number of arguments (0 for 1)

This is because deactivating a proposal causes a lookup of proposal
dependencies which are no longer initialized with an argument[2], but
all of the OpenStack barclamps still require this parameter. This patch
makes the OpenStack barclamps compatible with the new interface, though
more work will need to be done to clean up use of the logger parameter.

[1] https://github.com/crowbar/crowbar-core/pull/1025
[2] https://github.com/crowbar/crowbar-core/pull/1025/files#diff-494b2794304fa30be60cafd3d2c7f161