### PR TITLE
Set State Snapshot Transfer Settings

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -41,9 +41,95 @@ unless node[:database][:galera_bootstrapped]
   end
 end
 
+unless node[:database][:galera_bootstrapped]
+  if CrowbarPacemakerHelper.is_cluster_founder?(node)
+    # To bootstrap for the first time, start galera on one node
+    # to set up the seed sst user.
+
+    template "temporary bootstrap /etc/my.cnf.d/galera.cnf" do
+      path "/etc/my.cnf.d/galera.cnf"
+      source "galera.cnf.erb"
+      owner "root"
+      group "mysql"
+      mode "0640"
+      variables(
+        cluster_addresses: "gcomm://",
+        sstuser: "root",
+        sstuser_password: ""
+      )
+    end
+
+    case node[:platform_family]
+    when "rhel", "fedora"
+      mysql_service_name = "mysqld"
+    else
+      mysql_service_name = "mysql"
+    end
+
+    # use the initial root:'' credentials to set up the new user. The
+    # unauthenticated root user is later removed in server.rb after the
+    # bootstraping. Once the cluster has started other nodes will pick up on
+    # the sstuser and we are able to use these credentails.
+    db_settings = fetch_database_settings
+    db_connection = db_settings[:connection].dup
+    db_connection[:host] = "localhost"
+    db_connection[:username] = "root"
+    db_connection[:password] = ""
+
+    service "mysql-temp start" do
+      service_name mysql_service_name
+      supports status: true, restart: true, reload: true
+      action :start
+    end
+
+    database_user "create state snapshot transfer user" do
+      connection db_connection
+      username "sstuser"
+      password node[:database][:mysql][:sstuser_password]
+      host "localhost"
+      provider db_settings[:user_provider]
+      action :create
+    end
+
+    database_user "grant sstuser root privileges" do
+      connection db_connection
+      username "sstuser"
+      password node[:database][:mysql][:sstuser_password]
+      host "localhost"
+      provider db_settings[:user_provider]
+      action :grant
+    end
+
+    service "mysql-temp stop" do
+      service_name mysql_service_name
+      supports status: true, restart: true, reload: true
+      action :stop
+    end
+  end
+end
+
+service_name = "galera"
+
+cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)
+nodes_names = cluster_nodes.map { |n| n[:hostname] }
+
+cluster_addresses = "gcomm://" + nodes_names.join(",")
+
+template "/etc/my.cnf.d/galera.cnf" do
+  source "galera.cnf.erb"
+  owner "root"
+  group "mysql"
+  mode "0640"
+  variables(
+    cluster_addresses: cluster_addresses,
+    sstuser: "sstuser",
+    sstuser_password: node[:database][:mysql][:sstuser_password]
+  )
+end
+
 # Wait for all nodes to reach this point so we know that all nodes will have
-# all the required packages installed before we create the pacemaker
-# resources
+# all the required packages and configurations installed before we create the
+# pacemaker resources
 crowbar_pacemaker_sync_mark "sync-database_before_ha" do
   revision node[:database]["crowbar-revision"]
 end
@@ -55,16 +141,11 @@ crowbar_pacemaker_sync_mark "wait-database_ha_resources" do
   revision node[:database]["crowbar-revision"]
 end
 
-service_name = "galera"
-
-cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)
-nodes_names = cluster_nodes.map { |n| n[:hostname] }
-
 pacemaker_primitive service_name do
   agent resource_agent
   params({
     "enable_creation" => true,
-    "wsrep_cluster_address" => "gcomm://" + nodes_names.join(","),
+    "wsrep_cluster_address" => cluster_addresses,
     "check_user" => "monitoring",
     "socket" => "/var/run/mysql/mysql.sock",
     "datadir" => node[:database][:mysql][:datadir]

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -19,7 +19,7 @@
 
 resource_agent = "ocf:heartbeat:galera"
 
-["galera-3-wsrep-provider", "mariadb-tools", "xtrabackup"].each do |p|
+["galera-3-wsrep-provider", "mariadb-tools", "xtrabackup", "socat"].each do |p|
   package p
 end
 

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -35,10 +35,6 @@ unless node[:database][:galera_bootstrapped]
     command "mysql_install_db"
     action :run
   end
-
-  crowbar_pacemaker_sync_mark "sync-database_after_install_db" do
-    revision node[:database]["crowbar-revision"]
-  end
 end
 
 unless node[:database][:galera_bootstrapped]

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -66,10 +66,6 @@ service mysql start
 EOC
 end
 
-cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)
-nodes_names = cluster_nodes.map { |n| n[:hostname] }
-cluster_addresses = "gcomm://" + nodes_names.join(",")
-
 template "/etc/my.cnf.d/openstack.cnf" do
   source "my.cnf.erb"
   owner "root"
@@ -101,19 +97,6 @@ template "/etc/my.cnf.d/tuning.cnf" do
     max_heap_table_size: node[:database][:mysql][:max_heap_table_size]
   )
   notifies :restart, "service[mysql]", :immediately
-end
-
-if node[:database][:ha][:enabled]
-  template "/etc/my.cnf.d/galera.cnf" do
-    source "galera.cnf.erb"
-    owner "root"
-    group "mysql"
-    mode "0640"
-    variables(
-      cluster_addresses: cluster_addresses
-    )
-    notifies :restart, "service[mysql]", :immediately
-  end
 end
 
 unless Chef::Config[:solo]

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -44,7 +44,19 @@ end
 
 service "mysql" do
   service_name mysql_service_name
-  supports status: true, restart: true, reload: true
+  if ha_enabled
+    supports status: true,
+             restart: true,
+             reload: true,
+             restart_crm_resource: true,
+             pacemaker_resource: "galera",
+             crm_resource_stop_cmd: "force-demote",
+             crm_resource_start_cmd: "force-promote"
+  else
+    supports status: true,
+             restart: true,
+             reload: true
+  end
   action :enable
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end

--- a/chef/cookbooks/mysql/templates/default/galera.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera.cnf.erb
@@ -6,3 +6,7 @@ innodb_doublewrite=1
 query_cache_size=0
 wsrep_on=ON
 binlog_format=ROW
+
+# SST method
+wsrep_sst_method = xtrabackup-v2
+wsrep_sst_auth = <%= @sstuser %>:<%= @sstuser_password %>

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -19,6 +19,7 @@
               "required": false,
               "mapping" : {
                 "server_root_password": { "type": "str" },
+                "sstuser_password": { "type": "str" },
                 "datadir": { "type": "str", "required": true },
                 "slow_query_logging": { "type": "bool", "required": true },
                 "innodb_buffer_pool_size": { "type": "int", "required": true },

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -174,6 +174,9 @@ class DatabaseService < PacemakerServiceObject
 
     if ( sql_engine == "mysql" )
       role.default_attributes["database"]["mysql"]["server_root_password"] = (old_role && old_role.default_attributes["database"]["mysql"]["server_root_password"]) || random_password
+      if database_ha_enabled
+        role.default_attributes["database"]["mysql"]["sstuser_password"] = (old_role && old_role.default_attributes["database"]["mysql"]["sstuser_password"]) || random_password
+      end
       @logger.debug("setting mysql specific attributes")
     elsif ( sql_engine == "postgresql" )
       # Attribute is not living in "database" namespace, but that's because


### PR DESCRIPTION
Use xtrabackup-v2 for transferring the state to new nodes joining the cluster.
This requires access to a root mysql user to do the transfer. Set up a new one
called "sstuser".