### PR TITLE
ironic: Update for ocata

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -77,11 +77,7 @@ template node[:glance][:api][:config_file] do
       rabbit_settings: fetch_rabbitmq_settings,
       swift_api_insecure: swift_insecure,
       cinder_api_insecure: cinder_insecure,
-      # v1 api is (temporarily) enforced by ironic
-      # Newton version of Ironic supports only v1
-      # Ocata and Pike have option to set glance_api_version
-      # Queens will only support v2
-      enable_v1: !ironics.empty? || node[:glance][:enable_v1],
+      enable_v1: node[:glance][:enable_v1],
       glance_stores: glance_stores.join(",")
   )
   notifies :restart, "service[#{node[:glance][:api][:service_name]}]"

--- a/chef/cookbooks/ironic/libraries/helpers.rb
+++ b/chef/cookbooks/ironic/libraries/helpers.rb
@@ -62,10 +62,5 @@ module IronicHelper
         port: swift[:swift][:ports][:proxy]
       }
     end
-
-    def ironic_net_id(keystone_settings)
-      cmd = "#{openstack_command(keystone_settings)} network show ironic -f value -c id"
-      Mixlib::ShellOut.new(cmd).run_command.stdout.chomp
-    end
   end
 end

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -26,12 +26,30 @@ glance_port=<%= @glance_settings[:port] %>
 glance_protocol=<%= @glance_settings[:protocol] %>
 glance_api_servers=<%= @glance_settings[:protocol] %>://<%= @glance_settings[:host] %>:<%= @glance_settings[:port] %>
 auth_strategy=keystone
+auth_type=password
+auth_url=<%= @keystone_settings['internal_auth_url'] %>
+region_name=<%= @keystone_settings['endpoint_region'] %>
+username=<%= @glance_settings[:service_user] %>
+password=<%= @glance_settings[:service_password] %>
+project_name=<%= @keystone_settings['service_tenant'] %>
+project_domain_name=<%= @keystone_settings["admin_domain"]%>
+user_domain_name=<%= @keystone_settings["admin_domain"] %>
 <% if @swift_settings %>
 swift_temp_url_key=<%= @swift_settings[:tempurl_key] %>
 swift_endpoint_url=<%= @swift_settings[:protocol] %>://<%= @swift_settings[:host] %>:<%= @swift_settings[:port] %>
 swift_container=<%= @swift_settings[:glance_container] %>
 swift_account=<%= @swift_settings[:glance_account] %>
 <% end %>
+
+[swift]
+auth_type=password
+auth_url=<%= @keystone_settings['internal_auth_url'] %>
+region_name=<%= @keystone_settings['endpoint_region'] %>
+username=<%= if @swift_settings then @swift_settings[:service_user] else '' end %>
+password=<%= if @swift_settings then @swift_settings[:service_password] else '' end %>
+project_name=<%= @keystone_settings['service_tenant'] %>
+project_domain_name=<%= @keystone_settings["admin_domain"]%>
+user_domain_name=<%= @keystone_settings["admin_domain"] %>
 
 [keystone]
 region_name=<%= @keystone_settings['endpoint_region'] %>
@@ -45,14 +63,49 @@ region_name=<%= @keystone_settings['endpoint_region'] %>
 username=<%= @keystone_settings['service_user'] %>
 password=<%= @keystone_settings['service_password'] %>
 project_name=<%= @keystone_settings['service_tenant'] %>
+project_domain_name=<%= @keystone_settings['admin_domain']%>
+user_domain_name=<%= @keystone_settings['admin_domain'] %>
+service_token_roles_required = true
+service_token_roles = admin
+memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:ironic][:memcache_secret_key] %>
 
 [neutron]
+auth_type=password
 url=<%= @neutron_settings[:protocol] %>://<%= @neutron_settings[:host] %>:<%= @neutron_settings[:port] %>
 auth_strategy=keystone
+auth_url=<%= @keystone_settings['internal_auth_url'] %>
+region_name=<%= @keystone_settings['endpoint_region'] %>
+username=<%= @neutron_settings[:service_user] %>
+password=<%= @neutron_settings[:service_password] %>
+project_name=<%= @keystone_settings['service_tenant'] %>
+project_domain_name=<%= @keystone_settings['admin_domain']%>
+user_domain_name=<%= @keystone_settings['admin_domain'] %>
 port_setup_delay=15
-<% unless @ironic_net_id.empty? %>
-cleaning_network_uuid=<%= @ironic_net_id %>
-<% end %>
+cleaning_network=<%= @ironic_net_name %>
+
+[inspector]
+auth_type=password
+auth_url=<%= @keystone_settings['admin_auth_url'] %>
+auth_version=<%= @auth_version %>
+region_name=<%= @keystone_settings['endpoint_region'] %>
+username=<%= @keystone_settings['service_user'] %>
+password=<%= @keystone_settings['service_password'] %>
+project_name=<%= @keystone_settings['service_tenant'] %>
+project_domain_name=<%= @keystone_settings['admin_domain']%>
+user_domain_name=<%= @keystone_settings['admin_domain'] %>
+
+[service_catalog]
+auth_type=password
+auth_url=<%= @keystone_settings['admin_auth_url'] %>
+auth_version=<%= @auth_version %>
+region_name=<%= @keystone_settings['endpoint_region'] %>
+username=<%= @keystone_settings['service_user'] %>
+password=<%= @keystone_settings['service_password'] %>
+project_name=<%= @keystone_settings['service_tenant'] %>
+project_domain_name=<%= @keystone_settings['admin_domain']%>
+user_domain_name=<%= @keystone_settings['admin_domain'] %>
 
 [oslo_concurrency]
 lock_path=/var/run/ironic
@@ -61,3 +114,6 @@ lock_path=/var/run/ironic
 tftp_server=<%= @tftp_ip %>
 tftp_root=<%= @tftproot %>
 tftp_master_path=<%= @tftproot %>/master_images
+
+[deploy]
+default_boot_option=netboot

--- a/chef/data_bags/crowbar/migrate/ironic/200_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/ironic/200_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/ironic/201_remove_deprecated_opts.rb
+++ b/chef/data_bags/crowbar/migrate/ironic/201_remove_deprecated_opts.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("verbose")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["verbose"] = ta["verbose"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ironic.json
+++ b/chef/data_bags/crowbar/template-ironic.json
@@ -4,7 +4,6 @@
   "attributes": {
     "ironic": {
       "debug": false,
-      "verbose": true,
       "max_header_line": 16384,
       "rabbitmq_instance": "none",
       "database_instance": "none",
@@ -13,6 +12,7 @@
       "neutron_instance": "none",
       "service_user": "ironic",
       "service_password": "",
+      "memcache_secret_key": "",
       "enabled_drivers": [],
       "automated_clean": true,
       "api": {
@@ -29,7 +29,7 @@
   "deployment": {
     "ironic": {
       "crowbar-revision": 0,
-      "schema-revision": 102,
+      "schema-revision": 201,
       "crowbar-applied": false,
       "element_states": {
         "ironic-server": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-ironic.schema
+++ b/chef/data_bags/crowbar/template-ironic.schema
@@ -13,7 +13,6 @@
           "required": true,
           "mapping": {
             "debug": { "type": "bool", "required": true },
-            "verbose": { "type": "bool", "required": true },
             "max_header_line": { "type": "int", "required": true },
             "database_instance": { "type": "str", "required": true },
             "rabbitmq_instance": { "type": "str", "required": true },
@@ -22,6 +21,7 @@
             "neutron_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
+            "memcache_secret_key": { "type": "str", "required": true },
             "enabled_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
             "automated_clean": { "type": "bool", "required": true },
             "api": {

--- a/crowbar_framework/app/models/ironic_service.rb
+++ b/crowbar_framework/app/models/ironic_service.rb
@@ -74,6 +74,7 @@ class IronicService < ServiceObject
     end
 
     base["attributes"][@bc_name]["service_password"] = random_password
+    base["attributes"][@bc_name]["memcache_secret_key"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
 
     @logger.debug("Ironic create_proposal: exiting")


### PR DESCRIPTION
This patch makes several updates for the ironic barclamp:

* Add service user credentials for the [glance], [neutron], [swift],
  [service_catalog], and [inspector] sections so that ironic can use 
  appropriate service users for each related service rather than getting
  credentials for all operations from [keystone_authtoken]. We still use 
  the ironic service user's credentials for the [inspector] and 
  [service_catalog] sections rather than creating new users for the 
  inspector service and API discovery. We must also include these auth
  options for the [swift] section even when swift is not being used in
  order to avoid a deprecation warning, but they of course do not have
  to work in that case. See the newton upgrade notes for more
  information about access credentials for services[1].
* Use the [keystone_authtoken]/service_token_roles and 
  [keystone_authtoken]/service_token_roles_required parameters that were
  introduced in Ocata and will soon become required[2] to ensure
  properly authenticated interservice communication.
* Add memcached settings for [keystone_authtoken] since the 
  keystonemiddleware in-process token cache has been deprecated since
  Newton[3].
* Add keystone v3 *_domain_name settings to [keystone_authtoken]
  section and update the auth_version to v3. 
* Explicitly set [deploy]/default_boot_option=netboot since the default
  is changing in Ocata[4].
* Change deprecated option [neutron]/cleaning_network_uuid to
  [neutron]/cleaning_network[4] and use the network name instead of uuid
  to enhance readability.
* Remove the "verbose" setting from the databag schema since it is
  deprecated in oslo.log[5] and it was never actually added to the 
  config template anyway.
* Stop forcing the glance barclamp to enable the v1 API when ironic is
  deployed since ironic can handle the glance v2 API now, and as of
  ocata defaults to using only v2[4].

[1] https://docs.openstack.org/releasenotes/ironic/newton.html#id13
[2] https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html
[3] https://docs.openstack.org/releasenotes/keystonemiddleware/newton.html
[4] https://docs.openstack.org/releasenotes/ironic/ocata.html
[5] https://docs.openstack.org/oslo.log/ocata/history.html#id33