### PR TITLE
manila: Init node hash for ceph config (bsc#1051229)

### DIFF
--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -208,6 +208,8 @@ keyring = /etc/ceph/ceph.client.manila.keyring
 
     all_nodes.each do |n|
       node = NodeObject.find_node_by_name n
+      node["ceph"] ||= {}
+      node["ceph"]["config_sections"] ||= {}
       node["ceph"]["config_sections"]["client.manila"] = ceph_conf_extra_section
       node.save
     end


### PR DESCRIPTION
When adding extra sections to the ceph config, the node hash might
not be initialized which leads to:

undefined method `[]' for nil:NilClass

(cherry picked from commit baac26ba06080a9b84490d6288f57262a316be59)