### PR TITLE
heat: heat-engine uses a old keys from keystone_authtoken

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -126,6 +126,9 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
 project_domain_name = <%= @keystone_settings['admin_domain']%>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
 auth_type = password
+admin_user = <%= @keystone_settings['service_user'] %>
+admin_password = <%= @keystone_settings['service_password'] %>
+user_domain_id = <%= @keystone_settings['admin_domain'] %>
 
 <% if node[:heat][:api][:protocol] == "https" %>
 [ssl]


### PR DESCRIPTION
we can revert this if https://review.openstack.org/#/c/473543/ is
merged. The review backports the original fix to newton branch.