### PR TITLE
monasca: Register logs endpoints in keystone

### DIFF
--- a/chef/cookbooks/monasca/attributes/default.rb
+++ b/chef/cookbooks/monasca/attributes/default.rb
@@ -26,6 +26,8 @@ default[:monasca][:api][:bind_port] = 8070
 
 default[:monasca][:log_api][:bind_port] = 5607
 
+default[:monasca][:kibana][:bind_port] = 5601
+
 # agent default service settings
 default[:monasca][:agent]["user"] = "monasca-agent"
 default[:monasca][:agent][:group] = "monasca"

--- a/chef/cookbooks/monasca/libraries/helper.rb
+++ b/chef/cookbooks/monasca/libraries/helper.rb
@@ -64,13 +64,55 @@ module MonascaHelper
     return monasca_api_url
   end
 
-  def self.log_api_public_url(node)
+  def self.log_api_public_url(node, version = "v3.0")
     host = monasca_public_host(node)
     # SSL is not supported at this moment
     # protocol = node[:monasca][:log_api][:ssl] ? "https" : "http"
     protocol = "http"
     port = node[:monasca][:log_api][:bind_port]
-    "#{protocol}://#{host}:#{port}/v3.0"
+    "#{protocol}://#{host}:#{port}/#{version}"
+  end
+
+  def self.log_api_admin_url(node, version = "v3.0")
+    host = monasca_admin_host(node)
+    # SSL is not supported at this moment
+    # protocol = node[:monasca][:log_api][:ssl] ? "https" : "http"
+    protocol = "http"
+    port = node[:monasca][:log_api][:bind_port]
+    "#{protocol}://#{host}:#{port}/#{version}"
+  end
+
+  def self.log_api_internal_url(node, version = "v3.0")
+    host = get_host_for_monitoring_url(node)
+    # SSL is not supported at this moment
+    # protocol = node[:monasca][:log_api][:ssl] ? "https" : "http"
+    protocol = "http"
+    port = node[:monasca][:log_api][:bind_port]
+    "#{protocol}://#{host}:#{port}/#{version}"
+  end
+
+  def self.logs_search_public_url(node)
+    host = monasca_public_host(node)
+    # SSL is not supported at this moment
+    protocol = "http"
+    port = node[:monasca][:kibana][:bind_port]
+    "#{protocol}://#{host}:#{port}/"
+  end
+
+  def self.logs_search_admin_url(node)
+    host = monasca_admin_host(node)
+    # SSL is not supported at this moment
+    protocol = "http"
+    port = node[:monasca][:kibana][:bind_port]
+    "#{protocol}://#{host}:#{port}/"
+  end
+
+  def self.logs_search_internal_url(node)
+    host = get_host_for_monitoring_url(node)
+    # SSL is not supported at this moment
+    protocol = "http"
+    port = node[:monasca][:kibana][:bind_port]
+    "#{protocol}://#{host}:#{port}/"
   end
 
   # log_api_network_url returns url to monasca-log-api based on check if custom

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -80,6 +80,84 @@ keystone_register "register monasca api endpoint" do
   action :add_endpoint_template
 end
 
+keystone_register "register logs service" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  service_name "logs"
+  service_type "logs"
+  service_description "Monasca logs service"
+  action :add_service
+end
+
+keystone_register "register logs endpoint" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  endpoint_service "logs"
+  endpoint_region keystone_settings["endpoint_region"]
+  endpoint_publicURL MonascaHelper.log_api_public_url(node, "v3.0")
+  endpoint_adminURL MonascaHelper.log_api_admin_url(node, "v3.0")
+  endpoint_internalURL MonascaHelper.log_api_internal_url(node, "v3.0")
+  action :add_endpoint_template
+end
+
+keystone_register "register logs_v2 service" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  service_name "logs_v2"
+  service_type "logs_v2"
+  service_description "Monasca logs_v2 service"
+  action :add_service
+end
+
+keystone_register "register logs_v2 endpoint" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  endpoint_service "logs_v2"
+  endpoint_region keystone_settings["endpoint_region"]
+  endpoint_publicURL MonascaHelper.log_api_public_url(node, "v2.0")
+  endpoint_adminURL MonascaHelper.log_api_admin_url(node, "v2.0")
+  endpoint_internalURL MonascaHelper.log_api_internal_url(node, "v2.0")
+  action :add_endpoint_template
+end
+
+keystone_register "register logs-search service" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  service_name "logs-search"
+  service_type "logs-search"
+  service_description "Monasca logs-search service"
+  action :add_service
+end
+
+keystone_register "register logs-search endpoint" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  endpoint_service "logs-search"
+  endpoint_region keystone_settings["endpoint_region"]
+  endpoint_publicURL MonascaHelper.logs_search_public_url(node)
+  endpoint_adminURL MonascaHelper.logs_search_admin_url(node)
+  endpoint_internalURL MonascaHelper.logs_search_internal_url(node)
+  action :add_endpoint_template
+end
+
 monasca_project = node[:monasca][:service_tenant]
 monasca_roles = node[:monasca][:service_roles]
 


### PR DESCRIPTION
This PR needs back porting to stable/4.0, unfortunately I don't have permissions (?) to add the appropriate label :(