### PR TITLE
neutron: remove options deprecated in Pike

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -272,7 +272,6 @@ if neutron[:neutron][:networking_plugin] == "ml2"
             (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
-        of_interface: neutron[:neutron][:ovs][:of_interface],
         ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
         bridge_mappings: bridge_mappings
       )

--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -1,6 +1,6 @@
 [DEFAULT]
 <% unless @nova_metadata_settings.empty? %>
-nova_metadata_ip = <%= @nova_metadata_settings[:host] %>
+nova_metadata_host = <%= @nova_metadata_settings[:host] %>
 metadata_proxy_shared_secret = <%= @nova_metadata_settings[:shared_secret] %>
 nova_metadata_protocol = <%= @nova_metadata_settings[:protocol] %>
 nova_metadata_insecure = <%= @nova_metadata_settings[:insecure] %>

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -77,7 +77,7 @@ lock_path = /var/run/neutron
 driver = neutron.openstack.common.notifier.rpc_notifier
 
 [oslo_messaging_rabbit]
-rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -20,7 +20,6 @@ tunnel_csum = True
 tunnel_bridge = br-tunnel
 <% end -%>
 ovsdb_interface = <%= @ovsdb_interface %>
-of_interface = <%= @of_interface %>
 <% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
 local_ip = <%= node.address("os_sdn").addr %>
 <% end -%>

--- a/chef/data_bags/crowbar/migrate/neutron/204_remove_of_interface.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/204_remove_of_interface.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ovs"].delete("of_interface")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["ovs"]["of_interface"] = ta["ovs"]["of_interface"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -37,7 +37,6 @@
       },
       "ovs": {
         "tunnel_csum": false,
-        "of_interface": "native",
         "ovsdb_interface": "native"
       },
       "apic": {
@@ -172,7 +171,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -42,8 +42,7 @@
                     }},
                     "ovs": { "type": "map", "required": true, "mapping": {
                       "tunnel_csum": { "type": "bool", "required": true },
-                      "ovsdb_interface": { "type": "str", "required": true },
-                      "of_interface": { "type": "str", "required": true }
+                      "ovsdb_interface": { "type": "str", "required": true }
                     }},
                     "apic": { "type": "map", "required": true, "mapping": {
                       "hosts": { "type" : "str", "required" : true },


### PR DESCRIPTION
The following neutron configuration options deprecated in Pike
are removed or renamed:

- the of_interface Open vSwitch agent configuration option.
 The current default (native) will be the only supported
 of_interface driver in Queens. [1]
 - the nova_metadata_ip option is deprecated in favor of the
 new nova_metadata_host option because it reflects better
 that the option accepts an IP address and also a DNS name. [1]
 - the [oslo_messaging_rabbit]/rabbit_use_ssl option is deprecated
 in favor of the ssl option under the same group [2]

More information:
 - [1] https://docs.openstack.org/releasenotes/neutron/pike.html#deprecation-notes
 - [2] https://review.openstack.org/#/c/438455/