### PR TITLE
keystone: Raise and expose number of wsgi workers

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -121,6 +121,8 @@ elsif node[:keystone][:frontend] == "apache"
     script_alias "/usr/bin/keystone-wsgi-public"
     pass_authorization true
     limit_request_body 114688
+    processes node[:keystone][:api][:processes]
+    threads node[:keystone][:api][:threads]
     ssl_enable node[:keystone][:api][:protocol] == "https"
     ssl_certfile node[:keystone][:ssl][:certfile]
     ssl_keyfile node[:keystone][:ssl][:keyfile]
@@ -140,6 +142,8 @@ elsif node[:keystone][:frontend] == "apache"
     script_alias "/usr/bin/keystone-wsgi-admin"
     pass_authorization true
     limit_request_body 114688
+    processes node[:keystone][:api][:processes]
+    threads node[:keystone][:api][:threads]
     ssl_enable node[:keystone][:api][:protocol] == "https"
     ssl_certfile node[:keystone][:ssl][:certfile]
     ssl_keyfile node[:keystone][:ssl][:keyfile]

--- a/chef/data_bags/crowbar/migrate/keystone/111_add_wsgi_params.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/111_add_wsgi_params.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["api"]["processes"] = ta["api"]["processes"]
+  a["api"]["threads"] = ta["api"]["threads"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["api"].delete("processes")
+  a["api"].delete("threads")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -33,7 +33,9 @@
         "admin_port": 35357,
         "admin_host": "0.0.0.0",
         "version": "3",
-        "region": "RegionOne"
+        "region": "RegionOne",
+        "processes" : 8,
+        "threads" : 8
       },
       "admin": {
         "tenant": "admin",
@@ -180,7 +182,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 110,
+      "schema-revision": 111,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -38,7 +38,9 @@
                       "api_host": { "type" : "str", "required" : true },
                       "admin_host": { "type" : "str", "required" : true },
                       "version": { "type" : "str", "required" : true },
-                      "region": { "type" : "str", "required" : true }
+                      "region": { "type" : "str", "required" : true },
+                      "processes": { "required": true, "type": "int" },
+                      "threads": { "required": true, "type": "int" }
                     }},
                     "admin": { "type": "map", "required": true, "mapping": {
                       "tenant": { "type" : "str", "required" : true },


### PR DESCRIPTION
It seems our default was way too low, especially for the UUID
backend. In experiments a chef-client on the controller node
was speed up almost by factor two by raising numbers accordingly.