### PR TITLE
keystone: grant admin role for default domain to admin (bsc#1040822)

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -610,6 +610,19 @@ if node[:keystone][:domain_specific_drivers]
   end
 end
 
+# Create default role admin for admin user in default domain
+keystone_register "add default admin role for domain default" do
+  protocol node[:keystone][:api][:protocol]
+  insecure keystone_insecure
+  host my_admin_host
+  port node[:keystone][:api][:admin_port]
+  auth register_auth_hash
+  user_name node[:keystone][:admin][:username]
+  role_name "admin"
+  domain_name "Default"
+  action :add_domain_role
+end
+
 # Create default user
 if node[:keystone][:default][:create_user]
   keystone_register "add default #{node[:keystone][:default][:username]} user" do

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-actions :add_service, :add_endpoint_template, :add_tenant, :add_domain, :add_user, :add_role,
-        :add_access, :add_ec2, :wakeup
+actions :add_service, :add_endpoint_template, :add_tenant, :add_domain, :add_domain_role, :add_user,
+        :add_role, :add_access, :add_ec2, :wakeup
 
 attribute :protocol, kind_of: String
 attribute :insecure, kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
We were missing giving out the admin role for the default admin
to the admin user, thus horizon would not display the domains
panel.

In order to do this a new action is created on the keystone helpers
add_domain_role that would take a user, a role and a domain and grant
that user the given role in that domain.

Unfortunately, the calls to the domain role modify will return
"204 - No content" on create/update so the "_update_item" method on
the keystone provider needed an update to also accept a http 204 as
"success". As to not affect any other calls that may receive a 204
but turning that response into a success is not wanted, a new parameter
was introduced into the function to activate this behaviour. This
safely allows the introduction of the new response as valid only for
those calls that need them