### PR TITLE
neutron: Setting apic to required:false

### DIFF
--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -45,7 +45,7 @@
                       "ovsdb_interface": { "type": "str", "required": true },
                       "of_interface": { "type": "str", "required": true }
                     }},
-                    "apic": { "type": "map", "required": true, "mapping": {
+                    "apic": { "type": "map", "required": false, "mapping": {
                       "hosts": { "type" : "str", "required" : true },
                       "system_id": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required": true },


### PR DESCRIPTION
This needs to be done  because
- default ml2_mechanism_driver is not apic 
- the json template does not have the default settings
- setting it to true causes error while applying barclamp (no 'apic' object)