### PR TITLE
ceilometer: remove deprecated collector

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -19,18 +19,15 @@ default[:ceilometer][:config_file] = "/etc/ceilometer/ceilometer.conf.d/100-ceil
 
 central_service_name = "ceilometer-agent-central"
 api_service_name = "ceilometer-api"
-collector_service_name = "ceilometer-collector"
 agent_notification_service_name = "ceilometer-agent-notification"
 
 if %w(rhel suse).include?(node[:platform_family])
   central_service_name = "openstack-ceilometer-agent-central"
   api_service_name = "openstack-ceilometer-api"
-  collector_service_name = "openstack-ceilometer-collector"
   agent_notification_service_name = "openstack-ceilometer-agent-notification"
 end
 
 default[:ceilometer][:api][:service_name] = api_service_name
-default[:ceilometer][:collector][:service_name] = collector_service_name
 default[:ceilometer][:agent_notification][:service_name] = agent_notification_service_name
 default[:ceilometer][:central][:service_name] = central_service_name
 
@@ -72,8 +69,6 @@ default[:ceilometer][:ha][:server][:enabled] = false
 
 # increase default timeout: ceilometer has to wait until mongodb is ready
 default[:ceilometer][:ha][:api][:op][:start][:timeout] = "60s"
-default[:ceilometer][:ha][:collector][:agent] = "systemd:#{collector_service_name}"
-default[:ceilometer][:ha][:collector][:op][:monitor][:interval] = "10s"
 default[:ceilometer][:ha][:agent_notification][:agent] = "systemd:#{agent_notification_service_name}"
 default[:ceilometer][:ha][:agent_notification][:op][:monitor][:interval] = "10s"
 

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -104,19 +104,16 @@ end
 
 case node[:platform_family]
 when "suse"
-  package "openstack-ceilometer-collector"
   package "openstack-ceilometer-agent-notification"
   package "openstack-ceilometer-api"
 when "rhel"
   package "openstack-ceilometer-common"
-  package "openstack-ceilometer-collector"
   package "openstack-ceilometer-agent-notification"
   package "openstack-ceilometer-api"
   package "python-ceilometerclient"
 else
   package "python-ceilometerclient"
   package "ceilometer-common"
-  package "ceilometer-collector"
   package "ceilometer-agent-notification"
   package "ceilometer-api"
 end
@@ -167,18 +164,6 @@ end
 crowbar_pacemaker_sync_mark "create-ceilometer_upgrade" if ha_enabled
 
 use_crowbar_pacemaker_service = ha_enabled && node[:pacemaker][:clone_stateless_services]
-
-service "ceilometer-collector" do
-  service_name node[:ceilometer][:collector][:service_name]
-  supports status: true, restart: true, start: true, stop: true
-  action [:enable, :start]
-  subscribes :restart, resources(template: node[:ceilometer][:config_file])
-  subscribes :restart, resources("template[/etc/ceilometer/pipeline.yaml]")
-  provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
-end
-utils_systemd_service_restart "ceilometer-collector" do
-  action use_crowbar_pacemaker_service ? :disable : :enable
-end
 
 service "ceilometer-agent-notification" do
   service_name node[:ceilometer][:agent_notification][:service_name]

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -33,7 +33,7 @@ if node[:pacemaker][:clone_stateless_services]
   crowbar_pacemaker_sync_mark "wait-ceilometer_server_ha_resources"
 
   rabbit_settings = fetch_rabbitmq_settings
-  services = ["collector", "agent_notification"]
+  services = ["agent_notification"]
   transaction_objects = []
 
   services.each do |service|

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -8,9 +8,6 @@ log_dir = /var/log/ceilometer
 use_stderr = false
 transport_url = <%= @rabbit_settings[:url] %>
 
-[collector]
-workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
-
 [database]
 metering_time_to_live = <%= @metering_time_to_live %>
 event_time_to_live = <%= @event_time_to_live %>

--- a/chef/cookbooks/ceilometer/templates/default/pipeline.yaml.erb
+++ b/chef/cookbooks/ceilometer/templates/default/pipeline.yaml.erb
@@ -39,7 +39,7 @@ sinks:
     - name: meter_sink
       transformers:
       publishers:
-          - notifier://
+          - database://
     - name: cpu_sink
       transformers:
           - name: "rate_of_change"
@@ -50,7 +50,7 @@ sinks:
                     type: "gauge"
                     scale: "100.0 / (10**9 * (resource_metadata.cpu_number or 1))"
       publishers:
-          - notifier://
+          - database://
     - name: cpu_delta_sink
       transformers:
           - name: "delta"
@@ -59,7 +59,7 @@ sinks:
                     name: "cpu.delta"
                 growth_only: True
       publishers:
-          - notifier://
+          - database://
     - name: disk_sink
       transformers:
           - name: "rate_of_change"
@@ -74,7 +74,7 @@ sinks:
                         unit: "\\1/s"
                     type: "gauge"
       publishers:
-          - notifier://
+          - database://
     - name: network_sink
       transformers:
           - name: "rate_of_change"
@@ -89,4 +89,4 @@ sinks:
                         unit: "\\1/s"
                     type: "gauge"
       publishers:
-          - notifier://
+          - database://


### PR DESCRIPTION
According to Pike release notes (https://docs.openstack.org/releasenotes/ceilometer/pike.html):

Collector is no longer supported in this release. The collector introduces lags in pushing data to backend. To optimize the architecture, Ceilometer push data through dispatchers using publishers in notification agent directly.