### PR TITLE
heat: justify trustee credentials

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -137,10 +137,11 @@ key_file = <%= @heat_ssl[:keyfile] %>
 <% end %>
 
 [trustee]
+auth_type = password
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
-project_name = <%= @keystone_settings['service_tenant'] %>
 username = <%= @keystone_settings['service_user'] %>
 password = <%= @keystone_settings['service_password'] %>
+user_domain_name = <%= @keystone_settings['admin_domain'] %>
 
 [oslo_messaging_rabbit]
 rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>


### PR DESCRIPTION
Using keystoneauth credentials for trustee user was deprecated, and
removed since ocata release. Trustee credentials must be defined in
a separate conf section now. We already have this section populated,
but it needs a few adjustments: need to provide auth_type, user and
project domain ids. Also, project_name needs to be removed, because
trustee token is scoped to a trust.