### PR TITLE
tempest: add support for vmware images

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -139,7 +139,13 @@ instance_type = <%= @heat_flavor_ref %>
 lock_path = /var/run/tempest
 
 [scenario]
+<% if @vmware_image -%>
+img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-disk.vmdk
+img_container_format = bare
+img_disk_format = vmdk
+<% else -%>
 img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-disk.img
+<% end -%>
 
 [service_available]
 neutron = true


### PR DESCRIPTION
This PR updates the tempest cookbook to create
and/or use qcow or vmware/vmdk images instead of the regular
ami type images, when VMware compute nodes are enabled.

This allows a user to control what is targeted by tempest
when both kvm and vmware compute nodes are present:
  - if an 'ami' type image file is supplied through the
  'tempest_test_images' barclamp attribute (the previous
  and current default behavior), tempest will only target the
  kvm backend and exclude vmware functionality from its scope.
  In this configuration, tempest will test if the kvm backend
  is functioning properly in a kvm-vmware multi-backend environment.
  - if a raw or vmdk image is supplied, tempest will do the opposite:
  it will target the vmware backend and exclude kvm functionality
  from its scope. A raw image file will also be automatically
  converted to its vmdk counterpart.

If no vmware compute nodes are present, the behaviour is unchanged.
