### PR TITLE
Heat: use the databags to find if magnum is deployed

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -404,9 +404,7 @@ template "/etc/heat/heat.conf.d/100-heat.conf" do
   )
 end
 
-magnum_env_filter = "magnum-server AND magnum_config_environment:magnum-config-default"
-magnum_servers = search(:node, "roles:#{magnum_env_filter}") || []
-unless magnum_servers.empty?
+unless Barclamp::Config.load("openstack", "magnum").empty?
 
   # https://bugs.launchpad.net/magnum/+bug/1589955
   # enable stacks global_index search so that magnum can use

--- a/chef/data_bags/crowbar/migrate/heat/200_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/heat/200_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "heat").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("heat-config-default")
+  config = {
+    insecure: a[:ssl][:insecure]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "heat", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-heat.json
+++ b/chef/data_bags/crowbar/template-heat.json
@@ -41,7 +41,7 @@
     "heat": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 200,
       "element_states": {
         "heat-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
Instead of doing a node search which is expensive, check
for the existance of the magnum databag which will mean that
magnum is deployed