### PR TITLE
mysql: Cleanup root password setting

### DIFF
--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -122,16 +122,10 @@ unless Chef::Config[:solo]
   end
 end
 
-# set the root password on platforms
-# that don't support pre-seeding
-unless platform_family?("debian")
-
-  execute "assign-root-password" do
-    command "/usr/bin/mysqladmin -u root password \"#{node['mysql']['server_root_password']}\""
-    action :run
-    only_if "/usr/bin/mysql -u root -e 'show databases;'"
-  end
-
+execute "assign-root-password" do
+  command "/usr/bin/mysqladmin -u root password \"#{node["mysql"]["server_root_password"]}\""
+  action :run
+  only_if "/usr/bin/mysql -u root -e 'show databases;'"
 end
 
 grants_path = value_for_platform_family(

--- a/chef/cookbooks/mysql/templates/default/grants.sql.erb
+++ b/chef/cookbooks/mysql/templates/default/grants.sql.erb
@@ -3,8 +3,5 @@
 
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE USER, CREATE VIEW, SHOW VIEW, TRIGGER, EXECUTE, CREATE ROUTINE, ALTER ROUTINE ON *.* TO 'db_maker'@'%' IDENTIFIED BY '<%= node[:database][:db_maker_password] %>' WITH GRANT OPTION;
 
-# Set the server root password. This should be preseeded by the package installation.
-SET PASSWORD FOR 'root'@'localhost' = PASSWORD('<%= node['mysql']['server_root_password'] %>');
-
 #Flush privileges
 FLUSH PRIVILEGES;


### PR DESCRIPTION
We don't really care about debian, so let's clean up the
root password setting mechanism and stop using the grants.sql file.