### PR TITLE
cinder: Provide NFS mount options to cinder volume shares (bsc#1036369)

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -230,8 +230,11 @@ node[:cinder][:volumes].each_with_index do |volume, volid|
     end
 
   when volume[:backend_driver] == "nfs"
+    shares_content = volume[:nfs][:nfs_shares]
+    nfs_opts = volume[:nfs][:nfs_mount_options].strip
+    shares_content += " -o #{nfs_opts}" unless nfs_opts.empty?
     file "/etc/cinder/nfs_shares-#{backend_id}" do
-      content volume[:nfs][:nfs_shares]
+      content shares_content
       owner "root"
       group node[:cinder][:group]
       mode "0640"


### PR DESCRIPTION
Cinder uses specific mount options only when they are
explicitely specified in nfs_shares_config file.

(cherry picked from commit 15d333d7351441e2f4d13fe44cc6a6d33aea7441)