### PR TITLE
mariadb: Enable slow query logging

### DIFF
--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -78,6 +78,17 @@ template "/etc/my.cnf.d/openstack.cnf" do
   notifies :restart, "service[mysql]", :immediately
 end
 
+template "/etc/my.cnf.d/logging.cnf" do
+  source "logging.cnf.erb"
+  owner "root"
+  group "mysql"
+  mode "0640"
+  variables(
+    slow_query_logging_enabled: node[:database][:mysql][:slow_query]
+  )
+  notifies :restart, "service[mysql]", :immediately
+end
+
 if node[:database][:ha][:enabled]
   template "/etc/my.cnf.d/galera.cnf" do
     source "galera.cnf.erb"

--- a/chef/cookbooks/mysql/templates/default/logging.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/logging.cnf.erb
@@ -1,0 +1,7 @@
+[mysqld]
+log_error=/var/log/mysql/mysql_error.log
+
+<% if @slow_query_logging_enabled -%>
+slow_query_log=1
+slow_query_log_file=/var/log/mysql/mysql_slow.log
+<% end -%>

--- a/chef/data_bags/crowbar/migrate/database/200_add_slow_query.rb
+++ b/chef/data_bags/crowbar/migrate/database/200_add_slow_query.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["mysql"]["slow_query"] = ta["mysql"]["slow_query"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["mysql"].delete("slow_query")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -5,7 +5,8 @@
     "database": {
       "sql_engine": "postgresql",
       "mysql": {
-        "datadir": "/var/lib/mysql"
+        "datadir": "/var/lib/mysql",
+        "slow_query": true
       },
       "postgresql": {
         "config": {
@@ -34,7 +35,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 200,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },
@@ -54,4 +55,3 @@
     }
   }
 }
-

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -19,7 +19,8 @@
               "required": false,
               "mapping" : {
                 "server_root_password": { "type": "str" },
-                "datadir": { "type": "str", "required": true }
+                "datadir": { "type": "str", "required": true },
+                "slow_query": { "type": "bool", "required": true }
               }
             },
             "postgresql" : {


### PR DESCRIPTION
Before the config cleanup some archs had slow_query_logging enabled.
Let's reenable it for all archs.