### PR TITLE
manila, ha: fix listen address in HA case

### DIFF
--- a/chef/cookbooks/manila/libraries/helpers.rb
+++ b/chef/cookbooks/manila/libraries/helpers.rb
@@ -17,6 +17,7 @@
 module ManilaHelper
   def self.get_bind_host_port(node)
     if node[:manila][:ha][:enabled]
+      bind_host = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
       bind_port = node[:manila][:ha][:ports][:api]
     else
       if node[:manila][:api][:bind_open_address]


### PR DESCRIPTION
The bind_host IP address value reflected in the
osapi_share_listen configuration option (the listening
address for manila-api) was previously set to an empty
value in the HA case, which defaulted to the 0.0.0.0 value
being used by the manila-api service.
However, since Pike, the configured value is checked
against an IP address syntax and having an empty
value causes all manila services to fail.

This PR is meant to fix the [Pike HA gate job](https://ci.suse.de/view/Cloud/view/Cloud8/job/cloud-mkcloud8-job-ha-pike/).