### PR TITLE
Do not search for nodes with database-server role

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -55,7 +55,7 @@ end
 
 service_name = "galera"
 
-cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "database-server")
+cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)
 nodes_names = cluster_nodes.map { |n| n[:hostname] }
 
 pacemaker_primitive service_name do

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -73,7 +73,7 @@ service mysql start
 EOC
 end
 
-cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "database-server")
+cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)
 nodes_names = cluster_nodes.map { |n| n[:hostname] }
 cluster_addresses = "gcomm://" + nodes_names.join(",")
 


### PR DESCRIPTION
The role might not be saved yet. It should be safe to use the
default search (pacemaker-cluster-member) because cluster_members
helper will take care that result is in the same cluster as current
node (by checking pacemaker_config_environment).

This should fix [bsc#1053703](https://bugzilla.suse.com/show_bug.cgi?id=1053703)