### PR TITLE
horizon: replace NullHandler option deprecated in Pike

### DIFF
--- a/chef/cookbooks/horizon/templates/centos/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/centos/local_settings.py.erb
@@ -90,7 +90,7 @@ LOGGING = {
     'handlers': {
         'null': {
             'level': 'DEBUG',
-            'class': 'django.utils.log.NullHandler',
+            'class': 'logging.NullHandler',
         },
         'console': {
             # Set the level to "DEBUG" for verbose output logging.

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -127,7 +127,7 @@ LOGGING = {
     'handlers': {
         'null': {
             'level': '<%= @debug ? 'DEBUG' : 'INFO' %>',
-            'class': 'django.utils.log.NullHandler',
+            'class': 'logging.NullHandler',
         },
         'console': {
             # Set the level to "DEBUG" for verbose output logging.

--- a/chef/cookbooks/horizon/templates/redhat/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/redhat/local_settings.py.erb
@@ -90,7 +90,7 @@ LOGGING = {
     'handlers': {
         'null': {
             'level': 'DEBUG',
-            'class': 'django.utils.log.NullHandler',
+            'class': 'logging.NullHandler',
         },
         'console': {
             # Set the level to "DEBUG" for verbose output logging.


### PR DESCRIPTION
The Django update from 1.8. to 1.11 that was
done as a result of switching to Pike packages
has deprecated and removed the 'django.utils.log.NullHandler'
option in favor of 'logging.NullHandler' option.

This change fixes the horizon barclamp deployment errors
in pikecloud8:

`ValueError: Unable to configure handler 'null': Cannot resolve 'django.utils.log.NullHandler': No module named NullHandler
`