### PR TITLE
[4.0] keystone: fix ha race condition during default objects creation

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -547,6 +547,11 @@ if node[:keystone][:signing][:token_format] == "fernet"
   crowbar_pacemaker_sync_mark "create-keystone_fernet_rotate" if ha_enabled
 end
 
+# Wait for all nodes to reach this point so we know that all nodes will have
+# all the required services correctly configured and running before we create
+# the keystone resources
+crowbar_pacemaker_sync_mark "sync-keystone_before_register" if ha_enabled
+
 crowbar_pacemaker_sync_mark "wait-keystone_register" if ha_enabled
 
 keystone_insecure = node["keystone"]["api"]["protocol"] == "https" && node[:keystone][:ssl][:insecure]
@@ -641,6 +646,7 @@ end
     auth register_auth_hash
     tenant_name tenant
     action :add_tenant
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end
 
@@ -654,6 +660,7 @@ if node[:keystone][:domain_specific_drivers]
       auth register_auth_hash
       domain_name domain
       action :add_domain
+      only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
     end
   end
 end
@@ -669,6 +676,7 @@ keystone_register "add default admin role for domain default" do
   role_name "admin"
   domain_name "Default"
   action :add_domain_role
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # Create default user
@@ -683,6 +691,7 @@ if node[:keystone][:default][:create_user]
     user_password node[:keystone][:default][:password]
     tenant_name node[:keystone][:default][:tenant]
     action :add_user
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end
 
@@ -695,6 +704,7 @@ keystone_register "add default Member role" do
   auth register_auth_hash
   role_name "Member"
   action :add_role
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # Create Access info
@@ -716,6 +726,7 @@ user_roles.each do |args|
     role_name args[1]
     tenant_name args[2]
     action :add_access
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end
 
@@ -737,6 +748,7 @@ ec2_creds.each do |args|
     user_name args[0]
     tenant_name args[1]
     action :add_ec2
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end
 


### PR DESCRIPTION
During the deployment of the keystone barclamp on an
HA cluster, it was observed that the apache service was
being restarted on a controller node (due to a delayed
reload action) while on another controller node the
default users/tenants/domains/etc. were being created.
This caused the second node to fail deploying the barclamp,
because there was a small time window during which the
keystone WSGI entry points on one of the controller nodes
could not be accessed.

This commit fixes this problem by ensuring two things:
   - the default users/roles/domains/etc. are only created
   by the cluster founder node
   - an additional synchronization marker is used at the
     beginning of the section that creates the keystone
     objects to ensure that keystone services are properly
     configured and running on all controller nodes *before*
     the founder node creates them

NOTE: another synchronization marker is not required to avoid
running delayed actions (e.g. like restarting the apache
service) on any of the controller nodes while the founder
node creates the default objects because a wait/create
synchronization section is already present

(backport of #1125)