### PR TITLE
monasca: Disable load_avg 5 and 15 min graphs on monasca dashboard

### DIFF
--- a/chef/cookbooks/horizon/files/default/grafana-monasca.json
+++ b/chef/cookbooks/horizon/files/default/grafana-monasca.json
@@ -1609,18 +1609,6 @@
               "column": "value",
               "series": "load.avg_1_min",
               "period": ""
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "load.avg_5_min"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "load.avg_15_min"
             }
           ],
           "aliasColors": {},


### PR DESCRIPTION
this is consistent with what we did for the OpenStack dashboard
and makes the graph slightly more bearable.

(cherry picked from commit 081174db6a7fa83898dc5d887b10c0f091f6c95d)