### PR TITLE
Forwardport neutron-ha-tool service

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -243,3 +243,14 @@ default[:neutron][:ha][:infoblox][:infoblox_ra] =
 default[:neutron][:ha][:infoblox][:op][:monitor][:interval] = "10s"
 # Ports to bind to when haproxy is used for the real ports
 default[:neutron][:ha][:ports][:server] = 5530
+
+default[:neutron][:ha][:neutron_l3_ha_resource][:op][:monitor][:interval] = "10s"
+
+default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:status][:terminate] = 300
+default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:status][:kill] = 120
+default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:router_migration][:terminate] = 1800
+default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:router_migration][:kill] = 120
+default[:neutron][:ha][:neutron_l3_ha_service][:hatool][:program] = "/usr/bin/neutron-ha-tool"
+default[:neutron][:ha][:neutron_l3_ha_service][:hatool][:env] = {}
+default[:neutron][:ha][:neutron_l3_ha_service][:seconds_to_sleep_between_checks] = 10
+default[:neutron][:ha][:neutron_l3_ha_service][:max_errors_tolerated] = 10

--- a/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
+++ b/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
@@ -1,0 +1,383 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'yaml'
+require 'open3'
+require 'logger'
+
+class HAToolLog
+  def self.log
+    if @logger.nil?
+      @logger = Logger.new(STDERR)
+      @logger.level = Logger::DEBUG
+    end
+    @logger
+  end
+end
+
+def main
+  terminator = Terminator.new
+  terminator.register_term_signal_handler
+  service_options = ServiceOptions.load ARGV[0]
+  ha_functions = HAFunctions.new(service_options)
+  error_counter = ErrorCounter.new service_options.max_errors_tolerated
+
+  while true
+    status = ha_functions.check_l3_agents
+    if status.exit_status == 2
+      error_counter.reset!
+
+      register_errors_to(
+        error_counter,
+        terminator.dont_exit_until_block_finished do
+          ha_functions.migrate_routers_away_from_dead_agents
+        end
+      )
+    elsif status.exit_status == 0
+      error_counter.reset!
+    else
+      error_counter.bump!
+    end
+
+    HAToolLog.log.info("Sleeping until next run")
+    sleep service_options.seconds_to_sleep_between_checks
+  end
+end
+
+
+def register_errors_to error_counter, result
+  if result.exit_status == 0
+    error_counter.reset!
+  else
+    error_counter.bump!
+  end
+end
+
+
+class Terminator
+  def initialize
+    @immediate_exit_enabled = true
+    @exit_requested = false
+  end
+
+  def register_term_signal_handler
+    Signal.trap "TERM" do
+      exit 0 if @immediate_exit_enabled
+      @exit_requested = true
+    end
+  end
+
+  def dont_exit_until_block_finished
+    @immediate_exit_enabled = false
+    result = yield
+    @immediate_exit_enabled = true
+    if @exit_requested
+      HAToolLog.log.info("TERM signal received while waiting for block to finish, exiting now")
+      exit 0
+    end
+    result
+  end
+end
+
+
+class HAFunctions
+  def initialize(service_options)
+    @service_options = service_options
+    @hatool = HATool.new service_options.hatool
+    # TODO(mlakat): Check if we can skip this step
+    # maybe we should just assume that the tool supports --retry?
+  end
+
+  def check_l3_agents
+    HAToolLog.log.info("checking for dead agents")
+    run_supervised(
+      @hatool.status_command,
+      @service_options.status_timeout
+    )
+  end
+
+  def migrate_routers_away_from_dead_agents
+    HAToolLog.log.info("migrating routers away from dead agents")
+    run_supervised(
+      @hatool.migration_command,
+      @service_options.router_migration_timeout
+    )
+  end
+
+  def run_supervised(command, timeout)
+    subprocess = Subprocess.new *command
+    subprocess.env.merge! @service_options.hatool.env
+    supervisor = Supervisor.new(subprocess, timeout)
+    supervisor.run_subprocess
+  end
+end
+
+
+class TimedOut < StandardError
+end
+
+
+class MaximumErrorsReached < StandardError
+end
+
+
+class AlreadyCompleted < StandardError
+end
+
+
+class RunningHelpFailed < StandardError
+end
+
+
+class LoggingStreamReader
+  def initialize
+    @lines = []
+    @thread = nil
+  end
+
+  def read stream, log_msg
+    @thread = Thread.new do
+      stream.each do |line|
+        @lines << line
+        HAToolLog.log.info("#{log_msg} #{line}")
+      end
+    end
+  end
+
+  def content
+    @lines.join("\n")
+  end
+
+  def join
+    # Leave 1 second for the thread to join, otherwise raise an exception
+    result = @thread.join 1
+    if result.nil?
+      raise StandardError
+    end
+  end
+end
+
+
+class Subprocess
+  attr_reader :env
+
+  def initialize *args
+    @args = args
+    @completed = false
+    @env = {}
+    @stdout_reader = LoggingStreamReader.new
+    @stderr_reader = LoggingStreamReader.new
+  end
+
+  def environment
+    Hash[@env.map { |key, val| [key, val.to_s] }]
+  end
+
+  def start
+    stdin, stdout, stderr, @wait_thr = Open3.popen3(environment, *@args)
+    @pid = @wait_thr.pid
+    @stdout_reader.read stdout, "#{self} stdout:"
+    @stderr_reader.read stderr, "#{self} stderr:"
+    stdin.close
+  end
+
+  def wait timeout
+    if @completed
+      raise AlreadyCompleted
+    end
+    wait_result = @wait_thr.join(timeout)
+    if wait_result.nil?
+      raise TimedOut
+    else
+      @completed = true
+      @stdout_reader.join
+      @stderr_reader.join
+      output = @stdout_reader.content
+      error = @stderr_reader.content
+      exitstatus = @wait_thr.value.exitstatus
+      RunResult.new output, error, exitstatus
+    end
+  end
+
+  def send_signal signal
+    begin
+      Process.kill(signal, @pid)
+    rescue Errno::ESRCH
+      # Process already killed
+    end
+  end
+
+  def to_s
+    status = @pid.nil? ? "not-started-yet" : @pid.to_s
+    status = "already-exited" if @completed
+    "Subprocess(#{@args.join " "})[#{status}]"
+  end
+end
+
+
+class ServiceOptions
+  attr_reader :status_timeout
+  attr_reader :router_migration_timeout
+  attr_reader :hatool
+  attr_reader :seconds_to_sleep_between_checks
+  attr_reader :max_errors_tolerated
+
+  def initialize(status_timeout, router_migration_timeout, hatool_options, sleep_time, max_errors_tolerated)
+    @status_timeout = status_timeout
+    @router_migration_timeout = router_migration_timeout
+    @hatool = hatool_options
+    @seconds_to_sleep_between_checks = sleep_time
+    @max_errors_tolerated = max_errors_tolerated
+  end
+
+  def self.load(path)
+    File.open path do |file|
+      data = YAML.load file.read
+      ServiceOptions.new(
+        TimeoutOptions.from_hash(data["timeouts"]["status"]),
+        TimeoutOptions.from_hash(data["timeouts"]["router_migration"]),
+        HAToolOptions.from_hash(data["hatool"]),
+        data["seconds_to_sleep_between_checks"].to_i,
+        data["max_errors_tolerated"].to_i
+      )
+    end
+  end
+end
+
+
+class ErrorCounter
+  attr_reader :errors
+
+  def initialize max_errors_tolerated
+    @max_errors_tolerated = max_errors_tolerated
+    @errors = 0
+  end
+
+  def reset!
+    HAToolLog.log.info("error counter: re-set to 0")
+    @errors = 0
+  end
+
+  def bump!
+    @errors += 1
+    HAToolLog.log.info("error counter: bumped to #{@errors}")
+    if @errors > @max_errors_tolerated
+      HAToolLog.log.error("error counter: exceeded limit #{@max_errors_tolerated}")
+      raise MaximumErrorsReached
+    end
+  end
+end
+
+
+class Supervisor
+  def initialize subprocess, timeout_options
+    @subprocess = subprocess
+    @timeout_options = timeout_options
+  end
+
+  def run_subprocess
+    HAToolLog.log.info("supervisor: starting #{@subprocess}")
+    @subprocess.start
+    HAToolLog.log.info("supervisor: monitoring #{@subprocess}")
+
+    result = begin
+      @subprocess.wait @timeout_options.terminate
+    rescue TimedOut
+      HAToolLog.log.info("supervisor: #{@subprocess} did not terminate, sending TERM signal")
+      @subprocess.send_signal "TERM"
+      begin
+        @subprocess.wait @timeout_options.kill
+      rescue TimedOut
+        HAToolLog.log.info("supervisor: #{@subprocess} did not terminate, sending KILL signal")
+        @subprocess.send_signal "KILL"
+        @subprocess.wait 1
+      end
+    end
+
+    HAToolLog.log.info("supervisor: done running #{@subprocess} exited with: #{result.exit_status}")
+    result
+  end
+end
+
+class HATool
+  attr_reader :extra_flags
+
+  def initialize(options)
+    @extra_flags = ["--retry"]
+    @options = options
+  end
+
+  def insecure_flag
+    @options.insecure ? ["--insecure"] : []
+  end
+
+  def status_command
+    [@options.program, "--l3-agent-check", "--quiet"]
+  end
+
+  def migration_command
+    [@options.program, "--l3-agent-migrate", "--now"] + @extra_flags + insecure_flag
+  end
+end
+
+class RunResult
+  attr_reader :output
+  attr_reader :error
+  attr_reader :exit_status
+
+  def initialize(output, error, exit_status)
+    @output = output
+    @error = error
+    @exit_status = exit_status
+  end
+end
+
+class TimeoutOptions
+  attr_reader :terminate
+  attr_reader :kill
+
+  def initialize(terminate_timeout, kill_timeout)
+    @terminate = terminate_timeout.to_i
+    @kill = kill_timeout.to_i
+  end
+
+  def self.from_hash(hash)
+    TimeoutOptions.new hash["terminate"], hash["kill"]
+  end
+end
+
+class HAToolOptions
+  attr_reader :program
+  attr_reader :env
+  attr_reader :insecure
+
+  def initialize(program, env, insecure)
+    @program = program
+    @env = env
+    @insecure = insecure
+  end
+
+  def self.to_bool(value)
+    value.to_s == "true"
+  end
+
+  def self.from_hash(hash)
+    HAToolOptions.new hash["program"], hash["env"], to_bool(hash["insecure"])
+  end
+end
+
+main if __FILE__ == $PROGRAM_NAME

--- a/chef/cookbooks/neutron/libraries/helpers.rb
+++ b/chef/cookbooks/neutron/libraries/helpers.rb
@@ -74,4 +74,33 @@ module NeutronHelper
       Chef::Node.load(network_node_name)
     end
   end
+
+  def self.stringify_keys_values(value)
+    if value.is_a? Hash
+      Hash[value.map { |key, val| [stringify_keys_values(key), stringify_keys_values(val)] }]
+    else
+      value.to_s
+    end
+  end
+
+  def self.serialize_to_yaml(hash)
+    stringify_keys_values(hash).to_yaml
+  end
+
+  def self.make_l3_ha_service_config(default_values, insecure)
+    settings = Marshal.load(Marshal.dump(default_values))  # non-elegant deep copy
+    yield settings["hatool"]["env"]
+    settings["hatool"]["insecure"] = insecure
+    serialize_to_yaml(settings)
+  end
+
+  def self.max_kill_timeout(timeout_records)
+    timeouts = []
+    timeout_records.each do |component, timeout_record|
+      timeout_record.each do |operation, timeout|
+        timeouts << timeout if operation.to_s == "kill"
+      end
+    end
+    timeouts.max
+  end
 end

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -53,6 +53,67 @@ if use_l3_agent
       keystone_settings: keystone_settings
     )
   end
+
+  # skip neutron-ha-tool resource creation during upgrade
+  unless CrowbarPacemakerHelper.being_upgraded?(node)
+
+    # FIXME: neutron-ha-tool can't do keystone v3 currently
+    os_auth_url_v2 = KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],
+                                                          keystone_settings["internal_url_host"],
+                                                          keystone_settings["service_port"],
+                                                          "2.0")
+
+    # Add configuration file
+    insecure_flag = keystone_settings["insecure"] || node[:neutron][:ssl][:insecure]
+    default_settings = node[:neutron][:ha][:neutron_l3_ha_service].to_hash
+    config_file_contents = NeutronHelper.make_l3_ha_service_config default_settings,
+                                                                   insecure_flag do |env|
+      env["OS_AUTH_URL"] = os_auth_url_v2
+      env["OS_REGION_NAME"] = keystone_settings["endpoint_region"]
+      env["OS_TENANT_NAME"] = keystone_settings["admin_tenant"]
+      env["OS_USERNAME"] = keystone_settings["admin_user"]
+    end
+
+    file "/etc/neutron/neutron-l3-ha-service.yaml" do
+      owner "root"
+      group "root"
+      mode "0600"
+      content config_file_contents
+      action :create
+    end
+
+    # Install service script
+    cookbook_file "neutron-l3-ha-service.rb" do
+      source "neutron-l3-ha-service.rb"
+      path "/usr/bin/neutron-l3-ha-service"
+      mode "0755"
+      owner "root"
+      group "root"
+    end
+
+    # install systemd unit configuration
+    systemd_kill_timeout = NeutronHelper.max_kill_timeout(
+      node[:neutron][:ha][:neutron_l3_ha_service][:timeouts]
+    ) + 5
+
+    template "/etc/systemd/system/neutron-l3-ha-service.service" do
+      source "neutron-l3-ha-service.service.erb"
+      mode "0644"
+      owner "root"
+      group "root"
+      variables(
+        timeout_in_seconds: systemd_kill_timeout
+      )
+    end
+
+    # Reload systemd when unit file changed
+    bash "reload systemd after neutron-l3-ha-service update" do
+      code "systemctl daemon-reload"
+      action :nothing
+      subscribes :run, resources("template[/etc/systemd/system/neutron-l3-ha-service.service]"),
+        :immediately
+    end
+  end
 end
 
 # Wait for all "neutron-network" nodes to reach this point so we know that they will
@@ -167,12 +228,6 @@ if CrowbarPacemakerHelper.being_upgraded?(node)
 end
 
 if use_l3_agent
-  # FIXME: neutron-ha-tool can't do keystone v3 currently
-  os_auth_url_v2 = KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],
-                                                         keystone_settings["internal_url_host"],
-                                                         keystone_settings["service_port"],
-                                                         "2.0")
-
   # Remove old resource
   ha_tool_primitive_name = "neutron-ha-tool"
   pacemaker_primitive ha_tool_primitive_name do
@@ -198,6 +253,7 @@ if use_l3_agent
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
+  # Add pacemaker resource for neutron-l3-ha-service
   ha_service_transaction_objects = []
   ha_service_primitive_name = "neutron-l3-ha-service"
 
@@ -207,7 +263,6 @@ if use_l3_agent
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-
   ha_service_transaction_objects << "pacemaker_primitive[#{ha_service_primitive_name}]"
 
   ha_service_location_name = openstack_pacemaker_controller_only_location_for(
@@ -225,7 +280,7 @@ if use_l3_agent
 
   rabbit_settings = fetch_rabbitmq_settings
 
-  crowbar_pacemaker_order_only_existing "o-#{ha_tool_primitive_name}" do
+  crowbar_pacemaker_order_only_existing "o-#{ha_service_primitive_name}" do
     # While neutron-ha-tool technically doesn't directly depend on postgresql or
     # rabbitmq, if these bits are not running, then neutron-server can run but
     # can't do what it's being asked. Note that neutron-server does have a
@@ -233,7 +288,7 @@ if use_l3_agent
     # doesn't need to be restarted when postgresql or rabbitmq are restarted).
     # So explicitly depend on postgresql and rabbitmq (if they are in the cluster).
     ordering "( postgresql #{rabbit_settings[:pacemaker_resource]} g-haproxy cl-neutron-server " \
-        "#{l3_agent_clone} ) #{ha_tool_primitive_name}"
+             "#{l3_agent_clone} ) #{ha_service_primitive_name}"
     score "Mandatory"
     action :create
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -173,29 +173,51 @@ if use_l3_agent
                                                          keystone_settings["service_port"],
                                                          "2.0")
 
-  ha_tool_transaction_objects = []
-
+  # Remove old resource
   ha_tool_primitive_name = "neutron-ha-tool"
   pacemaker_primitive ha_tool_primitive_name do
     agent node[:neutron][:ha][:network][:ha_tool_ra]
-    params ({
-      "os_auth_url"    => os_auth_url_v2,
-      "os_region_name" => keystone_settings["endpoint_region"],
-      "os_tenant_name" => keystone_settings["admin_tenant"],
-      "os_username"    => keystone_settings["admin_user"],
-      "os_insecure"    => keystone_settings["insecure"] || node[:neutron][:ssl][:insecure]
-    })
-    op node[:neutron][:ha][:neutron_ha_tool][:op]
+    action [:stop, :delete]
+    only_if "crm configure show #{ha_tool_primitive_name}"
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  # Remove old location
+  ha_tool_location_name = "l-#{ha_tool_primitive_name}-controller"
+  pacemaker_location ha_tool_location_name do
+    action :delete
+    only_if "crm configure show #{ha_tool_location_name}"
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  # Remove old ordering
+  ha_tool_ordering_name = "o-#{ha_tool_primitive_name}"
+  pacemaker_order ha_tool_ordering_name do
+    action :delete
+    only_if "crm configure show #{ha_tool_ordering_name}"
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  ha_service_transaction_objects = []
+  ha_service_primitive_name = "neutron-l3-ha-service"
+
+  pacemaker_primitive ha_service_primitive_name do
+    agent "systemd:neutron-l3-ha-service"
+    op node[:neutron][:ha][:neutron_l3_ha_resource][:op]
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
-  ha_tool_transaction_objects << "pacemaker_primitive[#{ha_tool_primitive_name}]"
 
-  ha_tool_location_name = openstack_pacemaker_controller_only_location_for ha_tool_primitive_name
-  ha_tool_transaction_objects << "pacemaker_location[#{ha_tool_location_name}]"
+  ha_service_transaction_objects << "pacemaker_primitive[#{ha_service_primitive_name}]"
 
-  pacemaker_transaction "neutron ha tool" do
-    cib_objects ha_tool_transaction_objects
+  ha_service_location_name = openstack_pacemaker_controller_only_location_for(
+    ha_service_primitive_name
+  )
+
+  ha_service_transaction_objects << "pacemaker_location[#{ha_service_location_name}]"
+
+  pacemaker_transaction "neutron ha service" do
+    cib_objects ha_service_transaction_objects
     # note that this will also automatically start the resources
     action :commit_new
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }

--- a/chef/cookbooks/neutron/templates/default/neutron-l3-ha-service.service.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron-l3-ha-service.service.erb
@@ -1,0 +1,24 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[Unit]
+Description=Neutron L3 HA Service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/neutron-l3-ha-service /etc/neutron/neutron-l3-ha-service.yaml
+# Time to wait for the process to react to the TERM signal
+TimeoutStopSec=<%= @timeout_in_seconds %>

--- a/spec/neutron_helpers_spec.rb
+++ b/spec/neutron_helpers_spec.rb
@@ -1,0 +1,102 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../chef/cookbooks/neutron/libraries/helpers"
+
+
+describe "yaml serialization" do
+  it "can deal with symbols" do
+    yaml = NeutronHelper.serialize_to_yaml({:key => "value"})
+
+    expect(yaml).to eq <<-EOF.gsub /^\s+/, ""
+    ---
+    key: value
+    EOF
+  end
+end
+
+
+describe "make config" do
+  it "adds environment variables" do
+    defaults = { "hatool" => { "env" => { "somekey" => "somevalue" }}}
+
+    config = NeutronHelper.make_l3_ha_service_config defaults, true do |env|
+      env["other_key"] = "other_value"
+    end
+
+    settings = YAML.safe_load config
+
+    expected = {
+        "hatool" => {
+            "env" => {
+                "somekey" => "somevalue",
+                "other_key" => "other_value"
+            },
+            "insecure" => "true"
+        }
+    }
+    expect(settings).to eq expected
+  end
+
+  it "sets insecure flag" do
+    defaults = { "hatool" => { "env" => { "somekey" => "somevalue" }}}
+
+    config = NeutronHelper.make_l3_ha_service_config defaults, true do |env|
+      env["other_key"] = "other_value"
+    end
+
+    settings = YAML.safe_load config
+
+    expect(settings["hatool"]["insecure"]).to eq "true"
+  end
+
+  it "leaves defaults at their value" do
+    defaults = { "hatool" => { "env" => { "somekey" => "somevalue" }}}
+
+    config = NeutronHelper.make_l3_ha_service_config defaults, true do |env|
+      env["other_key"] = "other_value"
+    end
+
+    YAML.safe_load config
+
+    expect(defaults).to eq({ "hatool" => { "env" => { "somekey" => "somevalue" }}})
+  end
+end
+
+
+describe "max timeout" do
+  context "some default values" do
+    before do
+      @timeout_records = {
+        status: {
+          kill: 12
+        },
+        some_operation: {
+          kill: 16
+        },
+        other_operation: {
+          kill: 11,
+          some_other_operation: 43
+        }
+      }
+    end
+    it "returns with the highest timeout value" do
+      result = NeutronHelper.max_kill_timeout @timeout_records
+
+      expect(result).to eq 16
+    end
+  end
+end

--- a/spec/neutron_l3_ha_service_spec.rb
+++ b/spec/neutron_l3_ha_service_spec.rb
@@ -1,0 +1,598 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "tmpdir"
+require "rbconfig"
+require_relative "../chef/cookbooks/neutron/files/default/neutron-l3-ha-service"
+
+ruby_bin = File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])
+# seconds to wait for simple subprocesses to complete. It might depend on the speed of your computer
+small_delay = 1
+
+class Tmpdir
+  # Helper class for creating files and getting their contents
+  # within a temporary directory.
+  def initialize(root_path)
+    @root_path = root_path
+  end
+
+  def path_for(basename)
+    File.join(@root_path, basename)
+  end
+
+  def write_file(basename, contents)
+    full_path = path_for(basename)
+    File.open(full_path, "w") do |script|
+      script.write contents
+    end
+    full_path
+  end
+
+  def write_script(basename, content)
+    full_path = write_file basename, content
+    FileUtils.chmod 0o700, full_path
+    full_path
+  end
+
+  def contents_of(basename)
+    File.read(path_for(basename))
+  end
+end
+
+def with_tmpdir
+  Dir.mktmpdir do |tmpdir|
+    yield Tmpdir.new(tmpdir)
+  end
+end
+
+describe ServiceOptions do
+  context "valid settings file" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        @tmpdir = tmpdir
+        tmpdir.write_file "settings.yml", {
+          "timeouts" => {
+            "status" => {
+              "terminate" => 1,
+              "kill" => 2
+            },
+            "router_migration" => {
+              "terminate" => 5,
+              "kill" => 6
+            }
+          },
+          "hatool" => {
+            "program" => "path-to-hatool",
+            "env" => {
+              "some-key" => "some-value"
+            },
+            "insecure" => "false"
+          },
+          "seconds_to_sleep_between_checks" => "10",
+          "max_errors_tolerated" => "13"
+        }.to_yaml
+        example.run
+      end
+    end
+
+    it "loads status timeout" do
+      service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
+      expect(service_options.status_timeout.terminate).to eq 1
+      expect(service_options.status_timeout.kill).to eq 2
+    end
+
+    it "loads router migration timeouts" do
+      service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
+      expect(service_options.router_migration_timeout.terminate).to eq 5
+      expect(service_options.router_migration_timeout.kill).to eq 6
+    end
+
+    it "loads hatool parameters" do
+      service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
+      expect(service_options.hatool.program).to eq "path-to-hatool"
+      expect(service_options.hatool.env).to eq("some-key" => "some-value")
+    end
+
+    it "loads seconds_to_sleep_between_checks parameter" do
+      service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
+      expect(service_options.seconds_to_sleep_between_checks).to eq 10
+    end
+
+    it "loads max_errors_tolerated parameter" do
+      service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
+      expect(service_options.max_errors_tolerated).to eq 13
+    end
+
+    it "loads insecure parameter" do
+      service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
+      expect(service_options.hatool.insecure).to eq false
+    end
+  end
+end
+
+describe TimeoutOptions do
+  context "mixed strings and numbers" do
+    before do
+      @data = {
+        "terminate" => 1,
+        "kill" => "2"
+      }
+    end
+
+    it "converts them to integers" do
+      timeout_options = TimeoutOptions.from_hash(@data)
+
+      expect(timeout_options.terminate).to eq 1
+      expect(timeout_options.kill).to eq 2
+    end
+  end
+end
+
+def sleep_workaround_for_subprocess
+  # After starting the subprocess, a small delay has to be added, otherwise
+  # the signals will not be received by the created processes for some reason
+  sleep 1
+end
+
+describe Subprocess do
+  before(:all) do
+    # supress all the log output that pollutes the terminal during tests
+    HAToolLog.log.level = Logger::FATAL
+  end
+  it "exit_status set to the exit code of the subprocess" do
+    subprocess = Subprocess.new ruby_bin, "-e", "exit 1"
+
+    subprocess.start
+    result = subprocess.wait 1
+
+    expect(result.exit_status).to eq 1
+  end
+
+  it "wait raises exception when run times out" do
+    subprocess = Subprocess.new ruby_bin, "-e", "sleep 0.2"
+    subprocess.start
+
+    expect { subprocess.wait 0.1 }.to raise_error TimedOut
+  end
+
+  it "output contains stdout of subprocess", focus: true do
+    subprocess = Subprocess.new ruby_bin, "-e", "puts 'hello'"
+    subprocess.start
+    run_result = subprocess.wait small_delay
+
+    expect(run_result.output).to include "hello"
+  end
+
+  it "error contains stderr of subprocess" do
+    subprocess = Subprocess.new ruby_bin, "-e", "STDERR.puts 'hello'"
+    subprocess.start
+    run_result = subprocess.wait small_delay
+
+    expect(run_result.error).to include "hello"
+  end
+
+  it "raises error when executable not found" do
+    subprocess = Subprocess.new "nonexisting-executable"
+
+    expect { subprocess.start }.to raise_error
+  end
+
+  it "raises an error when user waits for an already terminated subprocess" do
+    subprocess = Subprocess.new ruby_bin, "-e", ""
+    subprocess.start
+    subprocess.wait 1
+
+    expect { subprocess.wait 1 }.to raise_error
+  end
+
+  context "running a subprocess that exits with 2 on term signal" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        tmpdir.write_script "somescript", <<-EOF
+        Signal.trap "TERM" do
+          exit 2
+        end
+        sleep 2
+        exit 1
+        EOF
+        @path_to_script = tmpdir.path_for "somescript"
+        example.run
+      end
+    end
+
+    it "gets 2 as an exit value when term sent to subprocess" do
+      subprocess = Subprocess.new ruby_bin, @path_to_script
+      subprocess.start
+
+      sleep_workaround_for_subprocess
+      subprocess.send_signal "TERM"
+      run_result = subprocess.wait 1
+
+      expect(run_result.exit_status).to eq 2
+    end
+  end
+
+  it "converts environment values to strings" do
+    subprocess = Subprocess.new "irrelevant"
+    subprocess.env["somekey"] = 3
+
+    expect(subprocess.environment).to eq("somekey" => "3")
+  end
+
+  context "running a subprocess that exits with the value of EXITVAL environment variable" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        tmpdir.write_script "somescript", <<-EOF
+        exit ENV["EXITVAL"].to_i
+        EOF
+        @path_to_script = tmpdir.path_for "somescript"
+        example.run
+      end
+    end
+
+    it "gets exit code 2 when EXITVAL=2" do
+      subprocess = Subprocess.new ruby_bin, @path_to_script
+      subprocess.env["EXITVAL"] = 43
+      subprocess.start
+
+      run_result = subprocess.wait 1
+
+      expect(run_result.exit_status).to eq 43
+    end
+  end
+
+  context "running a subprocess that takes a long time" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        tmpdir.write_script "somescript", <<-EOF
+        STDOUT.puts "text on stdout"
+        STDERR.puts "text on stderr"
+        STDOUT.flush
+        STDERR.flush
+        sleep 1000
+        EOF
+        @path_to_script = tmpdir.path_for "somescript"
+        example.run
+      end
+    end
+
+    it "returns with nil exit status when process is killed" do
+      subprocess = Subprocess.new ruby_bin, @path_to_script
+      subprocess.start
+
+      sleep_workaround_for_subprocess
+      subprocess.send_signal "KILL"
+
+      run_result = subprocess.wait 1
+
+      expect(run_result.exit_status).to eq nil
+    end
+
+    it "returns the ooutput of the process killed" do
+      subprocess = Subprocess.new ruby_bin, @path_to_script
+      subprocess.start
+
+      sleep_workaround_for_subprocess
+      subprocess.send_signal "KILL"
+
+      run_result = subprocess.wait 1
+
+      expect(run_result.output).to include "text on stdout"
+      expect(run_result.error).to include "text on stderr"
+    end
+  end
+
+  context "running a subprocess that quits promptly" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        tmpdir.write_script "somescript", <<-EOF
+        puts "hi"
+        EOF
+        @path_to_script = tmpdir.path_for "somescript"
+        example.run
+      end
+    end
+
+    specify "should ignore when signal sent to a finished process" do
+      subprocess = Subprocess.new ruby_bin, @path_to_script
+      subprocess.start
+
+      sleep 0.4 # Assuming that this is enough time for the process to die
+
+      subprocess.send_signal "TERM"
+    end
+  end
+end
+
+describe HATool do
+  context "insecure flag is false" do
+    before do
+      @ha_tool = HATool.new(HAToolOptions.new("hatool", {}, false))
+    end
+  end
+
+  context "insecure flag is false" do
+    before do
+      @options = HAToolOptions.new("hatool", {}, false)
+    end
+
+    it "excludes extra_flags for status check" do
+      hatool = HATool.new @options
+      hatool.extra_flags.push "extra"
+
+      expected = ["hatool", "--l3-agent-check", "--quiet"]
+      expect(hatool.status_command).to eq expected
+    end
+
+    it "includes extra_flags for agent migration" do
+      hatool = HATool.new @options
+      hatool.extra_flags.push "extra"
+
+      expected = ["hatool", "--l3-agent-migrate", "--now", "--retry", "extra"]
+      expect(hatool.migration_command).to eq expected
+    end
+  end
+
+  context "insecure flag is true" do
+    before do
+      @options = HAToolOptions.new("hatool", {}, true)
+    end
+
+    it "includes --insecure for agent migration" do
+      hatool = HATool.new @options
+
+      expect(hatool.migration_command).to include "--insecure"
+    end
+  end
+end
+
+describe Supervisor do
+  context "subprocess does not time out" do
+    before do
+      timeout_options = TimeoutOptions.new 10, 2
+      @subprocess = double
+      allow(@subprocess).to receive(:start)
+      allow(@subprocess).to receive(:wait) { RunResult.new "out", "err", 1 }
+      @supervisor = Supervisor.new @subprocess, timeout_options
+    end
+
+    it "runs subprocess and waits" do
+      expect(@subprocess).to receive(:start).with(no_args)
+      expect(@subprocess).to receive(:wait).with(10)
+
+      @supervisor.run_subprocess
+    end
+
+    it "returns with the results of the subprocess" do
+      result = @supervisor.run_subprocess
+
+      expect(result.output).to eq "out"
+      expect(result.error).to eq "err"
+      expect(result.exit_status).to eq 1
+    end
+  end
+
+  context "subprocess times out but responds to term signal" do
+    before do
+      timeout_options = TimeoutOptions.new 10, 2
+      @subprocess = double
+      allow(@subprocess).to receive(:start)
+      @call_count = 0
+      allow(@subprocess).to receive(:wait) do
+        if @call_count == 0
+          @call_count += 1
+          raise TimedOut
+        end
+        RunResult.new "out", "err", 1
+      end
+      allow(@subprocess).to receive(:send_signal)
+      @supervisor = Supervisor.new @subprocess, timeout_options
+    end
+
+    it "sends the subprocess term signal" do
+      expect(@subprocess).to receive(:start).with(no_args)
+      expect(@subprocess).to receive(:wait).with(10)
+      expect(@subprocess).to receive(:send_signal).with("TERM")
+      expect(@subprocess).to receive(:wait).with(2)
+
+      @supervisor.run_subprocess
+    end
+
+    it "returns with the results of the subprocess" do
+      result = @supervisor.run_subprocess
+
+      expect(result.output).to eq "out"
+      expect(result.error).to eq "err"
+      expect(result.exit_status).to eq 1
+    end
+
+  end
+
+  context "subprocess does not respond to term" do
+    before do
+      timeout_options = TimeoutOptions.new 10, 2
+      @subprocess = double
+      allow(@subprocess).to receive(:start)
+      @call_count = 0
+      allow(@subprocess).to receive(:wait) do
+        if @call_count < 2
+          @call_count += 1
+          raise TimedOut
+        end
+        RunResult.new "out", "err", nil
+      end
+      allow(@subprocess).to receive(:send_signal)
+      @supervisor = Supervisor.new @subprocess, timeout_options
+    end
+
+    it "sends the subprocess term and kill signal" do
+      expect(@subprocess).to receive(:start).with(no_args)
+      expect(@subprocess).to receive(:wait).with(10)
+      expect(@subprocess).to receive(:send_signal).with("TERM")
+      expect(@subprocess).to receive(:wait).with(2)
+      expect(@subprocess).to receive(:send_signal).with("KILL")
+      expect(@subprocess).to receive(:wait).with(1)
+
+      @supervisor.run_subprocess
+    end
+
+    it "returns with the results of the subprocess" do
+      result = @supervisor.run_subprocess
+
+      expect(result.output).to eq "out"
+      expect(result.error).to eq "err"
+      expect(result.exit_status).to eq nil
+    end
+  end
+end
+
+describe ErrorCounter do
+  it "registers number of errors" do
+    error_counter = ErrorCounter.new 1
+    error_counter.bump!
+
+    expect(error_counter.errors).to eq 1
+  end
+
+  it "resets the number of errors" do
+    error_counter = ErrorCounter.new 1
+    error_counter.bump!
+    error_counter.reset!
+
+    expect(error_counter.errors).to eq 0
+  end
+
+  it "raises an error if error count is above tolerated" do
+    error_counter = ErrorCounter.new 1
+    error_counter.bump!
+    expect { error_counter.bump! }.to raise_error MaximumErrorsReached
+  end
+end
+
+def make_config(tmpdir)
+  tmpdir.write_file "settings.yml", {
+    "timeouts" => {
+      "status" => {
+        "terminate" => 1,
+        "kill" => 2
+      },
+      "router_migration" => {
+        "terminate" => 5,
+        "kill" => 6
+      }
+    },
+    "hatool" => {
+      "program" => @hatool_path,
+      "env" => {},
+      "timeout" => 60,
+      "insecure" => "false"
+    },
+    "seconds_to_sleep_between_checks" => "10",
+    "max_errors_tolerated" => "10"
+  }.to_yaml
+end
+
+describe "neutron-l3-ha-service" do
+  context "hatool reports dead agents" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        @hatool_path = tmpdir.write_script "fake-hatool", <<-EOF.gsub(/^\s+/, "")
+        #!#{ruby_bin}
+        puts (["HATOOL-CALL"] + ARGV).join(" ")
+        if ARGV.include? "--help"
+          puts "--retry"
+          exit 0
+        end
+        exit 2 if ARGV.include? "--l3-agent-check"
+        EOF
+
+        @settings_path = make_config tmpdir
+        @tmpdir = tmpdir
+        @ruby = File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])
+        @service_path = "chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb"
+        example.run
+      end
+    end
+
+    it "performs migration" do
+      subprocess = Subprocess.new @ruby, @service_path, @settings_path
+      subprocess.start
+      sleep_workaround_for_subprocess
+      sleep 1 # Let it run for a while
+      subprocess.send_signal "TERM"
+      result = subprocess.wait 0.1
+
+      expect(result.error).to include "HATOOL-CALL --l3-agent-check --quiet"
+      expect(result.error).to include "HATOOL-CALL --l3-agent-migrate --now --retry"
+
+      expect(result.exit_status).to eq 0
+    end
+  end
+
+  context "hatool reports dead agents, migration takes a lot of time" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        @hatool_path = tmpdir.write_script "fake-hatool", <<-EOF.gsub(/^\s+/, "")
+        #!#{ruby_bin}
+        Signal.trap "TERM" do
+          puts "HATOOL RECEIVED TERM SIGNAL"
+          exit 0
+        end
+
+        puts (["HATOOL-CALL"] + ARGV).join(" ")
+
+        exit 2 if ARGV.include? "--l3-agent-check"
+        if ARGV.include? "--l3-agent-migrate"
+          puts "MIGRATING AGENTS"
+          sleep 1000
+        end
+        EOF
+
+        @settings_path = make_config tmpdir
+        @tmpdir = tmpdir
+        @ruby = File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])
+        @service_path = "chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb"
+        example.run
+      end
+    end
+
+    it "TERM signal sent to the process group reaches hatool" do
+      # This test emulates what happens, when the TERM signal is sent to the process group of the
+      # service process. What we are expecting is that both the child process (hatool) and the
+      # service script receives the signal. Service script waits for the child process to respond,
+      # and only terminates afterwards.
+
+      # Start a subprocess in a new process group (as systemd would do)
+      stdin, _, stderr, wait_thr = Open3.popen3(
+        @ruby, @service_path, @settings_path, pgroup: true
+      )
+      stdin.close
+      # Let the script run for a while, so we know it"s now sleeping inside l3-agent-migration
+      sleep 3
+
+      Process.kill("TERM", -Process.getpgid(wait_thr.pid))
+
+      exit_status = wait_thr.value
+      error = stderr.read
+
+      expect(error).to include "HATOOL-CALL --l3-agent-check --quiet"
+      expect(error).to include "HATOOL-CALL --l3-agent-migrate --now --retry"
+      expect(error).to include "HATOOL RECEIVED TERM SIGNAL"
+
+      expect(exit_status).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
Turn neutron-ha-tool into a service

As an operator I want to see that neutron-ha-tool is a service monitored by pacemaker.
Currently NHT (Neutron HA-TOOL) is a one-shot script that's "managed" by pacemaker. This is a problem, because the model for a daemon and a one-time script differ. We want to modify NHT so that it is a service rather than a one-shot script.
https://suse-jira.dyndns.org/browse/SCRD-117
https://trello.com/c/qeBCsC0d/9-turn-neutron-ha-tool-into-a-service