### PR TITLE
horizon: remove telemetry policy file (bsc#1055293)

### DIFF
--- a/chef/cookbooks/horizon/attributes/default.rb
+++ b/chef/cookbooks/horizon/attributes/default.rb
@@ -31,7 +31,6 @@ default[:horizon][:policy_file][:volume] = "cinder_policy.json"
 default[:horizon][:policy_file][:image] = "glance_policy.json"
 default[:horizon][:policy_file][:orchestration] = "heat_policy.json"
 default[:horizon][:policy_file][:network] = "neutron_policy.json"
-default[:horizon][:policy_file][:telemetry] = "ceilometer_policy.json"
 
 default[:horizon][:apache][:ssl] = false
 default[:horizon][:apache][:ssl_crt_file] = "/etc/apache2/ssl.crt/openstack-dashboard-server.crt"

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -115,7 +115,6 @@ POLICY_FILES = {
     'image': '<%= @policy_file[:image] %>',
     'orchestration': '<%= @policy_file[:orchestration] %>',
     'network': '<%= @policy_file[:network] %>',
-    'telemetry': '<%= @policy_file[:telemetry] %>',
 }
 
 LOGGING = {

--- a/chef/data_bags/crowbar/migrate/horizon/201_remove_telemetry_policy_file.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/201_remove_telemetry_policy_file.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["policy_file"].delete("telemetry")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["policy_file"]["telemetry"] = ta["policy_file"]["telemetry"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -28,8 +28,7 @@
         "volume": "cinder_policy.json",
         "image": "glance_policy.json",
         "orchestration": "heat_policy.json",
-        "network": "neutron_policy.json",
-        "telemetry": "ceilometer_policy.json"
+        "network": "neutron_policy.json"
       },
       "can_set_mount_point": false,
       "can_set_password": false,
@@ -49,7 +48,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -48,8 +48,7 @@
                 "volume" : { "type": "str", "required": true },
                 "image" : { "type": "str", "required": true },
                 "orchestration" : { "type": "str", "required": true },
-                "network" : { "type": "str", "required": true },
-                "telemetry" : { "type": "str", "required": true }
+                "network" : { "type": "str", "required": true }
               }
             },
             "can_set_mount_point": { "type": "bool", "required": false },


### PR DESCRIPTION
ceilometer_policy.json is not anymore in the OpenStack Horizon
package, producing an exception during the login process.