### PR TITLE
horizon: fixed title/style for Monasca dashboard.

### DIFF
--- a/chef/cookbooks/horizon/files/default/grafana-monasca.json
+++ b/chef/cookbooks/horizon/files/default/grafana-monasca.json
@@ -1,9 +1,9 @@
 {
   "id": "sid-14393838984416185642089112666",
-  "title": "Monasca Service",
-  "originalTitle": "Monasca Service",
+  "title": "SUSE OpenStack Cloud Monitoring",
+  "originalTitle": "SUSE OpenStack Cloud Monitoring",
   "tags": [],
-  "style": "light",
+  "style": "dark",
   "timezone": "utc",
   "editable": true,
   "hideControls": false,


### PR DESCRIPTION
This commit aligns the Monasca dashboard with the OpenStack one ("SUSE OpenStack Cloud Monitoring" title and dark theme). I tested this against a fresh cloud (built this afternoon) and it works.