### PR TITLE
cinder: Remove nfs_mount_options key as redundant (bsc#1036369)

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -191,7 +191,6 @@ nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
 
   <% if volume['backend_driver'] == 'nfs' -%>
 nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
-nfs_mount_options = <%= volume['nfs']['nfs_mount_options'] %>
 volume_driver = cinder.volume.drivers.nfs.NfsDriver
   <% end -%>
 

--- a/chef/data_bags/crowbar/migrate/cinder/107_remote_nfs_mount_options.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/107_remote_nfs_mount_options.rb
@@ -1,0 +1,16 @@
+def upgrade(ta, td, a, d)
+  a["volume_defaults"]["nfs"].delete("nfs_mount_options")
+  a["volumes"].each do |volume|
+    next if volume["backend_driver"] != "nfs"
+    volume["nfs"].delete("nfs_mount_options")
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["volume_defaults"]["nfs"]["nfs_mount_options"] = ""
+  a["volumes"].each do |volume|
+    volume["nfs"]["nfs_mount_options"] = "" if volume["backend_driver"] == "nfs"
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -75,8 +75,7 @@
           "iscsi_ip": ""
         },
         "nfs": {
-          "nfs_shares": "",
-          "nfs_mount_options": ""
+          "nfs_shares": ""
         },
         "rbd": {
           "use_crowbar": true,
@@ -162,7 +161,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 106,
+      "schema-revision": 107,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -100,8 +100,7 @@
                 },
                 "nfs": {
                 "type": "map", "mapping": {
-                    "nfs_shares": { "type": "str", "required": true },
-                    "nfs_mount_options": { "type": "str", "required": true }
+                    "nfs_shares": { "type": "str", "required": true }
                 }
                 },
                 "rbd": {

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -140,7 +140,7 @@
               %span.help-block
                 = t(".volumes.nfs.nfs_shares_config_hint")
 
-              = string_field %w(volumes {{@index}} nfs nfs_mount_options)
+              = string_field %w(volumes {{@index}} nfs)
 
           {{/if_eq}}
           {{#if_eq backend_driver 'rbd'}}

--- a/crowbar_framework/config/locales/cinder/en.yml
+++ b/crowbar_framework/config/locales/cinder/en.yml
@@ -53,14 +53,14 @@ en:
           netapp_parameters: 'NetApp Parameters'
           netapp_volume_driver: 'NetApp'
           netapp:
-            nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path optional-nfs-mount-options'
+            nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path -o optional-nfs-mount-options'
             vfiler_hint: 'Only Use this option when utilizing the MultiStore feature on the NetApp storage with iSCSI'
             vserver_hint: 'If using the NFS storage protocol, this parameter is mandatory for storage service catalog support'
             volume_list_hint: 'Optional comma separated list of NetApp controller volume names'
           nfs_parameters: 'NFS Parameters'
           nfs_volume_driver: 'NFS'
           nfs:
-            nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path optional-nfs-mount-options'
+            nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path -o optional-nfs-mount-options'
           raw_parameters: 'Raw Devices Parameters'
           raw_volume_driver: 'Raw Devices'
           rbd_parameters: 'RADOS Parameters'
@@ -115,7 +115,6 @@ en:
               vserver: 'Name of the Virtual Storage Server (netapp_vserver)'
             nfs:
               nfs_shares: 'List of NFS Exports'
-              nfs_mount_options: 'Mount Options'
             raw:
               cinder_raw_method: 'Disk selection method'
               volume_name: 'Name of Volume'


### PR DESCRIPTION
Hint for nfs_shares value encourages user to put the options there
already, so we do not need extra field for specifying Mount Options.

An alternative approach to https://github.com/crowbar/crowbar-openstack/pull/939

UPDATE: not only that it is redundant, nfs_mount_options actually does not work