### PR TITLE
neutron,ec2-api: use ec2-api-metadata in neutron-metadata-agent

### DIFF
--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -24,6 +24,15 @@ ssl_ca_file = <%= node[:nova]["ec2-api"][:ssl][:ca_certs] %>
 s3_use_ssl = true
 <% end %>
 
+<% unless @nova_metadata_settings.empty? %>
+[metadata]
+nova_metadata_ip = <%= @nova_metadata_settings[:host] %>
+nova_metadata_port = <%= @nova_metadata_settings[:port] %>
+metadata_proxy_shared_secret = <%= @nova_metadata_settings[:shared_secret] %>
+nova_metadata_protocol = <%= @nova_metadata_settings[:protocol] %>
+nova_metadata_insecure = <%= @nova_metadata_settings[:insecure] %>
+<% end %>
+
 [database]
 connection = <%= @database_connection %>
 [oslo_concurrency]

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -12,7 +12,7 @@ metadata_listen_port = <%= @bind_port_metadata %>
 s3_listen = <%= @bind_host %>
 s3_listen_port = <%= @bind_port_s3 %>
 transport_url = <%= @rabbit_settings[:url] %>
-full_vpc_support = false
+full_vpc_support = true
 <% if node[:nova]["ec2-api"][:ssl][:enabled] %>
 ec2api_use_ssl = true
 metadata_use_ssl = true
@@ -23,6 +23,7 @@ ssl_ca_file = <%= node[:nova]["ec2-api"][:ssl][:ca_certs] %>
 <% end %>
 s3_use_ssl = true
 <% end %>
+external_network = 
 
 <% unless @nova_metadata_settings.empty? %>
 [metadata]

--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -1,8 +1,11 @@
 [DEFAULT]
-nova_metadata_ip = <%= @nova_metadata_host %>
-metadata_proxy_shared_secret = <%= @metadata_proxy_shared_secret %>
-nova_metadata_protocol = <%= @nova_metadata_protocol %>
-nova_metadata_insecure = <%= @nova_metadata_insecure ? "True" : "False" %>
+<% unless @nova_metadata_settings.empty? %>
+nova_metadata_ip = <%= @nova_metadata_settings[:host] %>
+metadata_proxy_shared_secret = <%= @nova_metadata_settings[:shared_secret] %>
+nova_metadata_protocol = <%= @nova_metadata_settings[:protocol] %>
+nova_metadata_insecure = <%= @nova_metadata_settings[:insecure] %>
+nova_metadata_port = <%= @nova_metadata_settings[:port] %>
+<% end %>
 metadata_workers = <%= [node["cpu"]["total"]/2, 4].min %>
 debug = <%= @debug ? "True" : "False" %>
 [AGENT]


### PR DESCRIPTION
When ec2-api is enabled, the ec2-api-metadata service
must be used instead of nova-metadata-agent when configuring
neutron.
The EC2 metadata service needs to act as a proxy between neutron
and the original nova metadata agent, adapting the metadata
information according to the EC2 API specifications.

This PR also re-enables VPC, for two main reasons:
  - without VPC enabled, ec2-api-metadata assumes it is running in a nova-network environment, which leads to failures (e.g. see [this upstream bug report](https://bugs.launchpad.net/ec2-api/+bug/1660888))
  - this was initially part of #1151, which aims to enable and pass as many applicable ec2-api tempest test cases as possible

Given the fact that VPC support was previously disabled precisely to correct some tempest test failures, a full tempest test run was executed on this PR to prove that no regression is incurred. The results show only 2 additional failures when compared to SOC7:

- new results (PR CI gating job):

```
      16:12:08 Ran: 2756 tests in 9265.0000 sec.
      16:12:08  - Passed: 2137
      16:12:08  - Skipped: 553
      16:12:08  - Expected Fail: 0
      16:12:08  - Unexpected Success: 0
      16:12:08  - Failed: 66
```
- old results (cloud 7 CI job - https://ci.suse.de/job/openstack-mkcloud/78718/console):

```
      06:52:37 Ran: 2340 tests in 8069.0000 sec.
      06:52:37  - Passed: 1729
      06:52:37  - Skipped: 547
      06:52:37  - Expected Fail: 0
      06:52:37  - Unexpected Success: 0
      06:52:37  - Failed: 64
```

The additional test failures are not related to the metadata service (they target the image and lbaas services).