### PR TITLE
keystone: Update for pike (SCRD-781)

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -49,10 +49,7 @@ default[:keystone][:assignment][:driver] = "sql"
 
 default[:keystone][:sql][:idle_timeout] = 30
 
-default[:keystone][:signing][:token_format] = "UUID"
-default[:keystone][:signing][:certfile] = "/etc/keystone/ssl/certs/signing_cert.pem"
-default[:keystone][:signing][:keyfile] = "/etc/keystone/ssl/private/signing_key.pem"
-default[:keystone][:signing][:ca_certs] = "/etc/keystone/ssl/certs/ca.pem"
+default[:keystone][:token_format] = "fernet"
 
 default[:keystone][:ssl][:certfile] = "/etc/keystone/ssl/certs/signing_cert.pem"
 default[:keystone][:ssl][:keyfile] = "/etc/keystone/ssl/private/signing_key.pem"

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -267,10 +267,7 @@ template node[:keystone][:config_file] do
         my_admin_host, node[:keystone][:api][:admin_port]
       ),
       memcached_servers: memcached_servers,
-      signing_token_format: node[:keystone][:signing][:token_format],
-      signing_certfile: node[:keystone][:signing][:certfile],
-      signing_keyfile: node[:keystone][:signing][:keyfile],
-      signing_ca_certs: node[:keystone][:signing][:ca_certs],
+      token_format: node[:keystone][:token_format],
       token_expiration: node[:keystone][:token_expiration],
       max_active_keys: max_active_keys,
       protocol: node[:keystone][:api][:protocol],
@@ -366,7 +363,7 @@ if ha_enabled
 end
 
 # Configure Keystone token fernet backend provider
-if node[:keystone][:signing][:token_format] == "fernet"
+if node[:keystone][:token_format] == "fernet"
   # To be sure that rsync package is installed
   package "rsync"
   crowbar_pacemaker_sync_mark "sync-keystone_install_rsync" if ha_enabled

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -99,9 +99,6 @@ kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 [oslo_policy]
 policy_file = <%= node[:keystone][:policy_file] %>
 
-[resource]
-driver = sql
-
 [role]
 driver = sql
 

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -105,11 +105,6 @@ driver = sql
 [role]
 driver = sql
 
-[signing]
-certfile = <%= @signing_certfile %>
-keyfile = <%= @signing_keyfile %>
-ca_certs = <%= @signing_ca_certs %>
-
 [token]
 expiration = <%= @token_expiration %>
-provider = <%= node[:keystone][:signing][:token_format] %>
+provider = <%= node[:keystone][:token_format] %>

--- a/chef/data_bags/crowbar/migrate/keystone/202_remove_signing.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/202_remove_signing.rb
@@ -1,0 +1,16 @@
+def upgrade(ta, td, a, d)
+  a["token_format"] = a["signing"]["token_format"]
+  a.delete("signing")
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["signing"] = {
+    "certfile" => "/etc/keystone/ssl/certs/signing_cert.pem",
+    "keyfile" => "/etc/keystone/ssl/private/signing_key.pem",
+    "ca_certs" => "/etc/keystone/ssl/certs/ca.pem",
+    "token_format" => a["token_format"]
+  }
+  a.delete("token_format")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -59,12 +59,7 @@
       "assignment": {
         "driver": "sql"
       },
-      "signing": {
-        "token_format": "fernet",
-        "certfile": "/etc/keystone/ssl/certs/signing_cert.pem",
-        "keyfile": "/etc/keystone/ssl/private/signing_key.pem",
-        "ca_certs": "/etc/keystone/ssl/certs/ca.pem"
-      },
+      "token_format": "fernet",
       "ldap" : {
         "url": "ldap://localhost",
         "user": "dc=Manager,dc=example,dc=com",
@@ -178,7 +173,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -64,12 +64,7 @@
                     "assignment" : { "type" : "map", "required" : true, "mapping": {
                       "driver": { "type": "str", "required": true }
                     }},
-                    "signing" : { "type" : "map", "required" : true, "mapping": {
-                      "token_format": { "type": "str", "required": true, "pattern": "/^(fernet|uuid)$/" },
-                      "certfile": { "type": "str" },
-                      "keyfile": { "type": "str" },
-                      "ca_certs": { "type": "str" }
-                    }},
+                    "token_format": { "type": "str", "required": true, "pattern": "/^(fernet|uuid)$/" },
                     "ldap" : { "type" : "map", "mapping": {
                       "url": { "type": "str" },
                       "user": { "type": "str" },

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -5,7 +5,7 @@
   .panel-body
     = instance_field :database
     = instance_field :rabbitmq
-    = select_field %w(signing token_format), :collection => :token_formats_for_keystone
+    = select_field %w(token_format), :collection => :token_formats_for_keystone
     = string_field %w(api region)
 
     %fieldset

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -21,8 +21,7 @@ en:
       edit_attributes:
         database_instance: 'Database Instance'
         rabbitmq_instance: 'RabbitMQ'
-        signing:
-          token_format: 'Algorithm for Token Generation'
+        token_format: 'Algorithm for Token Generation'
         default_credentials: 'Default Credentials'
         default:
           project: 'Default Project'


### PR DESCRIPTION
Remove the [signing] section which is only applicable to the now-defunct PKI token format, and remove the [resource]/driver setting.