### PR TITLE
neutron: migrate from neutronclient to openstackclient CLI

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -70,18 +70,19 @@ ssl_insecure = keystone_settings["insecure"] || neutron_insecure
 
 has_ironic = ironic_net && node.roles.include?("ironic-server")
 
-neutron_args = "--os-username '#{keystone_settings['service_user']}'"
-neutron_args = "#{neutron_args} --os-password '#{keystone_settings['service_password']}'"
-neutron_args = "#{neutron_args} --os-tenant-name '#{keystone_settings['service_tenant']}'"
-neutron_args = "#{neutron_args} --os-auth-url '#{keystone_settings['internal_auth_url']}'"
-neutron_args = "#{neutron_args} --os-region-name '#{keystone_settings['endpoint_region']}'"
+openstack_args = "--os-username '#{keystone_settings['service_user']}'"
+openstack_args = "#{openstack_args} --os-password '#{keystone_settings['service_password']}'"
+openstack_args = "#{openstack_args} --os-tenant-name '#{keystone_settings['service_tenant']}'"
+openstack_args = "#{openstack_args} --os-auth-url '#{keystone_settings['internal_auth_url']}'"
+openstack_args = "#{openstack_args} --os-region-name '#{keystone_settings['endpoint_region']}'"
 if keystone_settings["api_version"] != "2.0"
-  neutron_args = "#{neutron_args} --os-user-domain-name Default"
-  neutron_args = "#{neutron_args} --os-project-domain-name Default"
+  openstack_args = "#{openstack_args} --os-user-domain-name Default"
+  openstack_args = "#{openstack_args} --os-project-domain-name Default"
+  openstack_args = "#{openstack_args} --os-identity-api-version 3"
 end
-neutron_args = "#{neutron_args} --endpoint-type internalURL"
-neutron_args = "#{neutron_args} --insecure" if ssl_insecure
-neutron_cmd = "neutron #{neutron_args}"
+openstack_args = "#{openstack_args} --os-interface internal"
+openstack_args = "#{openstack_args} --insecure" if ssl_insecure
+openstack_cmd = "openstack #{openstack_args}"
 
 fixed_network_type = ""
 floating_network_type = ""
@@ -94,20 +95,20 @@ when "ml2"
   # find the network node, to figure out the right "physnet" parameter
   network_node = NeutronHelper.get_network_node_from_neutron_attributes(node)
   physnet_map = NeutronHelper.get_neutron_physnets(network_node, ["nova_floating", "ironic"])
-  floating_network_type = "--provider:network_type flat " \
-      "--provider:physical_network #{physnet_map["nova_floating"]}"
-  ironic_network_type = "--provider:network_type flat " \
-      "--provider:physical_network #{physnet_map["ironic"]}"
+  floating_network_type = "--provider-network-type flat " \
+      "--provider-physical-network #{physnet_map["nova_floating"]}"
+  ironic_network_type = "--provider-network-type flat " \
+      "--provider-physical-network #{physnet_map["ironic"]}"
   case ml2_type_drivers_default_provider_network
   when "vlan"
-    fixed_network_type = "--provider:network_type vlan " \
-        "--provider:segmentation_id #{fixed_net["vlan"]} " \
-        "--provider:physical_network physnet1"
+    fixed_network_type = "--provider-network-type vlan " \
+        "--provider-segment #{fixed_net["vlan"]} " \
+        "--provider-physical-network physnet1"
   when "gre"
-    fixed_network_type = "--provider:network_type gre --provider:segmentation_id 1"
+    fixed_network_type = "--provider-network-type gre --provider-segment 1"
   when "vxlan"
-    fixed_network_type = "--provider:network_type vxlan " \
-        "--provider:segmentation_id #{vni_start}"
+    fixed_network_type = "--provider-network-type vxlan " \
+        "--provider-segment #{vni_start}"
   else
     Chef::Log.error("default provider network ml2 type driver " \
         "'#{ml2_type_drivers_default_provider_network}' invalid for creating provider networks")
@@ -122,95 +123,101 @@ else
 end
 
 execute "create_fixed_network" do
-  command "#{neutron_cmd} net-create fixed --shared #{fixed_network_type}"
-  not_if "out=$(#{neutron_cmd} net-list); [ $? != 0 ] || echo ${out} | grep -q ' fixed '"
+  command "#{openstack_cmd} network create --share #{fixed_network_type} fixed"
+  not_if "out=$(#{openstack_cmd} network list); [ $? != 0 ] || echo ${out} | grep -q ' fixed '"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "create_floating_network" do
-  command "#{neutron_cmd} net-create floating --router:external #{floating_network_type}"
-  not_if "out=$(#{neutron_cmd} net-list); [ $? != 0 ] || echo ${out} | grep -q ' floating '"
+  command "#{openstack_cmd} network create --external #{floating_network_type} floating"
+  not_if "out=$(#{openstack_cmd} network list); [ $? != 0 ] || echo ${out} | grep -q ' floating '"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "create_ironic_network" do
-  command "#{neutron_cmd} net-create ironic --shared #{ironic_network_type}"
+  command "#{openstack_cmd} network create --share #{ironic_network_type} ironic"
   only_if { has_ironic }
-  not_if "out=$(#{neutron_cmd} net-list); [ $? != 0 ] || echo ${out} | grep -q ' ironic '"
+  not_if "out=$(#{openstack_cmd} network list); [ $? != 0 ] || echo ${out} | grep -q ' ironic '"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "create_fixed_subnet" do
-  command "#{neutron_cmd} subnet-create --name fixed --allocation-pool start=#{fixed_pool_start},end=#{fixed_pool_end} fixed #{fixed_range}"
-  not_if "out=$(#{neutron_cmd} subnet-list); [ $? != 0 ] || echo ${out} | grep -q ' fixed '"
+  command "#{openstack_cmd} subnet create --network fixed " \
+      "--allocation-pool start=#{fixed_pool_start},end=#{fixed_pool_end} " \
+      "--subnet-range #{fixed_range} fixed"
+  not_if "out=$(#{openstack_cmd} subnet list); [ $? != 0 ] || echo ${out} | grep -q ' fixed '"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "create_floating_subnet" do
-  command "#{neutron_cmd} subnet-create --name floating --allocation-pool start=#{floating_pool_start},end=#{floating_pool_end} --gateway #{floating_router} floating #{floating_range} --enable_dhcp False"
-  not_if "out=$(#{neutron_cmd} subnet-list); [ $? != 0 ] || echo ${out} | grep -q ' floating '"
+  command "#{openstack_cmd} subnet create --network floating " \
+      "--allocation-pool start=#{floating_pool_start},end=#{floating_pool_end} " \
+      "--gateway #{floating_router} --subnet-range #{floating_range} --no-dhcp floating"
+  not_if "out=$(#{openstack_cmd} subnet list); [ $? != 0 ] || echo ${out} | grep -q ' floating '"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "create_ironic_subnet" do
-  command "#{neutron_cmd} subnet-create --name ironic --ip-version=4 " \
+  command "#{openstack_cmd} subnet create --network ironic --ip-version=4 " \
       "--allocation-pool start=#{ironic_pool_start},end=#{ironic_pool_end} " \
-      "--gateway #{ironic_router} ironic #{ironic_range} --enable_dhcp"
+      "--gateway #{ironic_router} --subnet-range #{ironic_range} --dhcp ironic"
   only_if { has_ironic }
-  not_if "out=$(#{neutron_cmd} subnet-list); [ $? != 0 ] || echo ${out} | grep -q ' ironic '"
+  not_if "out=$(#{openstack_cmd} subnet list); [ $? != 0 ] || echo ${out} | grep -q ' ironic '"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "create_router" do
-  command "#{neutron_cmd} router-create router-floating"
-  not_if "out=$(#{neutron_cmd} router-list); [ $? != 0 ] || echo ${out} | grep -q router-floating"
+  command "#{openstack_cmd} router create router-floating"
+  not_if "out=$(#{openstack_cmd} router list); [ $? != 0 ] || echo ${out} | grep -q router-floating"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "set_router_gateway" do
-  command "#{neutron_cmd} router-gateway-set router-floating floating"
+  command "#{openstack_cmd} router set --external-gateway floating router-floating"
   # on Newton, the output for external_gateway_info was an empty string, on Ocata, the output is None
-  not_if "out=$(#{neutron_cmd} router-show router-floating -f shell) ; [ $? != 0 ] || eval $out && [ \"${external_gateway_info}\" != \"None\" ] && [ \"${external_gateway_info}\" != \"\" ]"
+  not_if "out=$(#{openstack_cmd} router show router-floating -f shell) ; " \
+      "[ $? != 0 ] || eval $out && [ \"${external_gateway_info}\" != \"None\" ] && " \
+      "[ \"${external_gateway_info}\" != \"\" ]"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "add_fixed_network_to_router" do
-  command "#{neutron_cmd} router-interface-add router-floating fixed"
-  not_if "out1=$(#{neutron_cmd} subnet-show -f shell fixed) ; rc1=$?; eval $out1 ; out2=$(#{neutron_cmd} router-port-list router-floating); [ $? != 0 ] || [ $rc1 != 0 ] || echo $out2 | grep -q $id"
+  command "#{openstack_cmd} router add subnet router-floating fixed"
+  not_if "out=$(#{openstack_cmd} port list --router router-floating --network fixed | wc -l); " \
+      "[ $? != 0 ] || (( ${out} > 1 ))"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "add_ironic_network_to_router" do
-  command "#{neutron_cmd} router-interface-add router-floating ironic"
+  command "#{openstack_cmd} router add subnet router-floating ironic"
   only_if { has_ironic }
-  not_if "out1=$(#{neutron_cmd} subnet-show -f shell ironic) ; rc1=$?; eval $out1 ; " \
-      "out2=$(#{neutron_cmd} router-port-list router-floating); " \
-      "[ $? != 0 ] || [ $rc1 != 0 ] || echo $out2 | grep -q $id"
+  not_if "out=$(#{openstack_cmd} port list --router router-floating --network ironic | wc -l); " \
+      "[ $? != 0 ] || (( ${out} > 1 ))"
   retries 5
   retry_delay 10
   action :nothing
 end
 
 execute "Neutron network configuration" do
-  command "#{neutron_cmd} net-list &>/dev/null"
+  command "#{openstack_cmd} network list &>/dev/null"
   retries 5
   retry_delay 10
   action :nothing

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -356,11 +356,8 @@ end
 
 ruby_block "get public network id" do
   block do
-    cmd = "neutron #{insecure} --os-user-domain-name Default --os-project-domain-name Default"
-    cmd << " --os-username #{tempest_comp_user} --os-password #{tempest_comp_pass}"
-    cmd << " --os-tenant-name #{tempest_comp_tenant}"
-    cmd << " --os-auth-url #{keystone_settings["internal_auth_url"]}"
-    cmd << " net-list -f value -c id --name floating"
+    cmd = "#{openstackcli} --os-user-domain-name Default --os-project-domain-name Default"
+    cmd << " network show -f value -c id floating"
     public_network_id =  `#{cmd}`.strip
     raise("Cannot fetch ID of floating network") if public_network_id.empty?
     node[:tempest][:public_network_id] = public_network_id


### PR DESCRIPTION
Replaces deprecated usage of neutronclient CLI occurrences
with openstackclient CLI equivalent commands.

References:
  * Ocata release notes for python-neutronclient: https://docs.openstack.org/releasenotes/python-neutronclient/ocata.html
  * neutronclient to openstackclient CLI mapping guide: https://docs.openstack.org/python-openstackclient/latest/cli/decoder.html

Important: these modifications are not backwards-compatible with
Newton because the 'openstack router set --external-gateway'
command support is not available in Newton (introduced in
python-openstackclient 3.6.0).