### PR TITLE
tempest: search of roles:monasca_server effectively

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -36,7 +36,7 @@ package "openstack-tempest-test"
   package "python-#{component}client"
 end
 
-if node[:kernel][:machine] == "x86_64" && !search(:node, "roles:monasca_server").nil?
+if node[:kernel][:machine] == "x86_64" && !node_search_with_cache("roles:monasca_server").empty?
   ["api", "log-api"].each do |component|
     package "python-monasca-#{component}"
   end


### PR DESCRIPTION
[].empty gives the expected result