### PR TITLE
sahara: fix sahara sync mark name

### DIFF
--- a/chef/cookbooks/sahara/recipes/ha.rb
+++ b/chef/cookbooks/sahara/recipes/ha.rb
@@ -34,7 +34,7 @@ end.run_action(:create)
 # Wait for all nodes to reach this point so we know that all nodes will have
 # all the required packages installed before we create the pacemaker
 # resources
-crowbar_pacemaker_sync_mark "sync-sahara before_ha"
+crowbar_pacemaker_sync_mark "sync-sahara_before_ha"
 
 # Avoid races when creating pacemaker resources
 crowbar_pacemaker_sync_mark "wait-sahara_ha_resources"


### PR DESCRIPTION
Name has spaces on it, while the rest of the other sync marks dont have
any spaces. This also causes problems with the existing task of trying
to move the sync marks into the pacemaker attributes, as the attributes
do not accept spaces, and we are using the name in the sync mark to set
it as the attribute.


Blocks: https://github.com/crowbar/crowbar-ha/pull/217