### PR TITLE
horizon: Reload horizon after migration instead of restart

### DIFF
--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -389,7 +389,7 @@ execute "python manage.py migrate" do
   group node[:apache][:group]
   action :nothing
   subscribes :run, "template[#{local_settings}]", :immediately
-  notifies :restart, resources(service: "apache2"), :immediately
+  notifies :reload, resources(service: "horizon"), :immediately
 end
 
 # Force-disable multidomain support when the default keystoneapi version is too


### PR DESCRIPTION
Apache reload (graceful) will signal the apache process, that will
restart the child process (WSGI).  This can cause a race, were an
OpenStack client try to contact to one of the WSGI services, and
the old WSGI process can answer.  This process will fail because
the WSGI socket is not anymore in the file system.


The aproach here is to use a dummy service for 'horizon', what
will SIGUSR1 the wsgi:horizon childs from apache, signaling the
reload of the configuration file which was introduced on commit 02120688d5d3bf35ba12d29ec68be3eba19253f9