### PR TITLE
Glance: get insecure values from databag

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -46,7 +46,7 @@ vmware_insecure = <%= node[:glance][:vsphere][:insecure] ? "True" : "False" %>
 cinder_catalog_info = volumev2:cinderv2:internalURL
 cinder_os_region_name = <%= @keystone_settings['endpoint_region'] %>
 cinder_api_insecure = <%= @cinder_api_insecure ? 'True' : 'False' %>
-swift_store_auth_insecure = <%= @swift_api_insecure || @keystone_settings['insecure'] ? 'True' : 'False' %>
+swift_store_auth_insecure = <%= @swift_api_insecure ? 'True' : 'False' %>
 swift_store_region = <%= @keystone_settings['endpoint_region'] %>
 swift_store_endpoint_type = internalURL
 swift_store_container = <%= node[:glance][:swift][:store_container] %>

--- a/chef/data_bags/crowbar/migrate/glance/201_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/glance/201_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "glance").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("glance-config-default")
+  config = {
+    insecure: a[:ssl][:insecure]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "glance", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -71,7 +71,7 @@
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
Instead of doing searches for the insecure values, get them from
the databag

Provides a migration that would look for the actual values
of the insecure attribute and create/update the databag with
them, so the cookbooks will always find the real value in there
instead of defaulting to false