### PR TITLE
neutron: Add ability to specify agent_boot_time

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -186,7 +186,8 @@ when "ml2"
       vxlan_end: vni_end,
       vxlan_mcast_group: node[:neutron][:vxlan][:multicast_group],
       external_networks: physnets,
-      mtu_value: mtu_value
+      mtu_value: mtu_value,
+      l2pop_agent_boot_time: node[:neutron][:l2pop][:agent_boot_time]
     )
     notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]"
   end

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -23,4 +23,6 @@ vni_ranges = <%= @vxlan_start %>:<%= @vxlan_end %>
 <% if @ml2_type_drivers.include?("vxlan") && @ml2_mechanism_drivers.include?("linuxbridge") && !@vxlan_mcast_group.empty? -%>
 vxlan_group = <%= @vxlan_mcast_group %>
 <% end -%>
+[l2pop]
+agent_boot_time = <%= @l2pop_agent_boot_time %>
 [securitygroup]

--- a/chef/data_bags/crowbar/migrate/neutron/109_add_agent_boot_time.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/109_add_agent_boot_time.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["l2pop"] = ta["l2pop"] unless a.key?("l2pop")
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("l2pop")
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -15,6 +15,9 @@
       "use_lbaas": true,
       "lbaasv2_driver": "haproxy",
       "use_l2pop": false,
+      "l2pop": {
+        "agent_boot_time": 180
+      },
       "use_dvr": false,
       "additional_external_networks": [],
       "networking_plugin": "ml2",
@@ -122,7 +125,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 108,
+      "schema-revision": 109,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -20,6 +20,9 @@
                     "use_lbaas": { "type": "bool", "required": true },
                     "lbaasv2_driver": { "type": "str", "required": true },
                     "use_l2pop": { "type": "bool", "required": true },
+                    "l2pop": { "type": "map", "required": true, "mapping": {
+                      "agent_boot_time": { "type" : "int", "required" : true }
+                    }},
                     "use_dvr": { "type": "bool", "required": true },
                     "additional_external_networks": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "networking_plugin": { "type": "str", "required": true },


### PR DESCRIPTION
With L2pop, when the first port on a node gets active, or when the agent
is still starting (uptime of agent  < agent_boot_time), then a full sync
of the L2pop for that network is done.

The sync therefore does not happen if there are more than one port on
the node (like dhcp + router) and if the agent gets the port
notification after start+agent_boot_time.

The first condition can occur fairly easily, and the second definitely
happens when the cloud is large and/or on boot (because the l3 agent
and the dhcp agent are start after the ovs agent, and sometimes the
addition of the ports can hence happen long after ovs agent has
started).

Closes https://github.com/sap-oc/crowbar-openstack/issues/36