### PR TITLE
Neutron: get insecure values from databag

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -20,11 +20,8 @@ neutron = nil
 if node.attribute?(:cookbook) and node[:cookbook] == "nova"
   neutrons = node_search_with_cache("roles:neutron-server", node[:nova][:neutron_instance])
   neutron = neutrons.first || raise("Neutron instance '#{node[:nova][:neutron_instance]}' for nova not found")
-  nova = node
 else
   neutron = node
-  nova = node_search_with_cache("roles:nova-controller").first
-  Chef::Log.warn("nova-controller not found") if nova.nil?
 end
 
 # RDO package magic (non-standard packages)
@@ -77,13 +74,7 @@ memcached_instance("neutron-server") if is_neutron_server
 
 bind_host, bind_port = NeutronHelper.get_bind_host_port(node)
 
-# Get Nova's insecure setting
-if nova.nil?
-  nova_insecure = keystone_settings["insecure"]
-else
-  nova_insecure = keystone_settings["insecure"] || (
-    nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure])
-end
+nova_insecure = Barclamp::Config.load("openstack", "nova")["insecure"] || false
 
 service_plugins = ["neutron.services.metering.metering_plugin.MeteringPlugin",
                    "neutron_fwaas.services.firewall.fwaas_plugin.FirewallPlugin"]

--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -65,8 +65,7 @@ vni_start = [node[:neutron][:vxlan][:vni_start], 0].max
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-neutron_insecure = node[:neutron][:api][:protocol] == "https" && node[:neutron][:ssl][:insecure]
-ssl_insecure = keystone_settings["insecure"] || neutron_insecure
+ssl_insecure = Barclamp::Config.load("openstack", "neutron")["insecure"] || false
 
 has_ironic = ironic_net && node.roles.include?("ironic-server")
 

--- a/chef/data_bags/crowbar/migrate/neutron/203_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/203_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "neutron").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("neutron-config-default")
+  config = {
+    insecure: a[:ssl][:insecure]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "neutron", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -171,7 +171,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]


### PR DESCRIPTION
Instead of doing searches for the insecure values, get them from
the databag

Provides a migration that would look for the actual values
of the insecure attribute and create/update the databag with
them, so the cookbooks will always find the real value in there
instead of defaulting to false