### PR TITLE
Re-add ignore_failure param for horizon service

### DIFF
--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -38,6 +38,7 @@ service "horizon" do
     reload_command 'sleep 1 && pkill --signal SIGUSR1 -f "^\(wsgi:horizon\)" && sleep 1'
   end
   supports reload: true, restart: true, status: true
+  ignore_failure true
 end
 
 case node[:platform_family]


### PR DESCRIPTION
In commit a64765b1 we removed the ignore_failure setting for the
horizon wsgi worker reload resource, intending to treat command failures
as fatal. This became a problem because there are still cases where the
refresh might fail, such as when apache is starting and there are no
wsgi processes yet, and we don't want that to cause the chef run to
abort. While we search for these corner cases, this patch adds back the
ignore_failure parameter so that chef can continue to run even if the
refresh fails.