### PR TITLE
Ironic agent with swift

### DIFF
--- a/chef/cookbooks/ironic/attributes/default.rb
+++ b/chef/cookbooks/ironic/attributes/default.rb
@@ -73,3 +73,5 @@ default[:ironic][:api][:port] = 6385
 default[:ironic][:config_file] = "/etc/ironic/ironic.conf.d/100-ironic.conf"
 
 default[:ironic][:tftproot] = "/var/lib/ironic/tftpboot"
+
+default[:ironic][:enabled_drivers] = []

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-# TODO: export to attributes
-ironic_drivers = ["pxe_ssh"]
-
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
@@ -55,7 +52,7 @@ node[:ironic][:platform][:packages].each do |p|
   package p
 end
 
-ironic_drivers.each do |d|
+node[:ironic][:enabled_drivers].each do |d|
   driver_dependencies = node[:ironic][:platform][:driver_dependencies][d] || []
   driver_dependencies.each do |p|
     package p
@@ -175,17 +172,46 @@ openstack_command << " --os-auth-url #{auth_url} #{insecure}"
 get_ironic_net_id = "#{openstack_command} network show ironic -f value -c id"
 ironic_net_id = Mixlib::ShellOut.new(get_ironic_net_id).run_command.stdout.chomp
 
+swift = search(:node, "roles:swift-proxy").first || {}
+# configure swift only if some agent_* drivers are enabled
+if swift && node[:ironic][:enabled_drivers].any? { |d| d.start_with?("agent_") }
+  glance_keystone_settings = KeystoneHelper.keystone_settings(glance, "glance")
+
+  swift_command = "swift --os-username #{glance_keystone_settings["service_user"]}"
+  swift_command << " --os-password #{glance_keystone_settings["service_password"]}"
+  swift_command << " --os-tenant-name #{glance_keystone_settings["service_tenant"]}"
+  swift_command << " --os-identity-api-version 3 --os-auth-url #{auth_url}"
+  swift_command << (swift[:swift][:ssl][:insecure] ? " --insecure" : "")
+
+  get_glance_account = "#{swift_command} stat | grep -m1 Account: | awk '{print $2}'"
+  glance_account = Mixlib::ShellOut.new(get_glance_account).run_command.stdout.chomp
+
+  get_tempurl_key = "#{swift_command} stat | grep -m1 'Meta Temp-Url-Key:' | awk '{print $3}'"
+  tempurl_key = Mixlib::ShellOut.new(get_tempurl_key).run_command.stdout.chomp
+
+  # use IP as this will be used by agent which can have no DNS configured
+  swift_address = Barclamp::Inventory.get_network_by_type(swift, "public").address
+
+  swift_settings = { tempurl_key: tempurl_key,
+                     glance_container: glance[:glance][:swift][:store_container],
+                     glance_account: glance_account,
+                     protocol: swift[:swift][:ssl][:enabled] ? "https" : "http",
+                     host: swift_address,
+                     port: swift[:swift][:ports][:proxy] }
+end
+
 template node[:ironic][:config_file] do
   source "ironic.conf.erb"
   owner "root"
   group node[:ironic][:group]
   mode "0640"
   variables(
-    drivers: ironic_drivers,
+    drivers: node[:ironic][:enabled_drivers],
     debug: node[:ironic][:debug],
     rabbit_settings: fetch_rabbitmq_settings,
     keystone_settings: keystone_settings,
     glance_settings: glance_settings,
+    swift_settings: swift_settings,
     neutron_settings: neutron_settings,
     database_connection: db_connection,
     ironic_net_id: ironic_net_id,

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -25,6 +25,12 @@ glance_port=<%= @glance_settings[:port] %>
 glance_protocol=<%= @glance_settings[:protocol] %>
 glance_api_servers=<%= @glance_settings[:protocol] %>://<%= @glance_settings[:host] %>:<%= @glance_settings[:port] %>
 auth_strategy=keystone
+<% if @swift_settings %>
+swift_temp_url_key=<%= @swift_settings[:tempurl_key] %>
+swift_endpoint_url=<%= @swift_settings[:protocol] %>://<%= @swift_settings[:host] %>:<%= @swift_settings[:port] %>
+swift_container=<%= @swift_settings[:glance_container] %>
+swift_account=<%= @swift_settings[:glance_account] %>
+<% end %>
 
 [keystone]
 region_name=<%= @keystone_settings['endpoint_region'] %>

--- a/chef/data_bags/crowbar/migrate/ironic/101_add_enabled_drivers.rb
+++ b/chef/data_bags/crowbar/migrate/ironic/101_add_enabled_drivers.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["enabled_drivers"] = ta["enabled_drivers"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if a["enabled_drivers"]
+    a.delete("enabled_drivers")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ironic.json
+++ b/chef/data_bags/crowbar/template-ironic.json
@@ -13,6 +13,7 @@
       "neutron_instance": "none",
       "service_user": "ironic",
       "service_password": "",
+      "enabled_drivers": [],
       "api": {
         "protocol": "http",
         "port": 6385
@@ -27,7 +28,7 @@
   "deployment": {
     "ironic": {
       "crowbar-revision": 0,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "crowbar-applied": false,
       "element_states": {
         "ironic-server": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-ironic.schema
+++ b/chef/data_bags/crowbar/template-ironic.schema
@@ -22,6 +22,7 @@
             "neutron_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
+            "enabled_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
             "api": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/models/ironic_service.rb
+++ b/crowbar_framework/app/models/ironic_service.rb
@@ -89,6 +89,10 @@ class IronicService < ServiceObject
       validation_error I18n.t("barclamp.#{@bc_name}.validation.ironic_network")
     end
 
+    if proposal["attributes"][@bc_name]["enabled_drivers"].empty?
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.no_drivers")
+    end
+
     # additional soft dependencies for agent_* drivers
     if proposal["attributes"][@bc_name]["enabled_drivers"].any? { |d| d.start_with?("agent_") }
       swift_svc = SwiftService.new @logger

--- a/crowbar_framework/app/models/ironic_service.rb
+++ b/crowbar_framework/app/models/ironic_service.rb
@@ -89,6 +89,25 @@ class IronicService < ServiceObject
       validation_error I18n.t("barclamp.#{@bc_name}.validation.ironic_network")
     end
 
+    # additional soft dependencies for agent_* drivers
+    if proposal["attributes"][@bc_name]["enabled_drivers"].any? { |d| d.start_with?("agent_") }
+      swift_svc = SwiftService.new @logger
+      swift_proposal = Proposal.find_by(barclamp: swift_svc.bc_name, name: "default")
+      if swift_proposal
+        unless swift_proposal["attributes"][swift_svc.bc_name]["middlewares"]["tempurl"]["enabled"]
+          validation_error I18n.t("barclamp.#{@bc_name}.validation.swift_tempurl_enabled")
+        end
+      else
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.swift_proposal")
+      end
+
+      glance_svc = GlanceService.new @logger
+      glance_proposal = Proposal.find_by(barclamp: glance_svc.bc_name, name: "default")
+      unless glance_proposal["attributes"][glance_svc.bc_name]["default_store"] == "swift"
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.glance_swift_default_store")
+      end
+    end
+
     super
   end
 

--- a/crowbar_framework/config/locales/ironic/en.yml
+++ b/crowbar_framework/config/locales/ironic/en.yml
@@ -34,3 +34,4 @@ en:
         swift_proposal: 'To use agent_* drivers, Swift needs to be enabled.'
         swift_tempurl_enabled: 'To use agent_* drivers, Swift TempURL middleware needs to be enabled.'
         glance_swift_default_store: 'To use agent_* drivers, Glance needs to have Swift set as Default Storage Store.'
+        no_drivers: 'No drivers enabled. Select at least one driver.'

--- a/crowbar_framework/config/locales/ironic/en.yml
+++ b/crowbar_framework/config/locales/ironic/en.yml
@@ -31,3 +31,6 @@ en:
         ssl_header: 'SSL Support'
       validation:
         ironic_network: 'Ironic network is not configured.'
+        swift_proposal: 'To use agent_* drivers, Swift needs to be enabled.'
+        swift_tempurl_enabled: 'To use agent_* drivers, Swift TempURL middleware needs to be enabled.'
+        glance_swift_default_store: 'To use agent_* drivers, Glance needs to have Swift set as Default Storage Store.'


### PR DESCRIPTION
Ironic agent_* drivers require proper Swift configuration for downloading
images. Additional validations were added to Ironic barclamp to make sure
all requirements are in place when using agent_* drivers.

Ironic uses TempURL feature of Swift for providing images to deployment
agent. Random TempURL key is set for glance user if it was not defined
before.

Ironic barclamp was modified to expose enabled_drivers as an attribute.