### PR TITLE
[4.0] Make sure the argument with auth settings is a Hash

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -108,7 +108,8 @@ class CrowbarOpenStackHelper
     @database_settings[instance]
   end
 
-  def self.database_connection_string(db_settings, db_auth)
+  def self.database_connection_string(db_settings, db_auth_attr)
+    db_auth = db_auth_attr.to_hash
     db_conn_scheme = db_settings[:url_scheme]
     db_charset = ""
 
@@ -118,8 +119,8 @@ class CrowbarOpenStackHelper
     end
 
     "#{db_conn_scheme}://" \
-    "#{db_auth[:user]}:#{db_auth[:password]}@#{db_settings[:address]}/" \
-    "#{db_auth[:database]}" \
+    "#{db_auth['user']}:#{db_auth['password']}@#{db_settings[:address]}/" \
+    "#{db_auth['database']}" \
     "#{db_charset}"
   end
 


### PR DESCRIPTION
db_auth may be passed as Chef::Node::Attribute, so let's make
sure we have Hash so we can correctly access its insides.

(cherry picked from commit 2ca4be4bdc6784cca5f783d62ad4f50804cf70f2)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1182