### PR TITLE
Barbican: reduce asynchronous workers to 1

### DIFF
--- a/chef/cookbooks/barbican/templates/default/barbican.conf.erb
+++ b/chef/cookbooks/barbican/templates/default/barbican.conf.erb
@@ -19,7 +19,7 @@ kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 
 [queue]
 
-asynchronous_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
+asynchronous_workers = 1
 
 [keystone_notifications]
 


### PR DESCRIPTION
During a join session with @aspiers it was found out that having more
than one asynchronous worker causes problems when shutting down the
service. That happens regardless the asynchronous queue is enabled or
not.

Having problems shutting down services is a reason for pacemaker to
fence a node. It is likely that this is what we have been observing
lately on HA nodes being fenced on reboot.