### PR TITLE
[4.0] Stop exposing passwords in the process table

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -95,15 +95,18 @@ end
 # ensure swift tempurl key only if some agent_* drivers are enabled in ironic
 if !swift_config.empty? && node[:glance][:default_store] == "swift" && \
     ironics.any? && ironics.first[:ironic][:enabled_drivers].any? { |d| d.start_with?("agent_") }
-  swift_command = "swift --os-username #{keystone_settings["service_user"]}"
-  swift_command << " --os-password #{keystone_settings["service_password"]}"
-  swift_command << " --os-tenant-name #{keystone_settings["service_tenant"]}"
-  swift_command << " --os-auth-url #{keystone_settings["public_auth_url"]}"
-  swift_command << " --os-identity-api-version 3"
+  swift_command = "swift "
   swift_command << (swift_insecure ? " --insecure" : "")
+  env = {
+    "OS_USERNAME" => keystone_settings["service_user"],
+    "OS_PASSWORD" => keystone_settings["service_password"],
+    "OS_PROJECT_NAME" => keystone_settings["service_tenant"],
+    "OS_AUTH_URL" => keystone_settings["public_auth_url"],
+    "OS_IDENTITY_API_VERSION" => 3
+  }
 
   get_tempurl_key = "#{swift_command} stat | grep -m1 'Meta Temp-Url-Key:' | awk '{print $3}'"
-  tempurl_key = Mixlib::ShellOut.new(get_tempurl_key).run_command.stdout.chomp
+  tempurl_key = Mixlib::ShellOut.new(get_tempurl_key, environment: env).run_command.stdout.chomp
   # no tempurl key set, set a random one
   if tempurl_key.empty?
     tempurl_key = secure_password

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -356,14 +356,13 @@ ruby_block "get stack user domain" do
   block do
     url = "#{keystone_settings["protocol"]}://#{keystone_settings["internal_url_host"]}"
     url << ":#{keystone_settings["service_port"]}/v3"
-    stack_user_domain_id = `openstack \
---os-username #{keystone_settings["admin_user"]} \
---os-password #{keystone_settings["admin_password"]} \
---os-tenant-name #{keystone_settings["admin_tenant"]} \
---os-auth-url=#{url} \
---os-region-name='#{keystone_settings["endpoint_region"]}' \
---os-identity-api-version=3 \
-#{insecure} \
+    env = "OS_USERNAME='#{keystone_settings["admin_user"]}' "
+    env << "OS_PASSWORD='#{keystone_settings["admin_password"]}' "
+    env << "OS_PROJECT_NAME='#{keystone_settings["admin_tenant"]}' "
+    env << "OS_AUTH_URL='#{url}' "
+    env << "OS_REGION_NAME='#{keystone_settings["endpoint_region"]}' "
+    env << "OS_IDENTITY_API_VERSION=3"
+    stack_user_domain_id = `#{env} openstack #{insecure} \
 domain show -f value -c id #{stack_user_domain_name}`
     raise "Could not obtain the stack user domain id" if stack_user_domain_id.empty?
     node[:heat][:stack_user_domain_id] = stack_user_domain_id.strip

--- a/chef/cookbooks/magnum/recipes/post_install.rb
+++ b/chef/cookbooks/magnum/recipes/post_install.rb
@@ -41,15 +41,14 @@ nova_config = Barclamp::Config.load("openstack", "nova", node[:magnum][:nova_ins
 nova_insecure = CrowbarOpenStackHelper.insecure(nova_config)
 openstack_args_nova = nova_insecure || keystone_settings["insecure"] ? "--insecure" : ""
 
-# create basic arguments for openstack client
-openstack_args = "--os-username #{keystone_settings["service_user"]}"
-openstack_args += " --os-auth-type password --os-identity-api-version 3"
-openstack_args += " --os-password #{keystone_settings["service_password"]}"
-openstack_args += " --os-tenant-name #{keystone_settings["service_tenant"]}"
-openstack_args += " --os-auth-url #{keystone_settings["internal_auth_url"]}"
-openstack_args += " --os-endpoint internalURL"
+env = "OS_USERNAME='#{keystone_settings["service_user"]}' "
+env << "OS_PASSWORD='#{keystone_settings["service_password"]}' "
+env << "OS_PROJECT_NAME='#{keystone_settings["service_tenant"]}' "
+env << "OS_AUTH_URL='#{keystone_settings["internal_auth_url"]}' "
+env << "OS_INTERFACE=internal "
+env << "OS_IDENTITY_API_VERSION=3"
 
-openstack_cmd = "openstack #{openstack_args}"
+openstack_cmd = "#{env} openstack"
 
 image_url = "http://#{provisioner_address}:8091/files/" \
   "#{service_sles_image_name}/" \

--- a/chef/cookbooks/magnum/recipes/setup.rb
+++ b/chef/cookbooks/magnum/recipes/setup.rb
@@ -31,11 +31,14 @@ auth_url = "#{keystone_settings["protocol"]}://"\
            "#{keystone_settings["internal_url_host"]}:"\
            "#{keystone_settings["service_port"]}/v3"
 
-openstack_command = "openstack --os-username #{keystone_settings["admin_user"]}"
-openstack_command << " --os-auth-type password --os-identity-api-version 3"
-openstack_command << " --os-password #{keystone_settings["admin_password"]}"
-openstack_command << " --os-tenant-name #{keystone_settings["admin_tenant"]}"
-openstack_command << " --os-auth-url #{auth_url} #{insecure}"
+env = {
+  "OS_USERNAME" => keystone_settings["admin_user"],
+  "OS_PASSWORD" => keystone_settings["admin_password"],
+  "OS_PROJECT_NAME" => keystone_settings["admin_tenant"],
+  "OS_AUTH_URL" => keystone_settings["internal_auth_url"],
+  "OS_IDENTITY_API_VERSION" => "3"
+}
+openstack_command = "openstack #{insecure}"
 
 ha_enabled = node[:magnum][:ha][:enabled]
 
@@ -47,7 +50,8 @@ create_magnum_domain << " --or-show"
 create_magnum_domain << " #{magnum_domain_name}"
 
 unless node["magnum"]["trustee"]["domain_id"] && node["magnum"]["trustee"]["domain_admin_id"]
-  magnum_domain_id = Mixlib::ShellOut.new(create_magnum_domain).run_command.stdout.chomp
+  magnum_domain_id = Mixlib::ShellOut.new(create_magnum_domain,
+                                          environment: env).run_command.stdout.chomp
 
   if magnum_domain_id && !magnum_domain_id.empty?
     create_magnum_domain_admin = "#{openstack_command} user create --domain #{magnum_domain_name}"
@@ -55,13 +59,15 @@ unless node["magnum"]["trustee"]["domain_id"] && node["magnum"]["trustee"]["doma
     create_magnum_domain_admin << " --password #{magnum_domain_admin_pass}"
     create_magnum_domain_admin << " --or-show -f value -c id #{magnum_domain_admin}"
 
-    magnum_domain_admin_id = Mixlib::ShellOut.new(create_magnum_domain_admin).run_command.stdout.chomp
+    magnum_domain_admin_id = Mixlib::ShellOut.new(create_magnum_domain_admin,
+                                                  environment: env).run_command.stdout.chomp
 
     if magnum_domain_admin_id && !magnum_domain_admin_id.empty?
       check_magnum_domain_role = "#{openstack_command} role assignment list -f csv --column Role"
       check_magnum_domain_role << " --domain #{magnum_domain_id} --user #{magnum_domain_admin_id} --names"
 
-      magnum_domain_role = Mixlib::ShellOut.new(check_magnum_domain_role).run_command.stdout
+      magnum_domain_role = Mixlib::ShellOut.new(check_magnum_domain_role,
+                                                environment: env).run_command.stdout
 
       unless magnum_domain_role.include?('"admin"')
         create_magnum_domain_role = "#{openstack_command} role add --user #{magnum_domain_admin_id}"

--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -68,18 +68,18 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 neutron_config = Barclamp::Config.load("openstack", "neutron")
 ssl_insecure = CrowbarOpenStackHelper.insecure(neutron_config) || keystone_settings["insecure"]
 
-neutron_args = "--os-username '#{keystone_settings['service_user']}'"
-neutron_args = "#{neutron_args} --os-password '#{keystone_settings['service_password']}'"
-neutron_args = "#{neutron_args} --os-tenant-name '#{keystone_settings['service_tenant']}'"
-neutron_args = "#{neutron_args} --os-auth-url '#{keystone_settings['internal_auth_url']}'"
-neutron_args = "#{neutron_args} --os-region-name '#{keystone_settings['endpoint_region']}'"
-if keystone_settings["api_version"] != "2.0"
-  neutron_args = "#{neutron_args} --os-user-domain-name Default"
-  neutron_args = "#{neutron_args} --os-project-domain-name Default"
-end
-neutron_args = "#{neutron_args} --endpoint-type internalURL"
+env = "OS_USERNAME='#{keystone_settings["service_user"]}' "
+env << "OS_PASSWORD='#{keystone_settings["service_password"]}' "
+env << "OS_PROJECT_NAME='#{keystone_settings["service_tenant"]}' "
+env << "OS_AUTH_URL='#{keystone_settings["internal_auth_url"]}' "
+env << "OS_REGION_NAME='#{keystone_settings["endpoint_region"]}' "
+env << "OS_INTERFACE=internal "
+env << "OS_USER_DOMAIN_NAME=Default "
+env << "OS_PROJECT_DOMAIN_NAME=Default "
+env << "OS_IDENTITY_API_VERSION=3"
+neutron_args = "--endpoint-type internalURL"
 neutron_args = "#{neutron_args} --insecure" if ssl_insecure
-neutron_cmd = "neutron #{neutron_args}"
+neutron_cmd = "#{env} neutron #{neutron_args}"
 
 fixed_network_type = ""
 floating_network_type = ""

--- a/chef/cookbooks/nova/libraries/availability_zone.rb
+++ b/chef/cookbooks/nova/libraries/availability_zone.rb
@@ -21,26 +21,24 @@ module NovaAvailabilityZone
     nova_config = BarclampLibrary::Barclamp::Config.load("openstack", "nova")
     ssl_insecure = CrowbarOpenStackHelper.insecure(nova_config) || keystone_settings["insecure"]
 
-    command = ["/usr/bin/crowbar-nova-set-availability-zone"]
-    command << "--os-username"
-    command << keystone_settings["admin_user"]
-    command << "--os-password"
-    command << keystone_settings["admin_password"]
-    command << "--os-tenant-name"
-    command << keystone_settings["default_tenant"]
-    command << "--os-auth-url"
-    command << KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],
+    auth_url = KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],
                                                     keystone_settings["internal_url_host"],
                                                     keystone_settings["service_port"],
                                                     "2.0")
-    command << "--os-region-name"
-    command << keystone_settings["endpoint_region"]
+    env = {
+      "OS_USERNAME" => keystone_settings["admin_user"],
+      "OS_PASSWORD" => keystone_settings["admin_password"],
+      "OS_TENANT_NAME" => keystone_settings["default_tenant"],
+      "OS_AUTH_URL" => auth_url,
+      "OS_REGION_NAME" => keystone_settings["endpoint_region"]
+    }
 
+    command = ["/usr/bin/crowbar-nova-set-availability-zone"]
     if ssl_insecure
       command << "--insecure"
     end
 
-    command
+    [env, command]
   end
 
   def self.add_arg_to_set_az_command(command_no_arg, compute_node)

--- a/chef/cookbooks/nova/recipes/availability_zones.rb
+++ b/chef/cookbooks/nova/recipes/availability_zones.rb
@@ -22,7 +22,7 @@
 elements = node[:nova][:elements_expanded] || node[:nova][:elements]
 return if elements["nova-compute-hyperv"].nil? || elements["nova-compute-hyperv"].empty?
 
-command_no_arg = NovaAvailabilityZone.fetch_set_az_command_no_arg(node, @cookbook_name)
+env, command_no_arg = NovaAvailabilityZone.fetch_set_az_command_no_arg(node, @cookbook_name)
 
 hyperv_nodes = node_search_with_cache("roles:nova-compute-hyperv")
 hyperv_nodes.each do |n|
@@ -30,6 +30,7 @@ hyperv_nodes.each do |n|
 
   execute "Set availability zone for #{n.hostname}" do
     command command
+    environment env
     timeout 60
     # Any exit code in the range 60-69 is a tempfail
     returns [0] + (60..69).to_a

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -383,11 +383,12 @@ unless cinder_servers.empty?
 end
 
 # Set our availability zone
-command_no_arg = NovaAvailabilityZone.fetch_set_az_command_no_arg(node, @cookbook_name)
+env, command_no_arg = NovaAvailabilityZone.fetch_set_az_command_no_arg(node, @cookbook_name)
 command = NovaAvailabilityZone.add_arg_to_set_az_command(command_no_arg, node)
 
 execute "Set availability zone for #{node.hostname}" do
   command command
+  environment env
   timeout 60
   # Any exit code in the range 60-69 is a tempfail
   returns [0] + (60..69).to_a

--- a/chef/cookbooks/nova/recipes/flavors.rb
+++ b/chef/cookbooks/nova/recipes/flavors.rb
@@ -75,11 +75,12 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 nova_config = Barclamp::Config.load("openstack", "nova")
 ssl_insecure = CrowbarOpenStackHelper.insecure(nova_config) || keystone_settings["insecure"]
 
-novacmd = "nova --os-username #{keystone_settings["service_user"]} " \
-"--os-password #{keystone_settings["service_password"]} " \
-"--os-tenant-name #{keystone_settings["service_tenant"]} " \
-"--os-auth-url #{keystone_settings["internal_auth_url"]} " \
-"--os-region-name '#{keystone_settings["endpoint_region"]}'"
+env = "OS_USERNAME='#{keystone_settings["service_user"]}' "
+env << "OS_PASSWORD='#{keystone_settings["service_password"]}' "
+env << "OS_PROJECT_NAME='#{keystone_settings["service_tenant"]}' "
+env << "OS_AUTH_URL='#{keystone_settings["internal_auth_url"]}' "
+env << "OS_REGION_NAME='#{keystone_settings["endpoint_region"]}'"
+novacmd = "#{env} nova"
 
 if ssl_insecure
   novacmd = "#{novacmd} --insecure"

--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -87,10 +87,16 @@ keystone_register "add #{service_user}:#{service_tenant} user admin role" do
 end
 
 dispersion_cmd="swift-dispersion-populate"
+
+env = "OS_USERNAME='#{service_user}' "
+env << "OS_PASSWORD='#{service_password}' "
+env << "OS_PROJECT_NAME='#{service_tenant}' "
+env << "OS_AUTH_URL='#{keystone_settings["internal_auth_url"]}' "
+env << "OS_ENDPOINT_TYPE=internalURL"
 if keystone_settings["insecure"]
-  swift_cmd="swift --insecure"
+  swift_cmd = "#{env} swift --insecure"
 else
-  swift_cmd="swift"
+  swift_cmd = "#{env} swift"
 end
 
 template node[:swift][:dispersion_config_file] do
@@ -117,10 +123,5 @@ execute "populate-dispersion" do
   ignore_failure true
   only_if "#{swift_cmd} \
                -V #{keystone_settings["api_version"]} \
-               --os-tenant-name #{service_tenant} \
-               --os-username #{service_user} \
-               --os-password '#{service_password}' \
-               --os-auth-url #{keystone_settings["internal_auth_url"]} \
-               --os-endpoint-type internalURL \
                stat dispersion_objects 2>&1 | grep 'Container.*not found'"
 end

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -71,18 +71,20 @@ auth_url = KeystoneHelper.service_URL(
     keystone_settings["protocol"], keystone_settings["internal_url_host"],
     keystone_settings["service_port"])
 # for non-admin usage
-openstackcli = "openstack --insecure --os-username #{tempest_comp_user}"
-openstackcli << " --os-identity-api-version #{keystone_settings["api_version"]}"
-openstackcli << " --os-password #{tempest_comp_pass}"
-openstackcli << " --os-project-name #{tempest_comp_tenant}"
-openstackcli << " --os-auth-url #{auth_url}"
+comp_environment = "OS_USERNAME='#{tempest_comp_user}' "
+comp_environment << "OS_PASSWORD='#{tempest_comp_pass}' "
+comp_environment << "OS_PROJECT_NAME='#{tempest_comp_tenant}' "
+comp_environment << "OS_AUTH_URL='#{auth_url}' "
+comp_environment << "OS_IDENTITY_API_VERSION='#{keystone_settings["api_version"]}'"
+openstackcli = "#{comp_environment} openstack --insecure"
 
 # for admin usage (listing the available services)
-openstackcli_adm = "openstack --insecure --os-username #{tempest_adm_user}"
-openstackcli_adm << " --os-identity-api-version #{keystone_settings["api_version"]}"
-openstackcli_adm << " --os-password #{tempest_adm_pass}"
-openstackcli_adm << " --os-project-name #{tempest_comp_tenant}"
-openstackcli_adm << " --os-auth-url #{auth_url}"
+adm_environment = "OS_USERNAME='#{tempest_adm_user}' "
+adm_environment << "OS_PASSWORD='#{tempest_adm_pass}' "
+adm_environment << "OS_PROJECT_NAME='#{tempest_comp_tenant}' "
+adm_environment << "OS_AUTH_URL='#{auth_url}' "
+adm_environment << "OS_IDENTITY_API_VERSION='#{keystone_settings["api_version"]}'"
+openstackcli_adm = "#{adm_environment} openstack --insecure"
 
 enabled_services = `#{openstackcli_adm} service list -f value -c Type`.split
 


### PR DESCRIPTION
Using --os-password in command line calls exposes the password in the
process table and may therefor potentially expose it to unprivileged
users. This patch converts all shell-outs to use the environment
variable version of their credential settings, which is not leaked to
the process table.

We can omit passing '--os-auth-type password' since it is always implied
by the use of '--os-password' or OS_PASSWORD.

For openstackclient commands, if we want to specify a particular
endpoint type, we should use --os-interface/OS_INTERFACE, not
--os-endpoint/OS_ENDPOINT.

Using OS_PROJECT_NAME instead of OS_TENANT_NAME is acceptable in all
cases except for the nova availability zone setter, which is a custom
script.

(cherry picked from commit a1accbafb6f46e6ab08862ce8b03ceea3f235423)