### PR TITLE
ironic: Remove deprecated glance params (SCRD-768)

### DIFF
--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -21,9 +21,6 @@ max_overflow=10
 pool_timeout=30
 
 [glance]
-glance_host=<%= @glance_settings[:host] %>
-glance_port=<%= @glance_settings[:port] %>
-glance_protocol=<%= @glance_settings[:protocol] %>
 glance_api_servers=<%= @glance_settings[:protocol] %>://<%= @glance_settings[:host] %>:<%= @glance_settings[:port] %>
 auth_strategy=keystone
 auth_type=password


### PR DESCRIPTION
The glance_host, glance_port, and glance_protocol options of the
[glance] section were deprecated in favor of the glance_api_servers
option[1], which we were already using anyway. This patch just removes
those unnecessary settings.

[1] https://docs.openstack.org/releasenotes/ironic/pike.html#deprecation-notes