### PR TITLE
crowbar: Use databags to store config

### DIFF
--- a/crowbar_framework/app/models/aodh_service.rb
+++ b/crowbar_framework/app/models/aodh_service.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-class AodhService < PacemakerServiceObject
+class AodhService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "aodh"

--- a/crowbar_framework/app/models/barbican_service.rb
+++ b/crowbar_framework/app/models/barbican_service.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-class BarbicanService < PacemakerServiceObject
+class BarbicanService < OpenstackServiceObject
   def initialize(thelogger = nil)
     @bc_name = "barbican"
     @logger = thelogger

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class CeilometerService < PacemakerServiceObject
+class CeilometerService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "ceilometer"

--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class CinderService < PacemakerServiceObject
+class CinderService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "cinder"

--- a/crowbar_framework/app/models/glance_service.rb
+++ b/crowbar_framework/app/models/glance_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class GlanceService < PacemakerServiceObject
+class GlanceService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "glance"

--- a/crowbar_framework/app/models/heat_service.rb
+++ b/crowbar_framework/app/models/heat_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class HeatService < PacemakerServiceObject
+class HeatService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "heat"

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class HorizonService < PacemakerServiceObject
+class HorizonService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "horizon"

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class KeystoneService < PacemakerServiceObject
+class KeystoneService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "keystone"

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -168,6 +168,10 @@ class KeystoneService < OpenstackServiceObject
       node.save
     end
 
+    # as we are overriding the apply_role_post_chef_call we have to call save_config_to_databag
+    # manually. We could also call super here.
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Keystone apply_role_post_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/magnum_service.rb
+++ b/crowbar_framework/app/models/magnum_service.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-class MagnumService < PacemakerServiceObject
+class MagnumService < OpenstackServiceObject
   def initialize(thelogger = nil)
     @bc_name = "magnum"
     @logger = thelogger

--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-class ManilaService < PacemakerServiceObject
+class ManilaService < OpenstackServiceObject
   def initialize(thelogger = nil)
     @bc_name = "manila"
     @logger = thelogger

--- a/crowbar_framework/app/models/monasca_service.rb
+++ b/crowbar_framework/app/models/monasca_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class MonascaService < PacemakerServiceObject
+class MonascaService < OpenstackServiceObject
   def initialize(thelogger = nil)
     @bc_name = "monasca"
     @logger = thelogger

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -17,7 +17,7 @@
 
 require "ipaddr"
 
-class NeutronService < PacemakerServiceObject
+class NeutronService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "neutron"

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class NovaService < PacemakerServiceObject
+class NovaService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "nova"

--- a/crowbar_framework/app/models/openstack_service_object.rb
+++ b/crowbar_framework/app/models/openstack_service_object.rb
@@ -1,0 +1,49 @@
+#
+# Copyright 2017, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This is a subclass of ServiceObject providing some helpers methods.
+# Barclamps that have roles using pacemaker clusters should subclass this.
+#
+# It also provides some helpers that ServiceObject will wrap.
+#
+
+class OpenstackServiceObject < PacemakerServiceObject
+  def apply_role_post_chef_call(old_role, role, all_nodes)
+    @logger.debug("#{@bc_name} apply_role_post_chef_call: entering")
+    # do this in post, because we depend on values that are computed in the
+    # cookbook
+    save_config_to_databag(old_role, role)
+    @logger.debug("#{@bc_name} apply_role_post_chef_call: leaving")
+  end
+
+  def save_config_to_databag(old_role, role)
+    @logger.debug("#{@bc_name} save_config_to_databag: entering")
+    if role.nil?
+      config = nil
+    else
+      insecure = Openstack::DataBagConfig.insecure(@bc_name, role)
+
+      config = {
+        insecure: insecure
+      }
+    end
+
+    instance = Crowbar::DataBagConfig.instance_from_role(old_role, role)
+    Crowbar::DataBagConfig.save("openstack", instance, @bc_name, config)
+    @logger.debug("#{@bc_name} save_config_to_databag: leaving")
+  end
+end

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -137,5 +137,33 @@ class RabbitmqService < OpenstackServiceObject
 
     super
   end
+
+  def save_config_to_databag(old_role, role)
+    @logger.debug("#{@bc_name} save_config_to_databag: entering")
+    if role.nil?
+      config = nil
+    else
+      _elements, nodes, _ha_enabled = role_expand_elements(role, "rabbitmq-server")
+      node = NodeObject.find_node_by_name(nodes.first)
+      address = node[:rabbitmq][:address]
+      port = role.default_attributes["rabbitmq"]["port"]
+      user = role.default_attributes["rabbitmq"]["user"]
+      password = role.default_attributes["rabbitmq"]["password"]
+      vhost = role.default_attributes["rabbitmq"]["vhost"]
+
+      config = {
+        address: address,
+        port: port,
+        user: user,
+        password: password,
+        vhost: "/#{vhost}",
+        url: "rabbit://#{user}:#{password}@#{address}:#{port}/#{vhost}"
+      }
+    end
+
+    instance = Crowbar::DataBagConfig.instance_from_role(old_role, role)
+    Crowbar::DataBagConfig.save("openstack", instance, @bc_name, config)
+    @logger.debug("#{@bc_name} save_config_to_databag: leaving")
+  end
 end
 

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class RabbitmqService < PacemakerServiceObject
+class RabbitmqService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "rabbitmq"

--- a/crowbar_framework/app/models/sahara_service.rb
+++ b/crowbar_framework/app/models/sahara_service.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-class SaharaService < PacemakerServiceObject
+class SaharaService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "sahara"

--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -17,7 +17,7 @@
 require "rexml/document"
 include ERB::Util # for html_escape
 
-class SwiftService < PacemakerServiceObject
+class SwiftService < OpenstackServiceObject
   class ServiceError < StandardError
   end
 

--- a/crowbar_framework/app/models/trove_service.rb
+++ b/crowbar_framework/app/models/trove_service.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-class TroveService < PacemakerServiceObject
+class TroveService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "trove"

--- a/crowbar_framework/lib/openstack.rb
+++ b/crowbar_framework/lib/openstack.rb
@@ -15,3 +15,4 @@
 #
 
 require "openstack/ha"
+require "openstack/data_bag_config"

--- a/crowbar_framework/lib/openstack/data_bag_config.rb
+++ b/crowbar_framework/lib/openstack/data_bag_config.rb
@@ -50,7 +50,15 @@ module Openstack
             role.default_attributes[barclamp]["keystone_instance"],
             "keystone"
         )
-        keystone_config["insecure"]
+        # If we have not run the keystone barclamp, this could be empty
+        if keystone_config["insecure"].blank?
+          keystone_proposal = Proposal.where(barclamp: "keystone", name: "default").first
+          unless keystone_proposal.nil?
+            keystone_proposal["attributes"]["keystone"]["ssl"]["insecure"]
+          end
+        else
+          keystone_config["insecure"]
+        end
       end
     end
   end

--- a/crowbar_framework/lib/openstack/data_bag_config.rb
+++ b/crowbar_framework/lib/openstack/data_bag_config.rb
@@ -1,0 +1,57 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Openstack
+  class DataBagConfig
+    class << self
+      def insecure(barclamp, role)
+        attributes = role.default_attributes[barclamp]
+
+        if attributes.key?("api") && attributes["api"].key?("protocol")
+          # aodh, cinder, glance, heat, keystone, manila, neutron
+          use_ssl = attributes["api"]["protocol"] == "https"
+        elsif attributes.key?("api") && attributes["api"].key?("ssl")
+          # barbican
+          use_ssl = attributes["api"]["ssl"]
+        elsif attributes.key?("ssl") && attributes["ssl"].key?("enabled")
+          # nova
+          use_ssl = attributes["ssl"]["enabled"]
+        else
+          # magnum, sahara, trove
+          use_ssl = false
+        end
+
+        insecure = use_ssl && attributes["ssl"]["insecure"]
+        unless barclamp == "keystone"
+          insecure ||= keystone_insecure(barclamp, role)
+        end
+
+        insecure
+      end
+
+      private
+
+      def keystone_insecure(barclamp, role)
+        keystone_config = Crowbar::DataBagConfig.load(
+            "openstack",
+            role.default_attributes[barclamp]["keystone_instance"],
+            "keystone"
+        )
+        keystone_config["insecure"]
+      end
+    end
+  end
+end

--- a/crowbar_framework/lib/openstack/data_bag_config.rb
+++ b/crowbar_framework/lib/openstack/data_bag_config.rb
@@ -20,18 +20,18 @@ module Openstack
       def insecure(barclamp, role)
         attributes = role.default_attributes[barclamp]
 
-        if attributes.key?("api") && attributes["api"].key?("protocol")
+        use_ssl = if attributes.key?("api") && attributes["api"].key?("protocol")
           # aodh, cinder, glance, heat, keystone, manila, neutron
-          use_ssl = attributes["api"]["protocol"] == "https"
+          attributes["api"]["protocol"] == "https"
         elsif attributes.key?("api") && attributes["api"].key?("ssl")
           # barbican
-          use_ssl = attributes["api"]["ssl"]
+          attributes["api"]["ssl"]
         elsif attributes.key?("ssl") && attributes["ssl"].key?("enabled")
           # nova
-          use_ssl = attributes["ssl"]["enabled"]
+          attributes["ssl"]["enabled"]
         else
           # magnum, sahara, trove
-          use_ssl = false
+          false
         end
 
         insecure = use_ssl && attributes["ssl"]["insecure"]
@@ -46,9 +46,9 @@ module Openstack
 
       def keystone_insecure(barclamp, role)
         keystone_config = Crowbar::DataBagConfig.load(
-            "openstack",
-            role.default_attributes[barclamp]["keystone_instance"],
-            "keystone"
+          "openstack",
+          role.default_attributes[barclamp]["keystone_instance"],
+          "keystone"
         )
         # If we have not run the keystone barclamp, this could be empty
         if keystone_config["insecure"].blank?


### PR DESCRIPTION
As we commonly search for the insecure value of a service in
all cookbooks, we provide a helper to quickly gather that value.

This is only the first building block, next one will save those insecure
values into the databag.