### PR TITLE
monasca: fix SSL for monasca-log-agent

### DIFF
--- a/chef/cookbooks/monasca/templates/default/log-agent.conf.erb
+++ b/chef/cookbooks/monasca/templates/default/log-agent.conf.erb
@@ -30,6 +30,7 @@ output {
   monasca_log_api {
     ### keystone based settings
     keystone_api_url => "<%= @keystone_settings['admin_auth_url'] %>/v3"
+    keystone_api_insecure => <%= @keystone_settings['insecure'] %>
     project_name => "<%= @log_agent_keystone['service_tenant'] %>"
     username => "<%= @log_agent_keystone['service_user'] %>"
     password => "<%= @log_agent_keystone['service_password'] %>"


### PR DESCRIPTION
This commit adds the keystone_api_insecure setting to
agent.yaml. This setting defaults to false, so we set
it to the value of keystone_settings['insecure'] for
monasca-log-agent to work in clouds with unsigned
Keystone API certificates.