### PR TITLE
monasca: fix health check URL for monasca-log-api.

### DIFF
--- a/chef/cookbooks/monasca/libraries/helper.rb
+++ b/chef/cookbooks/monasca/libraries/helper.rb
@@ -127,6 +127,17 @@ module MonascaHelper
     return monasca_log_api_url
   end
 
+  # Returns a log API health check URL for use by a Monasca agent's http_check
+  # plugin
+  def self.log_api_healthcheck_url(node)
+    my_net = node[:monasca][:network]
+    port = node[:monasca][:log_api][:bind_port]
+    listen_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
+      node, my_net).address
+
+    "http://#{listen_ip}:#{port}/healthcheck"
+  end
+
   def self.monasca_hosts(nodes)
     hosts = []
     nodes.each do |n|

--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -30,7 +30,7 @@ end
 agent_dimensions = { service: "monitoring" }
 
 monasca_api_url = MonascaHelper.api_network_url(monasca_server)
-monasca_log_api_url = MonascaHelper.log_api_network_url(monasca_server) + '/healthcheck'
+monasca_log_api_url = MonascaHelper.log_api_healthcheck_url(monasca_server)
 kibana_url = "http://" + MonascaHelper.monasca_public_host(monasca_server) + ":5601"
 monasca_net_ip = MonascaHelper.get_host_for_monitoring_url(monasca_server)
 


### PR DESCRIPTION
The monasca-log-api health check had an extra "v3.0" in its URL which
caused it to always fail. This commit generates a proper URL.