### PR TITLE
(NOT FULLY TESTED) nova: Subscribe to placement config (bsc#1055188)

### DIFF
--- a/chef/cookbooks/nova/definitions/nova_package.rb
+++ b/chef/cookbooks/nova/definitions/nova_package.rb
@@ -55,7 +55,8 @@ define :nova_package, enable: true, use_pacemaker_provider: false, restart_crm_r
       end
     end
 
-    subscribes :restart, resources(template: node[:nova][:config_file])
+    subscribes :restart, [resources(template: node[:nova][:config_file]),
+                          resources(template: node[:nova][:placement_config_file])]
 
     provider Chef::Provider::CrowbarPacemakerService if params[:use_pacemaker_provider]
   end


### PR DESCRIPTION
Without this change, an HA deployment will change the placement config file to
point to the cluster endpoint, but if this happens after the compute
service is refreshed (triggered by a change in the main config file), it
will not receive the changes and will fail to be able to access the
placement API. The nova compute service needs to be refreshed when this
file changes because it uses the placement user credentials contained in
it to look up, through keystone, the placement API endpoint. This change
ensures that nova services subscribe to the placement config file in
addition to the main config file.