### PR TITLE
[4.0] Use the same user for haproxy and RA monitoring.

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -63,7 +63,7 @@ pacemaker_primitive service_name do
   params({
     "enable_creation" => true,
     "wsrep_cluster_address" => "gcomm://" + nodes_names.join(","),
-    "check_user" => "''",
+    "check_user" => "monitoring",
     "socket" => "/var/run/mysql/mysql.sock"
   })
   op({
@@ -160,7 +160,7 @@ haproxy_loadbalancer "galera" do
   address CrowbarDatabaseHelper.get_listen_address(node)
   port 3306
   mode "tcp"
-  options ["mysql-check user haproxy"]
+  options ["mysql-check user monitoring"]
   stick ({ "on" => "dst" })
   servers ha_servers
   action :nothing

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -131,9 +131,9 @@ unless node[:database][:database_bootstrapped]
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
-  database_user "create haproxy monitoring user" do
+  database_user "create haproxy and galera monitoring user" do
     connection db_connection
-    username "haproxy"
+    username "monitoring"
     password ""
     host "%"
     provider db_settings[:user_provider]


### PR DESCRIPTION
(cherry picked from commit aa6a9815ec3249693856c8cf594bb468cf22d37c)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1161