### PR TITLE
ironic: Added missing dependency for agent_ssh

### DIFF
--- a/chef/cookbooks/ironic/attributes/default.rb
+++ b/chef/cookbooks/ironic/attributes/default.rb
@@ -28,7 +28,8 @@ when "rhel", "suse"
       "openstack-ironic-conductor"
     ],
     driver_dependencies: {
-      pxe_ssh: ["python-paramiko"]
+      pxe_ssh: ["python-paramiko"],
+      agent_ssh: ["python-paramiko"]
     }
   }
   default[:ironic][:api][:service_name] = "openstack-ironic-api"
@@ -47,7 +48,8 @@ when "debian"
       "ironic-api-conductor"
     ],
     driver_dependencies: {
-      pxe_ssh: ["python-paramiko"]
+      pxe_ssh: ["python-paramiko"],
+      agent_ssh: ["python-paramiko"]
     }
   }
   default[:ironic][:api][:service_name] = "ironic-api"


### PR DESCRIPTION
Paramiko is needed for all SSH based drivers.