### PR TITLE
cinder: Fix broken downgrades in schema migrations

### DIFF
--- a/chef/data_bags/crowbar/migrate/cinder/102_use_multipath.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/102_use_multipath.rb
@@ -7,7 +7,7 @@ end
 
 def downgrade(ta, td, a, d)
   unless ta.key? "use_multipath"
-    del a["use_multipath"]
+    a.delete("use_multipath")
   end
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/cinder/103_add_keymgr_fixed_key.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/103_add_keymgr_fixed_key.rb
@@ -7,7 +7,7 @@ end
 
 def downgrade(ta, td, a, d)
   unless ta.key? "keymgr_fixed_key"
-    del a["keymgr_fixed_key"]
+    a.delete("keymgr_fixed_key")
   end
   return a, d
 end


### PR DESCRIPTION
(cherry picked from commit 911fcc82eac53ae883010a9a0dbcac688a2c1b2f)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1083