### PR TITLE
Do not return VIP address as the database listening adress.

### DIFF
--- a/chef/cookbooks/database/libraries/crowbar.rb
+++ b/chef/cookbooks/database/libraries/crowbar.rb
@@ -10,7 +10,8 @@ module CrowbarDatabaseHelper
   end
 
   def self.get_listen_address(node)
-    if node[:database][:ha][:enabled]
+    # FIXME: temporarily do not expect there's any VIP for mysql database
+    if node[:database][:ha][:enabled] && node[:database][:sql_engine] != "mysql"
       vhostname = get_ha_vhostname(node)
       CrowbarPacemakerHelper.cluster_vip(node, "admin", vhostname)
     else


### PR DESCRIPTION
This is only temporary solution, while we are missing proper
haproxy setup in database (mysql) cluster.