### PR TITLE
framework: Fix the OpenstackServiceObject logger to use Rails.logger directly

### DIFF
--- a/crowbar_framework/app/models/openstack_service_object.rb
+++ b/crowbar_framework/app/models/openstack_service_object.rb
@@ -23,15 +23,15 @@
 
 class OpenstackServiceObject < PacemakerServiceObject
   def apply_role_post_chef_call(old_role, role, all_nodes)
-    @logger.debug("#{@bc_name} apply_role_post_chef_call: entering")
+    Rails.logger.debug("#{@bc_name} apply_role_post_chef_call: entering")
     # do this in post, because we depend on values that are computed in the
     # cookbook
     save_config_to_databag(old_role, role)
-    @logger.debug("#{@bc_name} apply_role_post_chef_call: leaving")
+    Rails.logger.debug("#{@bc_name} apply_role_post_chef_call: leaving")
   end
 
   def save_config_to_databag(old_role, role)
-    @logger.debug("#{@bc_name} save_config_to_databag: entering")
+    Rails.logger.debug("#{@bc_name} save_config_to_databag: entering")
     if role.nil?
       config = nil
     else
@@ -44,6 +44,6 @@ class OpenstackServiceObject < PacemakerServiceObject
 
     instance = Crowbar::DataBagConfig.instance_from_role(old_role, role)
     Crowbar::DataBagConfig.save("openstack", instance, @bc_name, config)
-    @logger.debug("#{@bc_name} save_config_to_databag: leaving")
+    Rails.logger.debug("#{@bc_name} save_config_to_databag: leaving")
   end
 end


### PR DESCRIPTION
It seems that during the rake task of update_config_db the @logger
is not passed properly, which can cause @logger to be nil.
So instead of that, use the Rails.logger directly

fixes: SCRD-739