### PR TITLE
monasca: More LWRP and checks

### DIFF
--- a/chef/cookbooks/monasca/providers/agent_plugin_postfix.rb
+++ b/chef/cookbooks/monasca/providers/agent_plugin_postfix.rb
@@ -1,0 +1,52 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "json"
+require "yaml"
+
+action :create do
+  # initialize the data structure if not available
+  node[:monasca] ||= {}
+  node[:monasca][:agent_plugin_config] ||= {}
+  node[:monasca][:agent_plugin_config][:postfix_instances] ||= {}
+
+  # add the hash with the given values
+  node[:monasca][:agent_plugin_config][:postfix_instances][new_resource.built_by] =
+    { "built_by" => new_resource.built_by,
+      "name" => new_resource.name,
+      "directory" => new_resource.directory,
+      "queues" => new_resource.queues }
+
+  postfix_instances = node[:monasca][:agent_plugin_config][:postfix_instances]
+
+  # be sure the package is installed. that way "/etc/monasca/agent/conf.d/" is available
+  # and also the user and group are there
+  package "openstack-monasca-agent"
+
+  # NOTE(toabctl): convert/parse first to/from json. Otherwise we have unwanted markers
+  # like "- !ruby/hash:Mash" in the yaml output
+  postfix_conf = JSON.parse({ "init_config" => nil,
+                            "instances" => postfix_instances.values }.to_json).to_yaml
+
+  # write http_check plugin config
+  file "/etc/monasca/agent/conf.d/postfix.yaml" do
+    content postfix_conf
+    owner node[:monasca][:agent][:user]
+    group node[:monasca][:agent][:group]
+    mode "0640"
+    notifies :restart, resources(service: node[:monasca][:agent][:agent_service_name]), :delayed
+  end
+end

--- a/chef/cookbooks/monasca/providers/agent_plugin_process.rb
+++ b/chef/cookbooks/monasca/providers/agent_plugin_process.rb
@@ -1,0 +1,54 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "json"
+require "yaml"
+
+action :create do
+  # initialize the data structure if not available
+  node[:monasca] ||= {}
+  node[:monasca][:agent_plugin_config] ||= {}
+  node[:monasca][:agent_plugin_config][:process_instances] ||= {}
+
+  # add the hash with the given values
+  node[:monasca][:agent_plugin_config][:process_instances][new_resource.built_by] =
+    { "built_by" => new_resource.built_by,
+      "name" => new_resource.name,
+      "dimensions" => new_resource.dimensions,
+      "detailed" => new_resource.detailed,
+      "exact_match" => new_resource.exact_match,
+      "search_string" => new_resource.search_string }
+
+  process_instances = node[:monasca][:agent_plugin_config][:process_instances]
+
+  # be sure the package is installed. that way "/etc/monasca/agent/conf.d/" is available
+  # and also the user and group are there
+  package "openstack-monasca-agent"
+
+  # NOTE(toabctl): convert/parse first to/from json. Otherwise we have unwanted markers
+  # like "- !ruby/hash:Mash" in the yaml output
+  process_conf = JSON.parse({ "init_config" => nil,
+                            "instances" => process_instances.values }.to_json).to_yaml
+
+  # write http_check plugin config
+  file "/etc/monasca/agent/conf.d/process.yaml" do
+    content process_conf
+    owner node[:monasca][:agent][:user]
+    group node[:monasca][:agent][:group]
+    mode "0640"
+    notifies :restart, resources(service: node[:monasca][:agent][:agent_service_name]), :delayed
+  end
+end

--- a/chef/cookbooks/monasca/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/monasca/recipes/monitor_monasca.rb
@@ -53,3 +53,11 @@ monasca_agent_plugin_zookeeper "zookeeper monitoring" do
   name "zookeeper"
   host monasca_net_ip
 end
+
+# postfix
+monasca_agent_plugin_postfix "postfix monitoring" do
+  built_by "monasca-server"
+  name "postfix"
+  directory "/var/spool/postfix"
+  queues [ "incoming", "active", "deferred" ]
+end

--- a/chef/cookbooks/monasca/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/monasca/recipes/monitor_monasca.rb
@@ -19,11 +19,28 @@ return unless node["roles"].include?("monasca-agent")
 monitor_url = MonascaHelper.api_admin_url(node)
 monasca_net_ip = MonascaHelper.get_host_for_monitoring_url(node)
 
+# http_check
 monasca_agent_plugin_http_check "http_check for monasca-api" do
-  built_by "monasca-server"
+  built_by "monasca-api"
   name "monitoring-api"
   url monitor_url
-  dimensions "service" => "monitoring-api"
+  dimensions ({ "service" => "monitoring", "component" => "monasca-api" })
+end
+
+monasca_agent_plugin_http_check "http_check for monasca-log-api" do
+  built_by "monasca-log-api"
+  name "monasca-log-api"
+  url monitor_url
+  dimensions ({ "service" => "monitoring", "component" => "monasca-log-api" })
+  use_keystone false
+end
+
+monasca_agent_plugin_http_check "http_check for monasca-persister" do
+  built_by "monasca-persister"
+  name "monasca-persister"
+  url "http://#{monasca_net_ip}:8191/healthcheck"
+  dimensions ({ "service" => "monitoring", "component" => "monasca-persister" })
+  use_keystone false
 end
 
 # influxdb
@@ -32,7 +49,7 @@ monasca_agent_plugin_http_check "http_check for influxdb" do
   built_by "influxdb"
   name "influxdb"
   url influxdb_monitor_url
-  dimensions "service" => "influxdb"
+  dimensions ({ "service" => "monitoring", "component" => "influxdb" })
 end
 
 # kafka
@@ -60,4 +77,70 @@ monasca_agent_plugin_postfix "postfix monitoring" do
   name "postfix"
   directory "/var/spool/postfix"
   queues [ "incoming", "active", "deferred" ]
+
+end
+
+# process checks
+monasca_agent_plugin_process "monasca-api process" do
+  built_by "monasca-api"
+  name "monasca-api"
+  dimensions ({ "service" => "monitoring", "component" => "monasca-api" })
+  detailed true
+  search_string [ "monasca-api" ]
+end
+
+monasca_agent_plugin_process "monasca-log-api process" do
+  built_by "monasca-log-api"
+  name "monasca-log-api"
+  dimensions ({ "service" => "monitoring", "component" => "monasca-log-api" })
+  detailed true
+  search_string [ "monasca-log-api" ]
+end
+
+monasca_agent_plugin_process "monasca-persister process" do
+  built_by "monasca-persister"
+  name "monasca-persister"
+  dimensions ({ "service" => "monitoring", "component" => "monasca-persister" })
+  detailed true
+  search_string [ "monasca-persister" ]
+end
+
+monasca_agent_plugin_process "monasca-notification process" do
+  built_by "monasca-notification"
+  name "monasca-notification"
+  dimensions ({ "service" => "monitoring", "component" => "monasca-notification" })
+  detailed true
+  search_string [ "monasca-notification" ]
+end
+
+monasca_agent_plugin_process "influxd process" do
+  built_by "influxd"
+  name "influxd"
+  dimensions ({ "service" => "monitoring", "component" => "influxd" })
+  detailed true
+  search_string [ "influxd" ]
+end
+
+monasca_agent_plugin_process "apache storm nimbus" do
+  built_by "apache-storm-nimbus"
+  name "storm.daemon.nimbus"
+  dimensions ({ "service" => "monitoring", "component" => "apache-storm" })
+  detailed false
+  search_string [ "storm.daemon.nimbus" ]
+end
+
+monasca_agent_plugin_process "apache storm supervisor" do
+  built_by "apache-storm-supervisor"
+  name "storm.daemon.supervisor"
+  dimensions ({ "service" => "monitoring", "component" => "apache-storm" })
+  detailed false
+  search_string [ "storm.daemon.supervisor" ]
+end
+
+monasca_agent_plugin_process "apache storm worker" do
+  built_by "apache-storm-worker"
+  name "storm.daemon.worker"
+  dimensions ({ "service" => "monitoring", "component" => "apache-storm" })
+  detailed false
+  search_string [ "storm.daemon.worker" ]
 end

--- a/chef/cookbooks/monasca/resources/agent_plugin_postfix.rb
+++ b/chef/cookbooks/monasca/resources/agent_plugin_postfix.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :built_by, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :name, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :directory, kind_of: String, required: true
+attribute :queues, kind_of: Array, required: true
+
+attr_accessor :exists

--- a/chef/cookbooks/monasca/resources/agent_plugin_process.rb
+++ b/chef/cookbooks/monasca/resources/agent_plugin_process.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :built_by, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :name, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :dimensions, kind_of: Hash, default: {}
+attribute :detailed, kind_of: [TrueClass, FalseClass], default: false
+attribute :exact_match, kind_of: [TrueClass, FalseClass], default: false
+attribute :search_string, kind_of: Array, required: true
+
+attr_accessor :exists


### PR DESCRIPTION
The monasca-agent has a plugin system to configure monitoring in
different scenarios. One plugin is the 'postfix' plugin which can
collect data from postfix.
This commit adds a LWRP and also uses it to collect postfix data.