### PR TITLE
Local cache for keystoneHelper

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -46,6 +46,7 @@ module KeystoneHelper
       end
       @keystone_settings = nil
       @keystone_node = nil
+      cache_reset
       @keystone_settings_cache_time = current_node[:ohai_time]
     end
 
@@ -122,5 +123,17 @@ module KeystoneHelper
 
     Chef::Log.info("Keystone server found at #{@keystone_node[instance].name}")
     return @keystone_node[instance]
+  end
+
+  def self.cache
+    @cache
+  end
+
+  def self.cache_update(update)
+    @cache = @cache.merge(update)
+  end
+
+  def self.cache_reset
+    @cache = {}
   end
 end


### PR DESCRIPTION
_find_id makes many redundant calls to keystone for listing users,
tenants... during one chef-client, but would return only what is
required right now.

This patch changes that behaviour, instead of throwing away all the
additional data, _find_id would cache the data in KeystoneHelper allowing
the listing (user, tenants...) to be reused, bypassing the need to
actually create a socket, connect and so.