### PR TITLE
tempest: enable ec2-api testsuite

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -130,11 +130,9 @@ default[:nova][:novnc][:ssl][:enabled] = false
 default[:nova][:novnc][:ssl][:certfile] = ""
 default[:nova][:novnc][:ssl][:keyfile] = ""
 
-default[:nova][:ports][:api_ec2] = 8788
 default[:nova][:ports][:api] = 8774
 default[:nova][:ports][:placement_api] = 8780
 default[:nova][:ports][:metadata] = 8775
-default[:nova][:ports][:objectstore] = 3333
 default[:nova][:ports][:novncproxy] = 6080
 default[:nova][:ports][:serialproxy] = 6083
 
@@ -152,10 +150,8 @@ default[:nova][:ha][:ports][:ec2_metadata] = 5558
 default[:nova][:ha][:ports][:ec2_s3] = 5559
 
 # Ports to bind to when haproxy is used for the real ports
-default[:nova][:ha][:ports][:api_ec2] = 5550
 default[:nova][:ha][:ports][:api] = 5551
 default[:nova][:ha][:ports][:metadata] = 5552
-default[:nova][:ha][:ports][:objectstore] = 5553
 default[:nova][:ha][:ports][:novncproxy] = 5554
 default[:nova][:ha][:ports][:serialproxy] = 5556
 default[:nova][:ha][:ports][:placement_api] = 5560

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -227,17 +227,13 @@ metadata_bind_address = admin_address
 if node[:nova][:ha][:enabled]
   bind_host = admin_address
   bind_port_api = node[:nova][:ha][:ports][:api]
-  bind_port_api_ec2 = node[:nova][:ha][:ports][:api_ec2]
   bind_port_metadata = node[:nova][:ha][:ports][:metadata]
-  bind_port_objectstore = node[:nova][:ha][:ports][:objectstore]
   bind_port_novncproxy = node[:nova][:ha][:ports][:novncproxy]
   bind_port_serialproxy = node[:nova][:ha][:ports][:serialproxy]
 else
   bind_host = "0.0.0.0"
   bind_port_api = node[:nova][:ports][:api]
-  bind_port_api_ec2 = node[:nova][:ports][:api_ec2]
   bind_port_metadata = node[:nova][:ports][:metadata]
-  bind_port_objectstore = node[:nova][:ports][:objectstore]
   bind_port_novncproxy = node[:nova][:ports][:novncproxy]
   bind_port_serialproxy = node[:nova][:ports][:serialproxy]
 end
@@ -341,17 +337,13 @@ template node[:nova][:config_file] do
     cpu_model: cpu_model,
     bind_host: bind_host,
     bind_port_api: bind_port_api,
-    bind_port_api_ec2: bind_port_api_ec2,
     bind_port_metadata: bind_port_metadata,
-    bind_port_objectstore: bind_port_objectstore,
     bind_port_novncproxy: bind_port_novncproxy,
     bind_port_serialproxy: bind_port_serialproxy,
     database_connection: database_connection,
     api_database_connection: api_database_connection,
     rabbit_settings: fetch_rabbitmq_settings,
     libvirt_type: node[:nova][:libvirt_type],
-    ec2_host: admin_api_host,
-    ec2_dmz_host: public_api_host,
     libvirt_migration: node[:nova]["use_migration"],
     live_migration_inbound_fqdn: live_migration_inbound_fqdn,
     shared_instances: node[:nova]["use_shared_instance_storage"],

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -495,11 +495,11 @@ template "/etc/tempest/tempest.conf" do
         use_horizon: use_horizon,
         enabled_services: enabled_services,
         # boto settings
-        ec2_protocol: nova[:nova][:ssl][:enabled] ? "https" : "http",
-        ec2_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova][:ha][:enabled]),
-        ec2_port: nova[:nova][:ports][:api_ec2],
-        s3_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova][:ha][:enabled]),
-        s3_port: nova[:nova][:ports][:objectstore],
+        ec2_protocol: nova[:nova]["ec2-api"][:ssl][:enabled] ? "https" : "http",
+        ec2_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova]["ec2-api"][:ha][:enabled]),
+        ec2_port: nova[:nova][:ports][:ec2_api],
+        s3_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova]["ec2-api"][:ha][:enabled]),
+        s3_port: nova[:nova][:ports][:ec2_s3],
         ec2_access: node[:tempest][:ec2_access],
         ec2_secret: node[:tempest][:ec2_secret],
         # cli settings

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -14,11 +14,17 @@ admin_project_name = <%= @keystone_settings['default_tenant'] %>
 admin_password = <%= @keystone_settings['admin_password'] %>
 admin_domain_name = Default
 
+<% if @enabled_services.include? "ec2" -%>
 [aws]
-ec2_url = <%= @ec2_protocol %>://<%= @ec2_host %>:<%= @ec2_port %>/
-s3_url = http://<%= @s3_host %>:<%= @s3_port %>/
+ec2_url = <%= @ec2_url %>
+s3_url = <%= @s3_url %>
 aws_secret = <%= @ec2_secret %>
 aws_access = <%= @ec2_access %>
+image_id = <%= node[:tempest][:ec2_image_id] %>
+ebs_image_id = <%= node[:tempest][:ebs_image_id] %>
+instance_type = tempest-stuff
+run_long_tests = true
+<% end -%>
 
 [baremetal]
 endpoint_type = internalURL
@@ -157,6 +163,7 @@ sahara = <%= @enabled_services.include? "data-processing" %>
 trove = <%= @enabled_services.include? "database" %>
 manila = <%= @enabled_services.include? "sharev2" %>
 magnum = <%= @enabled_services.include? "container-infra" %>
+ec2api = <%= @enabled_services.include? "ec2" %>
 
 [share]
 region = <%= @keystone_settings['endpoint_region'] %>

--- a/chef/data_bags/crowbar/migrate/tempest/201_add_ec2_api_options.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/201_add_ec2_api_options.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ec2_api"] = ta["ec2_api"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ec2_api")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -34,6 +34,9 @@
       },
       "heat": {
         "image_ref": "heat-cfntools-image"
+      },
+      "ec2_api": {
+        "enable_ebs_image": false
       }
     }
   },
@@ -41,7 +44,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -55,6 +55,12 @@
               "mapping": {
                 "image_ref": { "type": "str", "required": true }
               }
+            },
+            "ec2_api": {
+              "type": "map",
+              "mapping": {
+                "enable_ebs_image": { "type": "bool", "required": true }
+              }
             }
           }
         }


### PR DESCRIPTION
This PR updates the tempest cookbook to create
all the elements required to execute applicable
ec2-api test cases:
  - configure an image ID
  - create private network, subnet and router
  - create an EBS image by starting up a server
    and creating an image from it

The EBS image setup needs to be explicitly enabled by means of the (newly added) tempest.ec2_api.enable_ebs_image barclamp raw attribute.
    
The aws-cli package is required for this update, as well as the following upstream bugfix: https://review.openstack.org/#/c/493798/

EC2-API test statistics 
  - before:
```
Ran: 117 tests in 124.0000 sec.
 - Passed: 41
 - Skipped: 76
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 95.1280 sec.
```
  - after:
```
Ran: 177 tests in 1156.0000 sec.
 - Passed: 148
 - Skipped: 27
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 2
Sum of execute time for each test: 1912.7928 sec.
```
Reason for skipped test cases:
- 6 test cases skipped with 'vpnaas not available'
- 2 test cases skipped because they require an Ubuntu image
- 14 test cases skipped because they are test cases incompatible with Amazon (can be enabled by setting the aws.run_incompatible_tests configuration flag)
- 2 test cases skipped because the S3 image hasn't been configured (the effort is not justified for only 2 test cases)
- one test case (ec2api.tests.functional.api.test_instance_attributes.InstanceAttributeTest.test_instance_type_attribute) is disabled on purpose by not defining the alternative instance type, because it involves a VM migration which would only work in setups with 2 or more compute nodes

Reason for failed test cases:
- ec2api.tests.functional.api.test_images.ImageTest.test_check_image_operations_negative fails because it assumes the tempest test user does not have permission to modify the test image
- ec2api.tests.functional.scenario.test_instances.InstancesTest.test_metadata fails because neutron is not configured to use ec2-api-metadata instead of nova-api. Will be fixed by #1156.

