### PR TITLE
monasca: fix Kibana dashboard

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -96,6 +96,16 @@ ansible_vars = {
   memcached_listen_ip: monasca_net_ip,
   kafka_host: monasca_net_ip,
   kibana_host: pub_net_ip,
+  kibana_plugins: {
+    "monasca-kibana-plugin" => {
+      "url" => "file:///usr/share/monasca-kibana-plugin/monasca-kibana-plugin.tar.gz",
+      "configuration" => {
+        "monasca-kibana-plugin.enabled" => true,
+        "monasca-kibana-plugin.auth_uri" => keystone_settings["public_auth_url"],
+        "monasca-kibana-plugin.cookie.isSecure" => false
+      }
+    }
+  },
   log_api_bind_host: "*",
   influxdb_bind_address: monasca_net_ip,
   influxdb_host: monasca_net_ip,


### PR DESCRIPTION
This pull request should fix our current issues with the Monasca Kibana dashboard. I haven't fully tested this yet and I'm still unsure why we do not see logs when the dashboard _is_ working (even though curling the elasticsearch index does show some), so marking this WIP for now.