### PR TITLE
ceilometer: remove deprecated nova_http_log_debug option

### DIFF
--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -2,7 +2,6 @@
 shuffle_time_before_polling_task = 15
 hypervisor_inspector = <%= @hypervisor_inspector %>
 libvirt_type = <%= @libvirt_type %>
-nova_http_log_debug = <%= @debug ? "true" : "false" %>
 host = <%= @node_hostname %>
 debug = <%= @debug ? "true" : "false" %>
 log_dir = /var/log/ceilometer


### PR DESCRIPTION
Fix according to deprecation warning in log:

**Option "nova_http_log_debug" from group "DEFAULT" is deprecated for removal. Its value may be silently ignored in the future.**