### PR TITLE
Ironic neutron decouple + HA fixes

### DIFF
--- a/chef/cookbooks/ironic/attributes/default.rb
+++ b/chef/cookbooks/ironic/attributes/default.rb
@@ -21,7 +21,8 @@ when "rhel", "suse"
       "openstack-ironic-api",
       "openstack-ironic-conductor",
       "python-ironicclient",
-      "python-openstackclient"
+      "python-openstackclient",
+      "qemu-tools"
     ],
     services: [
       "openstack-ironic-api",
@@ -41,7 +42,8 @@ when "debian"
       "ironic-api",
       "ironic-conductor",
       "python-ironicclient",
-      "python-openstackclient"
+      "python-openstackclient",
+      "qemu-utils"
     ],
     services: [
       "ironic-api",

--- a/chef/cookbooks/ironic/libraries/helpers.rb
+++ b/chef/cookbooks/ironic/libraries/helpers.rb
@@ -51,7 +51,12 @@ module IronicHelper
       tempurl_key = Mixlib::ShellOut.new(get_tempurl_key).run_command.stdout.chomp
 
       # use IP as this will be used by agent which can have no DNS configured
-      swift_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(swift, "public").address
+      if swift[:swift][:ha][:enabled]
+        cluster_vhostname = CrowbarPacemakerHelper.cluster_vhostname(swift)
+        swift_address = CrowbarPacemakerHelper.cluster_vip(swift, "admin", cluster_vhostname)
+      else
+        swift_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(swift, "admin").address
+      end
 
       {
         tempurl_key: tempurl_key,

--- a/chef/cookbooks/ironic/libraries/helpers.rb
+++ b/chef/cookbooks/ironic/libraries/helpers.rb
@@ -1,0 +1,71 @@
+# Copyright 2017 SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module IronicHelper
+  class << self
+    def auth_url(keystone_settings)
+      "#{keystone_settings["protocol"]}://"\
+      "#{keystone_settings["internal_url_host"]}:"\
+      "#{keystone_settings["service_port"]}/v3"
+    end
+
+    def openstack_command(keystone_settings)
+      insecure = keystone_settings["insecure"] ? "--insecure" : ""
+      "openstack --os-username #{keystone_settings["admin_user"]}"\
+      " --os-auth-type password --os-identity-api-version 3"\
+      " --os-password #{keystone_settings["admin_password"]}"\
+      " --os-tenant-name #{keystone_settings["admin_tenant"]}"\
+      " --os-auth-url #{auth_url(keystone_settings)} #{insecure}"
+    end
+
+    def swift_settings(node, glance)
+      swift = CrowbarUtilsSearch.node_search_with_cache(node, "roles:swift-proxy").first || {}
+      # configure swift only if some agent_* drivers are enabled
+      return unless swift && node[:ironic][:enabled_drivers].any? { |d| d.start_with?("agent_") }
+
+      glance_keystone_settings = KeystoneHelper.keystone_settings(glance, "glance")
+
+      swift_command = "swift --os-username #{glance_keystone_settings["service_user"]}"
+      swift_command << " --os-password #{glance_keystone_settings["service_password"]}"
+      swift_command << " --os-tenant-name #{glance_keystone_settings["service_tenant"]}"
+      swift_command << " --os-identity-api-version 3"
+      swift_command << " --os-auth-url #{auth_url(glance_keystone_settings)}"
+      swift_command << (swift[:swift][:ssl][:insecure] ? " --insecure" : "")
+
+      get_glance_account = "#{swift_command} stat | grep -m1 Account: | awk '{print $2}'"
+      glance_account = Mixlib::ShellOut.new(get_glance_account).run_command.stdout.chomp
+
+      get_tempurl_key = "#{swift_command} stat | grep -m1 'Meta Temp-Url-Key:' | awk '{print $3}'"
+      tempurl_key = Mixlib::ShellOut.new(get_tempurl_key).run_command.stdout.chomp
+
+      # use IP as this will be used by agent which can have no DNS configured
+      swift_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(swift, "public").address
+
+      {
+        tempurl_key: tempurl_key,
+        glance_container: glance[:glance][:swift][:store_container],
+        glance_account: glance_account,
+        protocol: swift[:swift][:ssl][:enabled] ? "https" : "http",
+        host: swift_address,
+        port: swift[:swift][:ports][:proxy]
+      }
+    end
+
+    def ironic_net_id(keystone_settings)
+      cmd = "#{openstack_command(keystone_settings)} network show ironic -f value -c id"
+      Mixlib::ShellOut.new(cmd).run_command.stdout.chomp
+    end
+  end
+end

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -158,70 +158,32 @@ keystone_register "give ironic user admin role in service tenant" do
   action :add_access
 end
 
-insecure = keystone_settings["insecure"] ? "--insecure" : ""
-auth_url = "#{keystone_settings["protocol"]}://"\
-           "#{keystone_settings["internal_url_host"]}:"\
-           "#{keystone_settings["service_port"]}/v3"
-
-openstack_command = "openstack --os-username #{keystone_settings["admin_user"]}"
-openstack_command << " --os-auth-type password --os-identity-api-version 3"
-openstack_command << " --os-password #{keystone_settings["admin_password"]}"
-openstack_command << " --os-tenant-name #{keystone_settings["admin_tenant"]}"
-openstack_command << " --os-auth-url #{auth_url} #{insecure}"
-
-get_ironic_net_id = "#{openstack_command} network show ironic -f value -c id"
-ironic_net_id = Mixlib::ShellOut.new(get_ironic_net_id).run_command.stdout.chomp
-
-swift = search(:node, "roles:swift-proxy").first || {}
-# configure swift only if some agent_* drivers are enabled
-if swift && node[:ironic][:enabled_drivers].any? { |d| d.start_with?("agent_") }
-  glance_keystone_settings = KeystoneHelper.keystone_settings(glance, "glance")
-
-  swift_command = "swift --os-username #{glance_keystone_settings["service_user"]}"
-  swift_command << " --os-password #{glance_keystone_settings["service_password"]}"
-  swift_command << " --os-tenant-name #{glance_keystone_settings["service_tenant"]}"
-  swift_command << " --os-identity-api-version 3 --os-auth-url #{auth_url}"
-  swift_command << (swift[:swift][:ssl][:insecure] ? " --insecure" : "")
-
-  get_glance_account = "#{swift_command} stat | grep -m1 Account: | awk '{print $2}'"
-  glance_account = Mixlib::ShellOut.new(get_glance_account).run_command.stdout.chomp
-
-  get_tempurl_key = "#{swift_command} stat | grep -m1 'Meta Temp-Url-Key:' | awk '{print $3}'"
-  tempurl_key = Mixlib::ShellOut.new(get_tempurl_key).run_command.stdout.chomp
-
-  # use IP as this will be used by agent which can have no DNS configured
-  swift_address = Barclamp::Inventory.get_network_by_type(swift, "public").address
-
-  swift_settings = { tempurl_key: tempurl_key,
-                     glance_container: glance[:glance][:swift][:store_container],
-                     glance_account: glance_account,
-                     protocol: swift[:swift][:ssl][:enabled] ? "https" : "http",
-                     host: swift_address,
-                     port: swift[:swift][:ports][:proxy] }
-end
-
 template node[:ironic][:config_file] do
   source "ironic.conf.erb"
   owner "root"
   group node[:ironic][:group]
   mode "0640"
   variables(
-    automated_clean: node[:ironic][:automated_clean],
-    drivers: node[:ironic][:enabled_drivers],
-    debug: node[:ironic][:debug],
-    rabbit_settings: fetch_rabbitmq_settings,
-    keystone_settings: keystone_settings,
-    glance_settings: glance_settings,
-    swift_settings: swift_settings,
-    neutron_settings: neutron_settings,
-    database_connection: db_connection,
-    ironic_net_id: ironic_net_id,
-    ironic_ip: ironic_net_ip,
-    tftp_ip: ironic_net_ip,
-    tftproot: node[:ironic][:tftproot],
-    public_endpoint: public_endpoint,
-    api_port: api_port,
-    auth_version: auth_version
+    lazy {
+      {
+        automated_clean: node[:ironic][:automated_clean],
+        drivers: node[:ironic][:enabled_drivers],
+        debug: node[:ironic][:debug],
+        rabbit_settings: fetch_rabbitmq_settings,
+        keystone_settings: keystone_settings,
+        glance_settings: glance_settings,
+        swift_settings: IronicHelper.swift_settings(node, glance),
+        neutron_settings: neutron_settings,
+        database_connection: db_connection,
+        ironic_net_id: IronicHelper.ironic_net_id(keystone_settings),
+        ironic_ip: ironic_net_ip,
+        tftp_ip: ironic_net_ip,
+        tftproot: node[:ironic][:tftproot],
+        public_endpoint: public_endpoint,
+        api_port: api_port,
+        auth_version: auth_version
+      }
+    }
   )
 end
 

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -23,6 +23,8 @@ else
   nova_compute_ha_enabled = false
 end
 
+ironic_net = Barclamp::Inventory.get_network_definition(node, "ironic")
+
 # Disable rp_filter
 ruby_block "edit /etc/sysctl.conf for rp_filter" do
   block do
@@ -189,7 +191,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       end
     end
 
-    if (node.roles & ["ironic-server", "nova-compute-ironic"]).any?
+    if (node.roles & ["ironic-server", "nova-compute-ironic"]).any? ||
+        (ironic_net && node.roles.include?("neutron-network"))
       bridge_mappings.push("ironic:br-ironic")
     end
 

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -134,6 +134,8 @@ tenant_network_types = [[node[:neutron][:ml2_type_drivers_default_tenant_network
 
 interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
 
+ironic_net = Barclamp::Inventory.get_network_definition(node, "ironic")
+
 case node[:neutron][:networking_plugin]
 when "ml2"
   # Find out which physical interfaces we need to define in the config (depends
@@ -141,8 +143,8 @@ when "ml2"
   # with "nova_fixed".
   external_networks = ["nova_floating"]
 
-  # add ironic to external_networks if ironic-server role is on current node
-  external_networks << "ironic" if node.roles.include?("ironic-server")
+  # add ironic to external_networks if ironic network is configured
+  external_networks << "ironic" if ironic_net
 
   external_networks.concat(node[:neutron][:additional_external_networks])
   network_node = NeutronHelper.get_network_node_from_neutron_attributes(node)

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -270,12 +270,12 @@ if ironic_servers.any? && (node["roles"] & ["nova-compute-ironic", "nova-control
   ironic_settings[:keystone_version] = "v2.0"
   ironic_settings[:api_protocol] = ironic_node[:ironic][:api][:protocol]
   ironic_settings[:api_port] = ironic_node[:ironic][:api][:port]
-  ironic_settings[:service_user] = ironic_node[:ironic][:service_user]
-  ironic_settings[:service_password] = ironic_node[:ironic][:service_password]
-  ironic_settings[:public_host] = CrowbarHelper.get_host_for_public_url(
+  ironic_settings[:api_host] = CrowbarHelper.get_host_for_admin_url(
     ironic_node,
     ironic_settings[:api_protocol] == "https"
   )
+  ironic_settings[:service_user] = ironic_node[:ironic][:service_user]
+  ironic_settings[:service_password] = ironic_node[:ironic][:service_password]
   reserved_host_memory = 0
 else
   use_baremetal_filters = false

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -6,7 +6,7 @@ key = <%= @vncproxy_key_file %>
 instance_name_template=zvm%05x
 <% end %>
 my_ip = <%= node[:nova][:my_ip] %>
-<% if @libvirt_type.eql?('ironic') %>scheduler_host_manager = ironic_host_manager<% end %>
+<% unless @ironic_settings.nil? %>scheduler_host_manager = ironic_host_manager<% end %>
 notify_on_state_change = vm_and_task_state
 state_path = /var/lib/nova
 enabled_ssl_apis = <%= @ssl_enabled ? "osapi_compute,metadata" : "" %>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -145,6 +145,8 @@ protocol = <%= @glance_server_protocol %>
 
 <% unless @ironic_settings.nil? -%>
 [ironic]
+# temporary workaround for nova using public ironic endpoint (this will be deprecated in Queens)
+api_endpoint = <%= @ironic_settings[:api_protocol] %>://<%= @ironic_settings[:api_host] %>:<%= @ironic_settings[:api_port] %>
 auth_type = password
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 username = <%= @ironic_settings[:service_user] %>

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -494,6 +494,12 @@ class NeutronService < OpenstackServiceObject
           node.save
         end
       end
+
+      # enable ironic interface as preparation for ironic deployment
+      network_proposal = Proposal.find_by(barclamp: net_svc.bc_name, name: "default")
+      unless network_proposal["attributes"]["network"]["networks"]["ironic"].nil?
+        net_svc.enable_interface "default", "ironic", nodename
+      end
     elsif attributes["networking_plugin"] == "vmware"
       net_svc.allocate_ip "default", "os_sdn", "host", node
     end


### PR DESCRIPTION
This set of changes will enable deployment of ironic on non-neutron nodes. Also some old bugs with ironic deployment in HA clouds were fixed.

NOTE: these changes might possibly fix flapping status of CI jobs for ironic (looks like a race condition).
~~NOTE2: unfortunately the bug is still there after this change :o(~~
~~NOTE3: last commit is another attempt to fix this bug... looks promising~~