### PR TITLE
neutron: enable dns extension

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -156,7 +156,7 @@ when "ml2"
   os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
   mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
 
-  ml2_extension_drivers = ["port_security"]
+  ml2_extension_drivers = ["dns", "port_security"]
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv


### PR DESCRIPTION
This is a prerequisite for DNS as a Service integration,
but also allows assigning a dns_name attribute to ports,
see

https://docs.openstack.org/newton/networking-guide/config-dns-int.html