### PR TITLE
monasca: more agent checks

### DIFF
--- a/chef/cookbooks/monasca/providers/agent_plugin_kafka.rb
+++ b/chef/cookbooks/monasca/providers/agent_plugin_kafka.rb
@@ -1,0 +1,54 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "json"
+require "yaml"
+
+action :create do
+  # initialize the data structure if not available
+  node[:monasca] ||= {}
+  node[:monasca][:agent_plugin_config] ||= {}
+  node[:monasca][:agent_plugin_config][:kafka_instances] ||= {}
+
+  # add the hash with the given values
+  node[:monasca][:agent_plugin_config][:kafka_instances][new_resource.built_by] =
+    { "built_by" => new_resource.built_by,
+      "name" => new_resource.name,
+      "kafka_connect_str" => new_resource.kafka_connect_str,
+      "consumer_groups" => new_resource.consumer_groups,
+      "per_partition" => new_resource.per_partition,
+      "full_output" => new_resource.full_output }
+
+  kafka_instances = node[:monasca][:agent_plugin_config][:kafka_instances]
+
+  # be sure the package is installed. that way "/etc/monasca/agent/conf.d/" is available
+  # and also the user and group are there
+  package "openstack-monasca-agent"
+
+  # NOTE(toabctl): convert/parse first to/from json. Otherwise we have unwanted markers
+  # like "- !ruby/hash:Mash" in the yaml output
+  kafka_conf = JSON.parse({ "init_config" => nil,
+                            "instances" => kafka_instances.values }.to_json).to_yaml
+
+  # write http_check plugin config
+  file "/etc/monasca/agent/conf.d/kafka_consumer.yaml" do
+    content kafka_conf
+    owner node[:monasca][:agent][:user]
+    group node[:monasca][:agent][:group]
+    mode "0640"
+    notifies :restart, resources(service: node[:monasca][:agent][:agent_service_name]), :delayed
+  end
+end

--- a/chef/cookbooks/monasca/providers/agent_plugin_zookeeper.rb
+++ b/chef/cookbooks/monasca/providers/agent_plugin_zookeeper.rb
@@ -1,0 +1,53 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "json"
+require "yaml"
+
+action :create do
+  # initialize the data structure if not available
+  node[:monasca] ||= {}
+  node[:monasca][:agent_plugin_config] ||= {}
+  node[:monasca][:agent_plugin_config][:zookeeper_instances] ||= {}
+
+  # add the hash with the given values
+  node[:monasca][:agent_plugin_config][:zookeeper_instances][new_resource.built_by] =
+    { "built_by" => new_resource.built_by,
+      "name" => new_resource.name,
+      "host" => new_resource.host,
+      "port" => new_resource.port,
+      "timeout" => new_resource.timeout }
+
+  zookeeper_instances = node[:monasca][:agent_plugin_config][:zookeeper_instances]
+
+  # be sure the package is installed. that way "/etc/monasca/agent/conf.d/" is available
+  # and also the user and group are there
+  package "openstack-monasca-agent"
+
+  # NOTE(toabctl): convert/parse first to/from json. Otherwise we have unwanted markers
+  # like "- !ruby/hash:Mash" in the yaml output
+  zookeeper_conf = JSON.parse({ "init_config" => nil,
+                                "instances" => zookeeper_instances.values }.to_json).to_yaml
+
+  # write http_check plugin config
+  file "/etc/monasca/agent/conf.d/zk.yaml" do
+    content zookeeper_conf
+    owner node[:monasca][:agent][:user]
+    group node[:monasca][:agent][:group]
+    mode "0640"
+    notifies :restart, resources(service: node[:monasca][:agent][:agent_service_name]), :delayed
+  end
+end

--- a/chef/cookbooks/monasca/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/monasca/recipes/monitor_monasca.rb
@@ -17,6 +17,7 @@
 return unless node["roles"].include?("monasca-agent")
 
 monitor_url = MonascaHelper.api_admin_url(node)
+monasca_net_ip = MonascaHelper.get_host_for_monitoring_url(node)
 
 monasca_agent_plugin_http_check "http_check for monasca-api" do
   built_by "monasca-server"
@@ -24,3 +25,15 @@ monasca_agent_plugin_http_check "http_check for monasca-api" do
   url monitor_url
   dimensions "service" => "monitoring-api"
 end
+
+# kafka
+# FIXME: keep disabled until https://storyboard.openstack.org/#!/story/2001036
+# is done
+# consumer_groups = { "thresh-event" => { "events" => [] },
+#                     "thresh-metric" => { "metrics" => [] } }
+# monasca_agent_plugin_kafka "kafka monitoring" do
+#   built_by "monasca-server"
+#   name "kafka"
+#   kafka_connect_str monasca_net_ip
+#   consumer_groups consumer_groups
+# end

--- a/chef/cookbooks/monasca/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/monasca/recipes/monitor_monasca.rb
@@ -26,6 +26,15 @@ monasca_agent_plugin_http_check "http_check for monasca-api" do
   dimensions "service" => "monitoring-api"
 end
 
+# influxdb
+influxdb_monitor_url = "http://#{monasca_net_ip}:8086/ping"
+monasca_agent_plugin_http_check "http_check for influxdb" do
+  built_by "influxdb"
+  name "influxdb"
+  url influxdb_monitor_url
+  dimensions "service" => "influxdb"
+end
+
 # kafka
 # FIXME: keep disabled until https://storyboard.openstack.org/#!/story/2001036
 # is done

--- a/chef/cookbooks/monasca/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/monasca/recipes/monitor_monasca.rb
@@ -37,3 +37,10 @@ end
 #   kafka_connect_str monasca_net_ip
 #   consumer_groups consumer_groups
 # end
+
+# zookeeper
+monasca_agent_plugin_zookeeper "zookeeper monitoring" do
+  built_by "monasca-server"
+  name "zookeeper"
+  host monasca_net_ip
+end

--- a/chef/cookbooks/monasca/resources/agent_plugin_kafka.rb
+++ b/chef/cookbooks/monasca/resources/agent_plugin_kafka.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :built_by, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :name, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :kafka_connect_str, kind_of: String, required: true
+attribute :consumer_groups, kind_of: Hash, required: true
+attribute :per_partition, kind_of: [TrueClass, FalseClass], default: false
+attribute :full_output, kind_of: [TrueClass, FalseClass], default: false
+
+attr_accessor :exists

--- a/chef/cookbooks/monasca/resources/agent_plugin_zookeeper.rb
+++ b/chef/cookbooks/monasca/resources/agent_plugin_zookeeper.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :built_by, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :name, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :host, kind_of: String, required: true
+attribute :port, kind_of: Integer, default: 2181
+attribute :timeout, kind_of: Integer, default: 3
+
+attr_accessor :exists


### PR DESCRIPTION
The monasca-agent has a plugin system to configure monitoring in
different scenarios. One plugin is the 'kafka' plugin which can
collect data from kafka.
This commit adds a LWRP and also uses it to collect kafka data.