### PR TITLE
swift: Update keystonemiddleware authtoken config

### DIFF
--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -67,6 +67,8 @@ auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 delay_auth_decision = <%= @keystone_delay_auth_decision %>
 include_service_catalog = False
 cache = swift.cache
+service_token_roles_required = true
+service_token_roles = admin
 [filter:keystoneauth]
 use = egg:swift#keystoneauth
 operator_roles = Member, admin


### PR DESCRIPTION
Use the service_token_roles and service_token_roles_required parameters
that were introduced in Ocata and will soon become required[1] to ensure
properly authenticated interservice communication.

This wasn't producing deprecation warnings in the logs, but that is
likely due to a logging bug in swift[2]. Swift still uses
keystonemiddleware and we still need to keep its config up to date even
though swift wasn't kind enough to warn us about it.

[1] https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html
[2] https://bugs.launchpad.net/swift/+bug/1380815