### PR TITLE
[4.0] travis: separate the different checks

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation --color

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,12 @@ cache: bundler
 dist: trusty
 
 rvm: 2.1.9
+
+matrix:
+  include:
+    - env: SYNTAXCHECK
+      script:
+      - bundle exec rake syntaxcheck
+    - env: SPEC_TESTS
+      script:
+      - bundle exec rake spec


### PR DESCRIPTION
Until now, we are just running the default rake tasks which would do a
syntaxcheck and also run any tests that rspec found. Instead of that,
lets separate those into different travis jobs to have more visibility
in case of failure.

Also it enhances the rspec tests by setting the output format to a nicer
way for easy checking and tags the travis builds by using the
environment variables to give the jobs a easy visual distiction ont he
travis page.