### PR TITLE
Horizon: add SECRET_KEY as an attribute (bsc#1051439)

### DIFF
--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -442,6 +442,7 @@ template local_settings do
     neutron_ml2_type_drivers: neutron_ml2_type_drivers,
     help_url: node[:horizon][:help_url],
     session_timeout: node[:horizon][:session_timeout],
+    secret_key: node["horizon"]["secret_key"],
     memcached_locations: memcached_locations,
     can_set_mount_point: node["horizon"]["can_set_mount_point"],
     can_set_password: node["horizon"]["can_set_password"],
@@ -451,6 +452,7 @@ template local_settings do
     token_hash_enabled: node["horizon"]["token_hash_enabled"]
   )
   action :create
+  notifies :reload, "service[horizon]"
 end
 
 crowbar_pacemaker_sync_mark "create-horizon_config" if ha_enabled

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -255,3 +255,4 @@ EXTERNAL_MONITORING = [
 <% end -%>
 
 SESSION_TIMEOUT = <%= @session_timeout * 60 %>
+SECRET_KEY = "<%= @secret_key %>"

--- a/chef/data_bags/crowbar/migrate/horizon/200_add_dashboard_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/200_add_dashboard_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["secret_key"].nil? || a["secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -11,6 +11,7 @@
       "site_branding_link": "",
       "help_url": "http://docs.openstack.org/",
       "session_timeout": 240,
+      "secret_key": "",
       "db": {
         "database": "horizon",
         "user": "horizon",
@@ -48,7 +49,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 200,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -20,6 +20,7 @@
             "site_branding_link": { "type": "str", "required": true },
             "help_url": { "type": "str", "required": true },
             "session_timeout": { "type": "int", "required": true },
+            "secret_key": { "type": "str", "required": true },
             "db" : {
               "type" : "map",
               "required" : true,

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -66,6 +66,7 @@ class HorizonService < OpenstackServiceObject
     base["attributes"][@bc_name]["keystone_instance"] = find_dep_proposal("keystone")
 
     base["attributes"][@bc_name][:db][:password] = random_password
+    base["attributes"][@bc_name]["secret_key"] = random_password
 
     @logger.debug("Horizon create_proposal: exiting")
     base


### PR DESCRIPTION
In a HA environment the secret key used in Horizon to store the
session data is not shared, producing form with different CFSR
tokens. This invalidate the session after a HA failover.

This patch also reload the apache service when the local_settings
file is updated, removing the race condition from bsc#1051439