### PR TITLE
mysql: Make sure galera resources are started on controller nodes only

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -164,6 +164,7 @@ pacemaker_ms ms_name do
   rsc service_name
   meta(
     "master-max" => nodes_names.size,
+    "clone-max" => nodes_names.size,
     "ordered" => "false",
     "interleave" => "false",
     "notify" => "true"
@@ -173,6 +174,9 @@ pacemaker_ms ms_name do
 end
 
 transaction_objects.push("pacemaker_ms[#{ms_name}]")
+
+ms_location_name = openstack_pacemaker_controller_only_location_for ms_name
+transaction_objects << "pacemaker_location[#{ms_location_name}]"
 
 pacemaker_transaction "galera service" do
   cib_objects transaction_objects


### PR DESCRIPTION
Adding the location constraint should ensure that the service
is not running at remote cluster nodes.

mariadb: Set "clone-max" for the ms-galera resource

By setting this to the number of "real" cluster nodes (non-remote) we
avoid having the resource listed as "Stopped" on remote nodes
(compute-ha) in the crm status output. This is taken from the drbd
master/slave resource that we used for postgresql in the past.

(cherry picked from commit 132b287c2df0a399ad81ceb6415a3aaf81975b4a)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1265