### PR TITLE
monasca: Specify policy values for kibana button

### DIFF
--- a/chef/cookbooks/horizon/templates/default/_80_monasca_ui_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/_80_monasca_ui_settings.py.erb
@@ -63,6 +63,9 @@ ENABLE_KIBANA_BUTTON = getattr(settings, 'ENABLE_KIBANA_BUTTON', <%= @kibana_ena
 # TODO: this needs to be fixed for clustered deployment
 KIBANA_HOST = getattr(settings, 'KIBANA_HOST', 'http://<%= @kibana_host %>:5601/')
 
+KIBANA_POLICY_SCOPE = 'monitoring'
+KIBANA_POLICY_RULE = 'monitoring:kibana_access'
+
 OPENSTACK_SSL_NO_VERIFY = getattr(settings, 'OPENSTACK_SSL_NO_VERIFY', False)
 OPENSTACK_SSL_CACERT = getattr(settings, 'OPENSTACK_SSL_CACERT', None)
 OPENSTACK_ENDPOINT_TYPE="publicURL"


### PR DESCRIPTION
Configuration file for monasca-ui was missing
KIBANA_POLICY_SCOPE and KIBANA_POLICY_RULE
variables that are used when taking a decison
wheter or not given user should see buttont that
opens up Kibana.

Depends-On: https://review.openstack.org/#/c/472575/