### PR TITLE
ceilometer: update deprecated option rabbit_use_ssl

### DIFF
--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -74,7 +74,7 @@ insecure = <%= node[:nova][:vcenter][:insecure] %>
 [oslo_messaging_rabbit]
 amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>
 rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
-rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>


### PR DESCRIPTION
Option "rabbit_use_ssl" from group "oslo_messaging_rabbit" is deprecated.