### PR TITLE
monasca: log monasca-installer output

### DIFF
--- a/chef/cookbooks/monasca/files/default/monasca-installer.logrotate
+++ b/chef/cookbooks/monasca/files/default/monasca-installer.logrotate
@@ -1,0 +1,10 @@
+/var/log/monasca-installer.log {
+        weekly
+        rotate 10
+        size 1M
+        copytruncate
+        delaycompress
+        compress
+        notifempty
+        missingok
+}

--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -135,11 +135,19 @@ previous_versions = if Pathname.new(lock_file).file?
 get_versions = "rpm -qa | grep -e crowbar-openstack -e monasca-installer | sort"
 actual_versions = IO.popen(get_versions, &:read).gsub(/^$\n/, "")
 
+cookbook_file "/etc/logrotate.d/monasca-installer" do
+  owner "root"
+  group "root"
+  mode "0644"
+  action :create
+  source "monasca-installer.logrotate"
+end
+
 ansible_cmd =
   "rm -f #{lock_file} " \
   "&& ansible-playbook " \
     "-i monasca-hosts -e '@/opt/monasca-installer/crowbar_vars.yml' " \
-    "monasca.yml " \
+    "monasca.yml -vvv >> /var/log/monasca-installer.log 2>&1 " \
   "&& echo '#{actual_versions}' > #{lock_file}"
 
 execute "run ansible" do


### PR DESCRIPTION
By popular demand: log full debug output from monasca-installer to `/var/log/monasca-installer.log`.