### PR TITLE
monasca: Hide password in SMTP configuration

### DIFF
--- a/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
@@ -38,5 +38,5 @@
       = string_field %w(master smtp_host)
       = integer_field %w(master smtp_port)
       = string_field %w(master smtp_user)
-      = string_field %w(master smtp_password)
+      = password_field %w(master smtp_password)
       = string_field %w(master smtp_from_address)


### PR DESCRIPTION
(cherry picked from commit f4198aeef8198a31d735290fab2763d95b262e8c)