### PR TITLE
manila: Update keystone_authtoken parameters

### DIFF
--- a/chef/cookbooks/manila/recipes/common.rb
+++ b/chef/cookbooks/manila/recipes/common.rb
@@ -107,6 +107,16 @@ end
 enabled_share_protocols = ["NFS", "CIFS"]
 enabled_share_protocols << ["CEPHFS"] if ManilaHelper.has_cephfs_share? node
 
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  if node[:manila][:ha][:enabled]
+    CrowbarPacemakerHelper.cluster_nodes(node, "manila-server")
+  else
+    [node]
+  end
+)
+
+memcached_instance("manila") if node["roles"].include?("manila-server")
+
 template node[:manila][:config_file] do
   source "manila.conf.erb"
   owner "root"
@@ -132,7 +142,8 @@ template node[:manila][:config_file] do
     nova_admin_password: nova_admin_password,
     cinder_insecure: cinder_insecure,
     cinder_admin_username: cinder_admin_username,
-    cinder_admin_password: cinder_admin_password
+    cinder_admin_password: cinder_admin_password,
+    memcached_servers: memcached_servers
   )
 end
 

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -52,6 +52,11 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
 project_domain_name = <%= @keystone_settings['admin_domain']%>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
 auth_type = password
+service_token_roles_required = true
+service_token_roles = admin
+memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:manila][:memcache_secret_key] %>
 
 [neutron]
 url=<%= @neutron_protocol%>://<%= @neutron_server_host%>:<%= @neutron_server_port%>

--- a/chef/data_bags/crowbar/migrate/manila/200_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/manila/200_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-manila.json
+++ b/chef/data_bags/crowbar/template-manila.json
@@ -8,6 +8,7 @@
       "use_syslog": false,
       "service_user": "manila",
       "service_password": "",
+      "memcache_secret_key": "",
       "rabbitmq_instance": "none",
       "keystone_instance": "none",
       "database_instance": "none",
@@ -96,7 +97,7 @@
     "manila": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 200,
       "element_states": {
         "manila-server": [ "readying", "ready", "applying" ],
         "manila-share": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-manila.schema
+++ b/chef/data_bags/crowbar/template-manila.schema
@@ -19,6 +19,7 @@
             "max_header_line": { "type": "int", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
+            "memcache_secret_key": { "type": "str", "required": true },
             "default_share_type": { "type": "str", "required": false },
             "api": {
               "type": "map", "required": true, "mapping": {

--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -100,6 +100,7 @@ class ManilaService < OpenstackServiceObject
       find_dep_proposal("neutron")
 
     base["attributes"][@bc_name]["service_password"] = random_password
+    base["attributes"][@bc_name]["memcache_secret_key"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
 
     @logger.debug("Manila create_proposal: exiting")


### PR DESCRIPTION
Use the service_token_roles and service_token_roles_required parameters
to ensure properly authenticated interservice communication and to avoid
deprecation warnings[1].

Add a memcached instance for the manila controller and configure manila
to use it for token caching, since the in-process token cache is
deprecated and produces warnings[2]. This includes adding a parameter to
generate a secret key to use for cache encryption.

[1] https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html
[2] https://docs.openstack.org/releasenotes/keystonemiddleware/mitaka.html

manila: Add memcached servers