### PR TITLE
Ironic: add option to disable autoclean + conf update

### DIFF
--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -206,6 +206,7 @@ template node[:ironic][:config_file] do
   group node[:ironic][:group]
   mode "0640"
   variables(
+    automated_clean: node[:ironic][:automated_clean],
     drivers: node[:ironic][:enabled_drivers],
     debug: node[:ironic][:debug],
     rabbit_settings: fetch_rabbitmq_settings,

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -12,6 +12,7 @@ public_endpoint=<%= @public_endpoint %>
 
 [conductor]
 api_url=<%= @public_endpoint %>
+automated_clean=<%= @automated_clean %>
 
 [database]
 connection=<%= @database_connection %>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -145,11 +145,13 @@ protocol = <%= @glance_server_protocol %>
 
 <% unless @ironic_settings.nil? -%>
 [ironic]
-api_endpoint = <%= @ironic_settings[:api_protocol] %>://<%= @ironic_settings[:public_host] %>:<%= @ironic_settings[:api_port] %>
-admin_username = <%= @ironic_settings[:service_user] %>
-admin_password = <%= @ironic_settings[:service_password] %>
-admin_url = <%= @keystone_settings['protocol'] %>://<%= @keystone_settings['internal_url_host'] %>:<%= @keystone_settings['admin_port'] %>/<%= @ironic_settings[:keystone_version] %>/
-admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
+auth_type = password
+auth_url = <%= @keystone_settings['internal_auth_url'] %>
+username = <%= @ironic_settings[:service_user] %>
+password = <%= @ironic_settings[:service_password] %>
+project_name = <%= @keystone_settings['service_tenant'] %>
+project_domain_name = <%= @keystone_settings['admin_domain']%>
+user_domain_name = <%= @keystone_settings['admin_domain'] %>
 <% end -%>
 
 [key_manager]

--- a/chef/data_bags/crowbar/migrate/ironic/102_add_autoclean.rb
+++ b/chef/data_bags/crowbar/migrate/ironic/102_add_autoclean.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["automated_clean"] = ta["automated_clean"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if a["automated_clean"]
+    a.delete("automated_clean")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ironic.json
+++ b/chef/data_bags/crowbar/template-ironic.json
@@ -14,6 +14,7 @@
       "service_user": "ironic",
       "service_password": "",
       "enabled_drivers": [],
+      "automated_clean": true,
       "api": {
         "protocol": "http",
         "port": 6385
@@ -28,7 +29,7 @@
   "deployment": {
     "ironic": {
       "crowbar-revision": 0,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "crowbar-applied": false,
       "element_states": {
         "ironic-server": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-ironic.schema
+++ b/chef/data_bags/crowbar/template-ironic.schema
@@ -23,6 +23,7 @@
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
             "enabled_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
+            "automated_clean": { "type": "bool", "required": true },
             "api": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/views/barclamp/ironic/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ironic/_edit_attributes.html.haml
@@ -8,6 +8,8 @@
     = instance_field :rabbitmq
     = instance_field :glance
 
+    = boolean_field :automated_clean
+
     %fieldset
       %legend
         = t(".ssl_header")

--- a/crowbar_framework/config/locales/ironic/en.yml
+++ b/crowbar_framework/config/locales/ironic/en.yml
@@ -26,6 +26,7 @@ en:
         keystone_instance: 'Keystone'
         rabbitmq_instance: 'RabbitMQ'
         debug: 'Debug'
+        automated_clean: 'Enable automated node cleaning'
         api:
           protocol: 'Protocol'
         ssl_header: 'SSL Support'


### PR DESCRIPTION
A new attribute was added to disable automatic cleaning of baremetal nodes. This is especially useful during testing and development as the cleaning procedure can take a lot of time. For production it is not recommended but there are also some cases where it can be useful (e.g. when one tenant wants to quickly re-cycle hardware).

Second commit is update of nova conf to remove some deprecation warnings.