### PR TITLE
Use keystone v3 everywhere (SCRD-781)

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -69,7 +69,7 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(

--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -128,7 +128,7 @@ keystone_register "register aodh endpoint" do
   endpoint_publicURL "#{aodh_protocol}://#{my_public_host}:#{aodh_port}"
   endpoint_adminURL "#{aodh_protocol}://#{my_admin_host}:#{aodh_port}"
   endpoint_internalURL "#{aodh_protocol}://#{my_admin_host}:#{aodh_port}"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-aodh_keystone_register" if ha_enabled

--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -96,7 +96,7 @@ keystone_register "give aodh user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -85,7 +85,7 @@ keystone_register "register aodh user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -97,7 +97,7 @@ keystone_register "register barbican endpoint" do
   endpoint_publicURL "#{barbican_protocol}://#{public_host}:#{barbican_port}"
   endpoint_adminURL "#{barbican_protocol}://#{admin_host}:#{barbican_port}"
   endpoint_internalURL "#{barbican_protocol}://#{admin_host}:#{barbican_port}"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 keystone_register "register barbican user" do

--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -108,7 +108,7 @@ keystone_register "register barbican user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -59,7 +59,7 @@ public_host = CrowbarHelper.get_host_for_public_url(node,
                                                     node[:barbican][:ha][:enabled])
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 crowbar_pacemaker_sync_mark "wait-barbican_register" if ha_enabled
 

--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -119,7 +119,7 @@ keystone_register "give barbican user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -263,7 +263,7 @@ keystone_register "register ceilometer user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -244,7 +244,7 @@ crowbar_pacemaker_sync_mark "wait-ceilometer_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "ceilometer wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -274,7 +274,7 @@ keystone_register "give ceilometer user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end
@@ -288,7 +288,7 @@ unless swift_middlewares.empty?
     port keystone_settings["admin_port"]
     auth register_auth_hash
     user_name keystone_settings["service_user"]
-    tenant_name keystone_settings["service_tenant"]
+    project_name keystone_settings["service_tenant"]
     role_name "ResellerAdmin"
     action :add_access
   end

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -318,9 +318,7 @@ keystone_register "register ceilometer endpoint" do
   endpoint_publicURL "#{ceilometer_protocol}://#{my_public_host}:#{node[:ceilometer][:api][:port]}"
   endpoint_adminURL "#{ceilometer_protocol}://#{my_admin_host}:#{node[:ceilometer][:api][:port]}"
   endpoint_internalURL "#{ceilometer_protocol}://#{my_admin_host}:#{node[:ceilometer][:api][:port]}"
-#  endpoint_global true
-#  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 # In stoney/icehouse we have the cronjob crowbar-ceilometer-expirer in

--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -65,7 +65,7 @@ keystone_register "give cinder user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -35,7 +35,7 @@ crowbar_pacemaker_sync_mark "wait-cinder_register"
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "cinder api wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -54,7 +54,7 @@ keystone_register "register cinder user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -96,9 +96,7 @@ keystone_register "register cinder endpoint" do
                     "#{my_admin_host}:#{cinder_port}/v1/$(project_id)s"
   endpoint_internalURL "#{cinder_protocol}://"\
                        "#{my_admin_host}:#{cinder_port}/v1/$(project_id)s"
-#  endpoint_global true
-#  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 keystone_register "register cinder service v2" do
@@ -127,7 +125,7 @@ keystone_register "register cinder endpoint v2" do
                     "#{my_admin_host}:#{cinder_port}/v2/$(project_id)s"
   endpoint_internalURL "#{cinder_protocol}://"\
                        "#{my_admin_host}:#{cinder_port}/v2/$(project_id)s"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 keystone_register "register cinder service v3" do
@@ -156,7 +154,7 @@ keystone_register "register cinder endpoint v3" do
                     "#{my_admin_host}:#{cinder_port}/v3/$(project_id)s"
   endpoint_internalURL "#{cinder_protocol}://"\
                        "#{my_admin_host}:#{cinder_port}/v3/$(project_id)s"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-cinder_register"

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -83,7 +83,7 @@ keystone_settings = KeystoneHelper.keystone_settings(node, "nova")
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(node, ssl_enabled, ha_enabled)

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -138,7 +138,7 @@ keystone_register "register ec2-api endpoint" do
   endpoint_publicURL "#{api_protocol}://#{my_public_host}:#{ec2_api_port}"
   endpoint_adminURL "#{api_protocol}://#{my_admin_host}:#{ec2_api_port}"
   endpoint_internalURL "#{api_protocol}://#{my_admin_host}:#{ec2_api_port}"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 # Create ec2-metadata service
@@ -165,7 +165,7 @@ keystone_register "register ec2-metadata endpoint" do
   endpoint_publicURL "#{api_protocol}://#{my_public_host}:#{ec2_metadata_port}"
   endpoint_adminURL "#{api_protocol}://#{my_admin_host}:#{ec2_metadata_port}"
   endpoint_internalURL "#{api_protocol}://#{my_admin_host}:#{ec2_metadata_port}"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-ec2_api_register" if ha_enabled

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -109,7 +109,7 @@ keystone_register "give ec2 user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -98,7 +98,7 @@ keystone_register "register ec2 user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -138,7 +138,7 @@ crowbar_pacemaker_sync_mark "wait-glance_register_service" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "register glance service" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -163,9 +163,7 @@ keystone_register "register glance endpoint" do
   endpoint_publicURL "#{glance_protocol}://#{endpoint_public_ip}:#{api_port}"
   endpoint_adminURL "#{glance_protocol}://#{endpoint_admin_ip}:#{api_port}"
   endpoint_internalURL "#{glance_protocol}://#{endpoint_admin_ip}:#{api_port}"
-#  endpoint_global true
-#  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-glance_register_service" if ha_enabled

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -108,7 +108,7 @@ keystone_register "give glance user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -78,7 +78,7 @@ crowbar_pacemaker_sync_mark "wait-glance_register_user" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant:  keystone_settings["admin_tenant"] }
+                       project:  keystone_settings["admin_project"] }
 
 keystone_register "glance wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -97,7 +97,7 @@ keystone_register "register glance user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -119,7 +119,7 @@ crowbar_pacemaker_sync_mark "wait-heat_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "heat wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -149,7 +149,7 @@ keystone_register "give heat user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end
@@ -182,7 +182,7 @@ node[:heat][:trusts_delegated_roles].each do |role|
     port keystone_settings["admin_port"]
     auth register_auth_hash
     user_name keystone_settings["admin_user"]
-    tenant_name keystone_settings["default_tenant"]
+    project_name keystone_settings["default_tenant"]
     role_name role
     action :add_access
   end

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -160,8 +160,6 @@ keystone_register "add heat stack user role" do
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
   auth register_auth_hash
-  user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
   role_name "heat_stack_user"
   action :add_role
 end
@@ -173,8 +171,6 @@ node[:heat][:trusts_delegated_roles].each do |role|
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
     auth register_auth_hash
-    user_name keystone_settings["service_user"]
-    tenant_name keystone_settings["service_tenant"]
     role_name role
     action :add_role
   end

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -138,7 +138,7 @@ keystone_register "register heat user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -311,9 +311,7 @@ keystone_register "register heat Cfn endpoint" do
   endpoint_publicURL "#{node[:heat][:api][:protocol]}://#{my_public_host}:#{node[:heat][:api][:cfn_port]}/v1"
   endpoint_adminURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:cfn_port]}/v1"
   endpoint_internalURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:cfn_port]}/v1"
-  #  endpoint_global true
-  #  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 # Create Heat service
@@ -346,9 +344,7 @@ keystone_register "register heat endpoint" do
   endpoint_internalURL "#{node[:heat][:api][:protocol]}://"\
                        "#{my_admin_host}:"\
                        "#{node[:heat][:api][:port]}/v1/$(project_id)s"
-  #  endpoint_global true
-  #  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-heat_register" if ha_enabled

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -144,7 +144,7 @@ keystone_register "register ironic user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -133,7 +133,7 @@ keystone_register "register ironic endpoint" do
   endpoint_publicURL public_endpoint
   endpoint_adminURL admin_endpoint
   endpoint_internalURL internal_endpoint
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 keystone_register "register ironic user" do

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -95,7 +95,7 @@ db_connection = fetch_database_connection_string(node[:ironic][:db])
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "ironic wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -155,7 +155,7 @@ keystone_register "give ironic user admin role in service tenant" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -41,7 +41,7 @@ default[:keystone][:api][:service_port] = 5000
 default[:keystone][:api][:admin_port] = 35357
 default[:keystone][:api][:admin_host] = "0.0.0.0"
 default[:keystone][:api][:api_host] = "0.0.0.0"
-default[:keystone][:api][:version] = "2.0"
+default[:keystone][:api][:version] = "3"
 default[:keystone][:api][:region] = "RegionOne"
 
 default[:keystone][:identity][:driver] = "sql"

--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -81,17 +81,20 @@ module KeystoneHelper
         "service_port" => node["keystone"]["api"]["service_port"],
         "admin_port" => node["keystone"]["api"]["admin_port"],
         "admin_token" => node["keystone"]["service"]["token"],
-        "admin_tenant" => node["keystone"]["admin"]["tenant"],
+        "admin_project" => node["keystone"]["admin"]["project"],
+        "admin_tenant" => node["keystone"]["admin"]["project"],
         "admin_user" => node["keystone"]["admin"]["username"],
         "admin_domain" => default_domain,
         "admin_domain_id" => default_domain_id,
         "admin_password" => node["keystone"]["admin"]["password"],
-        "default_tenant" => node["keystone"]["default"]["tenant"],
+        "default_project" => node["keystone"]["default"]["project"],
+        "default_tenant" => node["keystone"]["default"]["project"],
         "default_user" => has_default_user ? node["keystone"]["default"]["username"] : nil,
         "default_user_domain" => has_default_user ? default_domain : nil,
         "default_user_domain_id" => has_default_user ? default_domain_id : nil,
         "default_password" => has_default_user ? node["keystone"]["default"]["password"] : nil,
-        "service_tenant" => node["keystone"]["service"]["tenant"],
+        "service_project" => node["keystone"]["service"]["project"],
+        "service_tenant" => node["keystone"]["service"]["project"]
       }
     end
 

--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -414,7 +414,7 @@ def _build_connection(new_resource)
     auth_token = _get_token(http,
                             new_resource.auth[:user],
                             new_resource.auth[:password],
-                            new_resource.auth[:tenant])
+                            new_resource.auth[:project])
     unless auth_token
       raise "Authentication failed for user #{new_resource.auth[:user]}"
     end

--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -74,7 +74,7 @@ action :add_project do
 end
 
 # :add_domain specific attributes
-# attribute :tenant_name, :kind_of => String
+# attribute :domain_name, :kind_of => String
 action :add_domain do
   http, headers = _build_connection(new_resource)
 

--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -598,15 +598,14 @@ def _build_project_object(project_name, domain_id = "default")
   body
 end
 
-private
-
 def _build_domain_object(domain_name)
-  svc_obj = {}
-  svc_obj.store("name", domain_name)
-  svc_obj.store("enabled", true)
-  ret = {}
-  ret.store("domain", svc_obj)
-  ret
+  body = {
+    domain: {
+      name: domain_name,
+      enabled: true
+    }
+  }
+  body
 end
 
 private

--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -428,26 +428,25 @@ def _build_connection(new_resource)
   [http, headers]
 end
 
-private
-def _find_id(http, headers, svc_name, spath, dir, key = "name", ret = "id")
+def _find_id(http, headers, item_name, path, dir, key = "name", ret = "id")
   # Construct the path
-  my_service_id = nil
+  my_item_id = nil
   error = false
-  resp = http.request_get(spath, headers)
+  resp = http.request_get(path, headers)
   if resp.is_a?(Net::HTTPOK)
     data = JSON.parse(resp.read_body)
     data = data[dir]
 
-    data.each do |svc|
-      my_service_id = svc[ret] if svc[key] == svc_name
-      break if my_service_id
+    data.each do |item|
+      my_item_id = item[ret] if item[key] == item_name
+      break if my_item_id
     end
   else
-    log_message = "Find #{spath}: #{svc_name}: Unknown response from Keystone Server"
+    log_message = "Find #{path}: #{item_name}: Unknown response from Keystone Server"
     _log_error(resp, log_message)
     error = true
   end
-  [my_service_id, error]
+  [my_item_id, error]
 end
 
 def _build_service_object(svc_name, svc_type, svc_desc)

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -496,7 +496,7 @@ unless updated_password.empty? ||
       auth register_auth_hash
       user_name node[:keystone][:admin][:username]
       user_password updated_password
-      tenant_name node[:keystone][:admin][:tenant]
+      project_name node[:keystone][:admin][:tenant]
       action :nothing
     end.run_action(:add_user)
   end
@@ -591,7 +591,7 @@ if node[:keystone][:default][:create_user]
     auth register_auth_hash
     user_name node[:keystone][:default][:username]
     user_password node[:keystone][:default][:password]
-    tenant_name node[:keystone][:default][:tenant]
+    project_name node[:keystone][:default][:tenant]
     action :add_user
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -538,16 +538,16 @@ ruby_block "mark node for keystone bootstrap" do
 end
 
 [:service, :default].each do |tenant_type|
-  tenant = node[:keystone][tenant_type][:tenant]
+  project = node[:keystone][tenant_type][:tenant]
 
-  keystone_register "add default #{tenant} tenant" do
+  keystone_register "add default #{project} project" do
     protocol node[:keystone][:api][:protocol]
     insecure keystone_insecure
     host my_admin_host
     port node[:keystone][:api][:admin_port]
     auth register_auth_hash
-    tenant_name tenant
-    action :add_tenant
+    project_name project
+    action :add_project
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -210,7 +210,7 @@ max_active_keys = (node[:keystone][:token_expiration].to_f / 3600).ceil + 2
 
 register_auth_hash = { user: node[:keystone][:admin][:username],
                        password: node[:keystone][:admin][:password],
-                       tenant: node[:keystone][:admin][:project] }
+                       project: node[:keystone][:admin][:project] }
 
 if node[:keystone].key?(:endpoint)
   endpoint_protocol = node[:keystone][:endpoint][:protocol]
@@ -479,7 +479,7 @@ end
 
 register_auth_hash = { user: node[:keystone][:admin][:username],
                        password: node[:keystone][:admin][:password],
-                       tenant: node[:keystone][:admin][:project] }
+                       project: node[:keystone][:admin][:project] }
 
 updated_password = node[:keystone][:admin][:updated_password]
 

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -648,7 +648,7 @@ ec2_creds.each do |args|
     auth register_auth_hash
     port node[:keystone][:api][:admin_port]
     user_name args[0]
-    tenant_name args[1]
+    project_name args[1]
     action :add_ec2
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -626,7 +626,7 @@ user_roles.each do |args|
     auth register_auth_hash
     user_name args[0]
     role_name args[1]
-    tenant_name args[2]
+    project_name args[2]
     action :add_access
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-actions :add_service, :add_endpoint_template, :add_project, :add_domain, :add_domain_role, :add_user,
+actions :add_service, :add_endpoint, :add_project, :add_domain, :add_domain_role, :add_user,
         :add_role, :add_access, :add_ec2, :wakeup, :update_endpoint
 
 attribute :protocol, kind_of: String
@@ -34,13 +34,12 @@ attribute :service_name, kind_of: String
 attribute :service_type, kind_of: String
 attribute :service_description, kind_of: String
 
-# :add_endpoint_template specific attributes
+# :add_endpoint specific attributes
 attribute :endpoint_service, kind_of: String
 attribute :endpoint_region, kind_of: String
 attribute :endpoint_adminURL, kind_of: String
 attribute :endpoint_internalURL, kind_of: String
 attribute :endpoint_publicURL, kind_of: String
-attribute :endpoint_global, default: true
 attribute :endpoint_enabled, default: true
 
 # :add_project specific attributes

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -63,4 +63,4 @@ attribute :tenant_name, kind_of: String
 
 # :add_ec2 specific attributes
 attribute :user_name, kind_of: String
-attribute :tenant_name, kind_of: String
+attribute :project_name, kind_of: String

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-actions :add_service, :add_endpoint_template, :add_tenant, :add_domain, :add_domain_role, :add_user,
+actions :add_service, :add_endpoint_template, :add_project, :add_domain, :add_domain_role, :add_user,
         :add_role, :add_access, :add_ec2, :wakeup, :update_endpoint
 
 attribute :protocol, kind_of: String
@@ -43,8 +43,8 @@ attribute :endpoint_publicURL, kind_of: String
 attribute :endpoint_global, default: true
 attribute :endpoint_enabled, default: true
 
-# :add_tenant specific attributes
-attribute :tenant_name, kind_of: String
+# :add_project specific attributes
+attribute :project_name, kind_of: String
 
 # :add_domain specific attributes
 attribute :domain_name, kind_of: String

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -60,7 +60,7 @@ attribute :role_name, kind_of: String
 # :add_access specific attributes
 attribute :user_name, kind_of: String
 attribute :role_name, kind_of: String
-attribute :tenant_name, kind_of: String
+attribute :project_name, kind_of: String
 
 # :add_ec2 specific attributes
 attribute :user_name, kind_of: String

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -52,6 +52,7 @@ attribute :domain_name, kind_of: String
 # :add_user specific attributes
 attribute :user_name, kind_of: String
 attribute :user_password, kind_of: String
+attribute :project_name, kind_of: String
 
 # :add_role specific attributes
 attribute :role_name, kind_of: String

--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -52,7 +52,7 @@ keystone_register "register magnum user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -94,7 +94,7 @@ keystone_register "register magnum endpoint" do
                     "#{my_admin_host}:#{magnum_port}/v1"
   endpoint_internalURL "#{magnum_protocol}://"\
                        "#{my_admin_host}:#{magnum_port}/v1"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-magnum_register" if ha_enabled

--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -33,7 +33,7 @@ crowbar_pacemaker_sync_mark "wait-magnum_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "magnum api wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -63,7 +63,7 @@ keystone_register "give magnum user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/manila/recipes/api.rb
+++ b/chef/cookbooks/manila/recipes/api.rb
@@ -35,7 +35,7 @@ crowbar_pacemaker_sync_mark "wait-manila_register"
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "manila api wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/manila/recipes/api.rb
+++ b/chef/cookbooks/manila/recipes/api.rb
@@ -96,9 +96,7 @@ keystone_register "register manila endpoint" do
                     "#{my_admin_host}:#{manila_port}/v1/$(project_id)s"
   endpoint_internalURL "#{manila_protocol}://"\
                        "#{my_admin_host}:#{manila_port}/v1/$(project_id)s"
-  #  endpoint_global true
-  #  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 # v2 API is new since Liberty
@@ -128,7 +126,7 @@ keystone_register "register manila endpoint v2" do
                     "#{my_admin_host}:#{manila_port}/v2/$(project_id)s"
   endpoint_internalURL "#{manila_protocol}://"\
                        "#{my_admin_host}:#{manila_port}/v2/$(project_id)s"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-manila_register"

--- a/chef/cookbooks/manila/recipes/api.rb
+++ b/chef/cookbooks/manila/recipes/api.rb
@@ -65,7 +65,7 @@ keystone_register "give manila user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/manila/recipes/api.rb
+++ b/chef/cookbooks/manila/recipes/api.rb
@@ -54,7 +54,7 @@ keystone_register "register manila user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -49,7 +49,7 @@ keystone_register "give monasca api user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end
@@ -208,7 +208,7 @@ keystone_register "give admin user admin role in monasca tenant" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["admin_user"]
-  tenant_name monasca_project
+  project_name monasca_project
   role_name "admin"
   action :add_access
 end
@@ -221,7 +221,7 @@ keystone_register "give admin user monasca-user role in monasca tenant" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["admin_user"]
-  tenant_name monasca_project
+  project_name monasca_project
   role_name "monasca-user"
   action :add_access
 end
@@ -254,7 +254,7 @@ unless agents_settings.empty?
       port keystone_settings["admin_port"]
       auth register_auth_hash
       user_name as["service_user"]
-      tenant_name as["service_tenant"]
+      project_name as["service_tenant"]
       role_name as["service_role"]
       action :add_access
     end

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -38,7 +38,7 @@ keystone_register "register monasca api user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 
@@ -243,7 +243,7 @@ unless agents_settings.empty?
       auth register_auth_hash
       user_name as["service_user"]
       user_password as["service_password"]
-      tenant_name as["service_tenant"]
+      project_name as["service_tenant"]
       action :add_user
     end
 

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -77,7 +77,7 @@ keystone_register "register monasca api endpoint" do
   endpoint_publicURL MonascaHelper.api_public_url(node)
   endpoint_adminURL MonascaHelper.api_admin_url(node)
   endpoint_internalURL MonascaHelper.api_internal_url(node)
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 keystone_register "register logs service" do
@@ -103,7 +103,7 @@ keystone_register "register logs endpoint" do
   endpoint_publicURL MonascaHelper.log_api_public_url(node, "v3.0")
   endpoint_adminURL MonascaHelper.log_api_admin_url(node, "v3.0")
   endpoint_internalURL MonascaHelper.log_api_internal_url(node, "v3.0")
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 keystone_register "register logs_v2 service" do
@@ -129,7 +129,7 @@ keystone_register "register logs_v2 endpoint" do
   endpoint_publicURL MonascaHelper.log_api_public_url(node, "v2.0")
   endpoint_adminURL MonascaHelper.log_api_admin_url(node, "v2.0")
   endpoint_internalURL MonascaHelper.log_api_internal_url(node, "v2.0")
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 keystone_register "register logs-search service" do
@@ -155,7 +155,7 @@ keystone_register "register logs-search endpoint" do
   endpoint_publicURL MonascaHelper.logs_search_public_url(node)
   endpoint_adminURL MonascaHelper.logs_search_admin_url(node)
   endpoint_internalURL MonascaHelper.logs_search_internal_url(node)
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 monasca_project = node[:monasca][:service_tenant]

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -18,7 +18,7 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 register_auth_hash = {
   user: keystone_settings["admin_user"],
   password: keystone_settings["admin_password"],
-  tenant: keystone_settings["admin_tenant"]
+  project: keystone_settings["admin_project"]
 }
 
 keystone_register "monasca api wakeup keystone" do
@@ -166,7 +166,7 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 register_auth_hash = {
   user: keystone_settings["admin_user"],
   password: keystone_settings["admin_password"],
-  tenant: keystone_settings["admin_tenant"]
+  project: keystone_settings["admin_project"]
 }
 
 keystone_register "monasca:common wakeup keystone" do

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -178,14 +178,14 @@ keystone_register "monasca:common wakeup keystone" do
   action :wakeup
 end
 
-keystone_register "monasca:common create tenant #{monasca_project} for monasca" do
+keystone_register "monasca:common create project #{monasca_project} for monasca" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
   auth register_auth_hash
-  tenant_name monasca_project
-  action :add_tenant
+  project_name monasca_project
+  action :add_project
 end
 
 monasca_roles.each do |role|

--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -85,9 +85,7 @@ keystone_register "register neutron endpoint" do
   endpoint_publicURL "#{neutron_protocol}://#{my_public_host}:#{api_port}/"
   endpoint_adminURL "#{neutron_protocol}://#{my_admin_host}:#{api_port}/"
   endpoint_internalURL "#{neutron_protocol}://#{my_admin_host}:#{api_port}/"
-#  endpoint_global true
-#  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-neutron_register" if ha_enabled

--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -46,7 +46,7 @@ keystone_register "register neutron user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -57,7 +57,7 @@ keystone_register "give neutron user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -27,7 +27,7 @@ crowbar_pacemaker_sync_mark "wait-neutron_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "neutron api wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
@@ -5,11 +5,13 @@ interface_driver = <%= @interface_driver %>
 auth_url = <%= KeystoneHelper.versioned_service_URL(@keystone_settings["protocol"],
                                                     @keystone_settings["internal_url_host"],
                                                     @keystone_settings["service_port"],
-                                                    "2.0") %>
-admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
+                                                    "3") %>
+admin_project_name = <%= @keystone_settings['service_tenant'] %>
 admin_user = <%= @keystone_settings['service_user'] %>
 admin_password = <%= @keystone_settings['service_password'] %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
+admin_user_domain = <%= @keystone_settings['admin_domain'] %>
+admin_project_domain = <%= @keystone_settings['admin_domain'] %>
 [service_providers]
 <% if @use_lbaas -%>
 <%

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -36,7 +36,7 @@ crowbar_pacemaker_sync_mark "wait-nova_register" if api_ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "nova api wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -66,7 +66,7 @@ keystone_register "give nova user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -55,7 +55,7 @@ keystone_register "register nova user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -109,9 +109,7 @@ keystone_register "register nova endpoint" do
                     "#{admin_api_host}:#{api_port}/v2.1/$(project_id)s"
   endpoint_internalURL "#{api_protocol}://"\
                        "#{admin_api_host}:#{api_port}/v2.1/$(project_id)s"
-#  endpoint_global true
-#  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 keystone_register "register nova_legacy endpoint" do
@@ -128,7 +126,7 @@ keystone_register "register nova_legacy endpoint" do
                     "#{admin_api_host}:#{api_port}/v2/$(project_id)s"
   endpoint_internalURL "#{api_protocol}://"\
                        "#{admin_api_host}:#{api_port}/v2/$(project_id)s"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-nova_register" if api_ha_enabled

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -249,7 +249,7 @@ if ironic_servers.any? && (node["roles"] & ["nova-compute-ironic", "nova-control
   override_force_config_drive = true
   ironic_node = ironic_servers.first
   ironic_settings = {}
-  ironic_settings[:keystone_version] = "v2.0"
+  ironic_settings[:keystone_version] = "v3"
   ironic_settings[:api_protocol] = ironic_node[:ironic][:api][:protocol]
   ironic_settings[:api_port] = ironic_node[:ironic][:api][:port]
   ironic_settings[:api_host] = CrowbarHelper.get_host_for_admin_url(

--- a/chef/cookbooks/nova/recipes/placement_api.rb
+++ b/chef/cookbooks/nova/recipes/placement_api.rb
@@ -87,7 +87,7 @@ keystone_register "register placement endpoint" do
   endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}"
   endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}"
   endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 if node[:nova][:ha][:enabled]

--- a/chef/cookbooks/nova/recipes/placement_api.rb
+++ b/chef/cookbooks/nova/recipes/placement_api.rb
@@ -59,7 +59,7 @@ keystone_register "give placement user '#{node["nova"]["placement_service_user"]
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name node["nova"]["placement_service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/nova/recipes/placement_api.rb
+++ b/chef/cookbooks/nova/recipes/placement_api.rb
@@ -38,7 +38,7 @@ crowbar_pacemaker_sync_mark "wait-nova-placement_register" if api_ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "register placement user '#{node["nova"]["placement_service_user"]}'" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/nova/recipes/placement_api.rb
+++ b/chef/cookbooks/nova/recipes/placement_api.rb
@@ -48,7 +48,7 @@ keystone_register "register placement user '#{node["nova"]["placement_service_us
   auth register_auth_hash
   user_name node["nova"]["placement_service_user"]
   user_password node["nova"]["placement_service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -227,14 +227,15 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
 auth_url = <%= KeystoneHelper.versioned_service_URL(@keystone_settings["protocol"],
                @keystone_settings["internal_url_host"],
                @keystone_settings["service_port"],
-               "2.0") %>
+               "3") %>
 auth_type = password
 insecure = <%= @neutron_insecure ? 'True' : 'False' %>
 password = <%= @neutron_service_password %>
 project_name = <%= @keystone_settings['service_tenant'] %>
-tenant_name = <%= @keystone_settings['service_tenant'] %>
 timeout = <%= node[:nova][:neutron_url_timeout] %>
 username = <%= @neutron_service_user %>
+user_domain_name = <%= @keystone_settings['admin_domain'] %>
+project_domain_name = <%= @keystone_settings['admin_domain'] %>
 
 [oslo_concurrency]
 <% if @need_shared_lock_path %>

--- a/chef/cookbooks/sahara/recipes/api.rb
+++ b/chef/cookbooks/sahara/recipes/api.rb
@@ -62,7 +62,7 @@ keystone_register "give sahara user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/sahara/recipes/api.rb
+++ b/chef/cookbooks/sahara/recipes/api.rb
@@ -51,7 +51,7 @@ keystone_register "register sahara user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/sahara/recipes/api.rb
+++ b/chef/cookbooks/sahara/recipes/api.rb
@@ -90,7 +90,7 @@ keystone_register "register sahara endpoint" do
   endpoint_publicURL "#{sahara_protocol}://#{my_public_host}:#{sahara_port}/v1.1/%(tenant_id)s"
   endpoint_adminURL "#{sahara_protocol}://#{my_admin_host}:#{sahara_port}/v1.1/%(tenant_id)s"
   endpoint_internalURL "#{sahara_protocol}://#{my_admin_host}:#{sahara_port}/v1.1/%(tenant_id)s"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-sahara_register" if ha_enabled

--- a/chef/cookbooks/sahara/recipes/api.rb
+++ b/chef/cookbooks/sahara/recipes/api.rb
@@ -30,7 +30,7 @@ my_public_host = CrowbarHelper.get_host_for_public_url(
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 crowbar_pacemaker_sync_mark "wait-sahara_register" if ha_enabled
 

--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -82,7 +82,7 @@ keystone_register "add #{service_user}:#{service_tenant} user admin role" do
   auth register_auth_hash
   user_name service_user
   role_name "admin"
-  tenant_name service_tenant
+  project_name service_tenant
   action :add_access
 end
 

--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -70,7 +70,7 @@ keystone_register "add #{service_user}:#{service_tenant} user" do
   auth register_auth_hash
   user_name service_user
   user_password service_password
-  tenant_name service_tenant
+  project_name service_tenant
   action :add_user
 end
 

--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -41,7 +41,7 @@ service_password = node[:swift][:dispersion][:service_password]
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "swift dispersion wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -58,8 +58,8 @@ keystone_register "create tenant #{service_tenant} for dispersion" do
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
   auth register_auth_hash
-  tenant_name service_tenant
-  action :add_tenant
+  project_name service_tenant
+  action :add_project
 end
 
 keystone_register "add #{service_user}:#{service_tenant} user" do

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -224,24 +224,22 @@ case proxy_config[:auth_method]
      end
 
      keystone_register "register swift-proxy endpoint" do
-         protocol keystone_settings["protocol"]
-         insecure keystone_settings["insecure"]
-         host keystone_settings["internal_url_host"]
-         auth register_auth_hash
-         port keystone_settings["admin_port"]
-         endpoint_service "swift"
-         endpoint_region keystone_settings["endpoint_region"]
-         endpoint_publicURL "#{swift_protocol}://#{public_host}:"\
+       protocol keystone_settings["protocol"]
+       insecure keystone_settings["insecure"]
+       host keystone_settings["internal_url_host"]
+       auth register_auth_hash
+       port keystone_settings["admin_port"]
+       endpoint_service "swift"
+       endpoint_region keystone_settings["endpoint_region"]
+       endpoint_publicURL "#{swift_protocol}://#{public_host}:"\
+                          "#{node[:swift][:ports][:proxy]}/v1/"\
+                          "#{node[:swift][:reseller_prefix]}$(project_id)s"
+       endpoint_adminURL "#{swift_protocol}://#{admin_host}:"\
+                         "#{node[:swift][:ports][:proxy]}/v1/"
+       endpoint_internalURL "#{swift_protocol}://#{admin_host}:"\
                             "#{node[:swift][:ports][:proxy]}/v1/"\
                             "#{node[:swift][:reseller_prefix]}$(project_id)s"
-         endpoint_adminURL "#{swift_protocol}://#{admin_host}:"\
-                           "#{node[:swift][:ports][:proxy]}/v1/"
-         endpoint_internalURL "#{swift_protocol}://#{admin_host}:"\
-                              "#{node[:swift][:ports][:proxy]}/v1/"\
-                              "#{node[:swift][:reseller_prefix]}$(project_id)s"
-         #  endpoint_global true
-         #  endpoint_enabled true
-        action :add_endpoint_template
+       action :add_endpoint
      end
 
      crowbar_pacemaker_sync_mark "create-swift_register" if ha_enabled

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -164,7 +164,7 @@ case proxy_config[:auth_method]
 
      register_auth_hash = { user: keystone_settings["admin_user"],
                             password: keystone_settings["admin_password"],
-                            tenant: keystone_settings["admin_tenant"] }
+                            project: keystone_settings["admin_project"] }
 
      keystone_register "swift proxy wakeup keystone" do
        protocol keystone_settings["protocol"]

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -195,7 +195,7 @@ case proxy_config[:auth_method]
        auth register_auth_hash
        user_name keystone_settings["service_user"]
        user_password keystone_settings["service_password"]
-       tenant_name keystone_settings["service_tenant"]
+       project_name keystone_settings["service_tenant"]
        action :add_user
      end
 

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -206,7 +206,7 @@ case proxy_config[:auth_method]
        port keystone_settings["admin_port"]
        auth register_auth_hash
        user_name keystone_settings["service_user"]
-       tenant_name keystone_settings["service_tenant"]
+       project_name keystone_settings["service_tenant"]
        role_name "admin"
        action :add_access
      end

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -145,7 +145,7 @@ end
     port keystone_settings["admin_port"]
     auth register_auth_hash
     user_name user["name"]
-    tenant_name tempest_comp_tenant
+    project_name tempest_comp_tenant
     action :add_ec2
   end
 end

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -134,7 +134,7 @@ end
     auth register_auth_hash
     user_name user["name"]
     role_name user["role"]
-    tenant_name tempest_comp_tenant
+    project_name tempest_comp_tenant
     action :add_access
   end
 
@@ -159,7 +159,7 @@ keystone_register "add #{keystone_settings['admin_user']}:#{tempest_comp_tenant}
   auth register_auth_hash
   user_name keystone_settings["admin_user"]
   role_name "admin"
-  tenant_name tempest_comp_tenant
+  project_name tempest_comp_tenant
   action :add_access
 end
 

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -110,7 +110,7 @@ users.each do |user|
     auth register_auth_hash
     user_name user["name"]
     user_password user["pass"]
-    tenant_name tempest_comp_tenant
+    project_name tempest_comp_tenant
     action :add_user
   end
 

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -46,7 +46,7 @@ tempest_heat_settings = node[:tempest][:heat]
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "tempest tempest wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -63,8 +63,8 @@ keystone_register "create tenant #{tempest_comp_tenant} for tempest" do
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
   auth register_auth_hash
-  tenant_name tempest_comp_tenant
-  action :add_tenant
+  project_name tempest_comp_tenant
+  action :add_project
 end
 
 auth_url = KeystoneHelper.service_URL(

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -106,7 +106,7 @@ keystone_register "give trove user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -95,7 +95,7 @@ keystone_register "register trove user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -137,9 +137,7 @@ keystone_register "register trove endpoint" do
                     "#{my_admin_host}:#{trove_port}/v1.0/$(project_id)s"
   endpoint_internalURL "#{trove_protocol}://"\
                        "#{my_admin_host}:#{trove_port}/v1.0/$(project_id)s"
-  #  endpoint_global true
-  #  endpoint_enabled true
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-trove_register" if ha_enabled

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -76,7 +76,7 @@ crowbar_pacemaker_sync_mark "wait-trove_register" if ha_enabled
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       project: keystone_settings["admin_project"] }
 
 keystone_register "trove api wakeup keystone" do
   protocol keystone_settings["protocol"]

--- a/chef/data_bags/crowbar/migrate/keystone/201_rename_tenant.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/201_rename_tenant.rb
@@ -1,0 +1,15 @@
+def upgrade(ta, td, a, d)
+  ["admin", "service", "default"].each do |user_type|
+    a[user_type]["project"] = a[user_type]["tenant"]
+    a[user_type].delete("tenant")
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  ["admin", "service", "default"].each do |user_type|
+    a[user_type]["tenant"] = a[user_type]["project"]
+    a[user_type].delete("project")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -38,18 +38,18 @@
         "threads" : 8
       },
       "admin": {
-        "tenant": "admin",
+        "project": "admin",
         "username": "admin",
         "password": "crowbar",
         "updated_password": ""
       },
       "service": {
-        "tenant": "service",
+        "project": "service",
         "token": "999888777666"
       },
       "default": {
         "create_user": true,
-        "tenant": "openstack",
+        "project": "openstack",
         "username": "crowbar",
         "password": "crowbar"
       },
@@ -178,7 +178,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -43,18 +43,18 @@
                       "threads": { "required": true, "type": "int" }
                     }},
                     "admin": { "type": "map", "required": true, "mapping": {
-                      "tenant": { "type" : "str", "required" : true },
+                      "project": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required" : true },
                       "password": { "type" : "str", "required" : true },
                       "updated_password": { "type" : "str", "required" : false }
                     }},
                     "service": { "type": "map", "required": true, "mapping": {
-                      "tenant": { "type" : "str", "required" : true },
+                      "project": { "type" : "str", "required" : true },
                       "token": { "type": "str", "required" : true }
                     }},
                     "default" : { "type" : "map", "required" : true, "mapping": {
                       "create_user": { "type" : "bool", "required" : true },
-                      "tenant": { "type" : "str", "required" : true },
+                      "project": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required" : true },
                       "password": { "type" : "str", "required" : true }
                     }},

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -12,7 +12,7 @@
       %legend
         = t(".default_credentials")
 
-      = string_field %w(default tenant)
+      = string_field %w(default project)
       = string_field %w(admin username)
       - if @proposal.active?
         = password_field %w(admin updated_password)

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -25,7 +25,7 @@ en:
           token_format: 'Algorithm for Token Generation'
         default_credentials: 'Default Credentials'
         default:
-          tenant: 'Default Tenant'
+          project: 'Default Project'
           create_user: 'Create Regular User'
           username: 'Regular User Username'
           password: 'Regular User Password'


### PR DESCRIPTION
The Identity v2.0 API has been deprecated since Mitaka and will be going away in T. As of the Pike release, usage of the v2.0 API started causing deprecation warnings in the keystone logs. This patch series does not turn off the v2.0 API (so customers can still use it) but it transforms the commands in the keystone_register provider to use the v3 endpoint so that crowbar creating keystone resources will stop causing deprecation warnings.

Along with choosing a different endpoint, I've started renaming parameters and variable names from "tenant" to "project", which is the v3 name for the same idea. This already very large patch series would be even more massive if I updated it everywhere, so this only updates it in the keystone barclamp, keystone_register provider and the keystone_settings helper and we can keep going from there little by little.

Where possible, this also updates the auth sections of config files for various services to use the v3  URL, which also usually means adding project_domain_name and user_domain_name parameters to those sections.

This also does a bit of cleanup of the keystone_register provider to enhance readability and DRY-ness.