### PR TITLE
Sahara: get insecure values from databag

### DIFF
--- a/chef/cookbooks/sahara/recipes/common.rb
+++ b/chef/cookbooks/sahara/recipes/common.rb
@@ -28,25 +28,28 @@ sql_connection = "#{db_settings[:url_scheme]}://#{node[:sahara][:db][:user]}:"\
                  "#{db_password}@#{db_settings[:address]}/"\
                  "#{node[:sahara][:db][:database]}"
 
-# cinder insecure?
-cinder = node_search_with_cache("roles:cinder-controller").first
-cinder_insecure = cinder[:cinder][:ssl][:insecure]
+cinder_instance = node[:sahara][:cinder_instance]
+heat_instance = node[:sahara][:heat_instance]
+neutron_instance = node[:sahara][:neutron_instance]
+nova_instance = node[:sahara][:nova_instance]
 
-# heat insecure?
-heat = node_search_with_cache("roles:heat-server").first
-heat_insecure = heat[:heat][:ssl][:insecure]
+cinder_insecure = Barclamp::Config.load(
+  "openstack", "cinder", cinder_instance
+)["insecure"] || false
 
-# neutron insecure?
-neutron = node_search_with_cache("roles:neutron-server").first
-neutron_insecure = neutron[:neutron][:ssl][:insecure]
+heat_insecure = Barclamp::Config.load(
+  "openstack", "heat", heat_instance
+)["insecure"] || false
 
-# nova insecure?
-nova = node_search_with_cache("roles:nova-controller").first
-nova_insecure = nova[:nova][:ssl][:insecure]
+neutron_insecure = Barclamp::Config.load(
+  "openstack", "neutron", neutron_instance
+)["insecure"] || false
 
-# use ceilometer?
-ceilometers = search_env_filtered(:node, "roles:ceilometer-server")
-use_ceilometer = !ceilometers.empty?
+nova_insecure = Barclamp::Config.load(
+  "openstack", "nova", nova_instance
+)["insecure"] || false
+
+use_ceilometer = !Barclamp::Config.load("openstack", "ceilometer").empty?
 
 template node[:sahara][:config_file] do
   source "sahara.conf.erb"

--- a/chef/data_bags/crowbar/migrate/sahara/201_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/sahara/201_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "sahara").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("sahara-config-default")
+  config = {
+    insecure: a["ssl"]["insecure"]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "sahara", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-sahara.json
+++ b/chef/data_bags/crowbar/template-sahara.json
@@ -34,7 +34,7 @@
     "sahara": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "sahara-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
Instead of doing searches for the insecure values, get them from
the databag

Provides a migration that would look for the actual values
of the insecure attribute and create/update the databag with
them, so the cookbooks will always find the real value in there
instead of defaulting to false