### PR TITLE
monasca: Fix keystone host to use FQDN instead of fixed IP

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -45,7 +45,7 @@ template "/opt/monasca-installer/monasca-hosts" do
   variables(
     monasca_hosts: monasca_hosts,
     ansible_ssh_user: "root",
-    keystone_host: keystone_settings["public_url_host"]
+    keystone_host: keystone_settings["internal_url_host"]
   )
   notifies :run, "execute[run ansible]", :delayed
 end


### PR DESCRIPTION
This will use `cluster-data.c0.cloud.suse.de` with Keystone cluster