### PR TITLE
Fix mysql cookbook for SLES12

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -25,8 +25,8 @@ default["mysql"]["logdir"]                    = "/var/lib/mysqllogs"
 
 case node[:platform_family]
 when "rhel", "fedora", "suse"
-  set["mysql"]["socket"]                      = "/var/lib/mysql/mysql.sock"
-  set["mysql"]["pid_file"]                    = "/var/run/mysqld/mysqld.pid"
+  set["mysql"]["socket"]                      = "/var/run/mysql/mysql.sock"
+  set["mysql"]["pid_file"]                    = "/var/run/mysql/mysqld.pid"
   set["mysql"]["old_passwords"]               = 1
 else
   set["mysql"]["socket"]                      = "/var/run/mysqld/mysqld.sock"

--- a/chef/cookbooks/mysql/recipes/client.rb
+++ b/chef/cookbooks/mysql/recipes/client.rb
@@ -17,15 +17,6 @@
 # limitations under the License.
 #
 
-package "mysql-devel" do
-  package_name value_for_platform_family(
-    ["rhel", "suse", "fedora"] => { "default" => "mysql-devel" },
-    ["debian"] => { "default" => "libmysqlclient-dev" },
-    "default" => "libmysqlclient-dev"
-  )
-  action :install
-end
-
 package "mysql-client" do
   package_name value_for_platform_family(
     ["rhel", "suse", "fedora"] => "mysql",
@@ -38,7 +29,8 @@ if platform_family?(%w{debian rhel fedora suse})
 
   package "mysql-ruby" do
     package_name value_for_platform_family(
-      ["rhel", "suse", "fedora"] => "ruby-mysql",
+      ["rhel", "fedora"] => "ruby-mysql",
+      "suse" => "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-mysql",
       "debian" => "libmysql-ruby",
       "default" => "libmysql-ruby"
     )

--- a/chef/cookbooks/mysql/recipes/client.rb
+++ b/chef/cookbooks/mysql/recipes/client.rb
@@ -28,7 +28,7 @@ end
 
 package "mysql-client" do
   package_name value_for_platform_family(
-    ["rhel", "suse", "fedora"] => { "default" => "mysql" },
+    ["rhel", "suse", "fedora"] => "mysql",
     "default" => "mysql-client"
   )
   action :install
@@ -38,8 +38,8 @@ if platform_family?(%w{debian rhel fedora suse})
 
   package "mysql-ruby" do
     package_name value_for_platform_family(
-      ["rhel", "suse", "fedora"] => { "default" => "ruby-mysql" },
-      ["debian"] => { "default" => "libmysql-ruby" },
+      ["rhel", "suse", "fedora"] => "ruby-mysql",
+      "debian" => "libmysql-ruby",
       "default" => "libmysql-ruby"
     )
     action :install

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -80,12 +80,6 @@ service "mysql" do
   action :enable
 end
 
-link value_for_platform_family(
-       ["rhel", "suse", "fedora"] => "/etc/my.cnf",
-       "default" => "/etc/mysql/my.cnf") do
-  to "#{node[:mysql][:datadir]}/my.cnf"
-end
-
 directory node[:mysql][:tmpdir] do
   owner "mysql"
   group "mysql"
@@ -110,11 +104,11 @@ service mysql start
 EOC
 end
 
-template "#{node[:mysql][:datadir]}/my.cnf" do
+template "/etc/my.cnf" do
   source "my.cnf.erb"
   owner "root"
-  group "root"
-  mode "0644"
+  group "mysql"
+  mode "0640"
   notifies :run, resources(script: "handle mysql restart"), :immediately if platform_family?("debian")
   notifies :restart, "service[mysql]", :immediately if platform_family?(%w{rhel suse fedora})
 end

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -80,7 +80,9 @@ service "mysql" do
   action :enable
 end
 
-link value_for_platform_family(["rhel", "suse", "fedora"] => { "default" => "/etc/my.cnf" }, "default" => "/etc/mysql/my.cnf") do
+link value_for_platform_family(
+       ["rhel", "suse", "fedora"] => "/etc/my.cnf",
+       "default" => "/etc/mysql/my.cnf") do
   to "#{node[:mysql][:datadir]}/my.cnf"
 end
 
@@ -179,20 +181,16 @@ script "fix_perms_hack" do
   EOH
   not_if "/usr/bin/mysql -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }#{node['mysql']['server_root_password']} -e 'show databases;'"
 end
-
+end
 # End hackness
 
 grants_path = value_for_platform_family(
-  ["rhel", "suse", "fedora"] => {
-    "default" => "/etc/mysql_grants.sql"
-  },
+  ["rhel", "suse", "fedora"] => "/etc/mysql_grants.sql",
   "default" => "/etc/mysql/grants.sql"
 )
 
 grants_key = value_for_platform_family(
-  ["rhel", "suse", "fedora"] => {
-    "default" => "/etc/applied_grants"
-  },
+  ["rhel", "suse", "fedora"] => "/etc/applied_grants",
   "default" => "/etc/mysql/applied_grants"
 )
 

--- a/chef/cookbooks/mysql/templates/default/my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/my.cnf.erb
@@ -102,7 +102,6 @@ query_cache_size        = <%= node['mysql']['tunable']['query_cache_size'] %>
 # Error logging goes to syslog. This is a Debian improvement :)
 #
 # Here you can see queries with especially long duration
-log_slow_queries        = <%= node['mysql']['tunable']['log_slow_queries'] %>
 long_query_time         = <%= node['mysql']['tunable']['long_query_time'] %>
 #log-queries-not-using-indexes
 
@@ -134,13 +133,7 @@ innodb_log_buffer_size  = <%= node['mysql']['tunable']['innodb_log_buffer_size']
 innodb_log_file_size    = <%= node['mysql']['tunable']['innodb_log_file_size'] %>
 innodb_file_per_table   = <%= node['mysql']['tunable']['innodb_file_per_table'] %>
 innodb_open_files       = <%= node['mysql']['tunable']['innodb_open_files'] %>
-#
-# * Federated
-#
-# The FEDERATED storage engine is disabled since 5.0.67 by default in the .cnf files
-# shipped with MySQL distributions (my-huge.cnf, my-medium.cnf, and so forth).
-#
-skip-federated
+
 #
 # * Security Features
 #


### PR DESCRIPTION
Some simple fixes to make mysql/mariadb work again on SLES 12.

This is currently not really required an just the result of a small experiment with mariadb on Cloud 7. It might be interesting for our way to Cloud 8 though.

(There is no HA support)