### PR TITLE
glance: update cookbook for pike

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -91,9 +91,9 @@ driver = messaging
 [oslo_messaging_rabbit]
 amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>
 rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
-rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
-kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+ssl_ca_file = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
 
 [paste_deploy]

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -43,9 +43,9 @@ driver = messaging
 [oslo_messaging_rabbit]
 amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>
 rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
-rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
-kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+ssl_ca_file = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
 
 [paste_deploy]


### PR DESCRIPTION
rabblt_use_ssl and kombu_ssl_ca_certs oslo messaging
config options were deprecated in Ocata.
They were replaced by ssl and ssl_ca_file instead.

Reference: https://review.openstack.org/#/c/438455/