### PR TITLE
cinder: volume snapshots for NFS (bsc#1053414)

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -180,6 +180,10 @@ nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
   <% if volume['backend_driver'] == 'nfs' -%>
 nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
 volume_driver = cinder.volume.drivers.nfs.NfsDriver
+    <% if volume['nfs']['nfs_snapshot'] -%>
+nfs_snapshot_support = true
+nas_secure_file_operations = false
+    <% end -%>
   <% end -%>
 
   <% if volume['backend_driver'] == 'nimble' -%><% end -%>

--- a/chef/data_bags/crowbar/migrate/cinder/206_add_nfs_snapshot.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/206_add_nfs_snapshot.rb
@@ -1,0 +1,25 @@
+def upgrade(ta, td, a, d)
+  unless a["volume_defaults"]["nfs"].key? "nfs_snapshot"
+    a["volume_defaults"]["nfs"]["nfs_snapshot"] = ta["volume_defaults"]["nfs"]["nfs_snapshot"]
+
+    a["volumes"].each do |volume|
+      next if volume["backend_driver"] != "nfs"
+      volume["nfs"]["nfs_snapshot"] = ta["volume_defaults"]["nfs"]["nfs_snapshot"]
+    end
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta["volume_defaults"]["nfs"].key? "nfs_snapshot"
+    a["volume_defaults"]["nfs"].delete("nfs_snapshot")
+
+    a["volumes"].each do |volume|
+      next if volume["backend_driver"] != "nfs"
+      volume["nfs"].delete("nfs_snapshot")
+    end
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -75,7 +75,8 @@
           "iscsi_ip": ""
         },
         "nfs": {
-          "nfs_shares": ""
+          "nfs_shares": "",
+          "nfs_snapshot": false
         },
         "rbd": {
           "use_crowbar": true,
@@ -176,7 +177,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 205,
+      "schema-revision": 206,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -100,7 +100,8 @@
                 },
                 "nfs": {
                 "type": "map", "mapping": {
-                    "nfs_shares": { "type": "str", "required": true }
+                    "nfs_shares": { "type": "str", "required": true },
+                    "nfs_snapshot": { "type": "bool", "required": true }
                 }
                 },
                 "rbd": {
@@ -237,7 +238,8 @@
                   },
                   "nfs": {
                     "type": "map", "mapping": {
-                      "nfs_shares": { "type": "str", "required": true }
+                      "nfs_shares": { "type": "str", "required": true },
+                      "nfs_snapshot": { "type": "bool", "required": true }
                     }
                   },
                   "rbd": {


### PR DESCRIPTION
Add a new parameter in the UI to allow volume snapshots in NFS. This
feature must also disable the parameter `nas_secure_file_operations`.

This is configuration have some security implications[1] and a
warning text is added as a help hint in the UI.

[1] https://docs.openstack.org/security-guide/block-storage/checklist.html#check-block-07-is-nas-operating-in-a-secure-environment