### PR TITLE
heat: ocata cookbook update

### DIFF
--- a/chef/cookbooks/heat/attributes/default.rb
+++ b/chef/cookbooks/heat/attributes/default.rb
@@ -67,7 +67,6 @@ if node[:platform_family] == "suse"
 end
 
 default[:heat][:debug] = false
-default[:heat][:verbose] = false
 default[:heat][:max_header_line] = 16384
 
 default[:heat][:user] = "heat"

--- a/chef/cookbooks/heat/metadata.rb
+++ b/chef/cookbooks/heat/metadata.rb
@@ -7,6 +7,7 @@ version "0.1"
 
 depends "nagios"
 depends "keystone"
+depends "memcached"
 depends "database"
 depends "crowbar-openstack"
 depends "crowbar-pacemaker"

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -101,6 +101,11 @@ if node[:heat][:api][:protocol] == "https"
   end
 end
 
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "heat-server") : [node]
+)
+memcached_instance("heat-server")
+
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 bind_host, api_port, cfn_port, cloud_watch_port = HeatHelper.get_bind_host_port(node)
@@ -383,6 +388,7 @@ template "/etc/heat/heat.conf.d/100-heat.conf" do
         debug: node[:heat][:debug],
         rabbit_settings: rabbit_settings,
         keystone_settings: keystone_settings,
+        memcached_servers: memcached_servers,
         database_connection: db_connection,
         bind_host: bind_host,
         api_port: api_port,

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -381,7 +381,6 @@ template "/etc/heat/heat.conf.d/100-heat.conf" do
     lazy {
       {
         debug: node[:heat][:debug],
-        verbose: node[:heat][:verbose],
         rabbit_settings: rabbit_settings,
         keystone_settings: keystone_settings,
         database_connection: db_connection,

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -125,6 +125,9 @@ password = <%= @keystone_settings['service_password'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings['admin_domain'] %>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
+memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:heat][:memcache_secret_key] %>
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -15,7 +15,6 @@ auth_encryption_key = <%= @auth_encryption_key %>
 loadbalancer_template = /etc/heat/loadbalancer.template
 <% end -%>
 debug = <%= node[:heat][:debug] ? 'true' : 'false' %>
-verbose = <%= node[:heat][:verbose] ? 'true' : 'false' %>
 log_dir = /var/log/heat
 use_stderr = false
 transport_url = <%= @rabbit_settings[:url] %>
@@ -115,17 +114,19 @@ workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 max_header_line = <%= node[:heat][:max_header_line] %>
 
 [keystone_authtoken]
+auth_type = password
 auth_uri = <%= @keystone_settings['public_auth_url'] %>
-identity_uri = <%= @keystone_settings['admin_auth_url'] %>
+auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
-username = <%= @keystone_settings['service_user'] %>
-password = <%= @keystone_settings['service_password'] %>
 insecure = <%= @keystone_settings['insecure'] %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
-admin_user = <%= @keystone_settings['service_user'] %>
-admin_password = <%= @keystone_settings['service_password'] %>
-admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
-user_domain_id = <%= @keystone_settings['admin_domain'] %>
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
+project_name = <%= @keystone_settings['service_tenant'] %>
+project_domain_name = <%= @keystone_settings['admin_domain'] %>
+user_domain_name = <%= @keystone_settings['admin_domain'] %>
+service_token_roles_required = true
+service_token_roles = admin
 
 <% if node[:heat][:api][:protocol] == "https" %>
 [ssl]

--- a/chef/data_bags/crowbar/migrate/heat/201_remove_deprecated_options.rb
+++ b/chef/data_bags/crowbar/migrate/heat/201_remove_deprecated_options.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("verbose")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["verbose"] = ta["verbose"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/heat/202_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/heat/202_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-heat.json
+++ b/chef/data_bags/crowbar/template-heat.json
@@ -4,7 +4,6 @@
   "attributes": {
     "heat": {
       "debug": false,
-      "verbose": true,
       "max_header_line": 16384,
       "rabbitmq_instance": "none",
       "database_instance": "none",
@@ -41,7 +40,7 @@
     "heat": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "heat-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-heat.json
+++ b/chef/data_bags/crowbar/template-heat.json
@@ -13,6 +13,7 @@
       "service_user": "heat",
       "service_password": "",
       "auth_encryption_key": "",
+      "memcache_secret_key": "",
       "trusts_delegated_roles": [ "Member" ],
       "api": {
         "protocol": "http",
@@ -40,7 +41,7 @@
     "heat": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "element_states": {
         "heat-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-heat.schema
+++ b/chef/data_bags/crowbar/template-heat.schema
@@ -22,6 +22,7 @@
             "stack_domain_admin": { "type": "str", "required": true },
             "stack_domain_admin_password": { "type": "str", "required": true },
             "auth_encryption_key": { "type": "str", "required": true },
+            "memcache_secret_key": { "type": "str", "required": true },
             "trusts_delegated_roles": {
               "type": "seq",
               "required": true,

--- a/chef/data_bags/crowbar/template-heat.schema
+++ b/chef/data_bags/crowbar/template-heat.schema
@@ -13,7 +13,6 @@
           "required": true,
           "mapping": {
             "debug": { "type": "bool", "required": true },
-            "verbose": { "type": "bool", "required": true },
             "max_header_line": { "type": "int", "required": true },
             "database_instance": { "type": "str", "required": true },
             "rabbitmq_instance": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/heat_service.rb
+++ b/crowbar_framework/app/models/heat_service.rb
@@ -69,6 +69,7 @@ class HeatService < OpenstackServiceObject
     end
 
     base["attributes"][@bc_name]["service_password"] = random_password
+    base["attributes"][@bc_name]["memcache_secret_key"] = random_password
     base["attributes"][@bc_name]["stack_domain_admin_password"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
     encryption_key = random_password

--- a/crowbar_framework/app/views/barclamp/heat/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/heat/_edit_attributes.html.haml
@@ -26,7 +26,3 @@
           "data-enabler" => "true",
           "data-enabler-target" => "#ssl_ca_certs"
         = string_field %w(ssl ca_certs)
-    %fieldset
-      %legend
-        = t(".logging_header")
-      = boolean_field :verbose

--- a/crowbar_framework/config/locales/heat/en.yml
+++ b/crowbar_framework/config/locales/heat/en.yml
@@ -21,8 +21,6 @@ en:
   barclamp:
     heat:
       edit_attributes:
-        logging_header: 'Logging'
-        verbose: 'Verbose Logging'
         database_instance: 'Database'
         keystone_instance: 'Keystone'
         rabbitmq_instance: 'RabbitMQ'


### PR DESCRIPTION
The following heat configuration options deprecated in Ocata (or earlier) are removed or replaced in this PR:
    
 - [default]/verbose deprecated option removed
 - [keystone_authtoken]/service_token_roles_required is set to True to enable fetching expired tokens based on valid service tokens and [keystone_authtoken]/service_token_roles is set to the admin role
 - the following deprecated keystone_authtoken configuration options: _identity_uri_, _admin_user_,
_admin_password_, and _admin_tenant_name_ are replaced with _auth_url_, _project_name_, _project_domain_name_ and _user_domain_name_

The deprecated keystonemiddleware.auth_token in-process token cache used by heat services is replaced with a memcached server. When HA is used, several memcached servers are configured and used, one for each heat-server node. 
The keystone token data stored in memcached is authenticated and encrypted using a generated secret key.

References:  
 - Ocata release notes for heat: https://docs.openstack.org/releasenotes/heat/ocata.html
 - Ocata release notes for keystonemiddleware: https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html
 - Mitaka release notes for keystonemiddleware: https://docs.openstack.org/r
eleasenotes/keystonemiddleware/mitaka
 - memcached protection options: https://docs.openstack.org/keystonemiddlewa
re/latest/middlewarearchitecture.html#memcache-protection
