### PR TITLE
Sahara: remove deprecated parameters

### DIFF
--- a/chef/cookbooks/sahara/attributes/default.rb
+++ b/chef/cookbooks/sahara/attributes/default.rb
@@ -14,7 +14,6 @@
 #
 
 default[:sahara][:debug] = false
-default[:sahara][:verbose] = false
 override[:sahara][:user] = "sahara"
 override[:sahara][:group] = "sahara"
 default[:sahara][:max_header_line] = 16384

--- a/chef/cookbooks/sahara/metadata.rb
+++ b/chef/cookbooks/sahara/metadata.rb
@@ -23,6 +23,7 @@ version "0.1"
 
 depends "database"
 depends "keystone"
+depends "memcached"
 depends "crowbar-openstack"
 depends "crowbar-pacemaker"
 depends "utils"

--- a/chef/cookbooks/sahara/recipes/common.rb
+++ b/chef/cookbooks/sahara/recipes/common.rb
@@ -51,6 +51,16 @@ nova_insecure = Barclamp::Config.load(
 
 use_ceilometer = !Barclamp::Config.load("openstack", "ceilometer").empty?
 
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  if node[:sahara][:ha][:enabled]
+    CrowbarPacemakerHelper.cluster_nodes(node, "sahara-server")
+  else
+    [node]
+  end
+)
+
+memcached_instance("sahara") if node["roles"].include?("sahara-server")
+
 template node[:sahara][:config_file] do
   source "sahara.conf.erb"
   owner "root"
@@ -64,6 +74,7 @@ template node[:sahara][:config_file] do
     keystone_settings: KeystoneHelper.keystone_settings(node, :sahara),
     cinder_insecure: cinder_insecure,
     heat_insecure: heat_insecure,
+    memcached_servers: memcached_servers,
     neutron_insecure: neutron_insecure,
     nova_insecure: nova_insecure,
     use_ceilometer: use_ceilometer

--- a/chef/cookbooks/sahara/templates/default/sahara.conf.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara.conf.erb
@@ -1,6 +1,5 @@
 [DEFAULT]
 debug = <%= node[:sahara][:debug] %>
-verbose = <%= node[:sahara][:verbose] %>
 log_dir = /var/log/sahara
 transport_url = <%= @rabbit_settings[:url] %>
 use_syslog=<%= node[:sahara][:use_syslog] ? "True" : "False" %>
@@ -41,6 +40,11 @@ auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_type = password
 insecure = <%= @keystone_settings["insecure"] %>
 region_name = <%= @keystone_settings["endpoint_region"] %>
+service_token_roles_required = true
+service_token_roles = admin
+memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:sahara][:memcache_secret_key] %>
 
 [neutron]
 api_insecure = <%= @neutron_insecure %>

--- a/chef/data_bags/crowbar/migrate/sahara/202_remove_deprecated_opts.rb
+++ b/chef/data_bags/crowbar/migrate/sahara/202_remove_deprecated_opts.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("verbose")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["verbose"] = ta["verbose"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/sahara/203_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/sahara/203_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-sahara.json
+++ b/chef/data_bags/crowbar/template-sahara.json
@@ -4,7 +4,6 @@
   "attributes": {
     "sahara": {
       "debug": false,
-      "verbose": true,
       "use_syslog": true,
       "keystone_instance": "none",
       "database_instance": "none",
@@ -16,6 +15,7 @@
       "cinder_instance": "none",
       "service_user": "sahara",
       "service_password": "",
+      "memcache_secret_key": "",
       "plugins": "vanilla,spark,storm,cdh,ambari,mapr",
       "api": {
         "protocol": "http",
@@ -34,7 +34,7 @@
     "sahara": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 203,
       "element_states": {
         "sahara-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-sahara.schema
+++ b/chef/data_bags/crowbar/template-sahara.schema
@@ -13,7 +13,6 @@
           "required": true,
           "mapping": {
             "debug": { "type": "bool", "required": true },
-            "verbose": { "type": "bool", "required": true },
             "use_syslog": { "type": "bool", "required": true },
             "database_instance": { "type": "str", "required": true },
             "keystone_instance": { "type": "str", "required": true },
@@ -25,6 +24,7 @@
             "cinder_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
+            "memcache_secret_key": { "type": "str", "required": true },
             "plugins": { "type": "str", "required": true },
             "api": {
               "type": "map", "required": true, "mapping": {

--- a/crowbar_framework/app/models/sahara_service.rb
+++ b/crowbar_framework/app/models/sahara_service.rb
@@ -76,6 +76,7 @@ class SaharaService < OpenstackServiceObject
     base["attributes"][@bc_name]["cinder_instance"] = find_dep_proposal("cinder")
 
     base["attributes"][@bc_name]["service_password"] = random_password
+    base["attributes"][@bc_name]["memcache_secret_key"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
 
     @logger.debug("sahara create_proposal: exiting")

--- a/crowbar_framework/app/views/barclamp/sahara/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/sahara/_edit_attributes.html.haml
@@ -12,7 +12,4 @@
     = instance_field :cinder
 
     %fieldset
-      %legend
-        = t(".logging_header")
-      = boolean_field :verbose
       = boolean_field :use_barbican_key_manager

--- a/crowbar_framework/config/locales/sahara/en.yml
+++ b/crowbar_framework/config/locales/sahara/en.yml
@@ -26,8 +26,6 @@ en:
         neutron_instance: 'Neutron'
         glance_instance: 'Glance'
         cinder_instance: 'Cinder'
-        logging_header: 'Logging'
-        verbose: 'Verbose Logging'
         use_barbican_key_manager: 'Use Barbican Key manager'
       validation:
         barbican_deployed: 'The Barbican barclamp needs to be deployed correctly to use it as Key Manager for Sahara.'


### PR DESCRIPTION
The following sahara parameters are deprecated:

  - DEFAULT.verbose

In addition, new parameters to the neutron.conf template:
  - keystone_authtoken.service_token_roles_required
  - keystone_authtoken.service_token_roles
  - keystone_authtoken.memcached_server
  - keystone_authtoken.memcache_security_strategy
   - keystone_authtoken.memcache_secret_key