### PR TITLE
nova: enable nested virt on Intel

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -111,7 +111,12 @@ case node[:nova][:libvirt_type]
             # load modules only when appropriate kernel is present
             execute "loading kvm modules" do
               command <<-EOF
-                  grep -qw vmx /proc/cpuinfo && /sbin/modprobe kvm-intel
+                  if grep -qw vmx /proc/cpuinfo ; then
+                    ! grep -q nested /etc/modprobe.d/80-kvm-intel.conf &&
+                      echo "options kvm_intel nested=1" > /etc/modprobe.d/80-kvm-intel.conf &&
+                      /sbin/modprobe -r kvm-intel
+                    /sbin/modprobe kvm-intel
+                  fi
                   grep -qw svm /proc/cpuinfo && /sbin/modprobe kvm-amd
                   grep -q POWER /proc/cpuinfo && /sbin/modprobe kvm
                   /sbin/modprobe vhost-net


### PR DESCRIPTION
because it defaults to off
but a lot of people rely on nested virt being available


While in https://fate.suse.com/320082 the virtualisation team
declined to promote nested virt to fully supported status for SLE12,
we are using this since 2012 in all kinds of places without problems.
So it remains in tech-preview.