### PR TITLE
nova: Use internal placement url (bsc#1055188)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
@@ -7,6 +7,7 @@ user_domain_name = <%= @keystone_settings['admin_domain'] %>
 auth_type = password
 username = <%= @placement_service_user %>
 password = <%= @placement_service_password %>
+os_interface = internal
 
 <% if @placement_database_connection -%>
 [placement_database]


### PR DESCRIPTION
By default, the nova compute service tries to access the public endpoint
of the placement API. The "public" network defined in network.json isn't
accessible to the compute nodes. Without this patch, the nova-compute
service is unable to connect to the placement API and so is unable to be
scheduled. This patch forces the service to request the internal
placement endpoint, which it can reach.