### PR TITLE
crowbar-openstack: Use databag to search for rabbitmq settings

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -100,57 +100,12 @@ class CrowbarOpenStackHelper
 
   def self.rabbitmq_settings(node, barclamp)
     instance = node[barclamp][:rabbitmq_instance] || "default"
+    config = BarclampLibrary::Barclamp::Config.load("openstack", "rabbitmq", instance)
 
-    # Cache the result for each cookbook in an instance variable hash. This
-    # cache needs to be invalidated for each chef-client run from chef-client
-    # daemon (which are all in the same process); so use the ohai time as a
-    # marker for that.
-    if @rabbitmq_settings_cache_time != node[:ohai_time]
-      if @rabbitmq_settings
-        Chef::Log.info("Invalidating rabbitmq settings cache " \
-                       "on behalf of #{barclamp}")
-      end
-      @rabbitmq_settings = nil
-      @rabbitmq_settings_cache_time = node[:ohai_time]
-    end
+    Chef::Log.warn("No RabbitMQ server found!") if config.empty?
+    Chef::Log.info("RabbitMQ server found at #{config[:address]}") unless config.empty?
 
-    if @rabbitmq_settings && @rabbitmq_settings.include?(instance)
-      Chef::Log.info("RabbitMQ server found at #{@rabbitmq_settings[instance][:address]} [cached]")
-    else
-      @rabbitmq_settings ||= Hash.new
-      rabbit = get_node(node, "rabbitmq-server", "rabbitmq", instance)
-
-      if rabbit.nil?
-        Chef::Log.warn("No RabbitMQ server found!")
-      else
-        if rabbit[:rabbitmq][:ssl][:enabled]
-          port = rabbit[:rabbitmq][:ssl][:port]
-        else
-          port = rabbit[:rabbitmq][:port]
-        end
-        client_ca_certs = if rabbit[:rabbitmq][:ssl][:enabled] && \
-            !rabbit[:rabbitmq][:ssl][:insecure]
-          rabbit[:rabbitmq][:ssl][:client_ca_certs]
-        end
-        @rabbitmq_settings[instance] = {
-          address: rabbit[:rabbitmq][:address],
-          port: port,
-          user: rabbit[:rabbitmq][:user],
-          password: rabbit[:rabbitmq][:password],
-          vhost: rabbit[:rabbitmq][:vhost],
-          use_ssl: rabbit[:rabbitmq][:ssl][:enabled],
-          client_ca_certs: client_ca_certs,
-          url: "rabbit://#{rabbit[:rabbitmq][:user]}:" \
-            "#{rabbit[:rabbitmq][:password]}@" \
-            "#{rabbit[:rabbitmq][:address]}:#{port}/" \
-            "#{rabbit[:rabbitmq][:vhost]}"
-        }
-
-        Chef::Log.info("RabbitMQ server found at #{@rabbitmq_settings[instance][:address]}")
-      end
-    end
-
-    @rabbitmq_settings[instance]
+    config
   end
 
   private

--- a/chef/data_bags/crowbar/migrate/rabbitmq/200_fill_databag_with_settings.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/200_fill_databag_with_settings.rb
@@ -1,0 +1,45 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "rabbitmq").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("rabbitmq-config-default")
+  node = NodeObject.find("roles:rabbitmq-config-default").first
+  address = node["rabbitmq"]["address"]
+
+  client_ca_certs = if a["ssl"]["enabled"] && !a["ssl"]["insecure"]
+    a["ssl"]["client_ca_certs"]
+  end
+
+  port = if a["ssl"]["enabled"]
+    a["ssl"]["port"]
+  else
+    a["port"]
+  end
+
+  config = {
+    address: address,
+    port: port,
+    user: a["user"],
+    password: a["password"],
+    vhost: a["vhost"],
+    use_ssl: a["ssl"]["enabled"],
+    client_ca_certs: client_ca_certs,
+    url: "rabbit://#{a["user"]}:#{a["password"]}@#{address}:#{port}/#{a["vhost"]}"
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "rabbitmq", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -44,7 +44,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 200,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -146,10 +146,19 @@ class RabbitmqService < OpenstackServiceObject
       _elements, nodes, _ha_enabled = role_expand_elements(role, "rabbitmq-server")
       node = NodeObject.find_node_by_name(nodes.first)
       address = node[:rabbitmq][:address]
-      port = role.default_attributes["rabbitmq"]["port"]
       user = role.default_attributes["rabbitmq"]["user"]
       password = role.default_attributes["rabbitmq"]["password"]
       vhost = role.default_attributes["rabbitmq"]["vhost"]
+      use_ssl = role.default_attributes["rabbitmq"]["ssl"]["enabled"]
+      client_ca_certs = if use_ssl && !role.default_attributes["rabbitmq"]["ssl"]["insecure"]
+        role.default_attributes["rabbitmq"]["ssl"]["client_ca_certs"]
+      end
+
+      port = if use_ssl
+        role.default_attributes["rabbitmq"]["ssl"]["port"]
+      else
+        role.default_attributes["rabbitmq"]["port"]
+      end
 
       config = {
         address: address,
@@ -157,6 +166,8 @@ class RabbitmqService < OpenstackServiceObject
         user: user,
         password: password,
         vhost: "/#{vhost}",
+        use_ssl: use_ssl,
+        client_ca_certs: client_ca_certs,
         url: "rabbit://#{user}:#{password}@#{address}:#{port}/#{vhost}"
       }
     end


### PR DESCRIPTION
Use the databag to provide the rabbitmq settings to other cookbooks.
Includes a rabbitmq migration to fill the rabbitmq databag in
case rabbitmq is already deployed when applying this commit.