### PR TITLE
horizon: Fix SSLCipherSuite for SOC6 (bsc#1043484)

### DIFF
--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -26,7 +26,7 @@
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
-    SSLCipherSuite DEFAULT_SUSE
+    SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
     SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>


### PR DESCRIPTION
Update SSLCipherSuite to avoid the wrong expansion from mod_ssl in
httpd-2.4.16 on SP1 (for a better explanation check the bug report)

https://bugzilla.suse.com/show_bug.cgi?id=1043484