### PR TITLE
horizon: Pike updates

### DIFF
--- a/chef/cookbooks/horizon/attributes/default.rb
+++ b/chef/cookbooks/horizon/attributes/default.rb
@@ -31,6 +31,7 @@ default[:horizon][:policy_file][:volume] = "cinder_policy.json"
 default[:horizon][:policy_file][:image] = "glance_policy.json"
 default[:horizon][:policy_file][:orchestration] = "heat_policy.json"
 default[:horizon][:policy_file][:network] = "neutron_policy.json"
+default[:horizon][:policy_file][:neutron_fwaas] = "neutron-fwaas-policy.json"
 
 default[:horizon][:apache][:ssl] = false
 default[:horizon][:apache][:ssl_crt_file] = "/etc/apache2/ssl.crt/openstack-dashboard-server.crt"

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -377,12 +377,8 @@ if neutrons.length > 0
   else
     neutron_ml2_type_drivers = "'*'"
   end
-  neutron_use_lbaas = neutron[:neutron][:use_lbaas]
-  neutron_use_vpnaas = neutron[:neutron][:use_vpnaas]
 else
   neutron_ml2_type_drivers = "'*'"
-  neutron_use_lbaas = false
-  neutron_use_vpnaas = false
 end
 
 # We're going to use memcached as a cache backend for Django
@@ -450,8 +446,6 @@ template local_settings do
     || manila_insecure \
     || ceilometer_insecure,
     db_settings: db_settings,
-    enable_lb: neutron_use_lbaas,
-    enable_vpn: neutron_use_vpnaas,
     timezone: (node[:provisioner][:timezone] rescue "UTC") || "UTC",
     use_ssl: node[:horizon][:apache][:ssl],
     password_validator_regex: node[:horizon][:password_validator][:regex],

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -73,6 +73,25 @@ else
   end
 end
 
+
+# install horizon neutron fwaas plugin if needed
+neutron_fwaas_ui_pkgname =
+  case node[:platform_family]
+  when "suse"
+    "openstack-horizon-plugin-neutron-fwaas-ui"
+  when "rhel"
+    "openstack-neutron-fwaas-ui"
+  end
+
+unless neutron_fwaas_ui_pkgname.nil?
+  unless Barclamp::Config.load("openstack", "neutron").empty?
+    package neutron_fwaas_ui_pkgname do
+      action :install
+      notifies :reload, "service[horizon]"
+    end
+  end
+end
+
 # install horizon neutron lbaas plugin if needed
 neutron_lbaas_ui_pkgname =
   case node[:platform_family]

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -61,8 +61,6 @@ OPENSTACK_NEUTRON_NETWORK = {
     'enable_ipv6': False,
     'enable_distributed_router': False,
     'enable_ha_router': False,
-    'enable_lb': <%= @enable_lb ? 'True' : 'False' %>,
-    'enable_vpn': <%= @enable_vpn ? 'True' : 'False' %>,
     'enable_fip_topology_check': True,
 
     # Neutron can be configured with a default Subnet Pool to be used for IPv4
@@ -76,12 +74,6 @@ OPENSTACK_NEUTRON_NETWORK = {
     # You must set this to enable IPv6 Prefix Delegation in a PD-capable
     # environment.
     'default_ipv6_subnet_pool_label': None,
-
-    # The profile_support option is used to detect if an external router can be
-    # configured via the dashboard. When using specific plugins the
-    # profile_support can be turned on if needed.
-    'profile_support': None,
-    #'profile_support': 'cisco',
 
     # Set which provider network types are supported. Only the network types
     # in this list will be available to choose from when creating a network.

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -62,7 +62,6 @@ OPENSTACK_NEUTRON_NETWORK = {
     'enable_distributed_router': False,
     'enable_ha_router': False,
     'enable_lb': <%= @enable_lb ? 'True' : 'False' %>,
-    'enable_firewall': True,
     'enable_vpn': <%= @enable_vpn ? 'True' : 'False' %>,
     'enable_fip_topology_check': True,
 
@@ -113,6 +112,7 @@ POLICY_FILES = {
     'image': '<%= @policy_file[:image] %>',
     'orchestration': '<%= @policy_file[:orchestration] %>',
     'network': '<%= @policy_file[:network] %>',
+    'neutron-fwaas': '<%= @policy_file[:neutron_fwaas] %>',
 }
 
 LOGGING = {

--- a/chef/data_bags/crowbar/migrate/horizon/202_add_neutron_fwaas_policy_file.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/202_add_neutron_fwaas_policy_file.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["policy_file"]["neutron_fwaas"] = ta["policy_file"]["neutron_fwaas"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["policy_file"].delete("neutron_fwaas")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -28,7 +28,8 @@
         "volume": "cinder_policy.json",
         "image": "glance_policy.json",
         "orchestration": "heat_policy.json",
-        "network": "neutron_policy.json"
+        "network": "neutron_policy.json",
+        "neutron_fwaas": "neutron-fwaas-policy.json"
       },
       "can_set_mount_point": false,
       "can_set_password": false,
@@ -48,7 +49,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -48,7 +48,8 @@
                 "volume" : { "type": "str", "required": true },
                 "image" : { "type": "str", "required": true },
                 "orchestration" : { "type": "str", "required": true },
-                "network" : { "type": "str", "required": true }
+                "network" : { "type": "str", "required": true },
+                "neutron_fwaas" : { "type": "str", "required": true }
               }
             },
             "can_set_mount_point": { "type": "bool", "required": false },


### PR DESCRIPTION
The following dashboard configuration options are deprecated in Pike [1]:
 - the profile_support setting has been removed from the OPENSTACK_NEUTRON_NETWORK dict
 - the enable_firewall, enable_vpn and enable_lb settings deprecated since Juno are dropped in Pike. Since Horizon has the ability to enable/disable dashboard panels automatically by checking the availability of FWaaS v1, LBaaS and VPNaaS services, no additional configuration steps are required to enable/disable these panels.

Starting with Pike, the VPNaaS horizon dashboard is maintained as a separate project neutron-vpnaas-dashboard that needs to be installed and configured separately [2]. The VPNaaS dashboard package [has been submitted upstream](https://review.openstack.org/#/c/501791/).
Starting with Pike, the FWaaS horizon dashboard is also maintained as a separate project neutron-fwaas-dashboard that needs to be installed and configured separately [3]. The FWaaS dashboard package [has been submitted upstream](https://review.openstack.org/#/c/501779/).

More info:
 - [1] Pike Horizon release notes: https://docs.openstack.org/releasenotes/horizon/pike.html
 - [2] neutron-vpnaas-dashboard project: http://git.openstack.org/cgit/openstack/neutron-vpnaas-dashboard/tree/doc/source
 - [3] neutron-fwaas-dashboard project: https://docs.openstack.org/neutron-fwaas-dashboard/pike/

