### PR TITLE
monasca: Deploy monasca-persister (python) via chef

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -114,7 +114,10 @@ ansible_vars = {
   elasticsearch_nodes: "[#{monasca_net_ip}]",
   elasticsearch_hosts: monasca_net_ip,
   monasca_api_log_level: node[:monasca][:api][:log_level],
-  log_api_log_level: node[:monasca][:log_api][:log_level]
+  log_api_log_level: node[:monasca][:log_api][:log_level],
+  # set an invalid run mode to really ignore monasca-persister. Otherwise monasca-persister
+  # will be stopped via ansible
+  monasca_persister_run_mode: "Ignore"
 }.to_json
 
 execute "run ansible" do

--- a/chef/cookbooks/monasca/recipes/persister.rb
+++ b/chef/cookbooks/monasca/recipes/persister.rb
@@ -1,0 +1,53 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+monasca_server = node_search_with_cache("roles:monasca-server").first
+if monasca_server.nil?
+  Chef::Log.warn("No monasca-server found. Skip monasca-persister setup.")
+  return
+end
+
+package "openstack-monasca-persister"
+
+monasca_net_ip = MonascaHelper.get_host_for_monitoring_url(monasca_server)
+
+# write monasca-persister config
+template "/etc/monasca/persister.conf" do
+  source "monasca-persister.conf.erb"
+  owner "monasca-persister"
+  group "monasca"
+  mode "0640"
+  variables(
+    debug: node[:monasca][:debug],
+    log_dir: "/var/log/monasca-persister/",
+    influxdb_host: monasca_net_ip,
+    influxdb_port: "8086",
+    influxdb_database_name: "mon",
+    influxdb_username: "mon_api",
+    influxdb_mon_persister_password: node[:monasca][:master][:influxdb_mon_persister_password],
+    zookeeper_hosts: monasca_net_ip,
+    kafka_hosts: "#{monasca_net_ip}:9092"
+  )
+end
+
+# enable and start the monasca-persister
+service "openstack-monasca-persister" do
+  service_name "openstack-monasca-persister"
+  supports status: true, restart: true, start: true, stop: true
+  action [:enable, :start]
+  # provider Chef::Provider::CrowbarPacemakerService if ha_enabled
+  subscribes :restart, resources(template: "/etc/monasca/persister.conf")
+end

--- a/chef/cookbooks/monasca/recipes/role_monasca_server.rb
+++ b/chef/cookbooks/monasca/recipes/role_monasca_server.rb
@@ -17,4 +17,5 @@
 if CrowbarRoleRecipe.node_state_valid_for_role?(node, "monasca", "monasca-server")
   include_recipe "#{@cookbook_name}::common"
   include_recipe "#{@cookbook_name}::server"
+  include_recipe "#{@cookbook_name}::persister"
 end

--- a/chef/cookbooks/monasca/templates/default/monasca-hosts-cluster.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-hosts-cluster.erb
@@ -67,11 +67,6 @@ keystone-node                    ansible_ssh_host=<%= @keystone_host %> ansible_
 <%= "monasca-notification-node-#{index} ansible_ssh_host=#{host}" %> ansible_ssh_user=<%= @ansible_ssh_user %>
 <% end %>
 
-# Monasca-persister nodes
-<% @monasca_hosts.each_with_index do |host, index| %>
-<%= "monasca-persister-node-#{index} ansible_ssh_host=#{host}" %> ansible_ssh_user=<%= @ansible_ssh_user %>
-<% end %>
-
 # Monasca-log-metrics nodes for cluster
 <% @monasca_hosts.each_with_index do |host, index| %>
 <%= "monasca-log-metrics-node-#{index} ansible_ssh_host=#{host}" %> ansible_ssh_user=<%= @ansible_ssh_user %>
@@ -133,9 +128,6 @@ keystone-node
 balancer-node
 
 [monasca_persister_group]
-<% @monasca_hosts.length.times do |index| %>
-<%= "monasca-persister-node-#{index} influxdb_node_for_persister=keepalived-virtual-node" %>
-<% end %>
 
 [monasca_api_group]
 <% @monasca_hosts.length.times do |index| %>

--- a/chef/cookbooks/monasca/templates/default/monasca-hosts-single.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-hosts-single.erb
@@ -43,9 +43,6 @@ monasca-log-api-node             ansible_ssh_host=<%= @monasca_hosts[0] %> ansib
 # Monasca-notification
 monasca-notification-node        ansible_ssh_host=<%= @monasca_hosts[0] %> ansible_ssh_user=<%= @ansible_ssh_user %>
 
-# Monasca-persister node
-monasca-persister-node           ansible_ssh_host=<%= @monasca_hosts[0] %> ansible_ssh_user=<%= @ansible_ssh_user %>
-
 # Monasca-log-metric node
 monasca-log-metrics-node         ansible_ssh_host=<%= @monasca_hosts[0] %> ansible_ssh_user=<%= @ansible_ssh_user %>
 
@@ -93,7 +90,6 @@ monasca-api-node database_node_for_api=monasca-node influxdb_node_for_api=influx
 monasca-notification-node database_node_for_notification=monasca-node
 
 [monasca_persister_group]
-monasca-persister-node influxdb_node_for_persister=influxdb-node
 
 [monasca_log_api_group]
 monasca-log-api-node

--- a/chef/cookbooks/monasca/templates/default/monasca-persister.conf.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-persister.conf.erb
@@ -1,0 +1,56 @@
+[DEFAULT]
+log_dir=<%= @log_dir %>
+log_file=<%= @log_dir %>/persister.log
+debug = <%= @debug ? "True" : "False" %>
+
+[repositories]
+metrics_driver = monasca_persister.repositories.influxdb.metrics_repository:MetricInfluxdbRepository
+alarm_state_history_driver = monasca_persister.repositories.influxdb.alarm_state_history_repository:AlarmStateHistInfluxdbRepository
+
+[zookeeper]
+# Comma separated list of host:port
+uri=<%= @zookeeper_hosts %>
+partition_interval_recheck_seconds = 15
+
+[kafka_alarm_history]
+# Comma separated list of Kafka broker host:port.
+uri=<%= @kafka_hosts %>
+group_id = 1_alarm-state-transitions
+topic = alarm-state-transitions
+consumer_id = 1
+client_id = 1
+database_batch_size = 1000
+max_wait_time_seconds = 30
+# The following 3 values are set to the kakfa-python defaults
+fetch_size_bytes = 4096
+buffer_size = 4096
+# 8 times buffer size
+max_buffer_size = 32768
+# Path in zookeeper for kafka consumer group partitioning algo
+zookeeper_path = /persister_partitions/alarm-state-transitions
+num_processors = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
+
+[kafka_metrics]
+# Comma separated list of Kafka broker host:port
+uri=<%= @kafka_hosts %>
+group_id = 1_metrics
+topic = metrics
+consumer_id = 1
+client_id = 1
+database_batch_size = 1000
+max_wait_time_seconds = 30
+# The following 3 values are set to the kakfa-python defaults
+fetch_size_bytes = 4096
+buffer_size = 4096
+# 8 times buffer size
+max_buffer_size = 32768
+# Path in zookeeper for kafka consumer group partitioning algo
+zookeeper_path = /persister_partitions/metrics
+num_processors = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
+
+[influxdb]
+ip_address=<%= @influxdb_host %>
+port=<%= @influxdb_port %>
+database_name=<%= @influxdb_database_name %>
+user=<%= @influxdb_username %>
+password=<%= @influxdb_mon_persister_password %>


### PR DESCRIPTION
This commit does 2 things:

1) Use the python version of monasca-persister. There is a java version
which is currently deployed via the monasca-installer (ansible based)
but there are known problems with that version. Also the python version
is more inline with the other OpenStack services and easier to debug.
2) Use chef to deploy monasca-persister. Instead of using
monasca-installer (ansible based) use directly chef which makes the
integration way easier.