### PR TITLE
[4.0] database: Move connection string creation to a helper (bsc#1053827)

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -133,11 +133,7 @@ end
 
 crowbar_pacemaker_sync_mark "create-aodh_keystone_register" if ha_enabled
 
-db_name = node[:aodh][:db][:database]
-db_user = node[:aodh][:db][:user]
-db_password = node[:aodh][:db][:password]
-db_connection =
-    "#{db_settings[:url_scheme]}://#{db_user}:#{db_password}@#{db_settings[:address]}/#{db_name}"
+db_connection = fetch_database_connection_string(node[:aodh][:db])
 
 if node[:aodh][:ha][:server][:enabled]
   admin_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address

--- a/chef/cookbooks/barbican/recipes/common.rb
+++ b/chef/cookbooks/barbican/recipes/common.rb
@@ -23,7 +23,6 @@ package "openstack-barbican"
 ha_enabled = node[:barbican][:ha][:enabled]
 
 db_settings = fetch_database_settings
-db_conn_scheme = db_settings[:url_scheme]
 
 barbican_protocol = node[:barbican][:api][:protocol]
 
@@ -31,15 +30,7 @@ public_host = CrowbarHelper.get_host_for_public_url(node,
                                                     barbican_protocol == "https",
                                                     node[:barbican][:ha][:enabled])
 
-if db_settings[:backend_name] == "mysql"
-  db_conn_scheme = "mysql+pymysql"
-end
-
-database_connection = "#{db_conn_scheme}://" \
-  "#{node[:barbican][:db][:user]}" \
-  ":#{node[:barbican][:db][:password]}" \
-  "@#{db_settings[:address]}" \
-  "/#{node[:barbican][:db][:database]}"
+database_connection = fetch_database_connection_string(node[:barbican][:db])
 
 crowbar_pacemaker_sync_mark "wait-barbican_database" if ha_enabled
 

--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -57,18 +57,16 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-db_password = ""
-if node.roles.include? "cinder-controller"
-  db_password = node[:cinder][:db][:password]
-else
+db_auth = node[:cinder][:db].dup
+unless node.roles.include? "cinder-controller"
   # pickup password to database from cinder-controller node
   node_controllers = node_search_with_cache("roles:cinder-controller")
   if node_controllers.length > 0
-    db_password = node_controllers[0][:cinder][:db][:password]
+    db_auth[:password] = node_controllers[0][:cinder][:db][:password]
   end
 end
 
-sql_connection = "#{db_settings[:url_scheme]}://#{node[:cinder][:db][:user]}:#{db_password}@#{db_settings[:address]}/#{node[:cinder][:db][:database]}"
+sql_connection = fetch_database_connection_string(db_auth)
 
 dirty = false
 

--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -24,6 +24,11 @@ class Chef
       CrowbarOpenStackHelper.database_settings(node, barclamp)
     end
 
+    def fetch_database_connection_string(db_auth, barclamp = @cookbook_name)
+      db_settings = CrowbarOpenStackHelper.database_settings(node, barclamp)
+      CrowbarOpenStackHelper.database_connection_string(db_settings, db_auth)
+    end
+
     def fetch_rabbitmq_settings(barclamp=@cookbook_name)
       CrowbarOpenStackHelper.rabbitmq_settings(node, barclamp)
     end
@@ -39,6 +44,11 @@ class Chef
     class Template
       def fetch_database_settings(barclamp=@cookbook_name)
         CrowbarOpenStackHelper.database_settings(node, barclamp)
+      end
+
+      def fetch_database_connection_string(db_auth, barclamp = @cookbook_name)
+        db_settings = CrowbarOpenStackHelper.database_settings(node, barclamp)
+        CrowbarOpenStackHelper.database_connection_string(db_settings, db_auth)
       end
 
       def fetch_rabbitmq_settings(barclamp=@cookbook_name)
@@ -96,6 +106,21 @@ class CrowbarOpenStackHelper
     end
 
     @database_settings[instance]
+  end
+
+  def self.database_connection_string(db_settings, db_auth)
+    db_conn_scheme = db_settings[:url_scheme]
+    db_charset = ""
+
+    if db_conn_scheme == "mysql"
+      db_conn_scheme = "mysql+pymysql"
+      db_charset = "?charset=utf8"
+    end
+
+    "#{db_conn_scheme}://" \
+    "#{db_auth[:user]}:#{db_auth[:password]}@#{db_settings[:address]}/" \
+    "#{db_auth[:database]}" \
+    "#{db_charset}"
   end
 
   def self.rabbitmq_settings(node, barclamp)

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -40,19 +40,9 @@ else
   bind_port_s3 = node[:nova][:ports][:ec2_s3]
 end
 
-db_conn_scheme = db_settings[:url_scheme]
-
-if db_settings[:backend_name] == "mysql"
-  db_conn_scheme = "mysql+pymysql"
-end
-
 crowbar_pacemaker_sync_mark "wait-ec2_api_database" if ha_enabled
 
-database_connection = "#{db_conn_scheme}://" \
-  "#{node[:nova]["ec2-api"][:db][:user]}" \
-  ":#{node[:nova]["ec2-api"][:db][:password]}" \
-  "@#{db_settings[:address]}" \
-  "/#{node[:nova]["ec2-api"][:db][:database]}"
+database_connection = fetch_database_connection_string(node[:nova]["ec2-api"][:db], "nova")
 
 # Create the ec2 Database
 database "create #{node[:nova]["ec2-api"][:db][:database]} database" do

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -64,10 +64,7 @@ end
 
 crowbar_pacemaker_sync_mark "create-glance_database" if ha_enabled
 
-glance_db = node[:glance][:db]
-sql_connection =
-  "#{db_settings[:url_scheme]}://#{glance_db[:user]}:#{glance_db[:password]}@"\
-  "#{db_settings[:address]}/#{glance_db[:database]}"
+sql_connection = fetch_database_connection_string(node[:glance][:db])
 if node[:glance][:sql_connection] != sql_connection
   node.set[:glance][:sql_connection] = sql_connection
   node.save

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -108,7 +108,7 @@ bind_host, api_port, cfn_port, cloud_watch_port = HeatHelper.get_bind_host_port(
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(node, node[:heat][:api][:protocol] == "https", ha_enabled)
 
-db_connection = "#{db_settings[:url_scheme]}://#{node[:heat][:db][:user]}:#{node[:heat][:db][:password]}@#{db_settings[:address]}/#{node[:heat][:db][:database]}"
+db_connection = fetch_database_connection_string(node[:heat][:db])
 
 crowbar_pacemaker_sync_mark "wait-heat_register" if ha_enabled
 

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -87,9 +87,7 @@ api_protocol = node[:ironic][:api][:protocol]
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node)
 my_public_host = CrowbarHelper.get_host_for_public_url(node, false)
 
-db_connection = "#{db_settings[:url_scheme]}://"\
-                "#{node[:ironic][:db][:user]}:#{node[:ironic][:db][:password]}@"\
-                "#{db_settings[:address]}/#{node[:ironic][:db][:database]}"
+db_connection = fetch_database_connection_string(node[:ironic][:db])
 
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -198,7 +198,7 @@ end
 
 crowbar_pacemaker_sync_mark "create-keystone_database" if ha_enabled
 
-sql_connection = "#{db_settings[:url_scheme]}://#{node[:keystone][:db][:user]}:#{node[:keystone][:db][:password]}@#{db_settings[:address]}/#{node[:keystone][:db][:database]}"
+sql_connection = fetch_database_connection_string(node[:keystone][:db])
 
 if ha_enabled
   memcached_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "keystone-server")

--- a/chef/cookbooks/magnum/recipes/common.rb
+++ b/chef/cookbooks/magnum/recipes/common.rb
@@ -24,10 +24,7 @@ include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 # get Database data
-db_password = node[:magnum][:db][:password]
-sql_connection = "#{db_settings[:url_scheme]}://#{node[:magnum][:db][:user]}:"\
-                 "#{db_password}@#{db_settings[:address]}/"\
-                 "#{node[:magnum][:db][:database]}"
+sql_connection = fetch_database_connection_string(node[:magnum][:db])
 
 # address/port binding
 my_ipaddress = Barclamp::Inventory.get_network_by_type(node, "admin").address

--- a/chef/cookbooks/neutron/recipes/database.rb
+++ b/chef/cookbooks/neutron/recipes/database.rb
@@ -67,8 +67,7 @@ props.each do |prop|
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
-  db_address =
-    "#{db_settings[:url_scheme]}://#{db_user}:#{db_pass}@#{db_settings[:address]}/#{db_name}"
+  db_address = fetch_database_connection_string(node[:neutron][:db])
   if node[@cookbook_name][:db][db_conn_name] != db_address
     node.set[@cookbook_name][:db][db_conn_name] = db_address
     dirty = true

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -46,21 +46,8 @@ if is_controller
   include_recipe "#{db_settings[:backend_name]}::client"
   include_recipe "#{db_settings[:backend_name]}::python-client"
 
-  db_conn_scheme = db_settings[:url_scheme]
-  if node[:platform_family] == "suse" && db_settings[:backend_name] == "mysql"
-    # The C-extensions (python-mysql) can't be monkey-patched by eventlet. Therefore,
-    # when only one nova-conductor is present, all DB queries are serialized.
-    # By using the pure-Python driver by default, eventlet can do it's job:
-    db_conn_scheme = "mysql+pymysql"
-  end
-
-  db = node[:nova][:db]
-  database_connection = \
-    "#{db_conn_scheme}://#{db[:user]}:#{db[:password]}@#{db_settings[:address]}/#{db[:database]}"
-
-  db = node[:nova][:api_db]
-  api_database_connection = \
-    "#{db_conn_scheme}://#{db[:user]}:#{db[:password]}@#{db_settings[:address]}/#{db[:database]}"
+  database_connection = fetch_database_connection_string(node[:nova][:db])
+  api_database_connection = fetch_database_connection_string(node[:nova][:api_db])
 else
   database_connection = nil
   api_database_connection = nil

--- a/chef/cookbooks/sahara/recipes/common.rb
+++ b/chef/cookbooks/sahara/recipes/common.rb
@@ -23,10 +23,7 @@ include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 # get Database data
-db_password = node[:sahara][:db][:password]
-sql_connection = "#{db_settings[:url_scheme]}://#{node[:sahara][:db][:user]}:"\
-                 "#{db_password}@#{db_settings[:address]}/"\
-                 "#{node[:sahara][:db][:database]}"
+sql_connection = fetch_database_connection_string(node[:sahara][:db])
 
 # cinder insecure?
 cinder = node_search_with_cache("roles:cinder-controller").first

--- a/chef/cookbooks/trove/libraries/helpers.rb
+++ b/chef/cookbooks/trove/libraries/helpers.rb
@@ -15,14 +15,6 @@
 #
 
 module TroveHelper
-  def self.get_sql_connection(node)
-    # get Database data
-    db_settings = CrowbarOpenStackHelper.database_settings(node, "trove")
-    "#{db_settings[:url_scheme]}://#{node[:trove][:db][:user]}:"\
-    "#{node[:trove][:db][:password]}@#{db_settings[:address]}/"\
-    "#{node[:trove][:db][:database]}"
-  end
-
   def self.get_rabbitmq_trove_url(node, rabbitmq_servers)
     # get rabbitmq-server information
     # NOTE: Trove uses it's own user/pass/vhost instead of the default one

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -53,7 +53,7 @@ else
   bind_port = node[:trove][:api][:bind_port]
 end
 
-sql_connection = TroveHelper.get_sql_connection node
+sql_connection = fetch_database_connection_string(node[:trove][:db])
 
 rabbitmq_servers = node_search_with_cache("roles:rabbitmq-server")
 rabbitmq_trove_settings = TroveHelper.get_rabbitmq_trove_url(node, rabbitmq_servers)

--- a/chef/cookbooks/trove/recipes/conductor.rb
+++ b/chef/cookbooks/trove/recipes/conductor.rb
@@ -17,7 +17,7 @@
 # Recipe:: conductor
 #
 
-sql_connection = TroveHelper.get_sql_connection node
+sql_connection = fetch_database_connection_string(node[:trove][:db])
 
 rabbitmq_servers = node_search_with_cache("roles:rabbitmq-server")
 rabbit_trove_url = TroveHelper.get_rabbitmq_trove_url(node, rabbitmq_servers)

--- a/chef/cookbooks/trove/recipes/taskmanager.rb
+++ b/chef/cookbooks/trove/recipes/taskmanager.rb
@@ -19,7 +19,7 @@
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-sql_connection = TroveHelper.get_sql_connection node
+sql_connection = fetch_database_connection_string(node[:trove][:db])
 
 rabbitmq_servers = node_search_with_cache("roles:rabbitmq-server")
 rabbit_trove_url = TroveHelper.get_rabbitmq_trove_url(node, rabbitmq_servers)


### PR DESCRIPTION
This commit moves the creation of all OpenStack database connection
strings to a helper. This is required to change the string in one place
to use the correct driver everywhere. Additional we use now the correct
mysql driver and charset everywhere.

(cherry picked from commit 9fd40e760f4a3f8f7e2e56e0ba25780f724f87f1)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1157