### PR TITLE
magnum: update config to Ocata release

### DIFF
--- a/chef/cookbooks/magnum/metadata.rb
+++ b/chef/cookbooks/magnum/metadata.rb
@@ -8,6 +8,7 @@ version "0.1"
 
 depends "database"
 depends "keystone"
+depends "memcached"
 depends "nova"
 depends "heat"
 depends "glance"

--- a/chef/cookbooks/magnum/recipes/common.rb
+++ b/chef/cookbooks/magnum/recipes/common.rb
@@ -19,6 +19,13 @@ package "openstack-magnum"
 db_settings = fetch_database_settings
 network_settings = MagnumHelper.network_settings(node)
 
+ha_enabled = node[:magnum][:ha][:enabled]
+
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "magnum-server") : [node]
+)
+memcached_instance("magnum-server")
+
 include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
@@ -48,5 +55,6 @@ template node[:magnum][:config_file] do
     sql_connection: sql_connection,
     rabbit_settings: fetch_rabbitmq_settings,
     keystone_settings: KeystoneHelper.keystone_settings(node, :magnum),
+    memcached_servers: memcached_servers
   )
 end

--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -49,11 +49,15 @@ auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 username = <%= @keystone_settings['service_user'] %>
 password = <%= @keystone_settings['service_password'] %>
-insecure = <%= @keystone_settings['insecure'] %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
 project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_type = password
+memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:magnum][:memcache_secret_key] %>
+service_token_roles_required = true
+service_token_roles = admin
 
 [magnum_client]
 region_name = <%= @keystone_settings['endpoint_region'] %>
@@ -87,4 +91,5 @@ cluster_user_trust = <%= @trustee["cluster_user_trust"] %>
 trustee_domain_id = <%= @trustee["domain_id"] %>
 trustee_domain_admin_id = <%= @trustee["domain_admin_id"] %>
 trustee_domain_admin_password = <%= @trustee["domain_admin_password"] %>
+trustee_keystone_interface = <%= @trustee["keystone_interface"] %>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/data_bags/crowbar/migrate/magnum/200_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/magnum/200_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/magnum/201_add_trustee_keystone_interface.rb
+++ b/chef/data_bags/crowbar/migrate/magnum/201_add_trustee_keystone_interface.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a["trustee"].key?("keystone_interface")
+    a["trustee"]["keystone_interface"] = ta["trustee"]["keystone_interface"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["trustee"].key?("keystone_interface")
+    a["trustee"].delete("keystone_interface")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-magnum.json
+++ b/chef/data_bags/crowbar/template-magnum.json
@@ -14,11 +14,13 @@
       "rabbitmq_instance": "none",
       "service_user": "magnum",
       "service_password": "",
+      "memcache_secret_key": "",
       "trustee": {
           "cluster_user_trust": false,
           "domain_name": "magnum",
           "domain_admin_name": "magnum_domain_admin",
-          "domain_admin_password": ""
+          "domain_admin_password": "",
+          "keystone_interface": "public"
       },
       "api": {
         "protocol": "http",
@@ -39,7 +41,7 @@
     "magnum": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 201,
       "element_states": {
         "magnum-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-magnum.schema
+++ b/chef/data_bags/crowbar/template-magnum.schema
@@ -23,12 +23,14 @@
             "rabbitmq_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
+            "memcache_secret_key": { "type": "str", "required": true },
             "trustee": {
               "type": "map", "required": true, "mapping": {
                 "cluster_user_trust": { "type" : "bool", "required" : true },
                 "domain_name": { "type" : "str", "required" : true },
                 "domain_admin_name": { "type": "str", "required": true },
-                "domain_admin_password": { "type": "str", "required": true }
+                "domain_admin_password": { "type": "str", "required": true },
+                "keystone_interface": { "type": "str", "required": true }
               }
             },
             "api": {

--- a/crowbar_framework/app/models/magnum_service.rb
+++ b/crowbar_framework/app/models/magnum_service.rb
@@ -84,6 +84,7 @@ class MagnumService < OpenstackServiceObject
       find_dep_proposal("heat")
 
     base["attributes"][@bc_name]["service_password"] = random_password
+    base["attributes"][@bc_name]["memcache_secret_key"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
     base["attributes"][@bc_name][:trustee][:domain_admin_password] = random_password
 


### PR DESCRIPTION
Added following new feature config option:
* Add trustee: keystone_interface
  Makes Keystone URL, used by Cluster Template instances, configurable

Replace keystone middleware, as in-process token cache, with memcache:
* Add [keystone_authtoken]/service_token_roles_required = ture
  Allows fetching expired token based on valid service token
* Add [keystone_authtoken]/service_token_roles = admin
  Service will request for token playing admin role
* Add memcached_servers cluster for magnum service
* Add memcache_security_strategy = ENCRYPT
* Add memcache_secret_key

References:
* Ocata release notes for magnum: https://docs.openstack.org/releasenotes/magnum/ocata.html
* Ocata release notes for keystonemiddleware: https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html
* Mitaka release notes for keystonemiddleware: https://docs.openstack.org/releasenotes/keystonemiddleware/mitaka
* memcached protection option: https://docs.openstack.org/keystonemiddleware/latest/middlewarearchitecture.html#memcache-protection