### PR TITLE
glance: remove options deprecated in ocata

### DIFF
--- a/chef/cookbooks/glance/attributes/default.rb
+++ b/chef/cookbooks/glance/attributes/default.rb
@@ -22,7 +22,6 @@
 override[:glance][:user]="glance"
 override[:glance][:group]="glance"
 
-default[:glance][:verbose] = "False"
 default[:glance][:debug] = "False"
 
 default[:glance][:enable_v3_api] = false

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -17,7 +17,6 @@ registry_port = <%= @registry_bind_port %>
 transport_url = <%= @rabbit_settings[:url] %>
 registry_client_insecure = <%= @keystone_settings["insecure"] %>
 debug = <%= node[:glance][:debug] ? "True" : "False" %>
-verbose = <%= node[:glance][:verbose] ? "True" : "False" %>
 log_file = <%= node[:glance][:api][:log_file] %>
 use_syslog = <%= node[:glance][:use_syslog] ? "True" : "False" %>
 use_stderr = false
@@ -43,7 +42,7 @@ vmware_server_password = <%= node[:glance][:vsphere][:password] %>
 <% node[:glance][:vsphere][:datastores].each do |datastore| -%>
 vmware_datastores ="<%= datastore %>"
 <% end -%>
-vmware_api_insecure = <%= node[:glance][:vsphere][:insecure] ? "True" : "False" %>
+vmware_insecure = <%= node[:glance][:vsphere][:insecure] ? "True" : "False" %>
 cinder_catalog_info = volumev2:cinderv2:internalURL
 cinder_os_region_name = <%= @keystone_settings['endpoint_region'] %>
 cinder_api_insecure = <%= @cinder_api_insecure ? 'True' : 'False' %>
@@ -77,6 +76,8 @@ project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_type = password
+service_token_roles_required = true
+service_token_roles = admin
 
 [oslo_concurrency]
 lock_path = /var/run/glance

--- a/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
@@ -7,7 +7,6 @@ registry_host = <%= @registry_bind_host %>
 registry_port = <%= @registry_bind_port %>
 registry_client_insecure = <%= @keystone_settings["insecure"] %>
 debug = <%= node[:glance][:debug] ? 'True' : 'False' %>
-verbose = <%= node[:glance][:verbose] ? 'True' : 'False' %>
 log_file = <%= node[:glance][:cache][:log_file] %>
 use_syslog = <%= node[:glance][:use_syslog] ? 'True' : 'False' %>
 use_stderr = false

--- a/chef/cookbooks/glance/templates/default/glance-manage.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-manage.conf.erb
@@ -1,7 +1,6 @@
 [DEFAULT]
 
 debug = <%= node[:glance][:debug] ? "True" : "False" %>
-verbose = <%= node[:glance][:verbose] ? "True" : "False" %>
 log_file = <%= node[:glance][:manage][:log_file] %>
 use_syslog = <%= node[:glance][:use_syslog] ? "True" : "False" %>
 use_stderr = false

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -5,7 +5,6 @@ workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 http_keepalive = false
 transport_url = <%= @rabbit_settings[:url] %>
 debug = <%= node[:glance][:debug] ? "True" : "False" %>
-verbose = <%= node[:glance][:verbose] ? "True" : "False" %>
 log_file = <%= node[:glance][:registry][:log_file] %>
 use_syslog = <%= node[:glance][:use_syslog] ? "True" : "False" %>
 use_stderr = false
@@ -32,6 +31,8 @@ project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_type = password
+service_token_roles_required = true
+service_token_roles = admin
 
 [oslo_messaging_notifications]
 driver = messaging

--- a/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
@@ -12,7 +12,6 @@ auth_region = <%= @keystone_settings['endpoint_region'] %>
 registry_host = <%= @registry_bind_host %>
 registry_port = <%= @registry_bind_port %>
 debug = <%= node[:glance][:debug] ? "True" : "False" %>
-verbose = <%= node[:glance][:verbose] ? "True" : "False" %>
 log_file = <%= node[:glance][:scrubber][:log_file] %>
 use_syslog = <%= node[:glance][:use_syslog] ? "True" : "False" %>
 use_stderr = false

--- a/chef/data_bags/crowbar/migrate/glance/200_remove_deprecated_opts.rb
+++ b/chef/data_bags/crowbar/migrate/glance/200_remove_deprecated_opts.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("verbose")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["verbose"] = ta["verbose"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -3,7 +3,6 @@
   "description": "Glance service (image registry and delivery service) for the cloud",
   "attributes": {
     "glance": {
-      "verbose": true,
       "debug": false,
       "max_header_line": 16384,
       "enable_v1": false,
@@ -72,7 +71,7 @@
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 104,
+      "schema-revision": 200,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-glance.schema
+++ b/chef/data_bags/crowbar/template-glance.schema
@@ -12,7 +12,6 @@
           "type": "map",
           "required": true,
           "mapping": {
-            "verbose": { "type": "bool", "required": true },
             "debug": { "type": "bool", "required": true },
             "max_header_line": { "type": "int", "required": true },
             "enable_v1": { "type": "bool", "required": true },


### PR DESCRIPTION
The following deprecated glance & related config options
are removed in this PR:

  * [default]/verbose deprecated option
  * [glance_store]/vmware_api_insecure - renamed to vmware_insecure
  * [keystone_authtoken]/service_token_roles_required is set
    to True to enable fetching expired tokens based on valid
    service tokens

The following deprecated glance config options are NOT
removed in this commit:

  * [default]/show_multiple_locations - this option is still required
    to enable cinder internal image transfer and there is no alternative
    in place (see bsc#945043). When this option is removed, it is expected
    that the underlying feature will be enabled by default, in which case
    the policy.json file is already updated in the glance package
    to protect against unauthorized access (see
    https://wiki.openstack.org/wiki/OSSN/OSSN-0065)

  * the admin_password, admin_tenant_name, admin_user, auth_region
    and auth_url options are still needed by the glance-scrubber
    service. In theory, these parameters should no longer be required
    (according to https://review.openstack.org/237742), but in
    reality this isn't the case.

  * the deprecated keystonemiddleware.auth_token in-process token
    needs to be replaced with a memcache server (done separately, due 
    to security implications - see #1090)

References:
  * Ocata release notes for glance: https://docs.openstack.org/releasenotes/glance/ocata.html
  * Ocata release notes for keystonemiddleware: https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html
  * OSSN extending the deprecated show_multiple_locations option
    to Pike: https://wiki.openstack.org/wiki/OSSN/OSSN-0065
  * OSSN deprecating the use_user_token and associated authN options:
    https://wiki.openstack.org/wiki/OSSN/OSSN-0060