### PR TITLE
horizon: fix Openstack Grafana for HA clouds

### DIFF
--- a/chef/cookbooks/horizon/files/default/grafana-openstack.json
+++ b/chef/cookbooks/horizon/files/default/grafana-openstack.json
@@ -28,7 +28,8 @@
           "interval": null,
           "targets": [
             {
-              "function": "none",
+              "function": "max",
+              "merge": true,
               "column": "value",
               "series": "http_status",
               "condition_filter": true,
@@ -86,7 +87,8 @@
           "interval": null,
           "targets": [
             {
-              "function": "none",
+              "function": "max",
+              "merge": true,
               "column": "value",
               "series": "http_status",
               "condition_filter": true,
@@ -144,7 +146,8 @@
           "interval": null,
           "targets": [
             {
-              "function": "none",
+              "function": "max",
+              "merge": true,
               "column": "value",
               "series": "http_status",
               "condition_filter": true,
@@ -202,7 +205,8 @@
           "interval": null,
           "targets": [
             {
-              "function": "none",
+              "function": "max",
+              "merge": true,
               "column": "value",
               "series": "http_status",
               "condition_filter": true,
@@ -260,7 +264,8 @@
           "interval": null,
           "targets": [
             {
-              "function": "none",
+              "function": "max",
+              "merge": true,
               "column": "value",
               "series": "http_status",
               "condition_filter": true,
@@ -318,7 +323,8 @@
           "interval": null,
           "targets": [
             {
-              "function": "none",
+              "function": "max",
+              "merge": true,
               "column": "value",
               "series": "http_status",
               "condition_filter": true,


### PR DESCRIPTION
In HA clouds a given service may be up on one controller and down on another.
In this case, the behaviour of the Grafana dashboard is undefined since it may
use the value from either http_status metric for displaying the service's
status. By computing the maximum over all status checks we get a more accurate
reading, i.e. the status transitions to DOWN if any backend is down in the time
period under scrutiny and remains UP otherwise.

(cherry picked from commit e1993cd6f9fa49c98f65770f7308aba4c32a294e)