### PR TITLE
keystone: Cleanup private declarations in register

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -386,6 +386,7 @@ def _update_item(http, headers, path, body, name)
 end
 
 private
+
 def _build_connection(new_resource)
   # Need to require net/https so that Net::HTTP gets monkey-patched
   # to actually support SSL:
@@ -574,7 +575,6 @@ def _build_endpoint_object(interface, service, new_resource)
   body
 end
 
-private
 def _build_headers(token = nil)
   ret = Hash.new
   ret.store("X-Auth-Token", token) if token


### PR DESCRIPTION
The 'private' declaration is not needed for every method, in ruby it is
sufficient to declare it once, then it applies to everything below it.
We've already cleaned up most of the unnecessary ones in an unrelated
refactor, this patch cleans up the last one.