### PR TITLE
monasca: Cleanup monasca-setup script generator

### DIFF
--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -45,7 +45,7 @@ template "/usr/sbin/monasca-reconfigure" do
     agent_keystone: agent_keystone,
     keystone_settings: keystone_settings,
     agent_dimensions: agent_dimensions,
-    install_plugins_only: false
+    setup: node[:monasca][:setup]
   )
 end
 

--- a/chef/cookbooks/monasca/templates/default/monasca-reconfigure.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-reconfigure.erb
@@ -21,8 +21,6 @@ then
         --user '<%= @agent_settings["user"] %>' \
         --dimensions '<%= @agent_dimensions.map{|k,v| "#{k}:#{v}"}.join(',') %>' \
         --insecure '<%= @agent_settings["insecure"] %>' \
-        <% if @agent_settings["system_only"] -%> --system_only <% end -%> \
-        <% if @agent_settings["overwrite_config"] -%> --overwrite <% end -%> \
         <% if @agent_settings["ca_file"].length > 0 -%> --ca_file '<%= @agent_settings["ca_file"] %>' <% end -%> \
         --log_dir '<%= @agent_settings["log_dir"] %>' \
         --log_level '<%= @agent_settings["log_level"] %>' \
@@ -36,6 +34,6 @@ then
         --backlog_send_rate '<%= @agent_settings["backlog_send_rate"].to_i %>' \
         --amplifier '<%= @agent_settings["amplifier"] %>' \
         --skip_enable \
-        <% if @install_plugins_only -%> --install_plugins_only <% end -%> \
-        --agent_service_name '<%= @agent_settings["agent_service_name"] %>'
+        --agent_service_name '<%= @agent_settings["agent_service_name"] %>' \
+        <%= @setup["extra_params"] %>
 fi

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -11,8 +11,6 @@
           "service_role": "monasca-agent"
         },
         "insecure": true,
-        "system_only": false,
-        "overwrite_config": false,
         "ca_file": "",
         "log_dir": "/var/log/monasca-agent/",
         "log_level": "INFO",
@@ -42,6 +40,9 @@
       },
       "log_api": {
         "log_level": "INFO"
+      },
+      "setup": {
+        "extra_params": ""
       },
       "master": {
         "influxdb_mon_api_password": "",

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -27,8 +27,6 @@
                   }
                 },
                 "insecure": { "type": "bool", "required": true },
-                "system_only": { "type": "bool", "required": true },
-                "overwrite_config": { "type": "bool", "required": true },
                 "ca_file": { "type": "str", "required": true },
                 "log_dir": { "type": "str", "required": true },
                 "log_level": { "type": "str", "required": true },
@@ -74,6 +72,13 @@
               "type": "map",
               "mapping": {
                 "log_level": { "type": "str", "required": true }
+              }
+            },
+            "setup": {
+              "required": true,
+              "type": "map",
+              "mapping": {
+                "extra_params": { "required": true, "type": "str" }
               }
             },
             "master": {

--- a/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
@@ -8,7 +8,6 @@
       %legend
         = t(".agent_header")
 
-      = boolean_field %w(agent system_only)
       = select_field %w(agent log_level), :collection => :agent_log_levels
       = integer_field %w(agent statsd_port)
       = integer_field %w(agent check_frequency)

--- a/crowbar_framework/config/locales/monasca/en.yml
+++ b/crowbar_framework/config/locales/monasca/en.yml
@@ -32,7 +32,6 @@ en:
         agent_header: 'Agent Settings'
         agent:
           monasca_url: 'Monasca URL'
-          system_only: 'Setting to true will cause Monasca setup to run in `system_only` mode only, configure the base config and system metrics (cpu, disk, load, memory, network)'
           insecure: 'Do you want insecure connection?'
           ca_file: 'Sets the path to the ca certs file if using certificates. Required only if insecure is set to False (ca_file)'
           log_level: 'Log level'


### PR DESCRIPTION
There were some options in the monasca-agent config which where in fact
only used by the monasca-reconfigure template (which triggers a
monasca-setup call).
Given that we do not use (and do not recommend) the monasca-reconfigure
script, delete these options and add a generic "extra_params" option
which can be used to customize the monasca-reconfigure script.