### PR TITLE
cookbooks: sync all nodes before setting wait database sync mark

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -21,6 +21,11 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
+
+# Wait for all nodes to reach this point so we avoid any timeouts due to the
+# non-founders being faster than the founder and not syncing properly with it
+crowbar_pacemaker_sync_mark "sync-heat_before_database"
+
 crowbar_pacemaker_sync_mark "wait-heat_database" if ha_enabled
 
 # Create the Heat Database


### PR DESCRIPTION
As we are not setting a sync mark before the database creation/migration
of heat, this could lead to a potential timeout in which the non-founder
nodes are faster than the founder and start waiting on the wait mark
earlier than the founder, which leads to the non-founder nodes starting
their timeout countdown earlier than the founder, potentially triggering
a timeout.

This makes it so all nodes are synced before starting the timeout
countdown for the database wait mark.