### PR TITLE
keystone: Set an origin flag on apache2 restart

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -63,6 +63,15 @@ memcached_servers = MemcachedHelper.get_memcached_servers(
 
 memcached_instance "keystone"
 
+# resource to set a flag when apache2 is restarted so we now which cookbook was the
+# one that triggered the restart, in order to know if the restart is allowed
+ruby_block "set origin for apache2 restart" do
+  block do
+    node.run_state["apache2_restart_origin"] = @cookbook_name
+  end
+  action :nothing
+end
+
 if node[:keystone][:frontend] == "uwsgi"
 
   service "keystone" do
@@ -278,6 +287,7 @@ template node[:keystone][:config_file] do
       rabbit_settings: fetch_rabbitmq_settings
     )
     if node[:keystone][:frontend] == "apache"
+      notifies :create, resources(ruby_block: "set origin for apache2 restart"), :immediately
       notifies :restart, resources(service: "apache2"), :immediately
     elsif node[:keystone][:frontend] == "uwsgi"
       notifies :restart, resources(service: "keystone-uwsgi"), :immediately
@@ -313,6 +323,7 @@ if node[:keystone][:domain_specific_drivers]
         domain: domain
       )
       if node[:keystone][:frontend] == "apache"
+        notifies :create, resources(ruby_block: "set origin for apache2 restart"), :immediately
         notifies :restart, resources(service: "apache2"), :immediately
       elsif node[:keystone][:frontend] == "uwsgi"
         notifies :restart, resources(service: "keystone-uwsgi"), :immediately


### PR DESCRIPTION
When we do a apache2 restart action, as the apache2 service is declared
on the apache2 cookbook, we have no idea of what triggered the restart
for it.

This makes it a problem to differentiate between the different cookbooks
calling the restart for the service, if we want to introduce a feature
to avoid restarts based on origin/barclamps.

This PR introduces a ruby_block that sets a temporal key on the node
when apache2 is restarted, to flag where the restart was triggered from.

The run_state values are ephemeral so we dont modify the node attributes
at all.

Only affected cookbook is keystone for the moment, as the other cookbooks do a reload instead of a restart.

Unblocks: This unblocks https://github.com/crowbar/crowbar-core/pull/1307
Required-By: https://github.com/crowbar/crowbar-core/pull/1307
