### PR TITLE
neutron: add VMware DVS ML2 networking support

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -117,6 +117,8 @@ when "suse"
     infoblox_pkgs: ["python-infoblox-client",
                     "openstack-neutron-infoblox",
                     "openstack-neutron-infoblox-ipam-agent"],
+    vmware_vsphere_pkg: "openstack-neutron-vsphere",
+    vmware_vsphere_dvs_agent_pkg: "openstack-neutron-vsphere-dvs-agent",
     user: "neutron",
     group: "neutron",
   }
@@ -158,6 +160,8 @@ when "rhel"
                         "lldpd",
                         "neutron-opflex-agent"],
     infoblox_pkgs: [],
+    vmware_vsphere_pkg: "",
+    vmware_vsphere_dvs_agent_pkg: "",
     user: "neutron",
     group: "neutron",
   }
@@ -198,6 +202,8 @@ else
     cisco_apic_gbp_pkgs: [""],
     cisco_opflex_pkgs: [""],
     infoblox_pkgs: [],
+    vmware_vsphere_pkg: "openstack-neutron-vsphere",
+    vmware_vsphere_dvs_agent_pkg: "openstack-neutron-vsphere-dvs-agent",
     user: "neutron",
     group: "neutron",
   }

--- a/chef/cookbooks/neutron/recipes/vmware_dvs_agents.rb
+++ b/chef/cookbooks/neutron/recipes/vmware_dvs_agents.rb
@@ -1,0 +1,39 @@
+#
+# Copyright 2017 SUSE Linux GmBH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package node[:neutron][:platform][:vmware_vsphere_dvs_agent_pkg]
+
+include_recipe "neutron::common_config"
+
+agent_config_path = "/etc/neutron/plugins/ml2/vmware_dvs_agent.ini"
+agent_service_name = "openstack-neutron-dvs-agent"
+
+template agent_config_path do
+  cookbook "neutron"
+  source "vmware_dvs_agent.ini.erb"
+  owner "root"
+  group node[:neutron][:platform][:group]
+  mode "0640"
+  variables(
+    vcenter_config: node[:nova][:vcenter]
+  )
+end
+
+service agent_service_name do
+  action [:enable, :start]
+  subscribes :restart, resources(template: node[:neutron][:config_file])
+  subscribes :restart, resources(template: agent_config_path)
+end

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -26,3 +26,8 @@ vxlan_group = <%= @vxlan_mcast_group %>
 [l2pop]
 agent_boot_time = <%= @l2pop_agent_boot_time %>
 [securitygroup]
+<% if @ml2_mechanism_drivers.include?("vmware_dvs") -%>
+[dvs]
+clean_on_restart = <%= @vmware_dvs_config[:clean_on_restart] ? 'True' : 'False' %>
+precreate_networks = <%= @vmware_dvs_config[:precreate_networks] ? 'True' : 'False' %>
+<% end -%>

--- a/chef/cookbooks/neutron/templates/default/vmware_dvs_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/vmware_dvs_agent.ini.erb
@@ -1,0 +1,14 @@
+[DEFAULT]
+[securitygroup]
+enable_security_group = <%= @vcenter_config[:dvs_security_groups] ? 'True' : 'False' %>
+#firewall_driver = networking_vsphere.agent.firewalls.vcenter_firewall.DVSFirewallDriver
+[ml2_vmware]
+vsphere_login = <%= @vcenter_config[:user] %>
+vsphere_hostname = <%= @vcenter_config[:host] %>
+vsphere_password = <%= @vcenter_config[:password] %>
+<% @vcenter_config[:clusters].each do |cluster| -%>
+cluster_name = <%= cluster %>
+<% end -%>
+ca_file = <%= @vcenter_config[:ca_file] %>
+insecure = <%= @vcenter_config[:insecure] %>
+network_maps = physnet1:<%= @vcenter_config[:dvs_name] %>

--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -73,6 +73,7 @@ default[:nova][:vcenter][:user] = ""
 default[:nova][:vcenter][:password] = ""
 default[:nova][:vcenter][:clusters] = []
 default[:nova][:vcenter][:interface] = ""
+default[:nova][:vcenter][:dvs_name] = "dvSwitch0"
 
 #
 # Scheduler Settings

--- a/chef/data_bags/crowbar/migrate/neutron/110_add_vmware_dvs_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/110_add_vmware_dvs_attributes.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["vmware_dvs"] = ta["vmware_dvs"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("vmware_dvs")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/nova/118_add_vmware_dvs_attrs.rb
+++ b/chef/data_bags/crowbar/migrate/nova/118_add_vmware_dvs_attrs.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["vcenter"]["dvs_name"] = ta["vcenter"]["dvs_name"]
+  a["vcenter"]["dvs_security_groups"] = ta["vcenter"]["dvs_security_groups"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["vcenter"].delete("dvs_name")
+  a["vcenter"].delete("dvs_security_groups")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -73,6 +73,10 @@
         "tz_uuid": "",
         "l3_gw_uuid": ""
       },
+      "vmware_dvs": {
+        "clean_on_restart": true,
+        "precreate_networks": false
+      },
       "zvm": {
         "zvm_xcat_server": "",
         "zvm_xcat_username": "",
@@ -125,7 +129,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 109,
+      "schema-revision": 110,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -107,6 +107,10 @@
                       "tz_uuid": { "type" : "str", "required" : true },
                       "l3_gw_uuid": { "type" : "str", "required" : true }
                     }},
+                    "vmware_dvs": { "type": "map", "required": true, "mapping": {
+                      "clean_on_restart": { "type" : "bool", "required" : true },
+                      "precreate_networks": { "type" : "bool", "required" : true }
+                    }},
                     "zvm": { "type": "map", "required": true, "mapping": {
                       "zvm_xcat_server": { "type": "str", "required": true },
                       "zvm_xcat_username": { "type": "str", "required": true },

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -80,7 +80,9 @@
         "datastore": "",
         "interface": "vmnic0",
         "ca_file": "",
-        "insecure": false
+        "insecure": false,
+        "dvs_name": "dvSwitch0",
+        "dvs_security_groups": false
       },
       "zvm": {
         "zvm_xcat_server": "",
@@ -157,7 +159,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 117,
+      "schema-revision": 118,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -130,7 +130,9 @@
                 "datastore": { "type": "str", "required": true },
                 "interface": { "type": "str", "required": true },
                 "ca_file": { "type": "str", "required": true },
-                "insecure": { "type": "bool", "required": true }
+                "insecure": { "type": "bool", "required": true },
+                "dvs_name": { "type": "str", "required": true },
+                "dvs_security_groups": { "type": "bool", "required": true }
               }
             },
             "zvm": {

--- a/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
@@ -344,6 +344,19 @@ function ml2_mechanism_drivers_check() {
     $('#cisco_switches').hide();
   }
 
+  // auto-select openvswitch & vlan if vmware_dvs is selected
+  if (values.indexOf("vmware_dvs") >= 0) {
+    if (values.indexOf("openvswitch") < 0 && values.indexOf("linuxbridge") < 0) {
+      values.push("openvswitch");
+      $("#ml2_mechanism_drivers").val(values).trigger('change');
+    }
+    var type_drivers = $('#ml2_type_drivers').val() || [];
+    if (type_drivers.indexOf('vlan') == -1) {
+        type_drivers.push('vlan');
+        $('#ml2_type_drivers').val(type_drivers).trigger('change');
+    }
+  }
+
   // show/hide l2pop depending on openvswitch/linuxbridge
   if (values.indexOf("openvswitch") >= 0 || values.indexOf("linuxbridge") >= 0) {
     $('#l2pop_container').show();

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -37,7 +37,7 @@ class NeutronService < PacemakerServiceObject
   end
 
   def self.networking_ml2_mechanism_drivers_valid
-    ["linuxbridge", "openvswitch", "cisco_nexus"]
+    ["linuxbridge", "openvswitch", "cisco_nexus", "vmware_dvs"]
   end
 
   class << self
@@ -206,6 +206,19 @@ class NeutronService < PacemakerServiceObject
       validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_nexus_vlan")
     end
 
+    # vmware_dvs mech driver needs also openvswitch or linuxbridge mech driver
+    # and vlan type driver
+    if ml2_mechanism_drivers.include?("vmware_dvs") &&
+        !ml2_mechanism_drivers.include?("openvswitch") &&
+        !ml2_mechanism_drivers.include?("linuxbridge")
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.vmware_dvs_ovs_lbr")
+    end
+
+    if ml2_mechanism_drivers.include?("vmware_dvs") &&
+        !ml2_type_drivers.include?("vlan")
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.vmware_dvs_vlan")
+    end
+
     # for now, openvswitch and linuxbrige can't be used in parallel
     if ml2_mechanism_drivers.include?("openvswitch") &&
         ml2_mechanism_drivers.include?("linuxbridge")
@@ -282,7 +295,6 @@ class NeutronService < PacemakerServiceObject
       if ml2_mechanism_drivers.include? "linuxbridge"
         validation_error I18n.t("barclamp.#{@bc_name}.validation.dvr_linuxbridge")
       end
-
     end
   end
 

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -141,3 +141,5 @@ en:
         dvr_requires_l2: 'DVR with GRE or VXLAN requires L2 population'
         dvr_vmware: 'DVR is not compatible with VMware NSX plugin'
         dvr_linuxbridge: 'DVR is not compatible with Linux Bridge ML2 driver'
+        vmware_dvs_vlan: 'The "vmware_dvs" mechanism driver needs the type driver "vlan"'
+        vmware_dvs_ovs_lbr: 'The "vmware_dvs" mechanism driver also needs either the "openvswitch" or the "linuxbridge" mechanism driver'


### PR DESCRIPTION
The PR extends the neutron barclamp to add support for the vmware_dvs ML2 mechanism driver available from the [openstack/networking-vsphere](https://github.com/openstack/networking-vsphere) GitHub project.

The plugin allows VMware/ESXi VMs to be attached to the VLAN-based neutron networks that are already implemented through the linuxbridge or openvswitch ML2 mech driver. It also provides the following features:
- connecting KVM VMs and VMware VMs to the same provider or tenant network
- for VMware VMs:
  - security groups support 
  - DHCP & metadata support
  - L3 services (routers, floating IPs, LBaaS, FWaaS etc)

Some architectural highlights:
- new s/w components are shipped with the openstack-networking-vsphere package
- the openvswitch or linuxbridge ML2 mech driver and the VLAN ML2 type driver are also required, but with no special modifications to their standard configuration. The vmware_dvs mech driver simply extends the way linuxbridge/OVS network virtualization is implemented to include VMware network resources.
- a new neutron-vmware-dvs L2 agent needs to run alongside every nova-compute instance. It manages VMware network resources remotely (doesn't need to create any additional linux or OVS bridges etc. locally)

More information about the implementation:
- [Fuel plugin for vSphere DVS integration](https://github.com/openstack/fuel-plugin-vmware-dvs/blob/master/specs/fuel-plugin-vmware-dvs.rst) - contains an excellent general presentation of features covered by this driver
- [research etherpad page](https://etherpad.suse.de/p/crowbar-vmware-nsx-t) with extensive documentation on this and other VMware networking integration options (see _Mirantis' DVS ML2 neutron plugin_ section)

Remaining issues:
- [ ] vmware_dvs security groups support is not working (neutron-dvs-agent throws SOAP errors and vCenter server crashes. Support is temporarily disabled.
- [x] deleting any network (VLAN or otherwise) hits a bug in the vmware_dvs mech driver
- [x] need to investigate if DVR setups are still possible, at least partially (for the openvswitch/linuxbridge based nova-compute nodes)

 