### PR TITLE
MariaDB config tuning

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -28,12 +28,7 @@ if attribute?("ec2")
 end
 
 default["mysql"]["tunable"]["max_allowed_packet"]       = "16M"
-default["mysql"]["tunable"]["max_connections"]          = "800"
-default["mysql"]["tunable"]["max_heap_table_size"]      = "32M"
 default["mysql"]["tunable"]["thread_cache_size"]        = 8
-
-# InnoDB Settings
-default["mysql"]["tunable"]["innodb_buffer_pool_size"]  = "256M"
 
 # Ports to bind to when haproxy is used
 default[:mysql][:ha][:ports][:admin_port] = 3306

--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -34,8 +34,6 @@ default["mysql"]["tunable"]["thread_cache_size"]        = 8
 
 # InnoDB Settings
 default["mysql"]["tunable"]["innodb_buffer_pool_size"]  = "256M"
-default["mysql"]["tunable"]["innodb_log_file_size"]     = "128M"
-
 
 # Ports to bind to when haproxy is used
 default[:mysql][:ha][:ports][:admin_port] = 3306

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -89,6 +89,20 @@ template "/etc/my.cnf.d/logging.cnf" do
   notifies :restart, "service[mysql]", :immediately
 end
 
+template "/etc/my.cnf.d/tuning.cnf" do
+  source "tuning.cnf.erb"
+  owner "root"
+  group "mysql"
+  mode "0640"
+  variables(
+    innodb_buffer_pool_size: node[:database][:mysql][:innodb_buffer_pool_size],
+    max_connections: node[:database][:mysql][:max_connections],
+    tmp_table_size: node[:database][:mysql][:tmp_table_size],
+    max_heap_table_size: node[:database][:mysql][:max_heap_table_size]
+  )
+  notifies :restart, "service[mysql]", :immediately
+end
+
 if node[:database][:ha][:enabled]
   template "/etc/my.cnf.d/galera.cnf" do
     source "galera.cnf.erb"

--- a/chef/cookbooks/mysql/templates/default/my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/my.cnf.erb
@@ -5,35 +5,14 @@
 #
 # The MySQL database server configuration file.
 
-# Here is entries for some specific programs
-# The following values assume you have at least 32M ram
-
 [mysqld]
 user                   = mysql
 datadir                = <%= node['mysql']['datadir'] %>
 tmpdir                 = <%= node['mysql']['tmpdir'] %>
 
-#
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
 bind-address            = <%= node['mysql']['bind_address'] %>
-#
-# * Fine Tuning
-#
-
-# FIXME: Remove after MariaDB 10.2.X switch (new default is 16777216)
-max_allowed_packet      = <%= node['mysql']['tunable']['max_allowed_packet'] %>
-# FIXME: Remove after MariaDB 10.2.X switch (new default is auto)
-thread_cache_size       = <%= node['mysql']['tunable']['thread_cache_size'] %>
-max_connections         = <%= node['mysql']['tunable']['max_connections'] %>
-max_heap_table_size     = <%= node['mysql']['tunable']['max_heap_table_size'] %>
-
-#
-# * InnoDB
-#
-# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
-# Read the manual for more InnoDB related options. There are many!
-innodb_buffer_pool_size = <%= node['mysql']['tunable']['innodb_buffer_pool_size'] %>
 
 [mysqldump]
 # FIXME: Remove after MariaDB 10.2.X switch (new default is 16777216)

--- a/chef/cookbooks/mysql/templates/default/my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/my.cnf.erb
@@ -34,7 +34,6 @@ max_heap_table_size     = <%= node['mysql']['tunable']['max_heap_table_size'] %>
 # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
 # Read the manual for more InnoDB related options. There are many!
 innodb_buffer_pool_size = <%= node['mysql']['tunable']['innodb_buffer_pool_size'] %>
-innodb_log_file_size    = <%= node['mysql']['tunable']['innodb_log_file_size'] %>
 
 [mysqldump]
 # FIXME: Remove after MariaDB 10.2.X switch (new default is 16777216)

--- a/chef/cookbooks/mysql/templates/default/tuning.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/tuning.cnf.erb
@@ -1,0 +1,11 @@
+[mysqld]
+innodb_buffer_pool_size = <%= @innodb_buffer_pool_size %>M
+
+max_connections = <%= @max_connections %>
+tmp_table_size = <%= @tmp_table_size %>M
+max_heap_table_size = <%= @max_heap_table_size %>M
+
+# FIXME: Remove after MariaDB 10.2.X switch (new default is auto)
+thread_cache_size = <%= node['mysql']['tunable']['thread_cache_size'] %>
+# FIXME: Remove after MariaDB 10.2.X switch (new default is 16777216)
+max_allowed_packet = <%= node['mysql']['tunable']['max_allowed_packet'] %>

--- a/chef/data_bags/crowbar/migrate/database/201_add_tuning_variables.rb
+++ b/chef/data_bags/crowbar/migrate/database/201_add_tuning_variables.rb
@@ -1,0 +1,15 @@
+def upgrade(ta, td, a, d)
+  a["mysql"]["innodb_buffer_pool_size"] = ta["mysql"]["innodb_buffer_pool_size"]
+  a["mysql"]["max_connections"] = ta["mysql"]["max_connections"]
+  a["mysql"]["tmp_table_size"] = ta["mysql"]["tmp_table_size"]
+  a["mysql"]["max_heap_table_size"] = ta["mysql"]["max_heap_table_size"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["mysql"].delete("innodb_buffer_pool_size")
+  a["mysql"].delete("max_connections")
+  a["mysql"].delete("tmp_table_size")
+  a["mysql"].delete("max_heap_table_size")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -6,7 +6,11 @@
       "sql_engine": "postgresql",
       "mysql": {
         "datadir": "/var/lib/mysql",
-        "slow_query_logging": true
+        "slow_query_logging": true,
+        "innodb_buffer_pool_size": 256,
+        "max_connections": 800,
+        "tmp_table_size": 64,
+        "max_heap_table_size": 64
       },
       "postgresql": {
         "config": {
@@ -35,7 +39,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -20,7 +20,11 @@
               "mapping" : {
                 "server_root_password": { "type": "str" },
                 "datadir": { "type": "str", "required": true },
-                "slow_query_logging": { "type": "bool", "required": true }
+                "slow_query_logging": { "type": "bool", "required": true },
+                "innodb_buffer_pool_size": { "type": "int", "required": true },
+                "max_connections": { "type": "int", "required": true },
+                "tmp_table_size": { "type": "int", "required": true },
+                "max_heap_table_size": { "type": "int", "required": true }
               }
             },
             "postgresql" : {


### PR DESCRIPTION
This PR splits the tuning related config options in a extra config and makes them available via crowbar (for tuning purposes).

This settings expect at least 1GB of total memory and are optimized for this.