### PR TITLE
neutron: Fix metadata server for ocata again

### DIFF
--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -1,6 +1,7 @@
 [DEFAULT]
 <% unless @nova_metadata_settings.empty? %>
-nova_metadata_host = <%= @nova_metadata_settings[:host] %>
+# Change to nova_metadata_host after Pike is required
+nova_metadata_ip = <%= @nova_metadata_settings[:host] %>
 metadata_proxy_shared_secret = <%= @nova_metadata_settings[:shared_secret] %>
 nova_metadata_protocol = <%= @nova_metadata_settings[:protocol] %>
 nova_metadata_insecure = <%= @nova_metadata_settings[:insecure] %>


### PR DESCRIPTION
The recent PR #1229 introduced config options that don't work
in Ocata. Revert to an Ocata compatible code.