### PR TITLE
ceilometer: replaced auth_token in process cache with memcached in ocata cookbook

### DIFF
--- a/chef/cookbooks/ceilometer/metadata.rb
+++ b/chef/cookbooks/ceilometer/metadata.rb
@@ -7,6 +7,7 @@ version "0.1"
 
 depends "nagios"
 depends "keystone"
+depends "memcached"
 depends "database"
 depends "crowbar-openstack"
 depends "crowbar-pacemaker"

--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -1,5 +1,14 @@
 include_recipe "apache2"
 
+is_controller = node["roles"].include?("ceilometer-server")
+ha_enabled = node[:ceilometer][:ha][:server][:enabled]
+
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "ceilometer-server") : [node]
+)
+
+memcached_instance("ceilometer-server") if is_controller
+
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 if node[:ceilometer][:use_mongodb]
@@ -68,6 +77,7 @@ template node[:ceilometer][:config_file] do
       debug: node[:ceilometer][:debug],
       rabbit_settings: fetch_rabbitmq_settings,
       keystone_settings: keystone_settings,
+      memcached_servers: memcached_servers,
       bind_host: bind_host,
       bind_port: bind_port,
       metering_secret: node[:ceilometer][:metering_secret],

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -31,6 +31,11 @@ project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_type = password
+memcached_servers = <%= @memcached_servers.join(',') %>
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = <%= node[:ceilometer][:memcache_secret_key] %>
+service_token_roles_required = true
+service_token_roles = admin
 
 [notification]
 workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>

--- a/chef/data_bags/crowbar/migrate/ceilometer/201_add_memcache_secret_key.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/201_add_memcache_secret_key.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  if a["memcache_secret_key"].nil? || a["memcache_secret_key"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["memcache_secret_key"] = service.random_password
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("memcache_secret_key")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -15,6 +15,7 @@
       "keystone_instance": "none",
       "service_user": "ceilometer",
       "service_password": "",
+      "memcache_secret_key": "",
       "api": {
         "protocol": "http",
         "port": 8777
@@ -42,7 +43,7 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-central": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-ceilometer.schema
+++ b/chef/data_bags/crowbar/template-ceilometer.schema
@@ -24,6 +24,7 @@
             "keystone_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
+            "memcache_secret_key": { "type": "str", "required": true },
             "api": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -117,6 +117,7 @@ class CeilometerService < OpenstackServiceObject
     } unless agent_nodes.nil? or server_nodes.nil?
 
     base["attributes"]["ceilometer"]["service_password"] = random_password
+    base["attributes"][@bc_name]["memcache_secret_key"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
     base["attributes"][@bc_name][:metering_secret] = random_password
 


### PR DESCRIPTION
The following Ceilometer configuration options deprecated in Ocata (or earlier) are removed or replaced in this PR:

- [keystone_authtoken]/service_token_roles_required  is set to True to enable fetching expired tokens based on valid service tokens and [keystone_authtoken]/service_token_roles is set to the admin role

The deprecated keystonemiddleware.auth_token in-process token cache used by ceilometer services is replaced with a memcached server. When HA is used, several memcached servers are configured and used, one for each ceilometer-server node. The keystone token data stored in memcached is authenticated and encrypted using a generated secret key.

References:

- Ocata release notes for Ceilometer: https://docs.openstack.org/releasenotes/ceilometer/ocata.html
- Ocata release notes for keystonemiddleware: https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html
- Mitaka release notes for keystonemiddleware: https://docs.openstack.org/releasenotes/keystonemiddleware/mitaka
- memcached protection options: https://docs.openstack.org/keystonemiddleware/latest/middlewarearchitecture.html#memcache-protection