### PR TITLE
SCRD-39 removed deprecated verbose option for ceilometer

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -35,7 +35,6 @@ default[:ceilometer][:agent_notification][:service_name] = agent_notification_se
 default[:ceilometer][:central][:service_name] = central_service_name
 
 default[:ceilometer][:debug] = false
-default[:ceilometer][:verbose] = false
 
 default[:ceilometer][:use_mongodb] = false
 

--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -66,7 +66,6 @@ template node[:ceilometer][:config_file] do
     mode "0640"
     variables(
       debug: node[:ceilometer][:debug],
-      verbose: node[:ceilometer][:verbose],
       rabbit_settings: fetch_rabbitmq_settings,
       keystone_settings: keystone_settings,
       bind_host: bind_host,

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -5,7 +5,6 @@ libvirt_type = <%= @libvirt_type %>
 nova_http_log_debug = <%= @debug ? "true" : "false" %>
 host = <%= @node_hostname %>
 debug = <%= @debug ? "true" : "false" %>
-verbose = <%= @verbose ? "true" : "false" %>
 log_dir = /var/log/ceilometer
 use_stderr = false
 transport_url = <%= @rabbit_settings[:url] %>

--- a/chef/data_bags/crowbar/migrate/ceilometer/200_remove_deprecated_opts.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/200_remove_deprecated_opts.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("verbose")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["verbose"] = ta["verbose"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -4,7 +4,6 @@
   "attributes": {
     "ceilometer": {
       "debug": false,
-      "verbose": true,
       "use_mongodb": false,
       "cpu_interval": 600,
       "disk_interval": 600,
@@ -43,7 +42,7 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 104,
+      "schema-revision": 200,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-central": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-ceilometer.schema
+++ b/chef/data_bags/crowbar/template-ceilometer.schema
@@ -13,7 +13,6 @@
           "required": true,
           "mapping": {
             "debug": { "type": "bool", "required": true },
-            "verbose": { "type": "bool", "required": true },
             "use_mongodb": { "type": "bool", "required": true },
             "cpu_interval": { "type": "int", "required": true },
             "disk_interval": { "type": "int", "required": true },

--- a/crowbar_framework/app/views/barclamp/ceilometer/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ceilometer/_edit_attributes.html.haml
@@ -41,8 +41,3 @@
           "data-enabler" => "true",
           "data-enabler-target" => "#ssl_ca_certs"
         = string_field %w(ssl ca_certs)
-
-    %fieldset
-      %legend
-        = t(".logging_header")
-      = boolean_field :verbose

--- a/crowbar_framework/config/locales/ceilometer/en.yml
+++ b/crowbar_framework/config/locales/ceilometer/en.yml
@@ -32,8 +32,6 @@ en:
         network_interval: 'Interval used for network meter updates (in seconds)'
         meters_interval: 'Interval used for other meter updates (in seconds)'
         use_mongodb: 'Use MongoDB instead of standard database'
-        logging_header: 'Logging'
-        verbose: 'Verbose Logging'
         database:
           metering_time_to_live: 'How long are metering samples kept in the database (in days)'
           metering_time_to_live_hint: '-1 means that samples are kept in the database forever'


### PR DESCRIPTION
The following Ceilometer configuration options deprecated in Ocata (or earlier) are removed or replaced in this PR:

- [default]/verbose  deprecated option removed

References:

- Ocata release notes for Ceilometer: https://docs.openstack.org/releasenotes/ceilometer/ocata.html