### PR TITLE
cinder: Provide NFS mount options to cinder volume shares (bsc#1036369)

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -212,8 +212,17 @@ node[:cinder][:volumes].each_with_index do |volume, volid|
     end
 
   when volume[:backend_driver] == "nfs"
+    shares_content = volume[:nfs][:nfs_shares]
+    nfs_opts = volume[:nfs][:nfs_mount_options].strip
+    unless nfs_opts.empty?
+      # Add global NFS options to each mount
+      shares_content = shares_content.split("\n").collect do |l|
+        opt = l.index(" -o ").nil? ? "-o" : ""
+        l + " #{opt} #{nfs_opts}"
+      end.join("\n")
+    end
     file "/etc/cinder/nfs_shares-#{backend_id}" do
-      content volume[:nfs][:nfs_shares]
+      content shares_content
       owner "root"
       group node[:cinder][:group]
       mode "0640"

--- a/crowbar_framework/config/locales/cinder/en.yml
+++ b/crowbar_framework/config/locales/cinder/en.yml
@@ -53,14 +53,14 @@ en:
           netapp_parameters: 'NetApp Parameters'
           netapp_volume_driver: 'NetApp'
           netapp:
-            nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path optional-nfs-mount-options'
+            nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path -o optional-nfs-mount-options'
             vfiler_hint: 'Only Use this option when utilizing the MultiStore feature on the NetApp storage with iSCSI'
             vserver_hint: 'If using the NFS storage protocol, this parameter is mandatory for storage service catalog support'
             volume_list_hint: 'Optional comma separated list of NetApp controller volume names'
           nfs_parameters: 'NFS Parameters'
           nfs_volume_driver: 'NFS'
           nfs:
-            nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path optional-nfs-mount-options'
+            nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path -o optional-nfs-mount-options'
           raw_parameters: 'Raw Devices Parameters'
           raw_volume_driver: 'Raw Devices'
           rbd_parameters: 'RADOS Parameters'


### PR DESCRIPTION
Cinder uses specific mount options only when they are explicitely specified in nfs_shares_config file.

Alternative PR: https://github.com/crowbar/crowbar-openstack/pull/972