### PR TITLE
keystone: Make password hash algorithm configurable

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -20,6 +20,10 @@ idle_timeout = <%= @sql_idle_timeout %>
 max_active_keys = <%= @max_active_keys %>
 
 [identity]
+password_hash_algorithm = <%= node[:keystone][:identity][:password_hash_algorithm] %>
+<% if node[:keystone][:identity].key?("password_hash_rounds") -%>
+password_hash_rounds = <%= node[:keystone][:identity][:password_hash_rounds] %>
+<% end -%>
 domain_specific_drivers_enabled = <%= node[:keystone][:domain_specific_drivers] ? "True" : "False" %>
 
 <% if node[:keystone][:domain_specific_drivers] -%>

--- a/chef/data_bags/crowbar/migrate/keystone/203_add_password_hash_algorithm.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/203_add_password_hash_algorithm.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  a["identity"]["password_hash_algorithm"] = ta["identity"]["password_hash_algorithm"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["identity"].delete("password_hash_algorithm")
+  if a["identity"].key?("password_hash_rounds")
+    a["identity"].delete("password_hash_rounds")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -54,7 +54,8 @@
         "password": "crowbar"
       },
       "identity": {
-        "driver": "sql"
+        "driver": "sql",
+        "password_hash_algorithm": "bcrypt"
       },
       "assignment": {
         "driver": "sql"
@@ -173,7 +174,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -59,7 +59,9 @@
                       "password": { "type" : "str", "required" : true }
                     }},
                     "identity" : { "type" : "map", "required" : true, "mapping": {
-                      "driver": { "type": "str", "required": true }
+                      "driver": { "type": "str", "required": true },
+                      "password_hash_algorithm": { "type": "str", "required": true, "pattern": "/^bcrypt$|^scrypt$|^pbkdf2_sha512$/" },
+                      "password_hash_rounds": { "type": "int", "required": false }
                     }},
                     "assignment" : { "type" : "map", "required" : true, "mapping": {
                       "driver": { "type": "str", "required": true }

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -47,3 +47,6 @@ en:
         api_version: 'API version %{api_version} not recognized.'
         enable_keystone_api: 'Keystone API version 3 needs to be enabled in order to use domain specific drivers.'
         timeout: 'Setting the Horizon timeout (%{horizon_timeout} minutes) longer than the Keystone token expiration timeout (%{keystone_timeout} minutes) is not supported.'
+        bcrypt_password_hash_rounds: "Password hash rounds for bcrypt must be between 4 and 31"
+        scrypt_password_hash_rounds: "Password hash rounds for scrypt must be between 1 and 31"
+        pbkdf_sha512_password_hash_rounds: "Password hash rounds for pbkdfsha512 must be between 1 and 4294967295"


### PR DESCRIPTION
Since Pike, the new default password hash algorithm is
"bcrypt"[1]. This is more secure but also significantly slower (factor 10
in my tests) when eg. trying to get a new token via the v3 API.
To be able to increase performance (if wanted), make the hashing
algorithm and the hashing rounds for the selected algorithm
configurable. Reducing the value for "password_hash_rounds" increases
the performance.

[1]
https://docs.openstack.org/releasenotes/keystone/pike.html#new-features