### PR TITLE
[3.0] Add resource limit controls (bsc#1020922)

### DIFF
--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -125,3 +125,14 @@ crowbar_pacemaker_sync_mark "create-cinder_register"
 cinder_service "api" do
   use_pacemaker_provider ha_enabled
 end
+
+service = "openstack-cinder-api"
+if node[:cinder][:resource_limits] && node[:cinder][:resource_limits][service]
+  limits = node[:cinder][:resource_limits][service]
+  action = limits.values.any? ? :create : :delete
+  utils_systemd_override_limits "Resource limits for #{service}" do
+    service_name service
+    limits limits
+    action action
+  end
+end

--- a/chef/cookbooks/cinder/recipes/scheduler.rb
+++ b/chef/cookbooks/cinder/recipes/scheduler.rb
@@ -22,3 +22,14 @@ include_recipe "#{@cookbook_name}::common"
 cinder_service "scheduler" do
   use_pacemaker_provider node[:cinder][:ha][:enabled]
 end
+
+service = "openstack-cinder-scheduler"
+if node[:cinder][:resource_limits] && node[:cinder][:resource_limits][service]
+  limits = node[:cinder][:resource_limits][service]
+  action = limits.values.any? ? :create : :delete
+  utils_systemd_override_limits "Resource limits for #{service}" do
+    service_name service
+    limits limits
+    action action
+  end
+end

--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -347,3 +347,14 @@ else
     notifies :restart, "service[cinder-volume]"
   end
 end
+
+service = "openstack-cinder-volume"
+if node[:cinder][:resource_limits] && node[:cinder][:resource_limits][service]
+  limits = node[:cinder][:resource_limits][service]
+  action = limits.values.any? ? :create : :delete
+  utils_systemd_override_limits "Resource limits for #{service}" do
+    service_name service
+    limits limits
+    action action
+  end
+end

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -418,3 +418,46 @@ end
 apache_site "openstack-dashboard.conf" do
   enable true
 end
+
+if node[:horizon][:resource_limits] && \
+    node[:horizon][:resource_limits].include?("apache2") && \
+    node[:horizon][:resource_limits]["apache2"].values.any?
+  ruby_block "set global apache limits" do
+    block do
+      # Get the limits set in the proposal
+      horizon_apache_limits = node[:horizon][:resource_limits]["apache2"]
+
+      # If this value hasn't been set in this chef run, make it a hash
+      node.default[:resource_limits] = {} unless node[:resource_limits]
+
+      # If apache limits have already been set in this chef run, get those
+      global_apache_limits = node[:resource_limits]["apache2"] || {}
+      global_apache_limits = global_apache_limits.to_hash
+
+      # For each limit setting, get the maximum across all barclamps seen so far
+      horizon_apache_limits.each do |name, value|
+        global_apache_limits[name] = [global_apache_limits[name].to_i, value].max
+      end
+
+      # Set the new limits in the node so it can be re-used in this chef run.
+      # node.default is cleared before every chef run so this will not pollute the node.
+      node.default[:resource_limits]["apache2"] = global_apache_limits
+
+      # Now that the limits variable is set, override the lwrp parameter at compile time
+      rsc_name = "Resource limits for apache2"
+      override_rsc = Chef::Resource::UtilsSystemdOverrideLimits.new(rsc_name, run_context)
+      override_rsc.service_name "apache2"
+      override_rsc.limits node[:resource_limits]["apache2"]
+      override_rsc.run_action :create
+    end
+  end
+# If we've deleted limits across the board, delete leftover override files (and don't create them)
+# Note that other recipes may come along later in the chef run and set these node values
+# and then the resource will be created again.
+elsif !node[:resource_limits] || !node[:resource_limits]["apache2"] || \
+    (node[:resource_limits]["apache2"] || {}).to_hash.values.none?
+  utils_systemd_override_limits "Resource limits for apache2" do
+    service_name "apache2"
+    action :delete
+  end
+end

--- a/chef/cookbooks/postgresql/templates/default/limits.erb
+++ b/chef/cookbooks/postgresql/templates/default/limits.erb
@@ -1,0 +1,6 @@
+# Resource limits for the postgres user
+
+<% @limits.each do |name, value| -%>
+postgres    hard    <%= name %>    <%= value %>
+postgres    soft    <%= name %>    <%= value %>
+<% end -%>

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -123,5 +123,39 @@ else
   end
 end
 
+service = "rabbitmq-server"
+if node[:rabbitmq][:resource_limits] && node[:rabbitmq][:resource_limits][service]
+  limits = node[:rabbitmq][:resource_limits][service]
+  limit_action = limits.values.any? ? :create : :delete
+  # If using HA, we manage pam_limits for rabbitmq with limits.conf, otherwise
+  # we manage it through systemd
+  if ha_enabled
+    limits = Hash[limits.map { |k, v| [k.gsub(/^Limit/, "").downcase, v] }]
+    directory "/etc/security/limits.d" do
+      action :create
+      owner "root"
+      group "root"
+      mode "0755"
+    end
+    template "/etc/security/limits.d/rabbitmq.conf" do
+      action limit_action
+      source "limits.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(
+        limits: limits
+      )
+      notifies :restart, resources(service: service)
+    end
+  else
+    utils_systemd_override_limits "Resource limits for #{service}" do
+      service_name service
+      limits limits
+      action limit_action
+    end
+  end
+end
+
 # save data so it can be found by search
 node.save

--- a/chef/cookbooks/rabbitmq/templates/default/limits.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/limits.erb
@@ -1,0 +1,6 @@
+# Resource limits for the rabbitmq user
+
+<% @limits.each do |name, value| -%>
+rabbitmq    hard    <%= name %>    <%= value %>
+rabbitmq    soft    <%= name %>    <%= value %>
+<% end -%>

--- a/chef/data_bags/crowbar/migrate/cinder/052_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/052_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/database/005_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/database/005_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/horizon/039_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/039_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/keystone/036_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/036_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/rabbitmq/012_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/012_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -155,6 +155,17 @@
         "password": "",
         "user": "cinder",
         "database": "cinder"
+      },
+      "resource_limits": {
+        "openstack-cinder-api": {
+          "LimitNOFILE": null
+        },
+        "openstack-cinder-scheduler": {
+          "LimitNOFILE": null
+        },
+        "openstack-cinder-volume": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -162,7 +173,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 51,
+      "schema-revision": 52,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -324,6 +324,27 @@
                 "user": { "type": "str", "required": true },
                 "database": { "type": "str", "required": true }
               }
+            },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "openstack-cinder-api": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                },
+                "openstack-cinder-scheduler": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                },
+                "openstack-cinder-volume": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
             }
           }
         }

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -26,6 +26,11 @@
             "options": ""
           }
         }
+      },
+      "resource_limits": {
+        "postgresql": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -33,7 +38,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 4,
+      "schema-revision": 5,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -67,6 +67,17 @@
                   }
                 }
               }
+            },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "postgresql": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
             }
           }
         }

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -43,14 +43,19 @@
         "ssl_crt_chain_file": ""
       },
       "external_monitoring": {},
-      "token_hash_enabled": true
+      "token_hash_enabled": true,
+      "resource_limits": {
+        "apache2": {
+          "LimitNOFILE": null
+        }
+      }
     }
   },
   "deployment": {
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 38,
+      "schema-revision": 39,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -72,7 +72,18 @@
                 =: { "type": "str",  "required": false }
               }
             },
-	    "token_hash_enabled": { "type": "bool", "required": true }
+	    "token_hash_enabled": { "type": "bool", "required": true },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "apache2": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
+            }
           }
         }
       }

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -132,6 +132,11 @@
         "use_tls": false,
         "tls_req_cert": "demand",
         "use_pool": false
+      },
+      "resource_limits": {
+        "apache2": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -139,7 +144,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 35,
+      "schema-revision": 36,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -137,7 +137,18 @@
                       "use_tls": { "type": "bool" },
                       "use_pool": { "type": "bool" },
                       "tls_req_cert": { "type": "str" }
-                    }}
+                    }},
+                    "resource_limits": {
+                      "type": "map",
+                      "required": false,
+                      "mapping": {
+                        "apache2": {
+                          "type": "map",
+                          "required": false,
+                          "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                        }
+                      }
+                    }
               }}
      }},
     "deployment": { "type": "map", "required": true,

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -26,6 +26,11 @@
         "password": "",
         "user": "trove",
         "vhost": "/trove"
+      },
+      "resource_limits": {
+        "rabbitmq-server": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -33,7 +38,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 11,
+      "schema-revision": 12,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -55,6 +55,17 @@
                 "user": { "type": "str", "required": true },
                 "vhost": { "type": "str", "required": true }
               }
+            },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "rabbitmq-server": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Some services require modifications to the system resource limits, such
as the maximum number of open files, that we cannot necessarily predict
a reasonable default for. Without this patch, there is no way to control
those limits from crowbar and they must be changed manually. This patch
adds a resource_limits parameter to a few barclamps to allow
administrators to set these limits for specific services from the
barclamp that controls those services. Currently only the LimitNOFILE
(systemd's name for the maximum number of open files) limit is supported.

This pull request is split into four commits and it will be easiest to review them each one at a time.

1. Create a systemd_override LWRP and use it in the cinder barclamp.
2. Use the same LWRP in the keystone and horizon barclamps to demonstrate
how it should be used for barclamps that share a service (take the max).
3. Fix the rabbitmq service resource, which was unable to restart when deployed with pacemaker.
4. Add the parameter to the rabbitmq barclamp, which will either use the systemd_override resource or /etc/security/limits.conf depending on whether it is deployed with pacemaker or not.

Depends on #1034 