### PR TITLE
mysql: Add support for HA provisioning with Galera

### DIFF
--- a/chef/cookbooks/database/libraries/crowbar.rb
+++ b/chef/cookbooks/database/libraries/crowbar.rb
@@ -10,7 +10,8 @@ module CrowbarDatabaseHelper
   end
 
   def self.get_listen_address(node)
-    if node[:database][:ha][:enabled]
+    # FIXME: temporarily do not expect there's any VIP for mysql database
+    if node[:database][:ha][:enabled] && node[:database][:sql_engine] != "mysql"
       vhostname = get_ha_vhostname(node)
       CrowbarPacemakerHelper.cluster_vip(node, "admin", vhostname)
     else

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -1,0 +1,144 @@
+#
+# Cookbook Name:: mysql
+# Recipe:: ha_galera
+#
+# Copyright 2017, SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+resource_agent = "ocf:heartbeat:galera"
+
+package "galera-3"
+
+unless node[:database][:galera_bootstrapped]
+  directory "/var/run/mysql/" do
+    owner "mysql"
+    group "root"
+    mode "0755"
+    action :create
+  end
+
+  execute "mysql_install_db" do
+    command "mysql_install_db"
+    action :run
+  end
+
+  crowbar_pacemaker_sync_mark "sync-database_after_install_db" do
+    revision node[:database]["crowbar-revision"]
+  end
+end
+
+# Wait for all nodes to reach this point so we know that all nodes will have
+# all the required packages installed before we create the pacemaker
+# resources
+crowbar_pacemaker_sync_mark "sync-database_before_ha" do
+  revision node[:database]["crowbar-revision"]
+end
+
+transaction_objects = []
+
+# Avoid races when creating pacemaker resources
+crowbar_pacemaker_sync_mark "wait-database_ha_resources" do
+  revision node[:database]["crowbar-revision"]
+end
+
+service_name = "galera"
+
+cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "database-server")
+nodes_names = cluster_nodes.map { |n| n[:hostname] }
+
+pacemaker_primitive service_name do
+  agent resource_agent
+  params({
+    "enable_creation" => true,
+    "wsrep_cluster_address" => "gcomm://" + nodes_names.join(","),
+    "check_user" => "''",
+    "socket" => "/var/run/mysql/mysql.sock"
+  })
+  op({
+    "monitor" => {
+      "interval" => "20s",
+      "role" => "Master"
+    }
+  })
+  action :update
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+transaction_objects.push("pacemaker_primitive[#{service_name}]")
+
+ms_name = "ms-#{service_name}"
+pacemaker_ms ms_name do
+  rsc service_name
+  meta(
+    "master-max" => nodes_names.size,
+    "ordered" => "false",
+    "interleave" => "false",
+    "notify" => "true"
+  )
+  action :update
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+transaction_objects.push("pacemaker_ms[#{ms_name}]")
+
+pacemaker_transaction "galera service" do
+  cib_objects transaction_objects
+  # note that this will also automatically start the resources
+  action :commit_new
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+crowbar_pacemaker_sync_mark "create-database_ha_resources" do
+  revision node[:database]["crowbar-revision"]
+end
+
+# The pacemaker galera resources agent will now bootstrap the cluster.
+# Which might take a while. Wait for that to complete by watching the
+# "wsrep_local_state_comment" status variable on all cluster nodes to reach
+# the "Synced" state, before continuing with the rest of the recipe.
+script "wait galera bootstrap" do
+  interpreter "bash"
+  code <<-EOH
+    sync_state=""
+    while [[ $sync_state != "Synced" ]]; do
+      sleep 1
+      sync_state=$(mysql -u "''" -N -B -e "SHOW STATUS WHERE Variable_name='wsrep_local_state_comment';" | cut -f 2)
+    done
+  EOH
+  not_if { node[:database][:galera_bootstrapped] }
+end
+
+ruby_block "mark node for galera bootstrap" do
+  block do
+    node.set[:database][:galera_bootstrapped] = true
+    node.save
+  end
+  not_if { node[:database][:galera_bootstrapped] }
+end
+
+crowbar_pacemaker_sync_mark "sync-database_boostrapped" do
+  revision node[:database]["crowbar-revision"]
+end
+
+execute "assign-root-password-galera" do
+  command "/usr/bin/mysqladmin -u root password \"#{node[:mysql][:server_root_password]}\""
+  action :run
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  only_if "/usr/bin/mysql -u root -e 'show databases;'"
+end
+
+crowbar_pacemaker_sync_mark "sync-database_root_password" do
+  revision node[:database]["crowbar-revision"]
+end

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+ha_enabled = node[:database][:ha][:enabled]
+
 include_recipe "mysql::client"
 
 if platform_family?("debian")
@@ -46,7 +48,6 @@ if platform_family?("debian")
     command "debconf-set-selections /var/cache/local/preseeding/mysql-server.seed"
     only_if "test -f /var/cache/local/preseeding/mysql-server.seed"
   end
-
 end
 
 # For Crowbar, we need to set the address to bind - default to admin node.
@@ -78,6 +79,7 @@ service "mysql" do
   end
   supports status: true, restart: true, reload: true
   action :enable
+  provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
 
 directory node[:mysql][:tmpdir] do
@@ -104,11 +106,18 @@ service mysql start
 EOC
 end
 
+cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "database-server")
+nodes_names = cluster_nodes.map { |n| n[:hostname] }
+cluster_addresses = "gcomm://" + nodes_names.join(",")
+
 template "/etc/my.cnf" do
   source "my.cnf.erb"
   owner "root"
   group "mysql"
   mode "0640"
+  variables(
+    cluster_addresses: cluster_addresses
+  )
   notifies :run, resources(script: "handle mysql restart"), :immediately if platform_family?("debian")
   notifies :restart, "service[mysql]", :immediately if platform_family?(%w{rhel suse fedora})
 end
@@ -122,9 +131,19 @@ unless Chef::Config[:solo]
   end
 end
 
+if ha_enabled
+  log "HA support for mysql is enabled"
+  include_recipe "mysql::ha_galera"
+else
+  log "HA support for mysql is disabled"
+end
+
+server_root_password = node[:mysql][:server_root_password]
+
 execute "assign-root-password" do
-  command "/usr/bin/mysqladmin -u root password \"#{node["mysql"]["server_root_password"]}\""
+  command "/usr/bin/mysqladmin -u root password \"#{server_root_password}\""
   action :run
+  not_if { ha_enabled } # password already set as part of the ha bootstrap
   only_if "/usr/bin/mysql -u root -e 'show databases;'"
 end
 
@@ -162,9 +181,10 @@ directory "/var/run/mysqld/" do
 end
 
 execute "mysql-install-privileges" do
-  command "/usr/bin/mysql -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }#{node['mysql']['server_root_password']} < #{grants_path}"
+  command "/usr/bin/mysql -u root -p\"#{server_root_password}\" < #{grants_path}"
   action :nothing
   subscribes :run, resources("template[#{grants_path}]"), :immediately
+  only_if "/usr/bin/mysql -u root -p\"#{server_root_password}\" -e 'show databases;'"
 end
 
 file grants_path do

--- a/chef/cookbooks/mysql/templates/default/my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/my.cnf.erb
@@ -52,6 +52,17 @@ datadir                = <%= node['mysql']['datadir'] %>
 tmpdir                 = <%= node['mysql']['tmpdir'] %>
 skip-external-locking
 
+<% if node[:database][:ha][:enabled] %>
+# GALERA
+
+wsrep_provider=/usr/lib64/galera-3/libgalera_smm.so
+wsrep_cluster_address="<%= @cluster_addresses %>"
+innodb_autoinc_lock_mode=2
+innodb_doublewrite=1
+query_cache_size=0
+wsrep_on=ON
+binlog_format=ROW
+<% end %>
 #
 # * Storage Engines
 #

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -60,6 +60,56 @@ class DatabaseService < PacemakerServiceObject
     base
   end
 
+  def validate_ha_attributes(attributes, cluster)
+    storage_mode = attributes["ha"]["storage"]["mode"]
+    role = available_clusters[cluster]
+
+    case attributes["sql_engine"]
+    when "postgresql"
+      unless ["shared", "drbd"].include?(storage_mode)
+        validation_error I18n.t(
+          "barclamp.#{@bc_name}.validation.unknown_mode_ha",
+          storage_mode: storage_mode
+        )
+      end
+      if storage_mode == "shared"
+        if attributes["ha"]["storage"]["shared"]["device"].blank?
+          validation_error I18n.t(
+            "barclamp.#{@bc_name}.validation.no_device"
+          )
+        end
+        if attributes["ha"]["storage"]["shared"]["fstype"].blank?
+          validation_error I18n.t(
+            "barclamp.#{@bc_name}.validation.no_filesystem"
+          )
+        end
+      elsif storage_mode == "drbd"
+        unless role.default_attributes["pacemaker"]["drbd"]["enabled"]
+          validation_error I18n.t(
+            "barclamp.#{@bc_name}.validation.drbd_not_enabled",
+            cluster_name: cluster_name(cluster)
+          )
+        end
+        if attributes["ha"]["storage"]["drbd"]["size"] <= 0
+          validation_error I18n.t(
+            "barclamp.#{@bc_name}.validation.invalid_size_drbd"
+          )
+        end
+      end
+    when "mysql"
+      nodes = PacemakerServiceObject.expand_nodes(cluster) || []
+      if nodes.size == 1
+        validation_error I18n.t(
+          "barclamp.#{@bc_name}.validation.cluster_size_one"
+        )
+      elsif nodes.size.even?
+        validation_error I18n.t(
+          "barclamp.#{@bc_name}.validation.cluster_size_even"
+        )
+      end
+    end
+  end
+
   def validate_proposal_after_save(proposal)
     validate_one_for_role proposal, "database-server"
 
@@ -73,34 +123,8 @@ class DatabaseService < PacemakerServiceObject
     # HA validation
     servers = proposal["deployment"][@bc_name]["elements"]["database-server"]
     unless servers.nil? || servers.first.nil? || !is_cluster?(servers.first)
-      validation_error I18n.t(
-        "barclamp.#{@bc_name}.validation.ha_postgresql"
-      ) unless db_engine == "postgresql"
-
-      storage_mode = attributes["ha"]["storage"]["mode"]
-      validation_error I18n.t(
-        "barclamp.#{@bc_name}.validation.unknown_mode_ha",
-        storage_mode: storage_mode
-      ) unless %w(shared drbd).include?(storage_mode)
-
-      if storage_mode == "shared"
-        validation_error I18n.t(
-          "barclamp.#{@bc_name}.validation.no_device"
-        ) if attributes["ha"]["storage"]["shared"]["device"].blank?
-        validation_error I18n.t(
-          "barclamp.#{@bc_name}.validation.no_filesystem"
-        ) if attributes["ha"]["storage"]["shared"]["fstype"].blank?
-      elsif storage_mode == "drbd"
-        cluster = servers.first
-        role = available_clusters[cluster]
-        validation_error I18n.t(
-          "barclamp.#{@bc_name}.validation.drbd_not_enabled",
-          cluster_name: cluster_name(cluster)
-        ) unless role.default_attributes["pacemaker"]["drbd"]["enabled"]
-        validation_error I18n.t(
-          "barclamp.#{@bc_name}.validation.invalid_size_drbd"
-        ) if attributes["ha"]["storage"]["drbd"]["size"] <= 0
-      end
+      cluster = servers.first
+      validate_ha_attributes(attributes, cluster)
     end
 
     super

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -45,9 +45,10 @@ en:
               options: 'Mount Options'
       validation:
         invalid_db_engine: 'Invalid database engine: %{db_engine}.'
-        ha_postgresql: 'High availability support is only available for PostgreSQL.'
         unknown_mode_ha: 'Unknown mode for HA storage: %{storage_mode}.'
         no_device: 'No device specified for shared storage.'
         no_filesystem: 'No filesystem type specified for shared storage.'
         drbd_not_enabled: 'DRBD is not enabled for cluster %{cluster_name}.'
         invalid_size_drbd: 'Invalid size for DRBD device.'
+        cluster_size_one: 'The Galera cluster needs more than one cluster member.'
+        cluster_size_even: 'The Galera cluster needs an odd number of cluster members and at least three of them.'


### PR DESCRIPTION
Add a ha_galera recipe that will install Galera on a cluster. It will
create Pacemaker resources for bootstrapping and monitoring the cluster,
with other support sprinkled into the mysql::server recipe.

A current limitation of the configuration it creates is, that it relies
on the passwordless user "''@'localhost'" for monitoring the local
cluster node.

Remove limitation that only PostgreSQL can be deployed in a HA fashion.

Co-Authored-By: Ralf Haferkamp <rhafer@suse.de>
Co-Authored-By: Jiří Suchomel <jiri.suchomel@suse.com>