### PR TITLE
testing: use knife to check syntax of cookbooks

### DIFF
--- a/.knife-test.rb
+++ b/.knife-test.rb
@@ -1,0 +1,5 @@
+# knife config file for travis-ci jobs that require knife
+# set a dir for the cache in the HOME dir or it will try to write to /var/chef
+cache_type "BasicFile"
+cache_options(:path => "#{ENV['HOME']}/.chef/checksums")
+cookbook_path "chef/cookbooks/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,10 @@ cache: bundler
 dist: trusty
 
 rvm: 2.1.9
+
+matrix:
+  include:
+    - script:
+      - bundle exec rake
+    - script:
+      - bundle exec knife cookbook test -c .knife-test.rb -a

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development do
   gem "sprockets-standalone", "~> 1.2.1"
   gem "sprockets", "~> 2.11.0"
   gem "rspec", "~> 3.1.0"
+  gem "chef", "~> 10.32.2"
 end
 
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"


### PR DESCRIPTION
Use the installed knife command to check for cookbook syntax.
This will catch ruby issues on the cookbooks and also
template issues that we are not checking right now