### PR TITLE
[4.0] mariadb: Install the galera-3-wsrep-provider package

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -19,7 +19,7 @@
 
 resource_agent = "ocf:heartbeat:galera"
 
-package "galera-3"
+package "galera-3-wsrep-provider"
 
 unless node[:database][:galera_bootstrapped]
   directory "/var/run/mysql/" do


### PR DESCRIPTION
The galera-3 got splited into a base package and a wsrep-provider
package.

(cherry picked from commit c1ff439e8399f745e51dd2a79f22c1710c0d7c2b)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1192