### PR TITLE
Do not search for nodes with database-server role (bsc#1053703).

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -55,7 +55,7 @@ end
 
 service_name = "galera"
 
-cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "database-server")
+cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)
 nodes_names = cluster_nodes.map { |n| n[:hostname] }
 
 pacemaker_primitive service_name do

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -107,7 +107,7 @@ service mysql start
 EOC
 end
 
-cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "database-server")
+cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)
 nodes_names = cluster_nodes.map { |n| n[:hostname] }
 cluster_addresses = "gcomm://" + nodes_names.join(",")
 


### PR DESCRIPTION
Backport of https://github.com/crowbar/crowbar-openstack/pull/1155

The role might not be saved yet in which case no cluster node would be found.

It should be safe to use the default search without specifying the role:
CrowbarPacemakerHelper.cluster_members helper will use pacemaker-cluster-member
role and by searching for pacemaker_config_environment from current node
it ensures that the nodes are not from any different cluster.

(cherry picked from commit 2fbfe4cf6f4d878e3ddb5868540bf27a18a3c47d)