### PR TITLE
horizon: Fix cache backend KEY_PREFIX

### DIFF
--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -37,9 +37,7 @@ CACHES = {
           '<%= memcached_location %>',
 <% end -%>
         ],
-        'OPTIONS': {
-          'KEY_PREFIX': '<%= node[:horizon][:config][:environment] %>'
-        }
+        'KEY_PREFIX': '<%= node[:horizon][:config][:environment] %>'
     }
 }
 


### PR DESCRIPTION
When configuring a cache in Django, the KEY_PREFIX is a key of the
configured cache itself, not of the OPTIONS dict[1].
This was not a problem until Django 1.11 but since commit
65ec8fa8ca5[2] in Django itself, the OPTIONS are passed to the client
__init__() call which leads to:

File
"/usr/lib/python2.7/site-packages/django/core/cache/backends/memcached.py",
    line 173, in _cache
self._client = self._lib.Client(self._servers, **client_kwargs)
TypeError: __init__() got an unexpected keyword argument 'KEY_PREFIX'

[1] https://docs.djangoproject.com/en/1.11/ref/settings/#caches
[2] https://github.com/django/django/commit/65ec8fa8ca56a53783453