### PR TITLE
magnum: Fix add_cluster_user_trust migration (bsc#1038122)

### DIFF
--- a/chef/data_bags/crowbar/migrate/magnum/101_add_cluster_user_trust.rb
+++ b/chef/data_bags/crowbar/migrate/magnum/101_add_cluster_user_trust.rb
@@ -1,13 +1,13 @@
 def upgrade(ta, td, a, d)
-  unless a["trust"].key? "cluster_user_trust"
-    a["trust"]["cluster_user_trust"] = ta["trust"]["cluster_user_trust"]
+  unless a["trustee"].key?("cluster_user_trust")
+    a["trustee"]["cluster_user_trust"] = ta["trust"]["cluster_user_trust"]
   end
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  if ta["trust"].key? "cluster_user_trust"
-    a["trust"].delete("cluster_user_trust")
+  unless ta["trustee"].key?("cluster_user_trust")
+    a["trustee"].delete("cluster_user_trust")
   end
   return a, d
 end


### PR DESCRIPTION
The key is called trustee not trust. See
https://github.com/crowbar/crowbar-openstack/blob/master/chef/data_bags/crowbar/template-magnum.json#L17