### PR TITLE
[4.0] Add resource limit controls (bsc#1020922)

### DIFF
--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -164,3 +164,14 @@ crowbar_pacemaker_sync_mark "create-cinder_register"
 cinder_service "api" do
   use_pacemaker_provider ha_enabled
 end
+
+service = "openstack-cinder-api"
+if node[:cinder][:resource_limits] && node[:cinder][:resource_limits][service]
+  limits = node[:cinder][:resource_limits][service]
+  action = limits.values.any? ? :create : :delete
+  crowbar_openstack_systemd_override "Resource limits for #{service}" do
+    service_name service
+    limits limits
+    action action
+  end
+end

--- a/chef/cookbooks/cinder/recipes/scheduler.rb
+++ b/chef/cookbooks/cinder/recipes/scheduler.rb
@@ -22,3 +22,14 @@ include_recipe "#{@cookbook_name}::common"
 cinder_service "scheduler" do
   use_pacemaker_provider node[:cinder][:ha][:enabled]
 end
+
+service = "openstack-cinder-scheduler"
+if node[:cinder][:resource_limits] && node[:cinder][:resource_limits][service]
+  limits = node[:cinder][:resource_limits][service]
+  action = limits.values.any? ? :create : :delete
+  crowbar_openstack_systemd_override "Resource limits for #{service}" do
+    service_name service
+    limits limits
+    action action
+  end
+end

--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -327,3 +327,14 @@ else
     notifies :restart, "service[cinder-volume]"
   end
 end
+
+service = "openstack-cinder-volume"
+if node[:cinder][:resource_limits] && node[:cinder][:resource_limits][service]
+  limits = node[:cinder][:resource_limits][service]
+  action = limits.values.any? ? :create : :delete
+  crowbar_openstack_systemd_override "Resource limits for #{service}" do
+    service_name service
+    limits limits
+    action action
+  end
+end

--- a/chef/cookbooks/crowbar-openstack/providers/systemd_override.rb
+++ b/chef/cookbooks/crowbar-openstack/providers/systemd_override.rb
@@ -1,0 +1,104 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Support whyrun
+def whyrun_supported?
+  true
+end
+
+action :create do
+  current_resource = @current_resource
+  converge_by("Create #{@new_resource}") do
+    execute "systemctl daemon-reload" do
+      action :nothing
+    end
+
+    directory _get_override_directory do
+      owner "root"
+      group "root"
+      mode "0755"
+    end
+
+    service_resource_name = _get_service_resource_name
+    template _get_override_file_path do
+      source "systemd-override.conf.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      cookbook "crowbar-openstack"
+      variables(
+        limits: current_resource.limits
+      )
+      notifies :run, resources(execute: "systemctl daemon-reload"), :delayed
+      notifies :restart, resources(service: service_resource_name), :delayed
+    end
+    Chef::Log.info "#{@new_resource} created / updated"
+  end
+end
+
+action :delete do
+  if @current_resource.exists
+    converge_by("Delete #{@new_resource}") do
+      execute "systemctl daemon-reload" do
+        action :nothing
+      end
+
+      override_file_path = _get_override_file_path
+      service_resource_name = _get_service_resource_name
+      file override_file_path do
+        action :delete
+        only_if { ::File.exist?(override_file_path) }
+        notifies :run, resources(execute: "systemctl daemon-reload"), :delayed
+        notifies :restart, resources(service: service_resource_name), :delayed
+      end
+      override_directory = _get_override_directory
+      directory override_directory do
+        action :delete
+        only_if { ::File.exist?(override_directory) }
+      end
+      Chef::Log.info "#{@new_resource} deleted"
+    end
+  else
+    Chef::Log.info "#{@current_resource} doesn't exist - can't delete."
+  end
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::CrowbarOpenstackSystemdOverride.new(@new_resource.name)
+  @current_resource.service_name(@new_resource.service_name)
+  @current_resource.limits(@new_resource.limits)
+  @current_resource.exists = true if ::File.exist?(_get_override_file_path)
+  @current_resource
+end
+
+private
+
+# For openstack services the service name is prefixed with openstack-
+# but the name of the chef resource is not
+def _get_service_resource_name
+  current_resource.service_name.sub(/^openstack-/, "")
+end
+
+def _get_unit_name
+  "#{@new_resource.service_name}.service"
+end
+
+def _get_override_directory
+  "/etc/systemd/system/#{_get_unit_name}.d"
+end
+
+def _get_override_file_path
+  "#{_get_override_directory}/60-limits.conf"
+end

--- a/chef/cookbooks/crowbar-openstack/resources/systemd_override.rb
+++ b/chef/cookbooks/crowbar-openstack/resources/systemd_override.rb
@@ -1,0 +1,7 @@
+actions :create, :delete
+default_action :create
+
+attribute :service_name
+attribute :limits
+
+attr_accessor :exists

--- a/chef/cookbooks/crowbar-openstack/templates/default/systemd-override.conf.erb
+++ b/chef/cookbooks/crowbar-openstack/templates/default/systemd-override.conf.erb
@@ -1,0 +1,4 @@
+[Service]
+<% @limits.each do |name, value| -%>
+<%= name %>=<%= value %>
+<% end -%>

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -552,3 +552,46 @@ end
 apache_site "openstack-dashboard.conf" do
   enable true
 end
+
+if node[:horizon][:resource_limits] && \
+    node[:horizon][:resource_limits].include?("apache2") && \
+    node[:horizon][:resource_limits]["apache2"].values.any?
+  ruby_block "set global apache limits" do
+    block do
+      # Get the limits set in the proposal
+      horizon_apache_limits = node[:horizon][:resource_limits]["apache2"]
+
+      # If this value hasn't been set in this chef run, make it a hash
+      node.default[:resource_limits] = {} unless node[:resource_limits]
+
+      # If apache limits have already been set in this chef run, get those
+      global_apache_limits = node[:resource_limits]["apache2"] || {}
+      global_apache_limits = global_apache_limits.to_hash
+
+      # For each limit setting, get the maximum across all barclamps seen so far
+      horizon_apache_limits.each do |name, value|
+        global_apache_limits[name] = [global_apache_limits[name].to_i, value].max
+      end
+
+      # Set the new limits in the node so it can be re-used in this chef run.
+      # node.default is cleared before every chef run so this will not pollute the node.
+      node.default[:resource_limits]["apache2"] = global_apache_limits
+
+      # Now that the limits variable is set, override the lwrp parameter at compile time
+      rsc_name = "Resource limits for apache2"
+      override_rsc = Chef::Resource::CrowbarOpenstackSystemdOverride.new(rsc_name, run_context)
+      override_rsc.service_name "apache2"
+      override_rsc.limits node[:resource_limits]["apache2"]
+      override_rsc.run_action :create
+    end
+  end
+# If we've deleted limits across the board, delete leftover override files (and don't create them)
+# Note that other recipes may come along later in the chef run and set these node values
+# and then the resource will be created again.
+elsif !node[:resource_limits] || !node[:resource_limits]["apache2"] || \
+    (node[:resource_limits]["apache2"] || {}).to_hash.values.none?
+  crowbar_openstack_systemd_override "Resource limits for apache2" do
+    service_name "apache2"
+    action :delete
+  end
+end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -760,3 +760,44 @@ node.set[:keystone][:api][:internal_url_host] = keystone_settings["internal_url_
 node.save
 Chef::Log.debug("setting new endpoint host to " \
                 "#{node[:keystone][:api][:internal_url_host]}")
+
+if node[:keystone][:resource_limits] && \
+    node[:keystone][:resource_limits].include?("apache2") && \
+    node[:keystone][:resource_limits]["apache2"].values.any?
+  ruby_block "set global apache limits" do
+    block do
+      # Get the limits set in the proposal
+      keystone_apache_limits = node[:keystone][:resource_limits]["apache2"]
+
+      # If this value hasn't been set in this chef run, make it a hash
+      node.default[:resource_limits] = {} unless node[:resource_limits]
+
+      # If apache limits have already been set in this chef run, get those
+      global_apache_limits = node[:resource_limits]["apache2"] || {}
+      global_apache_limits = global_apache_limits.to_hash
+
+      # For each limit setting, get the maximum across all barclamps seen so far
+      keystone_apache_limits.each do |name, value|
+        global_apache_limits[name] = [global_apache_limits[name].to_i, value].max
+      end
+
+      # Set the new limits in the node so it can be re-used in this chef run.
+      # node.default is cleared before every chef run so this will not pollute the node.
+      node.default[:resource_limits]["apache2"] = global_apache_limits
+
+      # Now that the limits variable is set, override the lwrp parameter at compile time
+      rsc_name = "Resource limits for apache2"
+      override_rsc = Chef::Resource::CrowbarOpenstackSystemdOverride.new(rsc_name, run_context)
+      override_rsc.service_name "apache2"
+      override_rsc.limits node[:resource_limits]["apache2"]
+      override_rsc.run_action :create
+    end
+  end
+# If we've deleted limits across the board, delete leftover override files (and don't create them)
+elsif !node[:resource_limits] || !node[:resource_limits]["apache2"] || \
+    (node[:resource_limits]["apache2"] || {}).to_hash.values.none?
+  crowbar_openstack_systemd_override "Resource limits for apache2" do
+    service_name "apache2"
+    action :delete
+  end
+end

--- a/chef/cookbooks/postgresql/recipes/server.rb
+++ b/chef/cookbooks/postgresql/recipes/server.rb
@@ -160,3 +160,37 @@ bash "assign-db_maker-password" do
   only_if only_if_command if ha_enabled
   action :run
 end
+
+service = "postgresql"
+if node[:database][:resource_limits] && node[:database][:resource_limits][service]
+  limits = node[:database][:resource_limits][service]
+  limit_action = limits.values.any? ? :create : :delete
+  # If using HA, we manage pam_limits for postres with limits.conf, otherwise
+  # we manage it through systemd
+  if ha_enabled
+    limits = Hash[limits.map { |k, v| [k.gsub(/^Limit/, "").downcase, v] }]
+    directory "/etc/security/limits.d" do
+      action :create
+      owner "root"
+      group "root"
+      mode "0755"
+    end
+    template "/etc/security/limits.d/postgres.conf" do
+      action limit_action
+      source "limits.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(
+        limits: limits
+      )
+      notifies :restart, resources(service: service)
+    end
+  else
+    crowbar_openstack_systemd_override "Resource limits for #{service}" do
+      service_name service
+      limits limits
+      action limit_action
+    end
+  end
+end

--- a/chef/cookbooks/postgresql/templates/default/limits.erb
+++ b/chef/cookbooks/postgresql/templates/default/limits.erb
@@ -1,0 +1,6 @@
+# Resource limits for the postgres user
+
+<% @limits.each do |name, value| -%>
+postgres    hard    <%= name %>    <%= value %>
+postgres    soft    <%= name %>    <%= value %>
+<% end -%>

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -135,5 +135,39 @@ else
   end
 end
 
+service = "rabbitmq-server"
+if node[:rabbitmq][:resource_limits] && node[:rabbitmq][:resource_limits][service]
+  limits = node[:rabbitmq][:resource_limits][service]
+  limit_action = limits.values.any? ? :create : :delete
+  # If using HA, we manage pam_limits for rabbitmq with limits.conf, otherwise
+  # we manage it through systemd
+  if ha_enabled
+    limits = Hash[limits.map { |k, v| [k.gsub(/^Limit/, "").downcase, v] }]
+    directory "/etc/security/limits.d" do
+      action :create
+      owner "root"
+      group "root"
+      mode "0755"
+    end
+    template "/etc/security/limits.d/rabbitmq.conf" do
+      action limit_action
+      source "limits.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(
+        limits: limits
+      )
+      notifies :restart, resources(service: service)
+    end
+  else
+    crowbar_openstack_systemd_override "Resource limits for #{service}" do
+      service_name service
+      limits limits
+      action limit_action
+    end
+  end
+end
+
 # save data so it can be found by search
 node.save

--- a/chef/cookbooks/rabbitmq/templates/default/limits.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/limits.erb
@@ -1,0 +1,6 @@
+# Resource limits for the rabbitmq user
+
+<% @limits.each do |name, value| -%>
+rabbitmq    hard    <%= name %>    <%= value %>
+rabbitmq    soft    <%= name %>    <%= value %>
+<% end -%>

--- a/chef/data_bags/crowbar/migrate/cinder/109_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/109_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/database/101_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/database/101_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/horizon/102_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/102_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/keystone/113_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/113_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/rabbitmq/101_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/101_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -155,6 +155,17 @@
         "password": "",
         "user": "cinder",
         "database": "cinder"
+      },
+      "resource_limits": {
+        "openstack-cinder-api": {
+          "LimitNOFILE": null
+        },
+        "openstack-cinder-scheduler": {
+          "LimitNOFILE": null
+        },
+        "openstack-cinder-volume": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -162,7 +173,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 108,
+      "schema-revision": 109,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -324,6 +324,27 @@
                 "user": { "type": "str", "required": true },
                 "database": { "type": "str", "required": true }
               }
+            },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "openstack-cinder-api": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                },
+                "openstack-cinder-scheduler": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                },
+                "openstack-cinder-volume": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
             }
           }
         }

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -27,6 +27,11 @@
             "options": ""
           }
         }
+      },
+      "resource_limits": {
+        "postgresql": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -34,7 +39,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -68,6 +68,17 @@
                   }
                 }
               }
+            },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "postgresql": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
             }
           }
         }

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -41,14 +41,19 @@
         "ssl_crt_chain_file": ""
       },
       "external_monitoring": {},
-      "token_hash_enabled": true
+      "token_hash_enabled": true,
+      "resource_limits": {
+        "apache2": {
+          "LimitNOFILE": null
+        }
+      }
     }
   },
   "deployment": {
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -70,7 +70,18 @@
                 =: { "type": "str",  "required": false }
               }
             },
-	    "token_hash_enabled": { "type": "bool", "required": true }
+	    "token_hash_enabled": { "type": "bool", "required": true },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "apache2": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
+            }
           }
         }
       }

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -176,6 +176,11 @@
             "auth_pool_connection_lifetime": 60
           }
         }
+      },
+      "resource_limits": {
+        "apache2": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -183,7 +188,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 112,
+      "schema-revision": 113,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -184,6 +184,17 @@
                           }}
                         }}
                       }
+                    },
+                    "resource_limits": {
+                      "type": "map",
+                      "required": false,
+                      "mapping": {
+                        "apache2": {
+                          "type": "map",
+                          "required": false,
+                          "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                        }
+                      }
                     }
               }}
      }},

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -37,6 +37,11 @@
         "password": "",
         "user": "trove",
         "vhost": "/trove"
+      },
+      "resource_limits": {
+        "rabbitmq-server": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -44,7 +49,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -68,6 +68,17 @@
                 "user": { "type": "str", "required": true },
                 "vhost": { "type": "str", "required": true }
               }
+            },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "rabbitmq-server": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Backport of #974

Some services require modifications to the system resource limits, such
as the maximum number of open files, that we cannot necessarily predict
a reasonable default for. Without this patch, there is no way to control
those limits from crowbar and they must be changed manually. This patch
adds a resource_limits parameter to a few barclamps to allow
administrators to set these limits for specific services from the
barclamp that controls those services. Currently only the LimitNOFILE
(systemd's name for the maximum number of open files) limit is supported.

This pull request is split into four commits and it will be easiest to review them each one at a time.

Create a systemd_override LWRP and use it in the cinder barclamp.
Use the same LWRP in the keystone and horizon barclamps to demonstrate
how it should be used for barclamps that share a service (take the max).
Fix the rabbitmq service resource, which was unable to restart when deployed with pacemaker.
Add the parameter to the rabbitmq barclamp, which will either use the systemd_override resource or /etc/security/limits.conf depending on whether it is deployed with pacemaker or not.

Depends on #1040 