### PR TITLE
Configure Monasca for Keystone enabled SSL

### DIFF
--- a/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
@@ -12,6 +12,12 @@ keystone_monasca_operator_password: <%= @master_settings['keystone_monasca_opera
 keystone_monasca_agent_password: <%= @master_settings['keystone_monasca_agent_password'] %>
 keystone_admin_agent_password: <%= @master_settings['keystone_admin_agent_password'] %>
 keystone_admin_password: <%= @keystone_settings['admin_password'] %>
+keystone_use_https: <%= @keystone_settings['use_ssl'] %>
+<%- if @keystone_settings['use_ssl'] %>
+keystone_protocol: 'https'
+authProtocol: 'https'
+keystone_insecure: <%= @keystone_settings['insecure'] %>
+<%- end %>
 api_region: <%= @keystone_settings['endpoint_region'] %>
 database_grafana_password: <%= @master_settings['database_grafana_password'] %>
 


### PR DESCRIPTION
This should make monasca-log-api and monasca-api work with SSL enabled Keystone. Please do not merge yet, for it only configures monasca-log-api correctly so far. It still fails to configure monasca-api correctly.