### PR TITLE
neutron: enable dns extension

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -158,7 +158,7 @@ when "ml2"
   os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
   mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
 
-  ml2_extension_drivers = ["port_security"]
+  ml2_extension_drivers = ["dns", "port_security"]
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -291,10 +291,6 @@ elsif !node[:nova]["use_shared_instance_storage"]
   end
 end
 
-unless node[:nova][:user].empty? or node["etc"]["passwd"][node[:nova][:user]].nil?
-  nova_home_dir = node["etc"]["passwd"][node[:nova][:user]]["dir"]
-end
-
 # Create and distribute ssh keys for nova user on all compute nodes
 
 # if for some reason, we only have one of the two keys, we recreate the keys


### PR DESCRIPTION
This is a prerequisite for DNS as a Service integration,
but also allows assigning a dns_name attribute to ports,
see

https://docs.openstack.org/newton/networking-guide/config-dns-int.html
(cherry picked from commit e3ec41494fffd1f9c0df03022a1cb8294c7f8dc2)