### PR TITLE
nova: move leftover ec2-api attributes to ec2-api cookbook

### DIFF
--- a/chef/cookbooks/ec2-api/attributes/default.rb
+++ b/chef/cookbooks/ec2-api/attributes/default.rb
@@ -31,3 +31,11 @@ default[:nova]["ec2-api"][:ssl][:generate_certs] = false
 default[:nova]["ec2-api"][:ssl][:insecure] = false
 default[:nova]["ec2-api"][:ssl][:cert_required] = false
 default[:nova]["ec2-api"][:ssl][:ca_certs] = "/etc/ec2api/ssl/certs/ca.pem"
+
+default[:nova]["ec2-api"][:ports][:ec2_api] = 8788
+default[:nova]["ec2-api"][:ports][:ec2_metadata] = 8789
+default[:nova]["ec2-api"][:ports][:ec2_s3] = 3334
+
+default[:nova]["ec2-api"][:ha][:ports][:ec2_api] = 5557
+default[:nova]["ec2-api"][:ha][:ports][:ec2_metadata] = 5558
+default[:nova]["ec2-api"][:ha][:ports][:ec2_s3] = 5559

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -26,18 +26,18 @@ ha_enabled  = node[:nova]["ec2-api"][:ha][:enabled]
 ssl_enabled = node[:nova]["ec2-api"][:ssl][:enabled]
 api_protocol = ssl_enabled ? "https" : "http"
 db_settings = fetch_database_settings "nova"
-ec2_api_port = node[:nova][:ports][:ec2_api]
-ec2_metadata_port = node[:nova][:ports][:ec2_metadata]
+ec2_api_port = node[:nova]["ec2-api"][:ports][:ec2_api]
+ec2_metadata_port = node[:nova]["ec2-api"][:ports][:ec2_metadata]
 if ha_enabled
   bind_host = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  bind_port_ec2api = node[:nova][:ha][:ports][:ec2_api]
-  bind_port_metadata = node[:nova][:ha][:ports][:ec2_metadata]
-  bind_port_s3 = node[:nova][:ha][:ports][:ec2_s3]
+  bind_port_ec2api = node[:nova]["ec2-api"][:ha][:ports][:ec2_api]
+  bind_port_metadata = node[:nova]["ec2-api"][:ha][:ports][:ec2_metadata]
+  bind_port_s3 = node[:nova]["ec2-api"][:ha][:ports][:ec2_s3]
 else
   bind_host = "0.0.0.0"
-  bind_port_ec2api = node[:nova][:ports][:ec2_api]
-  bind_port_metadata = node[:nova][:ports][:ec2_metadata]
-  bind_port_s3 = node[:nova][:ports][:ec2_s3]
+  bind_port_ec2api = node[:nova]["ec2-api"][:ports][:ec2_api]
+  bind_port_metadata = node[:nova]["ec2-api"][:ports][:ec2_metadata]
+  bind_port_s3 = node[:nova]["ec2-api"][:ports][:ec2_s3]
 end
 
 db_conn_scheme = db_settings[:url_scheme]

--- a/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api_ha.rb
@@ -17,7 +17,7 @@ include_recipe "crowbar-pacemaker::haproxy"
 
 haproxy_loadbalancer "ec2-api" do
   address "0.0.0.0"
-  port node[:nova][:ports][:ec2_api]
+  port node[:nova]["ec2-api"][:ports][:ec2_api]
   use_ssl node[:nova]["ec2-api"][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(
     node, "nova", "ec2-api", "ec2_api"
@@ -27,7 +27,7 @@ end.run_action(:create)
 
 haproxy_loadbalancer "ec2-metadata" do
   address "0.0.0.0"
-  port node[:nova][:ports][:ec2_metadata]
+  port node[:nova]["ec2-api"][:ports][:ec2_metadata]
   use_ssl node[:nova]["ec2-api"][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(
     node, "nova", "ec2-api", "ec2_metadata"
@@ -37,7 +37,7 @@ end.run_action(:create)
 
 haproxy_loadbalancer "ec2-s3" do
   address "0.0.0.0"
-  port node[:nova][:ports][:ec2_s3]
+  port node[:nova]["ec2-api"][:ports][:ec2_s3]
   use_ssl node[:nova]["ec2-api"][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(
     node, "nova", "ec2-api", "ec2_s3"

--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -141,16 +141,6 @@ default[:nova][:ports][:serialproxy] = 6083
 default[:nova][:ha][:enabled] = false
 default[:nova][:ha][:op][:monitor][:interval] = "10s"
 
-# EC2 Role Attributes
-default[:nova][:ports][:ec2_api] = 8788
-default[:nova][:ports][:ec2_metadata] = 8789
-default[:nova][:ports][:ec2_s3] = 3334
-
-# EC2 Role HA Ports
-default[:nova][:ha][:ports][:ec2_api] = 5557
-default[:nova][:ha][:ports][:ec2_metadata] = 5558
-default[:nova][:ha][:ports][:ec2_s3] = 5559
-
 # Ports to bind to when haproxy is used for the real ports
 default[:nova][:ha][:ports][:api_ec2] = 5550
 default[:nova][:ha][:ports][:api] = 5551

--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -130,11 +130,9 @@ default[:nova][:novnc][:ssl][:enabled] = false
 default[:nova][:novnc][:ssl][:certfile] = ""
 default[:nova][:novnc][:ssl][:keyfile] = ""
 
-default[:nova][:ports][:api_ec2] = 8788
 default[:nova][:ports][:api] = 8774
 default[:nova][:ports][:placement_api] = 8780
 default[:nova][:ports][:metadata] = 8775
-default[:nova][:ports][:objectstore] = 3333
 default[:nova][:ports][:novncproxy] = 6080
 default[:nova][:ports][:serialproxy] = 6083
 
@@ -142,10 +140,8 @@ default[:nova][:ha][:enabled] = false
 default[:nova][:ha][:op][:monitor][:interval] = "10s"
 
 # Ports to bind to when haproxy is used for the real ports
-default[:nova][:ha][:ports][:api_ec2] = 5550
 default[:nova][:ha][:ports][:api] = 5551
 default[:nova][:ha][:ports][:metadata] = 5552
-default[:nova][:ha][:ports][:objectstore] = 5553
 default[:nova][:ha][:ports][:novncproxy] = 5554
 default[:nova][:ha][:ports][:serialproxy] = 5556
 default[:nova][:ha][:ports][:placement_api] = 5560

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -244,17 +244,13 @@ metadata_bind_address = admin_address
 if node[:nova][:ha][:enabled]
   bind_host = admin_address
   bind_port_api = node[:nova][:ha][:ports][:api]
-  bind_port_api_ec2 = node[:nova][:ha][:ports][:api_ec2]
   bind_port_metadata = node[:nova][:ha][:ports][:metadata]
-  bind_port_objectstore = node[:nova][:ha][:ports][:objectstore]
   bind_port_novncproxy = node[:nova][:ha][:ports][:novncproxy]
   bind_port_serialproxy = node[:nova][:ha][:ports][:serialproxy]
 else
   bind_host = "0.0.0.0"
   bind_port_api = node[:nova][:ports][:api]
-  bind_port_api_ec2 = node[:nova][:ports][:api_ec2]
   bind_port_metadata = node[:nova][:ports][:metadata]
-  bind_port_objectstore = node[:nova][:ports][:objectstore]
   bind_port_novncproxy = node[:nova][:ports][:novncproxy]
   bind_port_serialproxy = node[:nova][:ports][:serialproxy]
 end
@@ -358,9 +354,7 @@ template node[:nova][:config_file] do
     cpu_model: cpu_model,
     bind_host: bind_host,
     bind_port_api: bind_port_api,
-    bind_port_api_ec2: bind_port_api_ec2,
     bind_port_metadata: bind_port_metadata,
-    bind_port_objectstore: bind_port_objectstore,
     bind_port_novncproxy: bind_port_novncproxy,
     bind_port_serialproxy: bind_port_serialproxy,
     dhcpbridge: "/usr/bin/nova-dhcpbridge",
@@ -368,8 +362,6 @@ template node[:nova][:config_file] do
     api_database_connection: api_database_connection,
     rabbit_settings: fetch_rabbitmq_settings,
     libvirt_type: node[:nova][:libvirt_type],
-    ec2_host: admin_api_host,
-    ec2_dmz_host: public_api_host,
     libvirt_migration: node[:nova]["use_migration"],
     live_migration_inbound_fqdn: live_migration_inbound_fqdn,
     shared_instances: node[:nova]["use_shared_instance_storage"],

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -493,11 +493,11 @@ template "/etc/tempest/tempest.conf" do
         use_horizon: use_horizon,
         enabled_services: enabled_services,
         # boto settings
-        ec2_protocol: nova[:nova][:ssl][:enabled] ? "https" : "http",
-        ec2_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova][:ha][:enabled]),
-        ec2_port: nova[:nova][:ports][:api_ec2],
-        s3_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova][:ha][:enabled]),
-        s3_port: nova[:nova][:ports][:objectstore],
+        ec2_protocol: nova[:nova]["ec2-api"][:ssl][:enabled] ? "https" : "http",
+        ec2_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova]["ec2-api"][:ha][:enabled]),
+        ec2_port: nova[:nova]["ec2-api"][:ports][:ec2_api],
+        s3_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova]["ec2-api"][:ha][:enabled]),
+        s3_port: nova[:nova]["ec2-api"][:ports][:ec2_s3],
         ec2_access: node[:tempest][:ec2_access],
         ec2_secret: node[:tempest][:ec2_secret],
         # cli settings


### PR DESCRIPTION
This PR removes the old (and now unused) ec2-api service port
attributes from nova and move the current ec2-api service
port attributes from the nova to the ec2-api cookbook.
    
As a side-effect of this change, the tempest ec2-api
configuration, which was using the old and deprecated
port attributes, has been corrected.

NOTE: these changes are detached as a separate PR from the main bulk required to re-enable the ec2-api tempest test suite.