### PR TITLE
[4.0] database: Replace MySQL UI string with MariaDB

### DIFF
--- a/crowbar_framework/app/helpers/barclamp/database_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/database_helper.rb
@@ -20,7 +20,7 @@ module Barclamp
     def engines_for_database(selected)
       options_for_select(
         [
-          ["MySQL", "mysql"],
+          ["MariaDB", "mysql"],
           ["PostgreSQL", "postgresql"]
         ],
         selected.to_s

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -22,7 +22,7 @@ en:
     database:
       edit_attributes:
         sql_engine: 'SQL Engine'
-        mysql_attributes: 'MySQL Options'
+        mysql_attributes: 'MariaDB Options'
         mysql:
           datadir: 'Datadir'
         postgresql_attributes: 'PostgreSQL Options'


### PR DESCRIPTION
We're not using MySQL, but MariaDB as an option for OpenStack
database.

Instead of replacing all relevant mysql strings (including variable
and cookbook names), we go the easy way and only change the part
that is visible to user in crowbar UI.

(cherry picked from commit 49c0782483b8ff81eaf2b689068a4426c7e79c7e)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1225