### PR TITLE
tempest: Fix spelling of the monasca-server role

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -36,7 +36,8 @@ package "openstack-tempest-test"
   package "python-#{component}client"
 end
 
-if node[:kernel][:machine] == "x86_64" && !node_search_with_cache("roles:monasca_server").empty?
+if node[:kernel][:machine] == "x86_64" &&
+    !node_search_with_cache("roles:monasca-server").empty?
   ["api", "log-api"].each do |component|
     package "python-monasca-#{component}"
   end


### PR DESCRIPTION
When searching, the role is called 'monasca-server' and not
'monasca_server'.

(cherry picked from commit 774c16f5aacc683748a0d3ea19ae332fd94535e4)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1006