### PR TITLE
horizon: Update for Ocata

### DIFF
--- a/chef/cookbooks/horizon/templates/centos/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/centos/local_settings.py.erb
@@ -3,7 +3,6 @@ from django.utils.translation import ugettext_lazy as _
 from openstack_dashboard import exceptions
 
 DEBUG = <%= @debug ? 'True' : 'False' %>
-TEMPLATE_DEBUG = DEBUG
 <%= @use_ssl ? '' : '# ' %>SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
 ALLOWED_HOSTS = ['*']
 LOGIN_URL = '/auth/login/'

--- a/chef/cookbooks/horizon/templates/redhat/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/redhat/local_settings.py.erb
@@ -3,7 +3,6 @@ from django.utils.translation import ugettext_lazy as _
 from openstack_dashboard import exceptions
 
 DEBUG = <%= @debug ? 'True' : 'False' %>
-TEMPLATE_DEBUG = DEBUG
 <%= @use_ssl ? '' : '# ' %>SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
 ALLOWED_HOSTS = ['*']
 LOGIN_URL = '/auth/login/'


### PR DESCRIPTION
This patch removes usage of the TEMPLATE_DEBUG parameter from the
RHEL-based horizon config templates. Django template debugging is now
tied to the regular DEBUG parameter[1]. We were already not using this
parameter in the regular SUSE config templates, so this patch is just a
minor cleanup.

[1] https://docs.openstack.org/releasenotes/horizon/ocata.html