### PR TITLE
glance: Restrict image_location metadata (bsc#1023507)

### DIFF
--- a/chef/cookbooks/glance/templates/default/policy.json.erb
+++ b/chef/cookbooks/glance/templates/default/policy.json.erb
@@ -1,0 +1,61 @@
+{
+    "context_is_admin":  "role:admin",
+    "default": "role:admin",
+
+    "add_image": "",
+    "delete_image": "",
+    "get_image": "",
+    "get_images": "",
+    "modify_image": "",
+    "publicize_image": "role:admin",
+    "copy_from": "",
+
+    "download_image": "",
+    "upload_image": "",
+
+    "delete_image_location": <%= @show_multiple_locations? '"role:admin"' : '""' %>,
+    "get_image_location": <%= @show_multiple_locations? '"role:admin"' : '""' %>,
+    "set_image_location": <%= @show_multiple_locations? '"role:admin"' : '""' %>,
+
+    "add_member": "",
+    "delete_member": "",
+    "get_member": "",
+    "get_members": "",
+    "modify_member": "",
+
+    "manage_image_cache": "role:admin",
+
+    "get_task": "role:admin",
+    "get_tasks": "role:admin",
+    "add_task": "role:admin",
+    "modify_task": "role:admin",
+
+    "deactivate": "",
+    "reactivate": "",
+
+    "get_metadef_namespace": "",
+    "get_metadef_namespaces":"",
+    "modify_metadef_namespace":"",
+    "add_metadef_namespace":"",
+
+    "get_metadef_object":"",
+    "get_metadef_objects":"",
+    "modify_metadef_object":"",
+    "add_metadef_object":"",
+
+    "list_metadef_resource_types":"",
+    "get_metadef_resource_type":"",
+    "add_metadef_resource_type_association":"",
+
+    "get_metadef_property":"",
+    "get_metadef_properties":"",
+    "modify_metadef_property":"",
+    "add_metadef_property":"",
+
+    "get_metadef_tag":"",
+    "get_metadef_tags":"",
+    "modify_metadef_tag":"",
+    "add_metadef_tag":"",
+    "add_metadef_tags":""
+
+}


### PR DESCRIPTION
When `show_multiple_locations` is enabled in Glance, any user
can rewrite the metadata information for locations, causing
a securiy breach.

This patch limit to admin the editing of image_location metadata
when this feature is enabled.