### PR TITLE
Enable Swift support for temporary URLs by default.

### DIFF
--- a/chef/data_bags/crowbar/template-swift.json
+++ b/chef/data_bags/crowbar/template-swift.json
@@ -16,7 +16,7 @@
           "enabled": false
         },
         "tempurl": {
-          "enabled": false
+          "enabled": true
         },
         "formpost": {
           "enabled": false
@@ -105,8 +105,8 @@
       },
       "elements": {},
       "element_order": [
-        [ "swift-storage" ],  
-        [ "swift-ring-compute" ], 
+        [ "swift-storage" ],
+        [ "swift-ring-compute" ],
         [ "swift-storage" ],
         [ "swift-proxy" ],
         [ "swift-dispersion" ]


### PR DESCRIPTION
One example of the use of temporary URLs is the Ironic agent_... driver workflow in which the
agent on the deployed node downloads the image from Glance using a Swift temporary
URL.