### PR TITLE
travis: run foodcritic on our cookbooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ cache: bundler
 dist: trusty
 
 rvm: 2.1.9
+
+matrix:
+  fast_finish: true
+  include:
+    - script: bundle exec rake
+    - script: bundle exec rake foodcritic
+  allow_failures:
+    - script: bundle exec rake foodcritic

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ end
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   group :test do
     gem "simplecov", require: false
+    gem "foodcritic", "7.1.0"
 
     if ENV["CODECLIMATE_REPO_TOKEN"]
       gem "coveralls", require: false


### PR DESCRIPTION
Foodcritic can help us on cookbook style issues and hidden
bugs due to our ched dsl use. Make it run as a separate job
on jenkins but allow it to fail (it will fail) and dont make
the travis job wait for it to fail to post the status to
github