### PR TITLE
migrations: Add migrations for the new databag search

### DIFF
--- a/chef/data_bags/crowbar/migrate/aodh/200_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/aodh/200_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "aodh").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("aodh-config-default")
+  config = {
+    insecure: a["ssl"]["insecure"]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "aodh", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/barbican/200_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/barbican/200_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "barbican").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("barbican-config-default")
+  config = {
+    insecure: a["ssl"]["insecure"]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "barbican", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/ceilometer/200_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/200_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "ceilometer").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("ceilometer-config-default")
+  config = {
+    insecure: a["ssl"]["insecure"]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "ceilometer", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/keystone/201_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/201_fill_databag_with_insecure.rb
@@ -1,0 +1,24 @@
+def upgrade(ta, td, a, d)
+  # Check if the proposal is active. If its not then we dont need to do anything
+  # with the databag as it will be filled by the deployment
+  prop = Proposal.where(barclamp: "keystone").first
+  unless prop.nil?
+    return a, d unless prop.active?
+  end
+  # Find the role, get all the values and save the databag
+  role = RoleObject.find_role_by_name("keystone-config-default")
+  config = {
+    insecure: a["ssl"]["insecure"]
+  }
+  # as we dont have an old_role here, we just pass the role twice, wont affect anything
+  # as the instance_from_role method has an || to use any of those (old_role or role)
+  instance = Crowbar::DataBagConfig.instance_from_role(role, role)
+  Crowbar::DataBagConfig.save("openstack", instance, "keystone", config)
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # There is no current way of removing the databag
+  # not even sure if we should do it as it won't affect anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-aodh.json
+++ b/chef/data_bags/crowbar/template-aodh.json
@@ -35,7 +35,7 @@
     "aodh": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 200,
       "element_states": {
         "aodh-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-barbican.json
+++ b/chef/data_bags/crowbar/template-barbican.json
@@ -40,7 +40,7 @@
     "barbican" : {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 200,
       "element_states": {
         "barbican-controller": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -43,7 +43,7 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 104,
+      "schema-revision": 200,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-central": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -178,7 +178,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
As we are moving to reduce the searches for nodes and instead
using databags, we need a way to fill those databags if the
barclamp has already beeen deployed.

This migrations will check if the barclamp has been deployed and
if it is, it will try to fill the databag with the current values

--------------------------------------------------

This is for the leftover migrations, for other barclamp migrations they are on their own PR which also changes node searches in the cookbooks like this:


sahara https://github.com/crowbar/crowbar-openstack/pull/1127
nova https://github.com/crowbar/crowbar-openstack/pull/1126
manila https://github.com/crowbar/crowbar-openstack/pull/1124
neutron https://github.com/crowbar/crowbar-openstack/pull/1119
magnum https://github.com/crowbar/crowbar-openstack/pull/1118
horizon https://github.com/crowbar/crowbar-openstack/pull/1117
heat https://github.com/crowbar/crowbar-openstack/pull/1116
glance https://github.com/crowbar/crowbar-openstack/pull/1115
crowbar-openstack+rabbit https://github.com/crowbar/crowbar-openstack/pull/1114
cinder https://github.com/crowbar/crowbar-openstack/pull/1093




