### PR TITLE
[3.0] Fix postgresql and rabbitmq crm services

### DIFF
--- a/chef/cookbooks/postgresql/recipes/server_redhat.rb
+++ b/chef/cookbooks/postgresql/recipes/server_redhat.rb
@@ -111,7 +111,7 @@ end
 
 service "postgresql" do
   service_name node["postgresql"]["server"]["service_name"]
-  supports restart: true, status: true, reload: true
+  supports restart: true, status: true, reload: true, restart_crm_resource: true
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if node[:database][:ha][:enabled]
 end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -61,7 +61,8 @@ bash "enabling rabbit management" do
 end
 
 service "rabbitmq-server" do
-  supports restart: true, start: true, stop: true, status: true
+  supports restart: true, start: true, stop: true, status: true, \
+           restart_crm_resource: true, pacemaker_resource_name: "rabbitmq"
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if node[:rabbitmq][:ha][:enabled]
 end


### PR DESCRIPTION
Without these patches, the postgresql and rabbitmq OCF resource agents cannot be
restarted by crowbar. When running in HA mode, if the service is
notified to restart, both controller nodes will claim that the service
is not running. Since it is managed as a special OCF resource agent
instead of as a systemd resource, it is necessary to use crm to check
whether it is running and to restart it. This pull request sets the 
restart_crm_resource field in the 'supports' parameter for the 
postgresql and rabbitmq services so that they can be properly restarted if necessary.
This was not noticed previously because the configuration options for 
these services are rarely changed and so they rarely requires a
restart. However, the resource limits management feature added in pr#974
requires potentially multiple service restarts after initial
deployment as parameters are tuned over time, so we need to make sure
crowbar is capable of it.