### PR TITLE
monasca: fix monitoring for HA clouds

### DIFF
--- a/chef/cookbooks/barbican/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/barbican/recipes/monitor_monasca.rb
@@ -17,8 +17,14 @@
 return unless node["roles"].include?("monasca-agent")
 
 network_settings = BarbicanHelper.network_settings(node)
-bind_host = network_settings[:api][:ha_bind_host]
-bind_port = network_settings[:api][:bind_port]
+
+bind_port = node[:barbican][:api][:bind_port]
+
+if node[:barbican][:ha][:enabled]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+else
+  bind_host = network_settings[:api][:bind_host]
+end
 
 monitor_url = "#{node[:barbican][:api][:protocol]}://#{bind_host}:#{bind_port}/"
 

--- a/chef/cookbooks/cinder/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/cinder/recipes/monitor_monasca.rb
@@ -16,7 +16,13 @@
 
 return unless node["roles"].include?("monasca-agent")
 
-bind_host, bind_port = CinderHelper.get_bind_host_port(node)
+bind_port = node[:cinder][:api][:bind_port]
+
+if node[:cinder][:ha][:enabled]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+else
+  bind_host = CinderHelper.get_bind_host_port(node)[0]
+end
 
 monitor_url = "#{node[:cinder][:api][:protocol]}://#{bind_host}:#{bind_port}/"
 

--- a/chef/cookbooks/glance/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/glance/recipes/monitor_monasca.rb
@@ -18,8 +18,16 @@ return unless node["roles"].include?("monasca-agent")
 
 network_settings = GlanceHelper.network_settings(node)
 
-monitor_url = "#{node[:glance][:api][:protocol]}://#{network_settings[:api][:bind_host]}:" \
-              "#{network_settings[:api][:bind_port]}/"
+bind_port = node[:glance][:api][:bind_port]
+
+if node[:glance][:ha][:enabled]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+else
+  bind_host = network_settings[:api][:bind_host]
+end
+
+monitor_url = "#{node[:glance][:api][:protocol]}://#{bind_host}:" \
+              "#{bind_port}/"
 
 monasca_agent_plugin_http_check "http_check for glance-api" do
   built_by "glance-server"

--- a/chef/cookbooks/heat/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/heat/recipes/monitor_monasca.rb
@@ -16,7 +16,13 @@
 
 return unless node["roles"].include?("monasca-agent")
 
-bind_host, api_port, cfn_port, cloud_watch_port = HeatHelper.get_bind_host_port(node)
+api_port = node[:heat][:api][:port]
+
+if node[:heat][:ha][:enabled]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+else
+  bind_host = HeatHelper.get_bind_host_port(node)[0]
+end
 
 monitor_url = "#{node[:heat][:api][:protocol]}://#{bind_host}:#{api_port}/"
 

--- a/chef/cookbooks/keystone/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/keystone/recipes/monitor_monasca.rb
@@ -18,13 +18,12 @@ return unless node["roles"].include?("monasca-agent")
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
+bind_admin_port = node[:keystone][:api][:admin_port]
+
 if node[:keystone][:ha][:enabled]
-  admin_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  bind_admin_host = admin_address
-  bind_admin_port = node[:keystone][:ha][:ports][:admin_port]
+  bind_admin_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
 else
   bind_admin_host = node[:keystone][:api][:admin_host]
-  bind_admin_port = node[:keystone][:api][:admin_port]
 end
 
 # we want to monitor the service that is locally available (*not* the port bind to haproxy)

--- a/chef/cookbooks/magnum/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/magnum/recipes/monitor_monasca.rb
@@ -17,8 +17,15 @@
 return unless node["roles"].include?("monasca-agent")
 
 network_settings = MagnumHelper.network_settings(node)
+
 bind_port = network_settings[:api][:bind_port]
-bind_host = network_settings[:api][:bind_host]
+
+if node[:magnum][:ha][:enabled]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+else
+  bind_host = network_settings[:api][:bind_host]
+end
+
 api_protocol = node[:magnum][:api][:protocol]
 
 monitor_url = "#{api_protocol}://#{bind_host}:#{bind_port}/"

--- a/chef/cookbooks/manila/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/manila/recipes/monitor_monasca.rb
@@ -16,7 +16,13 @@
 
 return unless node["roles"].include?("monasca-agent")
 
-bind_host, bind_port = ManilaHelper.get_bind_host_port(node)
+bind_port = node[:manila][:api][:bind_port]
+
+if node[:manila][:ha][:enabled]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+else
+  bind_host = ManilaHelper.get_bind_host_port(node)[0]
+end
 
 monitor_url = "#{node[:manila][:api][:protocol]}://#{bind_host}:#{bind_port}/"
 

--- a/chef/cookbooks/neutron/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/neutron/recipes/monitor_monasca.rb
@@ -16,7 +16,13 @@
 
 return unless node["roles"].include?("monasca-agent")
 
-bind_host, bind_port = NeutronHelper.get_bind_host_port(node)
+bind_port = node[:neutron][:api][:service_port]
+
+if node[:neutron][:ha][:server][:enabled]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+else
+  bind_host = NeutronHelper.get_bind_host_port(node)[0]
+end
 
 monitor_url = "#{node[:neutron][:api][:protocol]}://#{bind_host}:#{bind_port}/"
 

--- a/chef/cookbooks/nova/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/nova/recipes/monitor_monasca.rb
@@ -16,12 +16,12 @@
 
 return unless node["roles"].include?("monasca-agent")
 
+bind_port = node[:nova][:ports][:api]
+
 if node[:nova][:ha][:enabled]
-  bind_host = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  bind_port = node[:nova][:ha][:ports][:api]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
 else
   bind_host = "0.0.0.0"
-  bind_port = node[:nova][:ports][:api]
 end
 api_protocol = node[:nova][:ssl][:enabled] ? "https" : "http"
 

--- a/chef/cookbooks/sahara/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/sahara/recipes/monitor_monasca.rb
@@ -17,9 +17,16 @@
 return unless node["roles"].include?("monasca-agent")
 
 network_settings = SaharaHelper.network_settings(node)
+bind_port = node[:sahara][:api][:bind_port]
 
-monitor_url = "#{node[:sahara][:api][:protocol]}://#{network_settings[:api][:bind_host]}:" \
-              "#{network_settings[:api][:bind_port]}/"
+if node[:sahara][:ha][:enabled]
+  bind_host = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+else
+  bind_host = network_settings[:api][:bind_host]
+end
+
+monitor_url = "#{node[:sahara][:api][:protocol]}://#{bind_host}:" \
+              "#{bind_port}/"
 
 monasca_agent_plugin_http_check "http_check for sahara-api" do
   built_by "sahara-server"

--- a/chef/cookbooks/swift/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/swift/recipes/monitor_monasca.rb
@@ -16,7 +16,15 @@
 
 return unless node["roles"].include?("monasca-agent")
 
-bind_host, bind_port = SwiftHelper.get_bind_host_port(node)
+bind_port = node[:swift][:ports][:proxy]
+
+if node[:swift][:ha][:enabled]
+  bind_host = Swift::Evaluator.get_ip_by_type(node, :admin_ip_expr)
+else
+  bind_host = SwiftHelper.get_bind_host_port(node)[0]
+end
+
+
 swift_protocol = node[:swift][:ssl][:enabled] ? "https" : "http"
 
 monitor_url = "#{swift_protocol}://#{bind_host}:#{bind_port}/"


### PR DESCRIPTION
This commit changes the Openstack service HTTP checks to

  1) Monitor the service on the node itself for non-HA clouds
  2) Monitor the service on the pacemaker VIP for HA enabled
     clouds.

Previously, HA clouds would show all services as down because only the active
node would report any given service as up whereas the others would report it as
down, resulting in a net status of down.

Marking as WIP since this is as yet untested.