### PR TITLE
monasca: Hardwire grafana timezone to UTC

### DIFF
--- a/chef/cookbooks/horizon/files/default/grafana-monasca.json
+++ b/chef/cookbooks/horizon/files/default/grafana-monasca.json
@@ -4,7 +4,7 @@
   "originalTitle": "Monasca Service",
   "tags": [],
   "style": "light",
-  "timezone": "browser",
+  "timezone": "utc",
   "editable": true,
   "hideControls": false,
   "sharedCrosshair": false,

--- a/chef/cookbooks/horizon/files/default/grafana-openstack.json
+++ b/chef/cookbooks/horizon/files/default/grafana-openstack.json
@@ -4,7 +4,7 @@
   "originalTitle": "SUSE OpenStack Cloud Monitoring",
   "tags": [],
   "style": "dark",
-  "timezone": "browser",
+  "timezone": "utc",
   "editable": true,
   "hideControls": false,
   "sharedCrosshair": false,


### PR DESCRIPTION
If the browser time zone differs from the time zone of
the monasca-server node we may get 'no results found'
until local time in the browser catches up with the
monasca-server node's time zone for the first time.

(cherry picked from commit 585de206aa49a09b424bbf9873e1a8484970b62c)