### PR TITLE
[4.0] keystone: Switch memcache backend to oslo_cache.memcache_pool

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -12,7 +12,7 @@ transport_url = <%= @rabbit_settings[:url] %>
 driver = <%= node[:keystone][:assignment][:driver] %>
 
 [cache]
-backend = dogpile.cache.memcached
+backend = oslo_cache.memcache_pool
 enabled = True
 memcache_servers = <%= @memcached_servers.join(',') %>
 


### PR DESCRIPTION
Per the oslo.cache documentation it's recommended to use the pooling
backend for eventlet based and threaded services. As our setup for the
keystone vhost in apache uses threads by default, let's use the pooling
backend. This seems to significantly reduce the number of open
connections to memcached.

Partial-Bug: bsc#1057822
(cherry picked from commit 2f512cf110cebea278285d0dd8ac846d75e8de57)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1266