### PR TITLE
keystone: Removed unused attribute

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -63,12 +63,6 @@ memcached_servers = MemcachedHelper.get_memcached_servers(
 
 memcached_instance "keystone"
 
-# Other barclamps need to know the hostname to reach keystone
-if node[:keystone][:api][:internal_URL_host] != my_admin_host
-  node.set[:keystone][:api][:internal_URL_host] = my_admin_host
-  node.save
-end
-
 if node[:keystone][:frontend] == "uwsgi"
 
   service "keystone" do


### PR DESCRIPTION
This looks like a leftover from changes in https://github.com/crowbar/crowbar-openstack/commit/e4bc9e55cc1203607239cabefc8262360ca9a272#diff-28b6adf7bd1f81183dace3201a2720a5L91

There are no other references to `internal_URL_host` attribute (note: capital "URL").

The original introduction of these attributes and comment: https://github.com/crowbar/crowbar-openstack/commit/8f7bc6eae7cad61ba49734f302e3cc501270a7ee#diff-28b6adf7bd1f81183dace3201a2720a5R112