### PR TITLE
database: Fix monitor op for galera pacemaker resource

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -68,8 +68,7 @@ pacemaker_primitive service_name do
   })
   op({
     "monitor" => {
-      "interval" => "20s",
-      "role" => "Master"
+      "interval" => "20s"
     }
   })
   action :update


### PR DESCRIPTION
Enable monitor also for nodes that are currently slaves. The galera
resource agent does regular checks for missing galera members and
latest commit in that case. Without this there might be issues
after a full reboot of the cluster.