### PR TITLE
glance,nova: remove leftover 'verbose' custom view attr

### DIFF
--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -76,8 +76,3 @@
         %span.help-block
           = t('.crossdomain.cross_domain_hosts_hint')
         = array_string_field %w(crossdomain cross_domain_hosts),  :only_comma => true
-
-    %fieldset
-      %legend
-        = t(".logging_header")
-      = boolean_field :verbose

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -116,8 +116,3 @@
 
         = string_field %w(novnc ssl certfile)
         = string_field %w(novnc ssl keyfile)
-
-    %fieldset
-      %legend
-        = t(".logging_header")
-      = boolean_field :verbose

--- a/crowbar_framework/config/locales/glance/en.yml
+++ b/crowbar_framework/config/locales/glance/en.yml
@@ -58,8 +58,6 @@ en:
         cache_header: 'Caching'
         enable_caching: 'Enable Caching'
         use_cachemanagement: 'Turn On Cache Management'
-        logging_header: 'Logging'
-        verbose: 'Verbose Logging'
         crossdomain:
           header: 'Cross-domain'
           enabled: 'Enabled'

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -80,8 +80,6 @@ en:
             enabled: 'NoVNC Protocol'
             certfile: 'SSL Certificate File'
             keyfile: 'SSL (Private) Key File'
-        logging_header: 'Logging'
-        verbose: 'Verbose Logging'
         ec2-api_header: 'EC2API Configuration'
         ec2-api:
           ssl_header: 'SSL Support'


### PR DESCRIPTION
Removes the deprecated 'verbose' attribute from the custom view, left over from two previous PRs that removed the 'verbose' attribute from the glance (#1069) and nova (#1091) cookbooks.
