### PR TITLE
nova,neutron,glance: keystone auth_token memcached protection

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -77,6 +77,8 @@ user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_type = password
 memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:glance][:memcache_secret_key] %>
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -32,6 +32,8 @@ user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_type = password
 memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:glance][:memcache_secret_key] %>
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -52,6 +52,8 @@ project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings['admin_domain'] %>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
 memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:neutron][:memcache_secret_key] %>
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -165,6 +165,8 @@ project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:nova][:memcache_secret_key] %>
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/data_bags/crowbar/migrate/glance/202_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/glance/202_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/neutron/204_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/204_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/nova/204_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/nova/204_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -64,14 +64,15 @@
       "keystone_instance": "none",
       "service_user": "glance",
       "database_instance": "none",
-      "rabbitmq_instance": "none"
+      "rabbitmq_instance": "none",
+      "memcache_secret_key": ""
     }
   },
   "deployment": {
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-glance.schema
+++ b/chef/data_bags/crowbar/template-glance.schema
@@ -95,6 +95,7 @@
             "keystone_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str" },
+            "memcache_secret_key": { "type": "str", "required": true },
             "database_instance": { "type": "str", "required": true }
           }
         }

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -6,6 +6,7 @@
       "service_user": "neutron",
       "rabbitmq_instance": "none",
       "keystone_instance": "none",
+      "memcache_secret_key": "",
       "max_header_line": 16384,
       "debug": false,
       "create_default_networks": true,
@@ -171,7 +172,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -11,6 +11,7 @@
                     "max_header_line": { "type": "int", "required": true },
                     "service_user": { "type": "str", "required": true },
                     "service_password": { "type": "str" },
+                    "memcache_secret_key": { "type": "str", "required": true },
                     "rabbitmq_instance": { "type": "str", "required": true },
                     "keystone_instance": { "type": "str", "required": true },
                     "create_default_networks": { "type": "bool", "required": true },

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -10,6 +10,7 @@
       "glance_instance": "none",
       "cinder_instance": "none",
       "neutron_instance": "none",
+      "memcache_secret_key": "",
       "itxt_instance": "none",
       "trusted_flavors": false,
       "libvirt_type": "kvm",
@@ -163,7 +164,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -18,6 +18,7 @@
             "keystone_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str" },
+            "memcache_secret_key": { "type": "str", "required": true },
             "glance_instance": { "type": "str", "required": true },
             "cinder_instance": { "type": "str", "required": true },
             "neutron_instance": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/glance_service.rb
+++ b/crowbar_framework/app/models/glance_service.rb
@@ -68,6 +68,7 @@ class GlanceService < OpenstackServiceObject
     base["attributes"][@bc_name]["keystone_instance"] = find_dep_proposal("keystone")
 
     base["attributes"]["glance"]["service_password"] = random_password
+    base["attributes"]["glance"]["memcache_secret_key"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
 
     @logger.debug("Glance create_proposal: exiting")

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -113,6 +113,7 @@ class NeutronService < OpenstackServiceObject
     } unless nodes.nil? or nodes.length ==0
 
     base["attributes"]["neutron"]["service_password"] = random_password
+    base["attributes"]["neutron"]["memcache_secret_key"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
 
     base

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -186,6 +186,7 @@ class NovaService < OpenstackServiceObject
     base["attributes"][@bc_name]["neutron_instance"] = find_dep_proposal("neutron")
 
     base["attributes"]["nova"]["service_password"] = random_password
+    base["attributes"]["nova"]["memcache_secret_key"] = random_password
     base["attributes"]["nova"]["api_db"]["password"] = random_password
     base["attributes"]["nova"]["placement_db"]["password"] = random_password
     base["attributes"]["nova"]["db"]["password"] = random_password


### PR DESCRIPTION
This PR continues the work done in #1090 by configuring the auth_token keystone middleware for all services currently using memcached caching (neutron, glance, nova) to authenticate and encrypt the token data stored in memcached using a generated secret key.
    
More information: 
- https://docs.openstack.org/keystonemiddleware/latest/middlewarearchitecture.html#memcache-protection


