### PR TITLE
[4.0] mysql: Provide datadir value to the pacemaker resource

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -66,7 +66,8 @@ pacemaker_primitive service_name do
     "enable_creation" => true,
     "wsrep_cluster_address" => "gcomm://" + nodes_names.join(","),
     "check_user" => "monitoring",
-    "socket" => "/var/run/mysql/mysql.sock"
+    "socket" => "/var/run/mysql/mysql.sock",
+    "datadir" => node[:database][:mysql][:datadir]
   })
   op({
     "monitor" => {


### PR DESCRIPTION
We allow users to change the default value of mysql data directory,
so we have to make sure galera resource agent knows about it.

(cherry picked from commit fc58131d7a5059f9a9ca7bb51fa06e97bacde87c)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1209