### PR TITLE
ceilometer: fix libvirt_type & host_ip null error

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -47,7 +47,7 @@ if is_compute_agent
   end
   if ["vmware"].include?(node[:nova][:libvirt_type])
     instance_discovery_method = "workload_partitioning"
-    hypervisor_inspector = "vmware"
+    hypervisor_inspector = "vsphere"
   else
     hypervisor_inspector = "libvirt"
     libvirt_type = node[:nova][:libvirt_type]

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -61,7 +61,7 @@ password = <%= @keystone_settings['service_password'] %>
 [service_types]
 neutron_lbaas_version = v2
 
-<% if @hypervisor_inspector == "vmware" -%>
+<% if @hypervisor_inspector == "vsphere" -%>
 [vmware]
 host_ip = <%= node[:nova][:vcenter][:host] rescue "" %>
 host_port = <%= node[:nova][:vcenter][:port] rescue "443" %>

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -1,7 +1,9 @@
 [DEFAULT]
 shuffle_time_before_polling_task = 15
+<% if @is_compute_agent -%>
 hypervisor_inspector = <%= @hypervisor_inspector %>
 libvirt_type = <%= @libvirt_type %>
+<% end -%>
 host = <%= @node_hostname %>
 debug = <%= @debug ? "true" : "false" %>
 log_dir = /var/log/ceilometer
@@ -59,16 +61,18 @@ password = <%= @keystone_settings['service_password'] %>
 [service_types]
 neutron_lbaas_version = v2
 
+<% if @hypervisor_inspector == "vmware" -%>
 [vmware]
 host_ip = <%= node[:nova][:vcenter][:host] rescue "" %>
 host_port = <%= node[:nova][:vcenter][:port] rescue "443" %>
 host_username = <%= node[:nova][:vcenter][:user] rescue "" %>
 host_password = <%= node[:nova][:vcenter][:password] rescue "" %>
-<% if @hypervisor_inspector == "vmware" && !node[:nova][:vcenter][:ca_file].empty? -%>
+<% if !node[:nova][:vcenter][:ca_file].empty? -%>
 ca_file = <%= node[:nova][:vcenter][:ca_file] -%>
 <% end -%>
-<% if @hypervisor_inspector == "vmware" && node[:nova][:vcenter][:insecure] -%>
+<% if node[:nova][:vcenter][:insecure] -%>
 insecure = <%= node[:nova][:vcenter][:insecure] %>
+<% end -%>
 <% end -%>
 
 [oslo_messaging_rabbit]
@@ -79,7 +83,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
 
-<% if @discovery_method -%>
+<% if @is_compute_agent -%>
 [compute]
-instance_discovery_method = <%= @discovery_method %>
+instance_discovery_method = <%= @instance_discovery_method %>
 <% end -%>


### PR DESCRIPTION
mkcloud deployed with cloudsource=pikecloud8 has below error in controller:

/var/log/ceilometer/ceilometer-collector.log (cotyledon._service_manager [-] ServiceManager raised exception during new_worker hooks: **ConfigFileValueError: Value for option libvirt_type is not valid: Valid values are [kvm, lxc, qemu, uml, xen], but found ''**)
/var/log/ceilometer/ceilometer-polling-central.log (cotyledon._service_manager [-] ServiceManager raised exception during new_worker hooks: **ConfigFileValueError: Value for option libvirt_type is not valid: Valid values are [kvm, lxc, qemu, uml, xen], but found ''**)
/var/log/ceilometer/ceilometer-polling-central.log (cotyledon._service_manager **ConfigFileValueError: Value for option host_ip is not valid:  is not a valid host address**)

Local tested the fix. **_ConfigFileValueError_** is now gone in ceilometer logs.