### PR TITLE
Update Ruby environment for trusty Travis-CI image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 sudo: false
+cache: bundler
+dist: trusty
 
-rvm:
-  - 2.1.0
+rvm: 2.1.9


### PR DESCRIPTION
backport from: https://github.com/crowbar/crowbar-openstack/pull/1073

Travis-CI has switched their default VM to the trusty release which also
upgraded the Ruby environment available.

This change updates our Travis-CI setting to a new Ruby environment
version, following [1].

[1] https://github.com/crowbar/crowbar-core/commit/cb037a689155c94cbef709d8bcb50dd4b1390e76