### PR TITLE
[4.0] sahara: use barbican key manager made configurable

### DIFF
--- a/chef/cookbooks/sahara/templates/default/sahara.conf.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara.conf.erb
@@ -16,6 +16,7 @@ admin_user_domain_name = <%= @keystone_settings["admin_domain"] %>
 admin_project_domain_name = <%= @keystone_settings["admin_domain"]%>
 os_region_name = <%= @keystone_settings['endpoint_region'] %>
 api_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
+use_barbican_key_manager = <%= node[:sahara][:use_barbican_key_manager] %>
 
 [cinder]
 api_insecure = <%= @cinder_insecure %>

--- a/chef/data_bags/crowbar/migrate/sahara/102_add_use_barbican_key_manager.rb
+++ b/chef/data_bags/crowbar/migrate/sahara/102_add_use_barbican_key_manager.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key?("use_barbican_key_manager")
+    a["use_barbican_key_manager"] = ta["use_barbican_key_manager"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key?("use_barbican_key_manager")
+    a.delete("use_barbican_key_manager")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-sahara.json
+++ b/chef/data_bags/crowbar/template-sahara.json
@@ -26,14 +26,15 @@
         "password": "",
         "user": "sahara",
         "database": "sahara"
-      }
+      },
+      "use_barbican_key_manager": false
     }
   },
   "deployment": {
     "sahara": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "sahara-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-sahara.schema
+++ b/chef/data_bags/crowbar/template-sahara.schema
@@ -41,7 +41,8 @@
                 "user": { "type": "str", "required": true },
                 "database": { "type": "str", "required": true }
               }
-            }
+            },
+            "use_barbican_key_manager": { "type": "bool", "required": true }
           }
         }
       }

--- a/crowbar_framework/app/models/sahara_service.rb
+++ b/crowbar_framework/app/models/sahara_service.rb
@@ -84,6 +84,14 @@ class SaharaService < PacemakerServiceObject
 
   def validate_proposal_after_save(proposal)
     validate_one_for_role proposal, "sahara-server"
+
+    # check if barbican is deployed in case we are using use_barbican_key_manager
+    if proposal["attributes"][@bc_name]["use_barbican_key_manager"]
+      if NodeObject.find("roles:barbican-controller").empty?
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.barbican_deployed")
+      end
+    end
+
     super
   end
 

--- a/crowbar_framework/app/views/barclamp/sahara/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/sahara/_edit_attributes.html.haml
@@ -15,3 +15,4 @@
       %legend
         = t(".logging_header")
       = boolean_field :verbose
+      = boolean_field :use_barbican_key_manager

--- a/crowbar_framework/config/locales/sahara/en.yml
+++ b/crowbar_framework/config/locales/sahara/en.yml
@@ -28,3 +28,6 @@ en:
         cinder_instance: 'Cinder'
         logging_header: 'Logging'
         verbose: 'Verbose Logging'
+        use_barbican_key_manager: 'Use Barbican Key manager'
+      validation:
+        barbican_deployed: 'The Barbican barclamp needs to be deployed correctly to use it as Key Manager for Sahara.'


### PR DESCRIPTION
People can configure on the barclamp's UI if they want to use Barbican's
key manager.

(cherry picked from commit 7f3fc4f45a65c719c660fbe4b3ab3e5769fab4aa)