### PR TITLE
neutron: Increase inotify max user instances

### DIFF
--- a/chef/cookbooks/neutron/files/default/sysctl-inotify-max-instances.conf
+++ b/chef/cookbooks/neutron/files/default/sysctl-inotify-max-instances.conf
@@ -1,0 +1,1 @@
+fs.inotify.max_user_instances = 8192

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -74,6 +74,20 @@ bash "reload enable-ip_forward-sysctl" do
   subscribes :run, resources(cookbook_file: enable_ip_forward_file), :delayed
 end
 
+# Increase inotify max user instances
+# one instance needed per dnsmasq instance / network
+inotify_instances_file = "/etc/sysctl.d/60-neutron-inotify-max-user-instances.conf"
+cookbook_file inotify_instances_file do
+  source "sysctl-inotify-max-instances.conf"
+  mode "0644"
+end
+
+bash "reload inotify-max-user-instances.conf" do
+  code "/sbin/sysctl -e -q -p #{inotify_instances_file}"
+  action :nothing
+  subscribes :run, resources(cookbook_file: inotify_instances_file), :delayed
+end
+
 # Kill all the libvirt default networks.
 execute "Destroy the libvirt default network" do
   command "virsh net-destroy default"


### PR DESCRIPTION
It has been found that during heavy network creation by Neutron (>1K
networks) dnsmasq is unable to complete due to lack of inotify user
instances.

Each neutron network spawns one dnsmasq process. Each dnsmasq process
consumes one inotify instance. Existing processes in network nodes consume
less than 10 inotify instances so this number would virtually be the
maximum number of networks supported.

For now we are setting this number to 8192 which will support over 8k
networks.

(cherry picked from commit 1bc0e2df01e8e8e40604b616e812d9798c14614c)