### PR TITLE
Tempest: disable encryption for RBD volumes

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -387,9 +387,12 @@ cinders = search(:node, "roles:cinder-controller") || []
 storage_protocol = "iSCSI"
 vendor_name = "Open Source"
 cinder_snapshot = true
+use_attach_encrypted_volume = true
 cinders[0][:cinder][:volumes].each do |volume|
   if volume[:backend_driver] == "rbd"
     storage_protocol = "ceph"
+    # no encryption support for rbd-backed volumes
+    use_attach_encrypted_volume = false
     break
   elsif volume[:backend_driver] == "emc"
     vendor_name = "EMC"
@@ -514,6 +517,7 @@ template "/etc/tempest/tempest.conf" do
         use_livemigration: use_livemigration,
         # compute-feature-enabled settings
         use_config_drive: use_config_drive,
+        use_attach_encrypted_volume: use_attach_encrypted_volume,
         # dashboard settings
         horizon_host: horizon_host,
         horizon_protocol: horizon_protocol,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -43,6 +43,7 @@ rescue = <%= @use_rescue %>
 interface_attach = <%= @use_interface_attach %>
 personality = false
 config_drive = <%= @use_config_drive %>
+attach_encrypted_volume = <%= @use_attach_encrypted_volume %>
 
 [dashboard]
 dashboard_url = <%= @horizon_protocol %>://<%= @horizon_host %>/


### PR DESCRIPTION
Until volume encryption is supported for RBD in Nova
(i.e. through qemu native RBD encryption), the tempest
tests that cover this scenario will have to be skipped
in Ceph environments.

This disables the following tempest test cases now failing 
in the cloud-mkcloud7-job-4nodes-linuxbridge-tempestfull-x86_64
CI job:

tempest.scenario.test_encrypted_cinder_volumes.TestEncryptedCinderVolumes.test_encrypted_cinder_volumes_cryptsetup
tempest.scenario.test_encrypted_cinder_volumes.TestEncryptedCinderVolumes.test_encrypted_cinder_volumes_luks
