### PR TITLE
Add missing keystone roles for Monasca

### DIFF
--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -123,6 +123,19 @@ monasca_roles.each do |role|
   end
 end
 
+# Required for Kibana access
+keystone_register "give admin user admin role in monasca tenant" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["admin_user"]
+  tenant_name monasca_project
+  role_name "admin"
+  action :add_access
+end
+
 agents_settings = []
 
 agents_settings.push(node[:monasca][:agent][:keystone])

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -136,6 +136,19 @@ keystone_register "give admin user admin role in monasca tenant" do
   action :add_access
 end
 
+# Required for Grafana access
+keystone_register "give admin user monasca-user role in monasca tenant" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["admin_user"]
+  tenant_name monasca_project
+  role_name "monasca-user"
+  action :add_access
+end
+
 agents_settings = []
 
 agents_settings.push(node[:monasca][:agent][:keystone])

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -78,7 +78,7 @@
       "service_password": "none",
       "service_user": "monasca",
       "service_tenant": "monasca",
-      "service_roles": ["monasca-agent"]
+      "service_roles": ["monasca-agent", "monasca-user"]
     }
   },
   "deployment": {


### PR DESCRIPTION
This pull request adds the roles we need to use the Kibana/Grafana dashboards in Monasca.