### PR TITLE
Hide the rabbitmq management plugin from admin network

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -24,7 +24,7 @@
  ]},
  {rabbitmq_management,
   [
-   {listener, [{ip, "<%= node[:rabbitmq][:management_address] %>"}, {port, <%= node[:rabbitmq][:management_port] %>}]}
+   {listener, [{ip, "127.0.0.1"}, {port, <%= node[:rabbitmq][:management_port] %>}]}
   ]
  }
 ].


### PR DESCRIPTION
As it is not behind SSL and the management plugin has some security
issues, it might become an additional attack vector.