### PR TITLE
nova: Fix placement API setup in HA

### DIFF
--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -32,6 +32,14 @@ haproxy_loadbalancer "nova-api" do
   action :nothing
 end.run_action(:create)
 
+haproxy_loadbalancer "nova-placement-api" do
+  address "0.0.0.0"
+  port node[:nova][:ports][:placement_api]
+  use_ssl node[:nova][:ssl][:enabled]
+  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "placement_api")
+  action :nothing
+end.run_action(:create)
+
 haproxy_loadbalancer "nova-metadata" do
   address cluster_admin_ip
   port node[:nova][:ports][:metadata]


### PR DESCRIPTION
haproxy needs to be setup in front of the placement API services. Otherwise
no service is listening on the correct port and the placement API is not
responsive.