### PR TITLE
mariadb: Rename slow_query to slow_query_logging

### DIFF
--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -84,7 +84,7 @@ template "/etc/my.cnf.d/logging.cnf" do
   group "mysql"
   mode "0640"
   variables(
-    slow_query_logging_enabled: node[:database][:mysql][:slow_query]
+    slow_query_logging_enabled: node[:database][:mysql][:slow_query_logging]
   )
   notifies :restart, "service[mysql]", :immediately
 end

--- a/chef/data_bags/crowbar/migrate/database/200_add_slow_query.rb
+++ b/chef/data_bags/crowbar/migrate/database/200_add_slow_query.rb
@@ -1,9 +1,9 @@
 def upgrade(ta, td, a, d)
-  a["mysql"]["slow_query"] = ta["mysql"]["slow_query"]
+  a["mysql"]["slow_query_logging"] = ta["mysql"]["slow_query_logging"]
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  a["mysql"].delete("slow_query")
+  a["mysql"].delete("slow_query_logging")
   return a, d
 end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -6,7 +6,7 @@
       "sql_engine": "postgresql",
       "mysql": {
         "datadir": "/var/lib/mysql",
-        "slow_query": true
+        "slow_query_logging": true
       },
       "postgresql": {
         "config": {

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -20,7 +20,7 @@
               "mapping" : {
                 "server_root_password": { "type": "str" },
                 "datadir": { "type": "str", "required": true },
-                "slow_query": { "type": "bool", "required": true }
+                "slow_query_logging": { "type": "bool", "required": true }
               }
             },
             "postgresql" : {


### PR DESCRIPTION
I just realized that slow query is not specific enough and does not
provide any context. This commit renames slow_query too
slow_query_logging and changes the migrations.