### PR TITLE
cinder: Remove non-multibackend support

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -136,7 +136,6 @@ template node[:cinder][:config_file] do
   variables(
     bind_host: bind_host,
     bind_port: bind_port,
-    use_multi_backend: node[:cinder][:use_multi_backend],
     volumes: node[:cinder][:volumes],
     sql_connection: sql_connection,
     rabbit_settings: fetch_rabbitmq_settings,

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -33,11 +33,9 @@ default_volume_type = <%= @default_volume_type %>
 
 auth_strategy = keystone
 
-<% if @use_multi_backend -%>
 enabled_backends=<%= @volumes.each_with_index.collect { |backend,idx|
     "backend-#{backend['backend_driver']}-#{idx}"
 }.join(',') %>
-<% end -%>
 
 nova_catalog_info = compute:nova:internalURL
 nova_catalog_admin_info = compute:nova:adminURL
@@ -59,10 +57,8 @@ strict_ssh_host_key_policy = <%= @strict_ssh_host_key_policy ? 'true' : 'false' 
     backend_id = "backend-#{volume['backend_driver']}-#{volid}"
 -%>
 
-  <% if @use_multi_backend -%>
 [<%= backend_id %>]
 volume_backend_name = <%= volume['backend_name'] %>
-  <% end -%>
 
   <% if volume['backend_driver'] == 'blockbridge' -%><% end -%>
   <% if volume['backend_driver'] == 'coho' -%><% end -%>
@@ -264,7 +260,6 @@ image_upload_use_cinder_backend = true
 max_over_subscription_ratio = <%= volume[volume['backend_driver']]['max_over_subscription_ratio'] %>
   <% end -%>
 
-  <% break unless @use_multi_backend -%>
 <% end -%>
 
 [key_manager]

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -299,7 +299,7 @@ lock_path = /var/run/cinder
 <% end -%>
 
 [oslo_messaging_rabbit]
-rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>

--- a/chef/data_bags/crowbar/migrate/cinder/203_remove_multi_backend.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/203_remove_multi_backend.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a.delete("use_multi_backend")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["use_multi_backend"] = ta["use_multi_backend"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -17,7 +17,6 @@
       "max_overflow": 10,
       "pool_timeout": 30,
       "rpc_response_timeout": 60,
-      "use_multi_backend": true,
       "use_multipath": false,
       "keymgr_fixed_key": "",
       "volume_defaults": {
@@ -163,7 +162,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -26,7 +26,6 @@
             "max_overflow": { "type": "int", "required": true },
             "pool_timeout": { "type": "int", "required": true },
             "rpc_response_timeout": { "type": "int", "required": true },
-            "use_multi_backend": { "type": "bool", "required": true },
             "use_multipath": { "type": "bool", "required": true },
             "keymgr_fixed_key": { "type": "str", "required": true },
             "volume_defaults": {

--- a/crowbar_framework/app/assets/javascripts/barclamps/cinder/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/cinder/application.js
@@ -27,9 +27,6 @@ $(document).ready(function($) {
       return opts.inverse(this);
   });
 
-  var use_multi_backend = $('#proposal_attributes').readJsonAttribute(
-                            'use_multi_backend', false);
-
   function cb_cinder_volume_delete()
   {
     //FIXME: right now, there's no good way to localize strings in js :/
@@ -76,7 +73,6 @@ $(document).ready(function($) {
     $('#cinder_backends').replaceWith(
       cinder_backend_template({
         "entries": volumes,
-        "use_multi_backend": use_multi_backend,
         "is_only_backend": volumes.length == 1
       })
     );
@@ -91,21 +87,6 @@ $(document).ready(function($) {
     // refresh data-change handlers
     detach_events();
     attach_events();
-  }
-
-  if (!use_multi_backend) {
-    $('#volumes_0_backend_driver').on('change', function() {
-      var volumes = $('#proposal_attributes').readJsonAttribute('volumes', {});
-      var new_backend = $(this).val();
-      var old_backend = volumes[0]["backend_driver"];
-      delete volumes[0][old_backend];
-
-      volumes[0]["backend_driver"] = new_backend;
-      volumes[0][new_backend] = $('#proposal_attributes').readJsonAttribute('volume_defaults/' + new_backend);
-      $('#proposal_attributes').writeJsonAttribute('volumes', volumes);
-
-      redisplay_backends();
-    });
   }
 
   if ($.queryString['attr_raw'] != "true") {

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -12,7 +12,6 @@
       %div#cinder_backends
         {{#each entries}}
         %ul.list-group(id="volume-entry-{{@index}}")
-          {{#if ../use_multi_backend }}
           %li.list-group-item.active
             %h3.list-group-item-heading
               Backend: {{ backend_name }}
@@ -20,7 +19,6 @@
               {{else}}
               = link_to icon_tag("trash"), "#", :class => "volume-backend-delete pull-right delete", "data-volumeid" => "{{@index}}"
               {{/if}}
-          {{/if}}
 
           {{#if_eq backend_driver 'raw'}}
           %li.list-group-item
@@ -220,13 +218,9 @@
       %legend
         = t(".volumes.listheader")
 
-      - if !@proposal.pretty_attributes.use_multi_backend
-        = select_field ["volumes", 0, "backend_driver"], :collection => :volume_driver_for_cinder
-
       %div#cinder_backends
         = t(".volumes.loading_text")
 
-    - if @proposal.pretty_attributes.use_multi_backend
       %fieldset
         %legend
           = t(".volumes.addheader")


### PR DESCRIPTION
Remove the attribute "use_multi_backend". All configured backends
should be in its own config section. The single-backend case is
deprecated since Ocata[1].

[1]
https://docs.openstack.org/releasenotes/cinder/ocata.html#upgrade-notes