### PR TITLE
nova: remove/rename config options deprecated in Pike

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -346,7 +346,6 @@ template node[:nova][:config_file] do
     bind_port_objectstore: bind_port_objectstore,
     bind_port_novncproxy: bind_port_novncproxy,
     bind_port_serialproxy: bind_port_serialproxy,
-    dhcpbridge: "/usr/bin/nova-dhcpbridge",
     database_connection: database_connection,
     api_database_connection: api_database_connection,
     rabbit_settings: fetch_rabbitmq_settings,

--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -129,7 +129,7 @@ end
 execute "nova-manage db sync up to revision 329" do
   user node[:nova][:user]
   group node[:nova][:group]
-  command "nova-manage db sync --version 329"
+  command "nova-manage db sync 329"
   action :run
   # We only do the sync the first time, and only if we're not doing HA or if we
   # are the founder of the HA cluster (so that it's really only done once).

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -43,13 +43,9 @@ compute_driver = libvirt.LibvirtDriver
 <% if @libvirt_type.eql?('xen') %>
 use_cow_images = false
 <% end %>
-firewall_driver = nova.virt.firewall.NoopFirewallDriver
 <% if @ssl_cert_required %>
 ssl_ca_file = <%= @ssl_ca_file %>
 <% end %>
-default_floating_pool = floating
-dhcpbridge = <%= @dhcpbridge %>
-linuxnet_interface_driver = ""
 <% if @force_config_drive || @libvirt_type.eql?('zvm') %>
 flat_injected = true
 <% end %>
@@ -110,7 +106,7 @@ enabled = true
 memcache_servers = <%= @memcached_servers.join(',') %>
 
 [cinder]
-catalog_info = volumev2:cinderv2:internalURL
+catalog_info = volumev3:cinderv3:internalURL
 os_region_name = <%= @keystone_settings['endpoint_region'] %>
 insecure = <%= @cinder_insecure ? 'True' : 'False' %>
 cross_az_attach = <%= node[:nova][:cross_az_attach] %>
@@ -140,9 +136,14 @@ pool_timeout = <%= node[:nova][:db][:pool_timeout] %>
 host = <%= @glance_server_host %>
 port = <%= @glance_server_port %>
 api_servers = <%= "#{@glance_server_protocol}://#{@glance_server_host}:#{@glance_server_port}" %>
-api_insecure = <%= @glance_server_insecure ? 'True' : 'False' %>
+insecure = <%= @glance_server_insecure ? 'True' : 'False' %>
 <% end %>
 protocol = <%= @glance_server_protocol %>
+<% if @ssl_cert_required %>
+cafile = <%= @ssl_ca_file %>
+<% end %>
+certfile = <%= @ssl_cert_file %>
+keyfile = <%= @ssl_key_file %>
 
 <% unless @ironic_settings.nil? %>
 [ironic]
@@ -236,6 +237,7 @@ timeout = <%= node[:nova][:neutron_url_timeout] %>
 username = <%= @neutron_service_user %>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
 project_domain_name = <%= @keystone_settings['admin_domain'] %>
+default_floating_pool = floating
 
 [oslo_concurrency]
 <% if @need_shared_lock_path %>
@@ -250,7 +252,7 @@ driver = messagingv2
 [oslo_messaging_rabbit]
 amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>
 rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
-rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] %>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end %>
@@ -262,13 +264,6 @@ base_url = ws://<%= @serialproxy_public_host %>:<%= node[:nova][:ports][:serialp
 proxyclient_address = <%= node[:nova][:my_ip] %>
 serialproxy_host = 0.0.0.0
 serialproxy_port = 6083
-
-[ssl]
-<% if @ssl_cert_required %>
-ca_file = <%= @ssl_ca_file %>
-<% end %>
-cert_file = <%= @ssl_cert_file %>
-key_file = <%= @ssl_key_file %>
 
 [trusted_computing]
 <% if @has_itxt %>
@@ -330,7 +325,7 @@ use_baremetal_filters = true
 <% end %>
 <% if @has_itxt %>
 available_filters = nova.scheduler.filters.standard_filters
-enabled_filters = RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,TrustedFilter
+enabled_filters = RetryFilter,AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,TrustedFilter
 <% end %>
 <% unless @track_instance_changes %>
 track_instance_changes = false


### PR DESCRIPTION
The following nova configuration options deprecated in Pike
are removed or renamed:

 - [DEFAULT]/default_floating_pool has been deprecated for neutron
users in favor of [neutron]/default_floating_pool [1]
 - the following [ssl] options are moved to the [glance] group:
ca_file, cert_file and key_file and renamed to cafile, certfile
and keyfile respectively (these options were only used by the
Nova code that interacts with the Glance client) [1]
 - api_insecure option from [glance] group is renamed to insecure [1]
 - the [DEFAULT]/firewall_driver is deprecated as its default
value has been changed to nova.virt.firewall.NoopFirewallDriver
to coincide with the default value of [DEFAULT]/use_neutron=True [1]
 - the --version optional parameter accepted by the
'nova-manage api_db sync' and 'nova-manage db sync' commands
is now a positional argument [1]
 - Nova is now configured to use the v3 version of the Cinder API.
Using the v2 version is deprecated [1]
 - the RamFilter entry is being removed from the enabled_filters
value, since the placement service is used to verify RAM resources
when using FilterScheduler [1]
 - the following nova-network [DEFAULT] group options are deprecated:
default_floating_pool, firewall_driver, dhcpbridge, linuxnet_interface_driver [1]
 - the [oslo_messaging_rabbit]/rabbit_use_ssl option is deprecated
in favor of the ssl option under the same group [2]

More information:
 - [1] https://docs.openstack.org/releasenotes/nova/pike.html
 - [2] https://review.openstack.org/#/c/438455/