### PR TITLE
nova: Randomize placement password

### DIFF
--- a/chef/data_bags/crowbar/migrate/nova/204_add_placement_password.rb
+++ b/chef/data_bags/crowbar/migrate/nova/204_add_placement_password.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  if a["placement_service_password"].nil? || a["placement_service_password"].empty?
+    service = ServiceObject.new "fake-logger"
+    a["placement_service_password"] = service.random_password
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("placement_service_password")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -164,7 +164,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -18,6 +18,7 @@
             "keystone_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str" },
+            "placement_service_password": { "type": "str" },
             "memcache_secret_key": { "type": "str", "required": true },
             "glance_instance": { "type": "str", "required": true },
             "cinder_instance": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -186,6 +186,7 @@ class NovaService < OpenstackServiceObject
     base["attributes"][@bc_name]["neutron_instance"] = find_dep_proposal("neutron")
 
     base["attributes"]["nova"]["service_password"] = random_password
+    base["attributes"]["nova"]["placement_service_password"] = random_password
     base["attributes"]["nova"]["memcache_secret_key"] = random_password
     base["attributes"]["nova"]["api_db"]["password"] = random_password
     base["attributes"]["nova"]["placement_db"]["password"] = random_password


### PR DESCRIPTION
Without this change, the nova placement user has a default password of
"placement", set in attributes.rb, and it is impossible to change it.
This is a massive security flaw for obvious reasons. This change adds
the ability to change the placement service password via the raw view of
the nova barclamp and also ensures it defaults to a random one.