### PR TITLE
Cookbooks: sync all nodes before setting wait database sync mark

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -25,6 +25,10 @@ ha_enabled = node[:nova][:ha][:enabled]
 
 db_settings = fetch_database_settings
 
+# Wait for all nodes to reach this point so we avoid any timeouts due to the
+# non-founders being faster than the founder and not syncing properly with it
+crowbar_pacemaker_sync_mark "sync-nova_before_database" if ha_enabled
+
 crowbar_pacemaker_sync_mark "wait-nova_database" do
   # the db sync is very slow for nova
   timeout 120


### PR DESCRIPTION
As we are not setting a sync mark before the database creation/migration
of nova, this could lead to a potential timeout in which the non-founder
nodes are faster than the founder and start waiting on the wait mark
earlier than the founder, which leads to the non-founder nodes starting
their timeout countdown earlier than the founder, potentially triggering
a timeout for no reason as the database creation/migration is not taking
120 seconds in the founder.

This makes it so all nodes are synced before starting the timeout
countdown for the database creation/migration.