### PR TITLE
[4.0] ec2-api: allow a single ec2-api node or cluster

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -97,7 +97,7 @@ class NovaService < OpenstackServiceObject
         },
         "ec2-api" => {
           "unique" => false,
-          "count" => -1,
+          "count" => 1,
           "exclude_platform" => {
             "suse" => "< 12.2",
             "windows" => "/.*/"


### PR DESCRIPTION
Fix the previous behaviour of allowing more than
one node or cluster to have the 'ec2-api' role
in the nova barclamp.

(backport of #1138)