### PR TITLE
Ceilometer: use nova-api for discovery hyp=xen, (bsc#1056142)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -38,7 +38,11 @@ is_swift_proxy = node.roles.include?("ceilometer-swift-proxy-middleware") && nod
 # Find hypervisor inspector
 hypervisor_inspector = nil
 libvirt_type = nil
+discovery_method = nil
 if is_compute_agent
+  if ["xen"].include?(node[:nova][:libvirt_type])
+    discovery_method = "workload_partitioning"
+  end
   if node.roles.include?("nova-compute-vmware")
     hypervisor_inspector = "vmware"
   else
@@ -87,6 +91,7 @@ template node[:ceilometer][:config_file] do
       libvirt_type: libvirt_type,
       metering_time_to_live: metering_time_to_live,
       event_time_to_live: event_time_to_live,
+      discovery_method: discovery_method
     )
     if is_compute_agent
       notifies :restart, "service[nova-compute]"

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -76,3 +76,8 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+
+<% if @discovery_method -%>
+[compute]
+instance_discovery_method = <%= @discovery_method %>
+<% end -%>


### PR DESCRIPTION
Instead of using libvirt to get metadata about a domain, use nova in
case of xen as it does not support call to DomainGetMetadata

[relevant ceilometer change](https://review.openstack.org/#/c/397654/)