### PR TITLE
monasca: make monasca-installer aware of SSL enabled Keystone

### DIFF
--- a/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
@@ -12,6 +12,12 @@ keystone_monasca_operator_password: <%= @master_settings['keystone_monasca_opera
 keystone_monasca_agent_password: <%= @master_settings['keystone_monasca_agent_password'] %>
 keystone_admin_agent_password: <%= @master_settings['keystone_admin_agent_password'] %>
 keystone_admin_password: <%= @keystone_settings['admin_password'] %>
+keystone_use_https: <%= @keystone_settings['use_ssl'] %>
+<%- if @keystone_settings['use_ssl'] %>
+keystone_protocol: 'https'
+authProtocol: 'https'
+keystone_insecure: <%= @keystone_settings['insecure'] %>
+<%- end %>
 api_region: <%= @keystone_settings['endpoint_region'] %>
 database_grafana_password: <%= @master_settings['database_grafana_password'] %>
 


### PR DESCRIPTION
This commit passes additional parameters to monasca-installer
in order to configure the [keystone_authtoken] correctly for
monasca-api and monasca-log-api.

(cherry picked from commit 5349119d36320dc20dafb274a81b0ecbe0dd1e8a)