### PR TITLE
Nova: get insecure values from databag

### DIFF
--- a/chef/cookbooks/nova/libraries/availability_zone.rb
+++ b/chef/cookbooks/nova/libraries/availability_zone.rb
@@ -18,7 +18,7 @@ module NovaAvailabilityZone
   def self.fetch_set_az_command_no_arg(node, cookbook_name)
     keystone_settings = KeystoneHelper.keystone_settings(node, cookbook_name)
 
-    nova_insecure = node[:nova][:ssl][:enabled] && node[:nova][:ssl][:insecure]
+    ssl_insecure = BarclampLibrary::Barclamp::Config.load("openstack", "nova")["insecure"] || false
 
     command = ["/usr/bin/crowbar-nova-set-availability-zone"]
     command << "--os-username"
@@ -35,7 +35,7 @@ module NovaAvailabilityZone
     command << "--os-region-name"
     command << keystone_settings["endpoint_region"]
 
-    if keystone_settings["insecure"] || nova_insecure
+    if ssl_insecure
       command << "--insecure"
     end
 

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -91,13 +91,14 @@ if glance_servers.length > 0
   glance_server_host = CrowbarHelper.get_host_for_admin_url(glance_server, (glance_server[:glance][:ha][:enabled] rescue false))
   glance_server_port = glance_server[:glance][:api][:bind_port]
   glance_server_protocol = glance_server[:glance][:api][:protocol]
-  glance_server_insecure = glance_server_protocol == "https" && glance_server[:glance][:ssl][:insecure]
 else
   glance_server_host = nil
   glance_server_port = nil
   glance_server_protocol = nil
-  glance_server_insecure = nil
 end
+
+glance_config = Barclamp::Config.load("openstack", "glance", node[:nova][:glance_instance])
+glance_insecure = glance_config["insecure"] || false
 Chef::Log.info("Glance server at #{glance_server_host}")
 
 # use memcached as a cache backend for nova-novncproxy
@@ -116,12 +117,9 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 rbd_enabled = false
 
-use_multipath = false
-
 cinder_servers = node_search_with_cache("roles:cinder-controller")
 if cinder_servers.length > 0
   cinder_server = cinder_servers[0]
-  cinder_insecure = cinder_server[:cinder][:api][:protocol] == "https" && cinder_server[:cinder][:ssl][:insecure]
   use_multipath = cinder_server[:cinder][:use_multipath]
   keymgr_fixed_key = cinder_server[:cinder][:keymgr_fixed_key]
 
@@ -131,9 +129,12 @@ if cinder_servers.length > 0
     end
   end
 else
-  cinder_insecure = false
+  use_multipath = false
   keymgr_fixed_key = ""
 end
+
+cinder_config = Barclamp::Config.load("openstack", "cinder", node[:nova][:cinder_instance])
+cinder_insecure = cinder_config["insecure"] || false
 
 if rbd_enabled
   include_recipe "nova::ceph"
@@ -153,7 +154,6 @@ if neutron_servers.length > 0
   neutron_protocol = neutron_server[:neutron][:api][:protocol]
   neutron_server_host = CrowbarHelper.get_host_for_admin_url(neutron_server, (neutron_server[:neutron][:ha][:server][:enabled] rescue false))
   neutron_server_port = neutron_server[:neutron][:api][:service_port]
-  neutron_insecure = neutron_protocol == "https" && neutron_server[:neutron][:ssl][:insecure]
   neutron_service_user = neutron_server[:neutron][:service_user]
   neutron_service_password = neutron_server[:neutron][:service_password]
   neutron_dhcp_domain = neutron_server[:neutron][:dns_domain]
@@ -167,6 +167,9 @@ else
   neutron_dhcp_domain = "novalocal"
   neutron_has_tunnel = false
 end
+
+neutron_config = Barclamp::Config.load("openstack", "neutron", node[:nova][:neutron_instance])
+neutron_insecure = neutron_config["insecure"] || false
 Chef::Log.info("Neutron server at #{neutron_server_host}")
 
 has_itxt = false
@@ -376,7 +379,7 @@ template node[:nova][:config_file] do
     glance_server_protocol: glance_server_protocol,
     glance_server_host: glance_server_host,
     glance_server_port: glance_server_port,
-    glance_server_insecure: glance_server_insecure || keystone_settings["insecure"],
+    glance_server_insecure: glance_insecure,
     need_shared_lock_path: need_shared_lock_path,
     metadata_bind_address: metadata_bind_address,
     vnc_enabled: node[:nova][:use_novnc],
@@ -391,13 +394,13 @@ template node[:nova][:config_file] do
     neutron_protocol: neutron_protocol,
     neutron_server_host: neutron_server_host,
     neutron_server_port: neutron_server_port,
-    neutron_insecure: neutron_insecure || keystone_settings["insecure"],
+    neutron_insecure: neutron_insecure,
     neutron_service_user: neutron_service_user,
     neutron_service_password: neutron_service_password,
     neutron_dhcp_domain: neutron_dhcp_domain,
     neutron_has_tunnel: neutron_has_tunnel,
     keystone_settings: keystone_settings,
-    cinder_insecure: cinder_insecure || keystone_settings["insecure"],
+    cinder_insecure: cinder_insecure,
     use_multipath: use_multipath,
     keymgr_fixed_key: keymgr_fixed_key,
     ceph_user: ceph_user,

--- a/chef/cookbooks/nova/recipes/flavors.rb
+++ b/chef/cookbooks/nova/recipes/flavors.rb
@@ -72,9 +72,7 @@ flavors =
   }
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
-
-nova_insecure = node[:nova][:ssl][:insecure]
-ssl_insecure = keystone_settings["insecure"] || nova_insecure
+ssl_insecure = Barclamp::Config.load("openstack", "nova")["insecure"] || false
 
 novacmd = "nova --os-username #{keystone_settings["service_user"]} " \
 "--os-password #{keystone_settings["service_password"]} " \

--- a/chef/data_bags/crowbar/migrate/nova/202_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/nova/202_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "nova").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("nova-config-default")
+  config = {
+    insecure: a[:ssl][:insecure]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "nova", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -164,7 +164,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],


### PR DESCRIPTION
Instead of doing searches for the insecure values, get them from
the databag

Provides a migration that would look for the actual values
of the insecure attribute and create/update the databag with
them, so the cookbooks will always find the real value in there
instead of defaulting to false