### PR TITLE
cinder: Fix broken downgrade in schema migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/cinder/102_use_multipath.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/102_use_multipath.rb
@@ -7,7 +7,7 @@ end
 
 def downgrade(ta, td, a, d)
   unless ta.key? "use_multipath"
-    del a["use_multipath"]
+    a.delete["use_multipath"]
   end
   return a, d
 end


### PR DESCRIPTION
(cherry picked from commit 88a1778c45b1e649ab5d187007fb8a68b42175d8)