### PR TITLE
migrations: fix databag migrations

### DIFF
--- a/chef/data_bags/crowbar/migrate/glance/201_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/glance/201_fill_databag_with_insecure.rb
@@ -8,7 +8,7 @@ def upgrade(ta, td, a, d)
   # Find the role, get all the values and save the databag
   role = RoleObject.find_role_by_name("glance-config-default")
   config = {
-    insecure: a[:ssl][:insecure]
+    insecure: a["ssl"]["insecure"]
   }
   # as we dont have an old_role here, we just pass the role twice, wont affect anything
   # as the instance_from_role method has an || to use any of those (old_role or role)

--- a/chef/data_bags/crowbar/migrate/heat/200_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/heat/200_fill_databag_with_insecure.rb
@@ -8,7 +8,7 @@ def upgrade(ta, td, a, d)
   # Find the role, get all the values and save the databag
   role = RoleObject.find_role_by_name("heat-config-default")
   config = {
-    insecure: a[:ssl][:insecure]
+    insecure: a["ssl"]["insecure"]
   }
   # as we dont have an old_role here, we just pass the role twice, wont affect anything
   # as the instance_from_role method has an || to use any of those (old_role or role)

--- a/chef/data_bags/crowbar/migrate/neutron/203_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/203_fill_databag_with_insecure.rb
@@ -8,7 +8,7 @@ def upgrade(ta, td, a, d)
   # Find the role, get all the values and save the databag
   role = RoleObject.find_role_by_name("neutron-config-default")
   config = {
-    insecure: a[:ssl][:insecure]
+    insecure: a["ssl"]["insecure"]
   }
   # as we dont have an old_role here, we just pass the role twice, wont affect anything
   # as the instance_from_role method has an || to use any of those (old_role or role)

--- a/chef/data_bags/crowbar/migrate/nova/203_fill_databag_with_insecure.rb
+++ b/chef/data_bags/crowbar/migrate/nova/203_fill_databag_with_insecure.rb
@@ -8,7 +8,7 @@ def upgrade(ta, td, a, d)
   # Find the role, get all the values and save the databag
   role = RoleObject.find_role_by_name("nova-config-default")
   config = {
-    insecure: a[:ssl][:insecure]
+    insecure: a["ssl"]["insecure"]
   }
   # as we dont have an old_role here, we just pass the role twice, wont affect anything
   # as the instance_from_role method has an || to use any of those (old_role or role)

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -163,7 +163,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],


### PR DESCRIPTION
Looks like during the upgrade, the templates being passed
to the upgrade method contains all values in strings and we
were trying to access them by symbol instead.

Also fixes a nova migration numbering issue.