### PR TITLE
Insist on precise for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 sudo: false
+cache: bundler
+dist: trusty
 
-rvm:
-  - 2.1.0
+rvm: 2.1.9


### PR DESCRIPTION
We seem to be running into Travis-CI issues lately. Travis-CI has
switched their default VM to the trusty release which might be reason
for the issues we are seeing. This patch is only a test to verify that
this is the case (or not).