### PR TITLE
cinder: volume snapshots for NFS (bsc#1053414)

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -192,6 +192,10 @@ nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
   <% if volume['backend_driver'] == 'nfs' -%>
 nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
 volume_driver = cinder.volume.drivers.nfs.NfsDriver
+    <% if volume['nfs']['nfs_snapshot'] -%>
+nfs_snapshot_support = true
+nas_secure_file_operations = false
+    <% end -%>
   <% end -%>
 
   <% if volume['backend_driver'] == 'nimble' -%><% end -%>

--- a/chef/data_bags/crowbar/migrate/cinder/109_add_nfs_snapshot.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/109_add_nfs_snapshot.rb
@@ -1,0 +1,25 @@
+def upgrade(ta, td, a, d)
+  unless a["volume_defaults"]["nfs"].key? "nfs_snapshot"
+    a["volume_defaults"]["nfs"]["nfs_snapshot"] = ta["volume_defaults"]["nfs"]["nfs_snapshot"]
+
+    a["volumes"].each do |volume|
+      next if volume["backend_driver"] != "nfs"
+      volume["nfs"]["nfs_snapshot"] = ta["volume_defaults"]["nfs"]["nfs_snapshot"]
+    end
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta["volume_defaults"]["nfs"].key? "nfs_snapshot"
+    a["volume_defaults"]["nfs"].delete("nfs_snapshot")
+
+    a["volumes"].each do |volume|
+      next if volume["backend_driver"] != "nfs"
+      volume["nfs"].delete("nfs_snapshot")
+    end
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -75,7 +75,8 @@
           "iscsi_ip": ""
         },
         "nfs": {
-          "nfs_shares": ""
+          "nfs_shares": "",
+          "nfs_snapshot": false
         },
         "rbd": {
           "use_crowbar": true,
@@ -162,7 +163,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 108,
+      "schema-revision": 109,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -100,7 +100,8 @@
                 },
                 "nfs": {
                 "type": "map", "mapping": {
-                    "nfs_shares": { "type": "str", "required": true }
+                    "nfs_shares": { "type": "str", "required": true },
+                    "nfs_snapshot": { "type": "bool", "required": true }
                 }
                 },
                 "rbd": {
@@ -237,7 +238,8 @@
                   },
                   "nfs": {
                     "type": "map", "mapping": {
-                      "nfs_shares": { "type": "str", "required": true }
+                      "nfs_shares": { "type": "str", "required": true },
+                      "nfs_snapshot": { "type": "bool", "required": true }
                     }
                   },
                   "rbd": {

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -140,8 +140,6 @@
               %span.help-block
                 = t(".volumes.nfs.nfs_shares_config_hint")
 
-              = string_field %w(volumes {{@index}} nfs)
-
           {{/if_eq}}
           {{#if_eq backend_driver 'rbd'}}
           %li.list-group-item

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -140,6 +140,11 @@
               %span.help-block
                 = t(".volumes.nfs.nfs_shares_config_hint")
 
+              = boolean_field %w(volumes {{@index}} nfs nfs_snapshot)
+
+              %span.help-block
+                = t(".volumes.nfs.nfs_snapshot_hint")
+
           {{/if_eq}}
           {{#if_eq backend_driver 'rbd'}}
           %li.list-group-item

--- a/crowbar_framework/config/locales/cinder/en.yml
+++ b/crowbar_framework/config/locales/cinder/en.yml
@@ -61,6 +61,7 @@ en:
           nfs_volume_driver: 'NFS'
           nfs:
             nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path -o optional-nfs-mount-options'
+            nfs_snapshot_hint: 'Security caution. This feature is not recommended because of its significant security implications.'
           raw_parameters: 'Raw Devices Parameters'
           raw_volume_driver: 'Raw Devices'
           rbd_parameters: 'RADOS Parameters'
@@ -115,6 +116,7 @@ en:
               vserver: 'Name of the Virtual Storage Server (netapp_vserver)'
             nfs:
               nfs_shares: 'List of NFS Exports'
+              nfs_snapshot: 'Enable volume snapshots'
             raw:
               cinder_raw_method: 'Disk selection method'
               volume_name: 'Name of Volume'


### PR DESCRIPTION
Add a new parameter in the UI to allow volume snapshots in NFS. This
feature must also disable the parameter `nas_secure_file_operations`.

This is configuration have some security implications[1] and a
warning text is added as a help hint in the UI.

[1] https://docs.openstack.org/security-guide/block-storage/checklist.html#check-block-07-is-nas-operating-in-a-secure-environment