### PR TITLE
tempest: Update for ocata

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -10,7 +10,7 @@ endpoint_type = internalURL
 
 [auth]
 admin_username = <%= @keystone_settings['admin_user'] %>
-admin_tenant_name = <%= @keystone_settings['default_tenant'] %>
+admin_project_name = <%= @keystone_settings['default_tenant'] %>
 admin_password = <%= @keystone_settings['admin_password'] %>
 admin_domain_name = Default
 
@@ -99,13 +99,7 @@ endpoint_type = internalURL
 http_image = <%= @http_image %>
 
 [image-feature-enabled]
-deactivate_image = true
 api_v1 = false
-
-[input-scenario]
-image_regex = <%= @image_regex %>
-flavor_regex = ^tempest-stuff$
-ssh_user_regex = [["^.*[Cc]irros.*$", "cirros"]]
 
 [magnum]
 image_id = <%= @magnum_settings['image_id'] %>
@@ -145,11 +139,7 @@ instance_type = <%= @heat_flavor_ref %>
 lock_path = /var/run/tempest
 
 [scenario]
-img_dir = <%= @tempest_path %>/etc/cirros/
 img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-disk.img
-ami_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-blank.img
-ari_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-initrd
-aki_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-vmlinuz
 
 [service_available]
 neutron = true
@@ -170,12 +160,12 @@ region = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internalURL
 multitenancy_enabled = False
 enable_protocols = <%= @manila_settings['enable_protocols'] %>
-storage_protocol = <%= @manila_settings['storage_protocol'] %>
+capability_storage_protocol = <%= @manila_settings['capability_storage_protocol'] %>
 enable_ip_rules_for_protocols = <%= @manila_settings['enable_ip_rules_for_protocols'] %>
 enable_cert_rules_for_protocols = <%= @manila_settings['enable_cert_rules_for_protocols'] %>
 suppress_errors_in_cleanup = true
 run_snapshot_tests =<%= @manila_settings['run_snapshot_tests'] %>
-run_consistency_group_tests =<%= @manila_settings['run_consistency_group_tests'] %>
+run_share_group_tests =<%= @manila_settings['run_share_group_tests'] %>
 image_with_share_tools = <%= @manila_settings['image_with_share_tools'] %>
 image_username = <%= @manila_settings['image_username'] %>
 image_password = <%= @manila_settings['image_password'] %>

--- a/chef/data_bags/crowbar/migrate/tempest/200_rename_manila_params.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/200_rename_manila_params.rb
@@ -1,0 +1,15 @@
+def upgrade(ta, td, a, d)
+  a["manila"]["capability_storage_protocol"] = a["manila"]["storage_protocol"]
+  a["manila"]["run_share_group_tests"] = a["manila"]["run_consistency_group_tests"]
+  a["manila"].delete("storage_protocol")
+  a["manila"].delete("run_consistency_group_tests")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["manila"]["storage_protocol"] = a["manila"]["capability_storage_protocol"]
+  a["manila"]["run_consistency_group_tests"] = a["manila"]["run_share_group_tests"]
+  a["manila"].delete("capability_storage_protocol")
+  a["manila"].delete("run_share_group_tests")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -22,10 +22,10 @@
         "default_share_type_name": "default",
         "enable_cert_rules_for_protocols": "glusterfs",
         "enable_ip_rules_for_protocols": "nfs, cifs",
-        "run_consistency_group_tests": false,
+        "run_share_group_tests": false,
         "run_snapshot_tests": true,
         "enable_protocols": "nfs, cifs",
-        "storage_protocol": "NFS_CIFS"
+        "capability_storage_protocol": "NFS_CIFS"
       },
       "magnum": {
         "image_id": "magnum-service-image",
@@ -41,7 +41,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 105,
+      "schema-revision": 200,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -36,10 +36,10 @@
                 "default_share_type_name": { "type": "str", "required": true },
                 "enable_cert_rules_for_protocols": { "type": "str", "required": true },
                 "enable_ip_rules_for_protocols": { "type": "str", "required": true },
-                "run_consistency_group_tests": { "type": "bool", "required": true },
+                "run_share_group_tests": { "type": "bool", "required": true },
                 "run_snapshot_tests": { "type": "bool", "required": true },
                 "enable_protocols": { "type": "str", "required": true },
-                "storage_protocol": { "type": "str", "required": true }
+                "capability_storage_protocol": { "type": "str", "required": true }
               }
             },
             "magnum": {


### PR DESCRIPTION
This patch updates the following config options noted as deprecated in
the ongoing release notes[1]:

  - remove [image-feature-enabled]/deactivate_image which has not been
    needed since kilo
  - remove the entire [input-scenario] section which are nonfunctional

It also updates the following config options which are not mentioned in
the release notes but produce deprecation warnings tempest.log:

  - switch [auth]/admin_tenant_name to [auth]/admin_project_name
  - remove [scenario]/img_dir and the different image container formats
    leaving only one raw disk image file
  - update manila config option names

[1] https://docs.openstack.org/releasenotes/tempest/unreleased.html