### PR TITLE
replace auth_token in process cache with memcached

### DIFF
--- a/chef/cookbooks/glance/metadata.rb
+++ b/chef/cookbooks/glance/metadata.rb
@@ -6,6 +6,7 @@ description "Installs/Configures Glance"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.2"
 depends "keystone"
+depends "memcached"
 depends "database"
 depends "nagios"
 depends "ceph"

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -53,6 +53,11 @@ ironics = node_search_with_cache("roles:ironic-server") || []
 
 network_settings = GlanceHelper.network_settings(node)
 
+ha_enabled = node[:glance][:ha][:enabled]
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "glance-server") : [node]
+)
+
 glance_stores = node.default[:glance][:glance_stores].dup
 glance_stores += ["vmware"] unless node[:glance][:vsphere][:host].empty?
 
@@ -79,6 +84,7 @@ template node[:glance][:api][:config_file] do
       registry_bind_host: network_settings[:registry][:bind_host],
       registry_bind_port: network_settings[:registry][:bind_port],
       keystone_settings: keystone_settings,
+      memcached_servers: memcached_servers,
       rabbit_settings: fetch_rabbitmq_settings,
       swift_api_insecure: swift_api_insecure,
       cinder_api_insecure: cinder_api_insecure,

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -13,6 +13,13 @@ end
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 network_settings = GlanceHelper.network_settings(node)
 
+ha_enabled = node[:glance][:ha][:enabled]
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "glance-server") : [node]
+)
+
+memcached_instance("glance")
+
 template node[:glance][:manage][:config_file] do
   source "glance-manage.conf.erb"
   owner "root"
@@ -29,6 +36,7 @@ template node[:glance][:registry][:config_file] do
       bind_host: network_settings[:registry][:bind_host],
       bind_port: network_settings[:registry][:bind_port],
       keystone_settings: keystone_settings,
+      memcached_servers: memcached_servers,
       rabbit_settings: fetch_rabbitmq_settings
   )
 end

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -76,6 +76,7 @@ project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_type = password
+memcached_servers = <%= @memcached_servers.join(',') %>
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -31,6 +31,7 @@ project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_type = password
+memcached_servers = <%= @memcached_servers.join(',') %>
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/neutron/metadata.rb
+++ b/chef/cookbooks/neutron/metadata.rb
@@ -8,6 +8,7 @@ version "1.0"
 
 depends "database"
 depends "keystone"
+depends "memcached"
 depends "nagios"
 depends "crowbar-openstack"
 depends "crowbar-pacemaker"

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -68,6 +68,13 @@ end
 
 keystone_settings = KeystoneHelper.keystone_settings(neutron, @cookbook_name)
 
+ha_enabled = node[:neutron][:ha][:server][:enabled]
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "neutron-server") : [node]
+)
+
+memcached_instance("neutron-server") if is_neutron_server
+
 bind_host, bind_port = NeutronHelper.get_bind_host_port(node)
 
 # Get Nova's insecure setting
@@ -130,6 +137,7 @@ template neutron[:neutron][:config_file] do
       # query on the "neutron" node, not on "node"
       rabbit_settings: CrowbarOpenStackHelper.rabbitmq_settings(neutron, "neutron"),
       keystone_settings: keystone_settings,
+      memcached_servers: memcached_servers,
       ssl_enabled: neutron[:neutron][:api][:protocol] == "https",
       ssl_cert_file: neutron[:neutron][:ssl][:certfile],
       ssl_key_file: neutron[:neutron][:ssl][:keyfile],

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -52,6 +52,7 @@ password = <%= @keystone_settings['service_password'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings['admin_domain'] %>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
+memcached_servers = <%= @memcached_servers.join(',') %>
 
 [nova]
 region_name = <%= @keystone_settings['endpoint_region'] %>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -171,6 +171,7 @@ password = <%= @keystone_settings['service_password'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
+memcached_servers = <%= @memcached_servers.join(',') %>
 
 [libvirt]
 <% if %w(kvm lxc qemu uml xen parallels).include? @libvirt_type -%>


### PR DESCRIPTION
The deprecated keystonemiddleware.auth_token in-process token
cache used by various services (glance-api, glance-registry, neutron-server, nova-api, nova-scheduler, etc) is replaced with a memcached server. When HA is used, several memcached servers are configured and used, one for each controller node.
    
References:
  * Mitaka release notes for keystonemiddleware: https://docs.openstack.org/releasenotes/keystonemiddleware/mitaka
