### PR TITLE
keystone: Remove deprecated options (SCRD-46)

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -26,7 +26,6 @@ default[:keystone][:group] = "keystone"
 
 default[:keystone][:debug] = false
 default[:keystone][:frontend] = "apache"
-default[:keystone][:verbose] = true
 default[:keystone][:domain_specific_drivers] = false
 default[:keystone][:domain_config_dir] = "/etc/keystone/domains"
 default[:keystone][:config_file] = "/etc/keystone/keystone.conf.d/100-keystone.conf"
@@ -65,7 +64,6 @@ default[:keystone][:ldap][:url] = "ldap://localhost"
 default[:keystone][:ldap][:user] = "dc=Manager,dc=example,dc=com"
 default[:keystone][:ldap][:password] = ""
 default[:keystone][:ldap][:suffix] = "cn=example,cn=com"
-default[:keystone][:ldap][:allow_subtree_delete] = false
 default[:keystone][:ldap][:page_size] = 0
 default[:keystone][:ldap][:alias_dereferencing] = "default"
 default[:keystone][:ldap][:query_scope] = "one"
@@ -84,9 +82,6 @@ default[:keystone][:ldap][:user_enabled_mask] = 0
 default[:keystone][:ldap][:user_enabled_default] = "True"
 default[:keystone][:ldap][:user_attribute_ignore] = "default_project_id"
 default[:keystone][:ldap][:user_default_project_id_attribute] = ""
-default[:keystone][:ldap][:user_allow_create] = true
-default[:keystone][:ldap][:user_allow_update] = true
-default[:keystone][:ldap][:user_allow_delete] = true
 default[:keystone][:ldap][:user_enabled_emulation] = false
 default[:keystone][:ldap][:user_enabled_emulation_dn] = ""
 default[:keystone][:ldap][:user_enabled_emulation_use_group_config] = false

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -271,11 +271,6 @@ template node[:keystone][:config_file] do
       sql_connection: sql_connection,
       sql_idle_timeout: node[:keystone][:sql][:idle_timeout],
       debug: node[:keystone][:debug],
-      verbose: node[:keystone][:verbose],
-      bind_admin_host: bind_admin_host,
-      bind_service_host: bind_service_host,
-      bind_admin_port: bind_admin_port,
-      bind_service_port: bind_service_port,
       admin_endpoint: KeystoneHelper.service_URL(
         node[:keystone][:api][:protocol],
         my_admin_host, node[:keystone][:api][:admin_port]

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -1,7 +1,6 @@
 [DEFAULT]
 admin_endpoint = <%= @admin_endpoint %>
 debug = <%= @debug ? "True" : "False" %>
-verbose = <%= @verbose ? "True" : "False" %>
 log_file = keystone.log
 log_dir = /var/log/keystone
 
@@ -17,12 +16,6 @@ memcache_servers = <%= @memcached_servers.join(',') %>
 connection = <%= @sql_connection %>
 idle_timeout = <%= @sql_idle_timeout %>
 
-[eventlet_server]
-public_bind_host = <%= @bind_service_host %>
-public_port = <%= @bind_service_port %>
-admin_bind_host = <%= @bind_admin_host %>
-admin_port = <%= @bind_admin_port %>
-
 [fernet_tokens]
 max_active_keys = <%= @max_active_keys %>
 
@@ -34,7 +27,6 @@ domain_config_dir = <%= node[:keystone][:domain_config_dir] %>
 <% end -%>
 driver = <%= node[:keystone][:identity][:driver] %>
 
-[kvs]
 <% if node[:keystone][:assignment][:driver] == 'hybrid' -%>
 [ldap_hybrid]
 default_roles = Member
@@ -46,7 +38,6 @@ url = <%= node[:keystone][:ldap][:url] %>
 user = <%= node[:keystone][:ldap][:user] %>
 password = <%= node[:keystone][:ldap][:password] %>
 suffix = <%= node[:keystone][:ldap][:suffix] %>
-allow_subtree_delete = <%= node[:keystone][:ldap][:allow_subtree_delete] %>
 query_scope = <%= node[:keystone][:ldap][:query_scope] %>
 page_size = <%= node[:keystone][:ldap][:page_size] %>
 alias_dereferencing = <%= node[:keystone][:ldap][:alias_dereferencing] %>
@@ -64,9 +55,6 @@ user_enabled_mask = <%= node[:keystone][:ldap][:user_enabled_mask] %>
 user_enabled_default = <%= node[:keystone][:ldap][:user_enabled_default] %>
 user_attribute_ignore = <%= node[:keystone][:ldap][:user_attribute_ignore] %>
 user_default_project_id_attribute = <%= node[:keystone][:ldap][:user_default_project_id_attribute] %>
-user_allow_create = <%= node[:keystone][:ldap][:user_allow_create] %>
-user_allow_update = <%= node[:keystone][:ldap][:user_allow_update] %>
-user_allow_delete = <%= node[:keystone][:ldap][:user_allow_delete] %>
 user_enabled_emulation = <%= node[:keystone][:ldap][:user_enabled_emulation] %>
 user_enabled_emulation_dn = <%= node[:keystone][:ldap][:user_enabled_emulation_dn] %>
 user_enabled_emulation_use_group_config = <%= node[:keystone][:ldap][:user_enabled_emulation_use_group_config] %>

--- a/chef/data_bags/crowbar/migrate/keystone/200_remove_deprecated_opts.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/200_remove_deprecated_opts.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  a.delete("verbose")
+
+  a["ldap"].delete("allow_subtree_delete") if a["ldap"].key?("allow_subtree_delete")
+  a["ldap"].delete("user_allow_create") if a["ldap"].key?("user_allow_create")
+  a["ldap"].delete("user_allow_update") if a["ldap"].key?("user_allow_update")
+  a["ldap"].delete("user_allow_delete") if a["ldap"].key?("user_allow_delete")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["verbose"] = ta["verbose"]
+
+  ldap_a = a["ldap"]
+  ldap_ta = ta["ldap"]
+  ldap_keys = ["allow_subtree_delete",
+               "user_allow_create",
+               "user_allow_update",
+               "user_allow_delete"]
+  ldap_keys.each do |key|
+    ldap_a[key] = ldap_ta[key] unless ldap_a.key?(key)
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -5,7 +5,6 @@
     "keystone": {
       "debug": false,
       "frontend": "apache",
-      "verbose": true,
       "policy_file": "policy.json",
       "database_instance": "none",
       "rabbitmq_instance": "none",
@@ -71,7 +70,6 @@
         "user": "dc=Manager,dc=example,dc=com",
         "password": "",
         "suffix": "cn=example,cn=com",
-        "allow_subtree_delete": false,
         "page_size": 0,
         "alias_dereferencing": "default",
         "query_scope": "one",
@@ -88,9 +86,6 @@
         "user_enabled_default": "True",
         "user_attribute_ignore": "default_project_id",
         "user_default_project_id_attribute": "",
-        "user_allow_create": true,
-        "user_allow_update": true,
-        "user_allow_delete": true,
         "user_enabled_invert": false,
         "user_enabled_emulation": false,
         "user_enabled_emulation_dn": "",
@@ -183,7 +178,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 112,
+      "schema-revision": 200,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -7,7 +7,6 @@
       "mapping": {
         "keystone": { "type": "map", "required": true,
              "mapping": {
-                    "verbose": { "type": "bool", "required": true },
                     "debug": { "type": "bool", "required": true },
                     "frontend": { "type": "str", "required": true },
                     "policy_file": { "type": "str", "required": true },
@@ -76,7 +75,6 @@
                       "user": { "type": "str" },
                       "password": { "type": "str" },
                       "suffix": { "type": "str" },
-                      "allow_subtree_delete": { "type": "bool" },
                       "page_size": { "type": "int" },
                       "alias_dereferencing": { "type": "str" },
                       "query_scope": { "type": "str" },
@@ -93,9 +91,6 @@
                       "user_enabled_default": { "type": "str" },
                       "user_attribute_ignore": { "type": "str" },
                       "user_default_project_id_attribute": { "type": "str" },
-                      "user_allow_create": { "type": "bool" },
-                      "user_allow_update": { "type": "bool" },
-                      "user_allow_delete": { "type": "bool" },
                       "user_enabled_invert": { "type": "bool" },
                       "user_enabled_emulation": { "type": "bool" },
                       "user_enabled_emulation_dn": { "type": "str" },


### PR DESCRIPTION
This patch removes settings that were deprecated in Ocata and earlier.
These changes are all compatible with the Newton release incorporated in
Cloud 7.

* Remove use of the "verbose" setting. This was deprecated in oslo.log
  in favor of always logging at the INFO level[1].
* Remove settings for [eventlet_server]. The eventlet server has been
  deprecated since kilo[2], though the config options remain in tree in
  Ocata and were not removed in Mitaka as planned. We are not making use
  of the eventlet server, we only support apache and uwsgi as frontends,
  and only test on apache. The bind port and host settings that are
  exposed to the user are still valid for these alternate frontends so
  we do not remove them from the databag, only from the
  [eventlet_server] section in the config file.
* Remove write-related [ldap] settings. Write support for LDAP as an
  identity backend was deprecated in Mitaka[3]. We never added these
  settings for the domain-specific backend options, so this just removes
  the settings for the LDAP-only setup.
* Remove the [kvs] section from the config file. It was deprecated in
  Ocata[4] and we never set any configuration here anyway.

Read keystone's Ocata release notes for more information[5].

[1] http://lists.openstack.org/pipermail/openstack-dev/2015-July/070754.html
[2] http://lists.openstack.org/pipermail/openstack-dev/2015-February/057359.html
[3] https://review.openstack.org/#/c/256257/
[4] https://blueprints.launchpad.net/keystone/+spec/deprecated-as-of-ocata
[5] https://docs.openstack.org/releasenotes/keystone/ocata.html