### PR TITLE
[WIP]: neutron: configure contrail backend for control and compute nodes.

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -75,6 +75,12 @@ default[:neutron][:apic][:opflex][:vxlan][:remote_ip] = ""
 default[:neutron][:apic][:opflex][:vxlan][:remote_port] = 8472
 default[:neutron][:apic][:opflex][:vlan][:encap_iface] = ""
 
+default[:neutron][:contrail][:api_server_ip] = ""
+default[:neutron][:contrail][:api_server_port] = "8082"
+default[:neutron][:contrail][:multi_tenancy] = false
+default[:neutron][:contrail][:analytics_api_ip] = ""
+default[:neutron][:contrail][:analytics_api_port] = "8081"
+
 case node[:platform_family]
 when "suse"
   default[:neutron][:platform] = {
@@ -117,6 +123,9 @@ when "suse"
     infoblox_pkgs: ["python-infoblox-client",
                     "openstack-neutron-infoblox",
                     "openstack-neutron-infoblox-ipam-agent"],
+    contrail_pkgs: ["contrail-lib",
+                    "neutron-plugin-contrail",
+                    "python-contrail"],
     vmware_vsphere_pkg: "openstack-neutron-vsphere",
     vmware_vsphere_dvs_agent_pkg: "openstack-neutron-vsphere-dvs-agent",
     user: "neutron",
@@ -160,6 +169,9 @@ when "rhel"
                         "lldpd",
                         "neutron-opflex-agent"],
     infoblox_pkgs: [],
+    contrail_pkgs: ["contrail-lib",
+                    "neutron-plugin-contrail",
+                    "python-contrail"],
     vmware_vsphere_pkg: "",
     vmware_vsphere_dvs_agent_pkg: "",
     user: "neutron",
@@ -202,6 +214,7 @@ else
     cisco_apic_gbp_pkgs: [""],
     cisco_opflex_pkgs: [""],
     infoblox_pkgs: [],
+    contrail_pkgs: [],
     vmware_vsphere_pkg: "openstack-neutron-vsphere",
     vmware_vsphere_dvs_agent_pkg: "openstack-neutron-vsphere-dvs-agent",
     user: "neutron",

--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -81,6 +81,13 @@ default[:neutron][:contrail][:multi_tenancy] = false
 default[:neutron][:contrail][:analytics_api_ip] = ""
 default[:neutron][:contrail][:analytics_api_port] = "8081"
 
+default[:neutron][:contrail][:api_server_ip] = ""
+default[:neutron][:contrail][:api_server_port] = "8082"
+default[:neutron][:contrail][:multi_tenancy] = false
+default[:neutron][:contrail][:analytics_api_ip] = ""
+default[:neutron][:contrail][:analytics_api_port] = "8081"
+default[:neutron][:contrail][:gateway_server_ip] = ""
+
 case node[:platform_family]
 when "suse"
   default[:neutron][:platform] = {
@@ -123,9 +130,24 @@ when "suse"
     infoblox_pkgs: ["python-infoblox-client",
                     "openstack-neutron-infoblox",
                     "openstack-neutron-infoblox-ipam-agent"],
-    contrail_pkgs: ["contrail-lib",
-                    "neutron-plugin-contrail",
-                    "python-contrail"],
+    contrail_control_pkgs: ["contrail-lib",
+                            "neutron-plugin-contrail",
+                            "python-contrail"],
+    contrail_compute_pkgs: ["contrail-lib",
+                            "contrail-nodemgr",
+                            "contrail-nova-vif",
+                            "contrail-openstack-vrouter",
+                            "contrail-setup",
+                            "contrail-utils",
+                            "contrail-vrouter",
+                            "contrail-vrouter-agent",
+                            "contrail-vrouter-common",
+                            "contrail-vrouter-init",
+                            "contrail-vrouter-utils",
+                            "python-contrail",
+                            "python-contrail-vrouter-api",
+                            "python-opencontrail-vrouter-netns",
+                            "yum"],
     vmware_vsphere_pkg: "openstack-neutron-vsphere",
     vmware_vsphere_dvs_agent_pkg: "openstack-neutron-vsphere-dvs-agent",
     user: "neutron",
@@ -169,9 +191,24 @@ when "rhel"
                         "lldpd",
                         "neutron-opflex-agent"],
     infoblox_pkgs: [],
-    contrail_pkgs: ["contrail-lib",
-                    "neutron-plugin-contrail",
-                    "python-contrail"],
+    contrail_control_pkgs: ["contrail-lib",
+                            "neutron-plugin-contrail",
+                            "python-contrail"],
+    contrail_compute_pkgs: ["contrail-lib",
+                            "contrail-nodemgr",
+                            "contrail-nova-vif",
+                            "contrail-openstack-vrouter",
+                            "contrail-setup",
+                            "contrail-utils",
+                            "contrail-vrouter",
+                            "contrail-vrouter-agent",
+                            "contrail-vrouter-common",
+                            "contrail-vrouter-init",
+                            "contrail-vrouter-utils",
+                            "python-contrail",
+                            "python-contrail-vrouter-api",
+                            "python-opencontrail-vrouter-netns",
+                            "yum"],
     vmware_vsphere_pkg: "",
     vmware_vsphere_dvs_agent_pkg: "",
     user: "neutron",
@@ -214,7 +251,8 @@ else
     cisco_apic_gbp_pkgs: [""],
     cisco_opflex_pkgs: [""],
     infoblox_pkgs: [],
-    contrail_pkgs: [],
+    contrail_control_pkgs: [],
+    contrail_compute_pkgs: [],
     vmware_vsphere_pkg: "openstack-neutron-vsphere",
     vmware_vsphere_dvs_agent_pkg: "openstack-neutron-vsphere-dvs-agent",
     user: "neutron",

--- a/chef/cookbooks/neutron/recipes/contrail_compute.rb
+++ b/chef/cookbooks/neutron/recipes/contrail_compute.rb
@@ -15,86 +15,86 @@
 #
 neutron = nil
 if node.attribute?(:cookbook) && node[:cookbook] == "nova"
-  neutrons = node_search_with_cache("roles:neutron-server", node[:nova][:neutron_instance])
-  neutron = neutrons.first || raise("Neutron instance '#{node[:nova][:neutron_instance]}' \
+        neutrons = node_search_with_cache("roles:neutron-server", node[:nova][:neutron_instance])
+        neutron = neutrons.first || raise("Neutron instance '#{node[:nova][:neutron_instance]}' \
                                     for nova not found")
 else
-  neutron = node
+        neutron = node
 end
 
 # Install all packages for contrail vrouter on compute node
 # Need to manually install (with force downgrade) contrail-vrouter-common
 # Command: zypper --no-gpg-checks --non-interactive in contrail-vrouter-common
 node[:neutron][:platform][:contrail_compute_pkgs].each do |p|
-  bash "install contrail packages" do
-    user "root"
-    code <<-EOF
+        bash "install contrail packages" do
+                user "root"
+                code <<-EOF
       zypper --no-gpg-checks --non-interactive in --auto-agree-with-licenses --force #{p}
-    EOF
-  end
+      EOF
+        end
 end
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 template "/etc/contrail/supervisord_vrouter.conf" do
-  cookbook "neutron"
-  source "supervisord_vrouter.conf.erb"
-  mode "0640"
-  owner "root"
-  group node[:neutron][:platform][:group]
+        cookbook "neutron"
+        source "supervisord_vrouter.conf.erb"
+        mode "0640"
+        owner "root"
+        group node[:neutron][:platform][:group]
 end
 
 template "/etc/contrail/contrail-vrouter-agent.conf" do
-  cookbook "neutron"
-  source "contrail-vrouter-agent.conf.erb"
-  mode "0640"
-  owner "root"
-  group node[:neutron][:platform][:group]
-  variables(
-    contrail_api_server_ip: neutron[:neutron][:contrail][:api_server_ip],
-    gateway_api_server: neutron[:neutron][:contrail][:gateway_server_ip],
-    metadata_proxy_secret: neutron[:nova][:neutron_metadata_proxy_shared_secret]
-  )
+        cookbook "neutron"
+        source "contrail-vrouter-agent.conf.erb"
+        mode "0640"
+        owner "root"
+        group node[:neutron][:platform][:group]
+        variables(
+                contrail_api_server_ip: neutron[:neutron][:contrail][:api_server_ip],
+                gateway_api_server: neutron[:neutron][:contrail][:gateway_server_ip],
+                metadata_proxy_secret: neutron[:nova][:neutron_metadata_proxy_shared_secret]
+        )
 end
 
 template "/etc/contrail/supervisord_vrouter_files/contrail-vrouter-agent.ini" do
-  cookbook "neutron"
-  source "contrail-vrouter-agent.ini.erb"
-  mode "0640"
-  owner "root"
-  group node[:neutron][:platform][:group]
+        cookbook "neutron"
+        source "contrail-vrouter-agent.ini.erb"
+        mode "0640"
+        owner "root"
+        group node[:neutron][:platform][:group]
 end
 
 template "/etc/contrail/contrail-vrouter-nodemgr.conf" do
-  cookbook "neutron"
-  source "contrail-vrouter-nodemgr.conf.erb"
-  mode "0640"
-  owner "root"
-  group node[:neutron][:platform][:group]
-  variables(
-    contrail_api_server_ip: neutron[:neutron][:contrail][:api_server_ip]
-  )
+        cookbook "neutron"
+        source "contrail-vrouter-nodemgr.conf.erb"
+        mode "0640"
+        owner "root"
+        group node[:neutron][:platform][:group]
+        variables(
+                contrail_api_server_ip: neutron[:neutron][:contrail][:api_server_ip]
+        )
 end
 
 template "/etc/contrail/supervisord_vrouter_files/contrail-vrouter-nodemgr.ini" do
-  cookbook "neutron"
-  source "contrail-vrouter-nodemgr.ini.erb"
-  mode "0640"
-  owner "root"
-  group node[:neutron][:platform][:group]
+        cookbook "neutron"
+        source "contrail-vrouter-nodemgr.ini.erb"
+        mode "0640"
+        owner "root"
+        group node[:neutron][:platform][:group]
 end
 
 file "/etc/contrail/supervisord_vrouter_files/contrail-vrouter.rules" do
-  content '{ "Rules": [
+        content '{ "Rules": [
                ]
            }'
-  mode "0640"
-  owner "root"
-  group node[:neutron][:platform][:group]
+        mode "0640"
+        owner "root"
+        group node[:neutron][:platform][:group]
 end
 
 file "/etc/contrail/agent_param" do
-  content "LOG=/var/log/contrail.log
+        content "LOG=/var/log/contrail.log
            CONFIG=/etc/contrail/agent.conf
            prog=/usr/bin/contrail-vrouter-agent
            kmod=vrouter
@@ -106,10 +106,44 @@ file "/etc/contrail/agent_param" do
            vgw_intf=
            qos_enabled=false
            LOGFILE=--log-file=/var/log/contrail/vrouter.log"
+        mode "0640"
+        owner "root"
+        group node[:neutron][:platform][:group]
+end
+
+# This is a temporary fix and the file should be automatically added by the package
+file "/usr/lib/systemd/system/supervisor-vrouter.service" do
+  content "[Unit]
+           Description=Contrail vrouter
+           After=rc-local.service
+
+           [Service]
+           Type=forking
+           ExecStart=/usr/bin/supervisord -c /etc/contrail/supervisord_vrouter.conf
+
+           [Install]
+           WantedBy=multi-user.target"
   mode "0640"
   owner "root"
   group node[:neutron][:platform][:group]
 end
 
+eth_addresses = node[:crowbar_wall][:network][:interfaces][:eth0][:addresses]
+eth_gateway = node[:crowbar_wall][:network][:interfaces][:eth0][:gateway]
+file "/root/set_vhost_interfaces.sh" do
+  content "DEV_MAC=$(cat /sys/class/net/eth0/address)
 
+           ip link add vhost0 type vhost
+           vif --create vhost0 --mac $DEV_MAC
 
+           vif --add eth0 --mac $DEV_MAC --vrf 0 --vhost-phys --type physical
+           vif --add vhost0 --mac $DEV_MAC --vrf 0 --type vhost --xconnect eth0
+
+           ip address delete #{eth_addresses} dev eth0
+           ip address add #{eth_addresses} dev vhost0
+           ip link set dev vhost0 up
+           ip route add default via #{eth_gateway}"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+end

--- a/chef/cookbooks/neutron/recipes/contrail_compute.rb
+++ b/chef/cookbooks/neutron/recipes/contrail_compute.rb
@@ -1,0 +1,115 @@
+#
+# Copyright 2017 SUSE Linux GmBH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+neutron = nil
+if node.attribute?(:cookbook) && node[:cookbook] == "nova"
+  neutrons = node_search_with_cache("roles:neutron-server", node[:nova][:neutron_instance])
+  neutron = neutrons.first || raise("Neutron instance '#{node[:nova][:neutron_instance]}' \
+                                    for nova not found")
+else
+  neutron = node
+end
+
+# Install all packages for contrail vrouter on compute node
+# Need to manually install (with force downgrade) contrail-vrouter-common
+# Command: zypper --no-gpg-checks --non-interactive in contrail-vrouter-common
+node[:neutron][:platform][:contrail_compute_pkgs].each do |p|
+  bash "install contrail packages" do
+    user "root"
+    code <<-EOF
+      zypper --no-gpg-checks --non-interactive in --auto-agree-with-licenses --force #{p}
+    EOF
+  end
+end
+
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+
+template "/etc/contrail/supervisord_vrouter.conf" do
+  cookbook "neutron"
+  source "supervisord_vrouter.conf.erb"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+end
+
+template "/etc/contrail/contrail-vrouter-agent.conf" do
+  cookbook "neutron"
+  source "contrail-vrouter-agent.conf.erb"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+  variables(
+    contrail_api_server_ip: neutron[:neutron][:contrail][:api_server_ip],
+    gateway_api_server: neutron[:neutron][:contrail][:gateway_server_ip],
+    metadata_proxy_secret: neutron[:nova][:neutron_metadata_proxy_shared_secret]
+  )
+end
+
+template "/etc/contrail/supervisord_vrouter_files/contrail-vrouter-agent.ini" do
+  cookbook "neutron"
+  source "contrail-vrouter-agent.ini.erb"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+end
+
+template "/etc/contrail/contrail-vrouter-nodemgr.conf" do
+  cookbook "neutron"
+  source "contrail-vrouter-nodemgr.conf.erb"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+  variables(
+    contrail_api_server_ip: neutron[:neutron][:contrail][:api_server_ip]
+  )
+end
+
+template "/etc/contrail/supervisord_vrouter_files/contrail-vrouter-nodemgr.ini" do
+  cookbook "neutron"
+  source "contrail-vrouter-nodemgr.ini.erb"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+end
+
+file "/etc/contrail/supervisord_vrouter_files/contrail-vrouter.rules" do
+  content '{ "Rules": [
+               ]
+           }'
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+end
+
+file "/etc/contrail/agent_param" do
+  content "LOG=/var/log/contrail.log
+           CONFIG=/etc/contrail/agent.conf
+           prog=/usr/bin/contrail-vrouter-agent
+           kmod=vrouter
+           pname=contrail-vrouter-agent
+           LIBDIR=/usr/lib64
+           VHOST_CFG=/etc/sysconfig/network-scripts/ifcfg-vhost0
+           dev=eth0
+           vgw_subnet_ip=
+           vgw_intf=
+           qos_enabled=false
+           LOGFILE=--log-file=/var/log/contrail/vrouter.log"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+end
+
+
+

--- a/chef/cookbooks/neutron/recipes/contrail_control.rb
+++ b/chef/cookbooks/neutron/recipes/contrail_control.rb
@@ -30,10 +30,13 @@
 
 # Install contrail-lib, neutron-plugin-contrail, python-contrail
 
-node[:neutron][:platform][:contrail_pkgs].each { |p| package p }
+node[:neutron][:platform][:contrail_control_pkgs].each { |p| package p }
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
+# TODO(mmnelemane): metadata_proxy_shared_secret from nova servers needs to be 
+# copied onto contrail-api server to ensure the contrail service can provide 
+# metadata access to nova servers.
 template "/etc/neutron/plugins/opencontrail/ContrailPlugin.ini" do
   cookbook "neutron"
   source "ContrailPlugin.ini.erb"

--- a/chef/cookbooks/neutron/recipes/contrail_control.rb
+++ b/chef/cookbooks/neutron/recipes/contrail_control.rb
@@ -1,0 +1,52 @@
+#
+# Copyright 2017 SUSE Linux GmBH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Configurations to be set on the controller for neutron:
+# # neutron.conf
+# [DEFAULT]
+# core_plugin = neutron_plugin_contrail.plugins.opencontrail.contrail_plugin.NeutronPluginContrailV2
+# service_plugins = neutron_plugin_contrail.plugins.opencontrail.loadbalancer.v2.plugin.LoadBalancerPluginV2
+#
+# [quotas]
+# quota_driver = neutron_plugin_contrail:plugins.opencontrail.quota.driver.QuotaDriver
+#
+# [service_providers]
+# service_provider = LOADBALANCER:Opencontrail:neutron_plugin_contrail.plugins.opencontrail.loadbalancer.driver.OpenContrailLoadbalancer:default
+#
+# # Add new plugin opencontrail/ContrailPlugin.ini
+#
+
+# Install contrail-lib, neutron-plugin-contrail, python-contrail
+
+node[:neutron][:platform][:contrail_pkgs].each { |p| package p }
+
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+
+template "/etc/neutron/plugins/opencontrail/ContrailPlugin.ini" do
+  cookbook "neutron"
+  source "ContrailPlugin.ini.erb"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+  variables(
+    contrail_api_server_ip: node[:neutron][:contrail][:api_server_ip],
+    contrail_api_server_port: node[:neutron][:contrail][:api_server_port],
+    multi_tenancy: node[:neutron][:contrail][:multi_tenancy],
+    contrail_analytics_api_ip: node[:neutron][:contrail][:analytics_api_ip],
+    contrail_analytics_api_port: node[:neutron][:contrail][:analytics_api_port],
+    keystone_settings: keystone_settings
+  )
+  notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]"
+end

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -16,6 +16,8 @@
 
 include_recipe "neutron::common_agent"
 
+return if node[:neutron][:networking_plugin] == "contrail"
+
 package node[:neutron][:platform][:dhcp_agent_pkg]
 package node[:neutron][:platform][:metering_agent_pkg]
 

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -235,8 +235,12 @@ if node[:neutron][:networking_plugin] == "ml2"
     include_recipe "neutron::cisco_apic_support"
   end
 end
+
 if node[:neutron][:networking_plugin] == "contrail"
   include_recipe "neutron::contrail_control"
+  if node.roles.include?("nova-compute-kvm")
+    include_recipe "neutron::contrail_compute"
+  end
 end
 
 if node[:neutron][:use_lbaas]

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -235,6 +235,9 @@ if node[:neutron][:networking_plugin] == "ml2"
     include_recipe "neutron::cisco_apic_support"
   end
 end
+if node[:neutron][:networking_plugin] == "contrail"
+  include_recipe "neutron::contrail_control"
+end
 
 if node[:neutron][:use_lbaas]
   template node[:neutron][:lbaas_service_file] do

--- a/chef/cookbooks/neutron/templates/default/ContrailPlugin.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ContrailPlugin.ini.erb
@@ -1,0 +1,90 @@
+[APISERVER]
+# (StrOpt) IP address of the API server
+#
+api_server_ip = <%= @contrail_api_server_ip %>
+# Example: api_server_ip = 10.0.0.1
+
+# (IntOpt) API server port
+#
+api_server_port = <%= @contrail_api_server_port %>
+multi_tenancy = <%= @multi_tenancy %>
+# Example: api_server_port = 8082
+
+# (BoolOpt) Enable multi tenancy
+#
+#multi_tenancy = true
+# Example: multi_tenancy = True
+
+# auth_token_url =
+#auth_token_url = http://192.168.124.81:35357/v2.0/tokens
+
+# (ListOpt) list of OpenContrail extensions to be supported.
+# OpenContrail extensions are - ipam, policy and route-table.
+# By default ipam, policy and route-table extensions are supported 
+# by the OpenContrail neutron plugin. Set this flag if you want to enable  
+# only a subset of these extensions or to disable all these extensions.
+# If this flag is not set, then all the OpenContrail extensions 
+# are enabled.
+#
+# Example : Enable ipam and policy extensions 
+# contrail_extensions = ipam,policy
+# Example : Enable only route-table extension
+# contrail_extensions = route-table
+# Example : disable all the extensions
+# contrail_extensions = 
+# Example : enable all the extensions
+# contrail_extensions = ipam,policy,route-table
+# Example : enable all the extensions
+# Do not defined this flag
+
+contrail_extensions = ipam:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_ipam.NeutronPluginContrailIpam,policy:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_policy.NeutronPluginContrailPolicy,route-table:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_vpc.NeutronPluginContrailVpc,contrail:None
+
+
+[COLLECTOR]
+analytics_api_ip = <%= @contrail_analytics_api_ip %>
+analytics_api_port = <%= @contrail_analytics_api_port %>
+
+[KEYSTONE]
+auth_url = <%= @keystone_settings['public_auth_url'] %>
+admin_user=<%= @keystone_settings['admin_user'] %>
+admin_password=<%= @keystone_settings['admin_password'] %>
+insecure = <%= @keystone_settings['insecure'] %>
+admin_tenant_name=<%= @keystone_settings['admin_tenant'] %>
+auth_host = <%= @keystone_settings['internal_url_host'] %>
+auth_port = <%= @keystone_settings['service_port'] %>
+<% if @nova_insecure -%>
+insecure = <%= @nova_insecure %>
+<% end -%>
+auth_protocol = <%= @keystone_settings['protocol'] %>
+auth_plugin = password
+
+#user_domain_name = Default
+
+#[ssl]
+#cert_file = /etc/neutron/ssl/certs/signing_cert.pem
+#key_file = /etc/neutron/ssl/private/signing_key.pem
+
+#username = neutron
+#password = jQNpeo3ZpIid
+
+# Example : auth_url = http://keystone-server:5000/v2.0
+
+# (StrOpt) admin user name 
+#
+#admin_user = admin
+# Example : admin_user = admin
+
+# (StrOpt) admin tenant name
+#
+#admin_tenant_name = crowbar
+# Example : admin_tenant_name = admin
+
+# (StrOpt) admin password
+# 
+#admin_password = crowbar
+# Example : admin_password = admin
+
+# (StrOpt) admin token 
+#
+#admin_token = crowbar
+# Example : admin_token = token1

--- a/chef/cookbooks/neutron/templates/default/contrail-vrouter-agent.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/contrail-vrouter-agent.conf.erb
@@ -1,0 +1,284 @@
+#
+# Vnswad configuration options
+#
+
+[CONTROL-NODE]
+# IP address to be used to connect to control-node. Maximum of 2 IP addresses
+# (separated by a space) can be provided. If no IP is configured then the
+# value provided by discovery service will be used. (optional)
+# server=10.0.0.1 10.0.0.2
+server= <%= @contrail_api_server_ip %>
+
+[DEFAULT]
+# Everything in this section is optional
+
+# IP address and port to be used to connect to collector. If these are not
+# configured, value provided by discovery service will be used. Multiple
+# IP:port strings separated by space can be provided
+collectors= <%= @contrail_api_server_ip %>:8086
+
+# Agent mode : can be vrouter / tsn / tor (default is vrouter)
+# agent_mode=
+
+# Aging time for flow-records in seconds
+# flow_cache_timeout=0
+
+# hostname= # Retrieved from gethostname() or `hostname -s` equivalent
+
+# Http server port for inspecting vnswad state (useful for debugging)
+# http_server_port=8085
+
+# Category for logging. Default value is '*'
+# log_category=
+
+# Number of tx-buffers on pkt0 interface
+# pkt0_tx_buffers=1000
+#
+# Measure delays in different queues
+# measure_queue_delay=0
+#
+# Local log file name
+log_file=/var/log/contrail/contrail-vrouter-agent.log
+
+# Log severity levels. Possible values are SYS_EMERG, SYS_ALERT, SYS_CRIT,
+# SYS_ERR, SYS_WARN, SYS_NOTICE, SYS_INFO and SYS_DEBUG. Default is SYS_DEBUG
+log_level=SYS_NOTICE
+
+# Enable/Disable local file logging. Possible values are 0 (disable) and 1 (enable)
+log_local=1
+
+# Enable/Disable local flow message logging. Possible values are 0 (disable) and 1 (enable)
+# log_flow=0
+
+# Encapsulation type for tunnel. Possible values are MPLSoGRE, MPLSoUDP, VXLAN
+# tunnel_type=
+
+# Enable/Disable headless mode for agent. In headless mode agent retains last
+# known good configuration from control node when all control nodes are lost.
+# Possible values are true(enable) and false(disable)
+# headless_mode=
+
+# DHCP relay mode (true or false) to determine if a DHCP request in fabric
+# interface with an unconfigured IP should be relayed or not
+# dhcp_relay_mode=
+
+# Sandesh send rate limit can be used to throttle system logs transmitted per
+# second. System logs are dropped if the sending rate is exceeded
+# sandesh_send_rate_limit=100
+
+# Enable/Disable SSL based XMPP Authentication
+# xmpp_auth_enable=false
+# xmpp_dns_auth_enable=false
+# xmpp_server_cert=/etc/contrail/ssl/certs/server.pem
+# xmpp_server_key=/etc/contrail/ssl/private/server-privkey.pem
+# xmpp_ca_cert=/etc/contrail/ssl/certs/ca-cert.pem
+
+# Gateway mode : can be server/ vcpe (default is none)
+# gateway_mode=
+
+[DISCOVERY]
+#If DEFAULT.collectors and/or CONTROL-NODE and/or DNS is not specified this
+#section is mandatory. Else this section is optional
+
+# IP address and port of discovery server
+# port=5998
+server= <%= @contrail_api_server_ip %>
+
+# Number of control-nodes info to be provided by Discovery service. Possible
+# values are 1 and 2
+# max_control_nodes=1
+
+[DNS]
+# IP address to be used to connect to dns-node. Maximum of 2 IP addresses
+# (separated by a space) can be provided. If no IP is configured then the
+# value provided by discovery service will be used. (Optional)
+# server=10.0.0.1 10.0.0.2
+server= <%= @contrail_api_server_ip %>
+
+# Client port used by vrouter-agent while connecting to contrail-named
+# dns_client_port=
+
+[HYPERVISOR]
+# Everything in this section is optional
+
+# Hypervisor type. Possible values are kvm, xen and vmware
+# type=kvm
+
+# Link-local IP address and prefix in ip/prefix_len format (for xen)
+# xen_ll_ip=
+
+# Link-local interface name when hypervisor type is Xen
+# xen_ll_interface=
+
+# Physical interface name when hypervisor type is vmware
+# vmware_physical_interface=
+
+# Mode of operation for VMWare. Possible values esxi_neutron, vcenter
+# default is esxi_neutron
+# vmware_mode=
+
+[FLOWS]
+# Everything in this section is optional
+
+# Number of threads for flow setup
+# thread_count = 4
+#
+# Maximum flows allowed per VM (given as % of maximum system flows)
+# max_vm_flows=
+
+# Maximum number of link-local flows allowed across all VMs
+# max_system_linklocal_flows=4096
+
+# Maximum number of link-local flows allowed per VM
+# max_vm_linklocal_flows=1024
+
+# Number of Index state-machine events to log
+# index_sm_log_count=0
+
+# Enable/Disable tracing of flow messages. Introspect can over-ride this value
+# trace_enable=false
+#
+# Number of add-tokens
+# add_tokens=100
+# Number of ksync-tokens
+# ksync_tokens=50
+# Number of del-tokens
+# del_tokens=50
+# Number of update-tokens
+# update_tokens=50
+[METADATA]
+# Shared secret for metadata proxy service (Optional)
+# metadata_proxy_secret=contrail
+metadata_proxy_secret = <%= @metadata_proxy_secret %>
+
+# Metadata proxy port on which agent listens (Optional)
+# metadata_proxy_port=
+
+[NETWORKS]
+# control-channel IP address used by WEB-UI to connect to vnswad to fetch
+# required information (Optional)
+control_network_ip = localhost
+
+[VIRTUAL-HOST-INTERFACE]
+# Everything in this section is mandatory
+
+# name of virtual host interface
+name=vhost0
+
+# IP address and prefix in ip/prefix_len format
+ip=localhost/24
+                                                                                                                    
+# Gateway IP address for virtual host
+gateway= <%= @gateway_api_server %>
+
+
+# Flag to indicate if hosts in vhost subnet can be resolved by ARP
+# If set to 1 host in subnet would be resolved by ARP, if set to 0
+# all the traffic destined to hosts within subnet also go via
+# default gateway
+# subnet_hosts_resolvable=0
+
+# Physical interface name to which virtual host interface maps to
+physical_interface=eth0
+# List of IP addresses assigned for the compute node other than vhost. Specify
+# this only if vhost interface is un-numbered in host-os. Agent will use one
+# of the compute_node_address to run services that need IP Address in host-os
+# (like metadata...)
+compute_node_address = localhost
+
+# We can have multiple gateway sections with different indices in the
+# following format
+[GATEWAY-0]
+# Name of the routing_instance for which the gateway is being configured
+# routing_instance=default-domain:admin:public:public
+
+# Gateway interface name
+# interface=vgw
+
+# Virtual network ip blocks for which gateway service is required. Each IP
+# block is represented as ip/prefix. Multiple IP blocks are represented by
+# separating each with a space
+# ip_blocks=1.1.1.1/24
+
+[GATEWAY-1]
+# Name of the routing_instance for which the gateway is being configured
+# routing_instance=default-domain:admin:public1:public1
+
+# Gateway interface name
+# interface=vgw1
+
+# Virtual network ip blocks for which gateway service is required. Each IP
+# block is represented as ip/prefix. Multiple IP blocks are represented by
+# separating each with a space
+# ip_blocks=2.2.1.0/24 2.2.2.0/24
+
+# Routes to be exported in routing_instance. Each route is represented as
+# ip/prefix. Multiple routes are represented by separating each with a space
+# routes=10.10.10.1/24 11.11.11.1/24
+
+[SERVICE-INSTANCE]
+# Path to the script which handles the netns commands
+netns_command=/usr/bin/opencontrail-vrouter-netns
+docker_command=/usr/bin/opencontrail-vrouter-docker
+
+# Number of workers that will be used to start netns commands
+#netns_workers=1
+
+# Timeout for each netns command, when the timeout is reached, the netns
+# command is killed.
+#netns_timeout=30
+#
+[TASK]
+# Number of threads used by TBB
+# thread_count = 8
+# Log message if time taken to execute task exceeds a threshold (in msec)
+# log_exec_threshold = 10
+#
+# Log message if time taken to schedule task exceeds a threshold (in msec)
+# log_schedule_threshold = 25
+#
+# TBB Keepawake timer interval
+# tbb_keepawake_timeout = 20
+
+[SERVICES]
+# bgp_as_a_service_port_range - reserving set of ports to be used.
+# bgp_as_a_service_port_range=30000-35000
+
+# [QOS]
+# [QUEUE-1]
+# Logical nic queues for qos config
+# logical_queue=
+
+# [QUEUE-2]
+# Logical nic queues for qos config
+# logical_queue=
+
+# [QUEUE-3]
+# This is the default hardware queue
+# default_hw_queue= true
+
+# Logical nic queues for qos config
+# logical_queue=
+
+# [QOS-NIANTIC]
+# [PG-1]
+# Scheduling algorithm for priority group (strict/rr)
+# scheduling=
+
+# Total hardware queue bandwidth used by priority group
+# bandwidth=
+
+# [PG-2]
+# Scheduling algorithm for priority group (strict/rr)
+# scheduling=
+
+# Total hardware queue bandwidth used by priority group
+# bandwidth=
+
+# [PG-3]
+# Scheduling algorithm for priority group (strict/rr)
+# scheduling=
+
+# Total hardware queue bandwidth used by priority group
+# bandwidth=
+

--- a/chef/cookbooks/neutron/templates/default/contrail-vrouter-agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/contrail-vrouter-agent.ini.erb
@@ -1,0 +1,12 @@
+[program:contrail-vrouter-agent]
+command=/usr/bin/contrail-vrouter-agent
+priority=420
+autostart=true
+killasgroup=true
+stopsignal=KILL
+stdout_capture_maxbytes=1MB
+redirect_stderr=true
+stdout_logfile=/var/log/contrail/contrail-vrouter-agent-stdout.log
+stderr_logfile=/dev/null
+startsecs=5
+exitcodes=0                   ; 'expected' exit codes for process (default 0,2)

--- a/chef/cookbooks/neutron/templates/default/contrail-vrouter-nodemgr.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/contrail-vrouter-nodemgr.conf.erb
@@ -1,0 +1,6 @@
+[DISCOVERY]
+server= <%= @contrail_api_server_ip %>
+port=5998
+
+[COLLECTOR]
+#server_list=ip1:port1 ip2:port2

--- a/chef/cookbooks/neutron/templates/default/contrail-vrouter-nodemgr.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/contrail-vrouter-nodemgr.ini.erb
@@ -1,0 +1,39 @@
+; The below sample eventlistener section shows all possible
+; eventlistener subsection values, create one or more 'real'
+; eventlistener: sections to be able to handle event notifications
+; sent by supervisor.
+
+[eventlistener:contrail-vrouter-nodemgr]
+command=/bin/bash -c "exec python /usr/bin/contrail-nodemgr --nodetype=contrail-vrouter"
+events=PROCESS_COMMUNICATION,PROCESS_STATE,TICK_60
+;[eventlistener:theeventlistnername]
+;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)
+;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
+;numprocs=1                    ; number of processes copies to start (def 1)
+;events=EVENT                  ; event notif. types to subscribe to (req'd)
+buffer_size=10000                ; event buffer queue size (default 10)
+;directory=/tmp                ; directory to cwd to before exec (def no cwd)
+;umask=022                     ; umask for process (default None)
+;priority=-1                   ; the relative start priority (default -1)
+;autostart=true                ; start at supervisord start (default: true)
+;autorestart=unexpected        ; whether/when to restart (default: unexpected)
+;startsecs=1                   ; number of secs prog must stay running (def. 1)
+;startretries=3                ; max # of serial start failures (default 3)
+;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
+;stopsignal=QUIT               ; signal used to kill process (default TERM)
+;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
+;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
+;killasgroup=false             ; SIGKILL the UNIX process group (def false)
+;user=chrism                   ; setuid to this UNIX account to run the program
+;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
+stdout_logfile=/var/log/contrail/contrail-vrouter-nodemgr-stdout.log ; stdout log path, NONE for none; default AUTO
+;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+;stdout_events_enabled=false   ; emit events on stdout writes (default false)
+stderr_logfile=/var/log/contrail/contrail-vrouter-nodemgr-stderr.log ; stderr log path, NONE for none; default AUTO
+;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stderr_logfile_backups        ; # of stderr logfile backups (default 10)
+;stderr_events_enabled=false   ; emit events on stderr writes (default false)
+;environment=A=1,B=2           ; process environment additions
+;serverurl=AUTO                ; override serverurl computation (childutils)
+

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -3,6 +3,7 @@ bind_host = <%= @bind_host %>
 bind_port = <%= @bind_port %>
 auth_strategy = keystone
 core_plugin = <%= @core_plugin %>
+api_extensions_path = <%= @api_extensions_path %>
 service_plugins = <%= @service_plugins %>
 dns_domain = <%= @dns_domain %>
 allow_overlapping_ips = <%= @allow_overlapping_ips ? "True" : "False" %>
@@ -104,3 +105,6 @@ http_pool_maxsize = <%= @infoblox[:grids][grid][:http_pool_maxsize] %>
 http_request_timeout = <%= @infoblox[:grids][grid][:http_request_timeout] %>
 <% end -%>
 <% end -%>
+
+[quotas]
+quota_driver = <%= @quota_driver %>

--- a/chef/cookbooks/neutron/templates/default/supervisord_vrouter.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/supervisord_vrouter.conf.erb
@@ -1,0 +1,92 @@
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[unix_http_server]
+file=/var/run/supervisord_vrouter.sock   ; (the path to the socket file)
+chmod=0700                 ; socket file mode (default 0700)
+;chown=nobody:nogroup       ; socket file uid:gid owner
+;username=user              ; (default is no username (open server))
+;password=123               ; (default is no password (open server))
+
+
+[supervisord]
+logfile=/var/log/contrail/supervisord-vrouter.log ; (main log file;default /supervisord.log)
+logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_backups=3            ; (num of main logfile rotation backups;default 10)
+loglevel=info                ; (log level;default info; others: debug,warn,trace)
+pidfile=/var/run/supervisord_vrouter.pid ; (supervisord pidfile;default supervisord.pid)
+nodaemon=false               ; (start in foreground if true;default false)
+minfds=10240                 ; (min. avail startup file descriptors;default 1024)
+minprocs=200                 ; (min. avail process descriptors;default 200)
+;umask=022                   ; (process file creation umask;default 022)
+;user=chrism                 ; (default is current user, required if root)
+;identifier=supervisor       ; (supervisord identifier, default is 'supervisor')
+;directory=/tmp              ; (default is not to cd during start)
+;nocleanup=true              ; (don't clean up tempfiles at start;default false)
+childlogdir=/var/log/contrail ; ('AUTO' child log dir, default )
+;environment=KEY=value       ; (key value pairs to add to environment)
+;strip_ansi=false            ; (strip ansi escape codes in logs; def. false)
+
+
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisord_vrouter.sock ; use a unix:// URL  for a unix socket
+;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
+;username=chris              ; should be same as http_username if set
+;password=123                ; should be same as http_password if set
+;prompt=mysupervisor         ; cmd line prompt (default "supervisor")
+;history_file=~/.sc_history  ; use readline history if available
+
+; The below sample program section shows all possible program subsection values,
+; create one or more 'real' program: sections to be able to control them under
+; supervisor.
+
+;[program:theprogramname]
+;command=/bin/cat              ; the program (relative uses PATH, can take args)
+;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
+;numprocs=1                    ; number of processes copies to start (def 1)
+;directory=/tmp                ; directory to cwd to before exec (def no cwd)
+;umask=022                     ; umask for process (default None)
+;priority=999                  ; the relative start priority (default 999)
+;autostart=true                ; start at supervisord start (default: true)
+;autorestart=unexpected        ; whether/when to restart (default: unexpected)
+;startsecs=1                   ; number of secs prog must stay running (def. 1)
+;startretries=3                ; max # of serial start failures (default 3)
+;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
+;stopsignal=QUIT               ; signal used to kill process (default TERM)
+;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
+;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
+;killasgroup=false             ; SIGKILL the UNIX process group (def false)
+;user=chrism                   ; setuid to this UNIX account to run the program
+;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
+;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
+;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+;stdout_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stdout_events_enabled=false   ; emit events on stdout writes (default false)
+;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
+;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
+;stderr_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stderr_events_enabled=false   ; emit events on stderr writes (default false)
+;environment=A=1,B=2           ; process environment additions (def no adds)
+;serverurl=AUTO                ; override serverurl computation (childutils)
+
+; The below sample group section shows all possible group values,
+; create one or more 'real' group: sections to create "heterogeneous"
+; process groups.
+
+;[group:thegroupname]
+;programs=progname1,progname2  ; each refers to 'x' in [program:x] definitions
+;priority=999                  ; the relative start priority (default 999)
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/contrail/supervisord_vrouter_files/*.ini

--- a/chef/cookbooks/neutron/templates/default/vnc_api_lib.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/vnc_api_lib.ini.erb
@@ -1,0 +1,17 @@
+[global]
+;WEB_SERVER = 127.0.0.1
+;WEB_PORT = 9696  ; connection through quantum plugin
+
+WEB_SERVER = 127.0.0.1
+WEB_PORT = 8082 ; connection to api-server directly
+BASE_URL = /
+;BASE_URL = /tenants/infra ; common-prefix for all URLs
+
+; Authentication settings (optional)
+[auth]
+;AUTHN_TYPE = keystone
+;AUTHN_PROTOCOL = http
+;AUTHN_SERVER = 127.0.0.1
+;AUTHN_PORT = 35357
+;AUTHN_URL = /v2.0/tokens
+;AUTHN_TOKEN_URL = http://127.0.0.1:35357/v2.0/tokens

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -335,6 +335,11 @@ if need_shared_lock_path
   include_recipe "crowbar-openstack::common"
 end
 
+libvirt_vif_driver = ""
+if neutron_server[:neutron][:networking_plugin] == "contrail"
+  libvirt_vif_driver = "nova_contrail_vif.contrailvif.VRouterVIFDriver"
+end
+
 template node[:nova][:config_file] do
   source "nova.conf.erb"
   user "root"
@@ -386,6 +391,7 @@ template node[:nova][:config_file] do
     neutron_has_tunnel: neutron_has_tunnel,
     keystone_settings: keystone_settings,
     cinder_insecure: cinder_insecure || keystone_settings["insecure"],
+    nova_libvirt_vif_driver: libvirt_vif_driver,
     use_multipath: use_multipath,
     keymgr_fixed_key: keymgr_fixed_key,
     ceph_user: ceph_user,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -90,6 +90,9 @@ control_exchange = nova
 <%= "zvm_user_profile=#{node[:nova][:zvm][:zvm_user_profile]}" if @libvirt_type.eql?('zvm') %>
 <%= "zvm_user_default_password=#{node[:nova][:zvm][:zvm_user_default_password]}" if @libvirt_type.eql?('zvm') %>
 <%= "zvm_user_default_privilege=#{node[:nova][:zvm][:zvm_user_default_privilege]}" if @libvirt_type.eql?('zvm') %>
+<% if @nova_libvirt_vif_driver -%>
+libvirt_vif_driver = <%= @nova_libvirt_vif_driver %>
+<% end -%>
 
 [api_database]
 <% if @api_database_connection -%>

--- a/chef/data_bags/crowbar/migrate/neutron/111_add_contrail_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/111_add_contrail_attributes.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["contrail"] = ta["contrail"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("contrail")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -172,7 +172,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 110,
+      "schema-revision": 111,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -208,7 +208,8 @@
                         "api_server_port": { "type": "str", "required": true },
                         "multi_tenancy": { "type": "bool", "required": true },
                         "analytics_api_ip": { "type": "str", "required": true },
-                        "analytics_api_port": { "type": "str", "required": true }
+                        "analytics_api_port": { "type": "str", "required": true },
+                        "gateway_server_ip": { "type": "str", "required": true }
                       } 
                     }
               }}

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -202,6 +202,14 @@
                           }]
                         }
                       }
+                    },
+                    "contrail" : { "type": "map", "required": false, "mapping": {
+                        "api_server_ip": { "type": "str", "required": true },
+                        "api_server_port": { "type": "str", "required": true },
+                        "multi_tenancy": { "type": "bool", "required": true },
+                        "analytics_api_ip": { "type": "str", "required": true },
+                        "analytics_api_port": { "type": "str", "required": true }
+                      } 
                     }
               }}
      }},

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -29,7 +29,7 @@ class NeutronService < PacemakerServiceObject
   end
 
   def self.networking_plugins_valid
-    ["ml2", "vmware"]
+    ["ml2", "vmware", "contrail"]
   end
 
   def self.networking_ml2_type_drivers_valid


### PR DESCRIPTION
These changes to the neutron barclamp is done to enable configuring Contrail backend for neutron. The following points summarizes the actions done:
- Allows setting of "networking_plugin" type to "contrail"
- Installs Contrail packages on control and compute nodes
- Configures neutron to use Contrail as the SDN backend (non-ML2)
- Configures ContrailPlugin.ini with parameters to access the contrail-server.
- It assumes that the Contrail control plane server is already up and running in the admin-network. Configuration of this node is not part of the barclamp.
- The packages installed are currently from a private repository and hence require ignoring gpg-keys  which is not supported by the standard "package" syntax of chef. Hence the script uses direct "zypper --no-gpg-checks" command to setup the packages.
- The compute node is configured and populated with a script "set_vhost_interfaces.sh" in the /root/ folder that needs to be run from the serial console since running it on ssh will disconnect the node.

**Note: The PR is created to check if the changes do not break the normal operations so that it can be used for POCs. Considerable work is required to be done for the packages as well as the barclamp to get this ready for review.**