### PR TITLE
ec2-api: add memcached cache backend for ec2-api-metadata

### DIFF
--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -40,6 +40,13 @@ else
   bind_port_s3 = node[:nova][:ports][:ec2_s3]
 end
 
+# use memcached as a cache backend for ec2-api-metadata
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "ec2-api") : [node]
+)
+
+memcached_instance "ec2-api"
+
 crowbar_pacemaker_sync_mark "wait-ec2_api_database" if ha_enabled
 
 database_connection = fetch_database_connection_string(node[:nova]["ec2-api"][:db], "nova")
@@ -210,7 +217,8 @@ template node[:nova]["ec2-api"][:config_file] do
     bind_port_ec2api: bind_port_ec2api,
     bind_port_metadata: bind_port_metadata,
     bind_port_s3: bind_port_s3,
-    nova_metadata_settings: nova_metadata_settings
+    nova_metadata_settings: nova_metadata_settings,
+    memcached_servers: memcached_servers
   )
 end
 

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -34,6 +34,11 @@ nova_metadata_protocol = <%= @nova_metadata_settings[:protocol] %>
 nova_metadata_insecure = <%= @nova_metadata_settings[:insecure] %>
 <% end %>
 
+[cache]
+backend = dogpile.cache.memcached
+enabled = true
+memcache_servers = <%= @memcached_servers.join(',') %>
+
 [database]
 connection = <%= @database_connection %>
 [oslo_concurrency]


### PR DESCRIPTION
Update the ec2-api cookbook to configure a memcached
instance running on every ec2-api node that will serve
as a cache backend for the ec2-api-metadata service.
This has been added in Pike as a recommended feature
without which the metadata service complains during
startup.

More info: https://review.openstack.org/#/c/469075/