### PR TITLE
nova: Subscribe to placement config (bsc#1055188)

### DIFF
--- a/chef/cookbooks/nova/definitions/nova_package.rb
+++ b/chef/cookbooks/nova/definitions/nova_package.rb
@@ -55,7 +55,8 @@ define :nova_package, enable: true, use_pacemaker_provider: false, restart_crm_r
       end
     end
 
-    subscribes :restart, resources(template: node[:nova][:config_file])
+    subscribes :restart, [resources(template: node[:nova][:config_file]),
+                          resources(template: node[:nova][:placement_config_file])]
 
     provider Chef::Provider::CrowbarPacemakerService if params[:use_pacemaker_provider]
   end


### PR DESCRIPTION
Without this change, changing the placement configuration after the
initial deployment will have no effect on any of the nova services. This
is a problem if we want to change the way the compute service connects
to the placement API after the initial deployment. This patch ensures
that nova services subscribe to both configuration files. The placement
config file is really just an extension of the main config file, so it
makes sense for the services to subscribe to both.