### PR TITLE
nova: fix cpu model overwrites

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -177,8 +177,8 @@ block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_M
   <% end -%>
 <% end -%>
 <%= "disk_prefix = xvd" if @libvirt_type.eql?('xen') %>
-<%= "cpu_mode = #{@cpu_mode}" unless @cpu_mode.empty? -%>
-<%= "cpu_model = #{@cpu_model}" unless @cpu_model.empty? -%>
+<%= "cpu_mode = #{@cpu_mode}" unless @cpu_mode.empty? %>
+<%= "cpu_model = #{@cpu_model}" unless @cpu_model.empty? %>
 <% if @libvirt_type.eql?('kvm') %>use_virtio_for_bridges = true<% end %>
 <%= "volume_use_multipath = true" if @use_multipath %>
 <%= "iser_use_multipath = true" if @use_multipath %>


### PR DESCRIPTION
The trailing -% caused erb to leave out the newline, which causes
this to be concatened and consequently non-working.