### PR TITLE
[4.0] ceilometer: Allow enabling SSL with HA (bsc#1049153)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -18,7 +18,7 @@ include_recipe "crowbar-pacemaker::haproxy"
 haproxy_loadbalancer "ceilometer-api" do
   address "0.0.0.0"
   port node[:ceilometer][:api][:port]
-  use_ssl false
+  use_ssl (node[:ceilometer][:api][:protocol] == "https")
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "ceilometer", "ceilometer-server", "api")
   action :nothing
 end.run_action(:create)


### PR DESCRIPTION
(cherry picked from commit 154f85d4af558df839ce2103f13b73b1a553ac55)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1072