### PR TITLE
keystone: Switch memcache backend to oslo_cache.memcache_pool

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -8,7 +8,7 @@ log_dir = /var/log/keystone
 driver = <%= node[:keystone][:assignment][:driver] %>
 
 [cache]
-backend = dogpile.cache.memcached
+backend = oslo_cache.memcache_pool
 enabled = True
 memcache_servers = <%= @memcached_servers.join(',') %>
 


### PR DESCRIPTION
Per the oslo.cache documentation it's recommended to use the pooling
backend for eventlet based and threaded services. As our setup for the
keystone vhost in apache uses threads by default, let's use the pooling
backend. This seems to significantly reduce the number of open
connections to memcached.

Partial-Bug: bsc#1057822

Note: An alternative fix might be to disable threads for the WSGIDaemonProcess. (I don't really have an idea how much good that does anyway, give pythons GIL) 