### PR TITLE
nova: disable memory usage statistics (bsc#1020906)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -198,6 +198,7 @@ block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_M
 <% if @libvirt_type.eql?('kvm') %>use_virtio_for_bridges = true<% end %>
 <%= "volume_use_multipath = true" if @use_multipath %>
 <%= "iser_use_multipath = true" if @use_multipath %>
+mem_stats_period_seconds = 0
 
 [neutron]
 service_metadata_proxy = true


### PR DESCRIPTION
to avoid VMs being stopped during live+block migration
https://bugzilla.suse.com/show_bug.cgi?id=1020906

This change helped on SOC6. Not sure if it also applies to SOC7.
And not sure if it has negative side effects.