### PR TITLE
[4.0] mariadb: Pull in additional packages required for SST

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -19,7 +19,9 @@
 
 resource_agent = "ocf:heartbeat:galera"
 
-package "galera-3-wsrep-provider"
+["galera-3-wsrep-provider", "mariadb-tools", "xtrabackup"].each do |p|
+  package p
+end
 
 unless node[:database][:galera_bootstrapped]
   directory "/var/run/mysql/" do


### PR DESCRIPTION
"mariadb-tools" and "xtrabackup" contain the tooling for "xtrabackup"
and "rsync" based SST (State Snapshot Transfer) to work.

(cherry picked from commit 51637d5c45b351e622158399714e184bef51d72e)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1201