### PR TITLE
barbican: remove options deprecated in Pike

### DIFF
--- a/chef/cookbooks/barbican/templates/default/barbican.conf.erb
+++ b/chef/cookbooks/barbican/templates/default/barbican.conf.erb
@@ -8,9 +8,9 @@ transport_url = <%= @rabbit_settings[:url] %>
 [oslo_messaging_rabbit]
 amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>
 rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
-rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
+ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
-kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
+ssl_ca_file = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
 
 [queue]


### PR DESCRIPTION
The following deprecated options have been updated:
 - the [oslo_messaging_rabbit]/rabbit_use_ssl option was
   renamed to [oslo_messaging_rabbit]/ssl [1]
 - the oslo_messaging_rabbit]/kombu_ssl_ca_certs option was
   renamed to [oslo_messaging_rabbit]/ssl_ca_file [1]

[1] https://review.openstack.org/#/c/438455/