### PR TITLE
tempest: Set domain specifc drivers identitiy feature flag

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -93,6 +93,9 @@ alt_tenant_name = <%= @alt_comp_tenant %>
 alt_password = <%= @alt_comp_pass %>
 alt_domain_name = Default
 
+[identity-feature-enabled]
+domain_specific_drivers = <%= node[:keystone][:domain_specific_drivers] ? "True" : "False" %>
+
 [image]
 region = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internalURL


### PR DESCRIPTION
The option "domain_specific_drivers" must be enabled when testing an environment
that is configured to use domain-specific identity drivers.
Otherwise the tempest test
tempest.api.identity.admin.v3.test_groups.GroupsV3TestJSON.test_list_groups
fails.