### PR TITLE
[4.0] mariadb: Drop anonymous database user

### DIFF
--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -172,6 +172,15 @@ unless node[:database][:database_bootstrapped]
     action :drop
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
+
+  database_user "drop anonymous database user" do
+    connection db_connection
+    username ""
+    host "*"
+    provider db_settings[:user_provider]
+    action :drop
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
 end
 
 ruby_block "mark node for database bootstrap" do


### PR DESCRIPTION
The mysql_secure_install script drops all anonymous database users to
prevent unauthorized logins. Let's do the same in our cookbooks.

(cherry picked from commit 7c4e10f2430021cbe708001f3b906e20c8e74e74)

Backport from https://github.com/crowbar/crowbar-openstack/pull/1145