### PR TITLE
mariadb: Increase timeout for the promote operation

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -37,4 +37,4 @@ default[:mysql][:ha][:ports][:admin_port] = 3306
 # in pacemamker
 default[:mysql][:ha][:op][:monitor][:interval] = "20s"
 default[:mysql][:ha][:op][:monitor][:role]     = "Master"
-
+default[:mysql][:ha][:op][:promote][:timeout]  = "300s"

--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -32,3 +32,9 @@ default["mysql"]["tunable"]["thread_cache_size"]        = 8
 
 # Ports to bind to when haproxy is used
 default[:mysql][:ha][:ports][:admin_port] = 3306
+
+# Default operation setting for the galera resource
+# in pacemamker
+default[:mysql][:ha][:op][:monitor][:interval] = "20s"
+default[:mysql][:ha][:op][:monitor][:role]     = "Master"
+

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -147,12 +147,7 @@ pacemaker_primitive service_name do
     "datadir" => node[:database][:mysql][:datadir],
     "log" => "/var/log/mysql/mysql_error.log"
   })
-  op({
-    "monitor" => {
-      "interval" => "20s",
-      "role" => "Master"
-    }
-  })
+  op node[:mysql][:ha][:op]
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end


### PR DESCRIPTION
Promoting the galera resource to master might require a full State
Transfer (SST) which can be time consuming. Increase the default timeout
for that to 300 seconds.

Partial-Bug: #1057806