### PR TITLE
keystone: Increase timeout for keystone_register actions

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -454,7 +454,11 @@ end
 # the keystone resources
 crowbar_pacemaker_sync_mark "sync-keystone_before_register" if ha_enabled
 
-crowbar_pacemaker_sync_mark "wait-keystone_register" if ha_enabled
+crowbar_pacemaker_sync_mark "wait-keystone_register" do
+  # keystone_register might be slow
+  timeout 90
+  only_if { ha_enabled }
+end
 
 keystone_insecure = node["keystone"]["api"]["protocol"] == "https" && node[:keystone][:ssl][:insecure]
 


### PR DESCRIPTION
In various tests, actions happening inside keystone_register syncmark
block tend to take more than 40 secods. Depending on the setup,
it could be even little bit over 1 minute which is the default value
when the waiting nodes time out.

