### PR TITLE
Fix monasca-agent on Pike

### DIFF
--- a/chef/cookbooks/monasca/templates/default/monasca-agent_agent.yaml.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-agent_agent.yaml.erb
@@ -23,6 +23,8 @@ Api:
   insecure: <%= @keystone_settings['insecure'] %>
   # Name of the ca certs file
   # ca_file: <%= @ca_file %>
+  user_domain_name: Default
+  project_domain_name: Default
 
   # The following 3 options are for handling buffering and reconnection to the monasca-api
   # If the agent forwarder is consuming too much memory, you may want to set

--- a/chef/cookbooks/monasca/templates/default/monasca-reconfigure-server.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-reconfigure-server.erb
@@ -13,6 +13,8 @@ run_setup()
       <% if defined?(@service) -%> --service '<%= @service %>' <% end -%> \
       --keystone_url '<%= @keystone_settings["admin_auth_url"] %>/v3' \
       --monasca_url '<%= @monasca_api_url %>' \
+      --user_domain_name Default \
+      --project_domain_name Default \
       --user '<%= @agent_settings["user"] %>' \
       --dimensions '<%= @agent_dimensions.map{|k,v| "#{k}:#{v}"}.join(',') %>' \
       --insecure '<%= @agent_settings["insecure"] %>' \

--- a/chef/cookbooks/monasca/templates/default/monasca-reconfigure.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-reconfigure.erb
@@ -17,6 +17,8 @@ then
         --project_name '<%= @agent_keystone["service_tenant"] %>' \
         <% if defined?(@service) -%> --service '<%= @service %>' <% end -%> \
         --keystone_url '<%= @keystone_settings["admin_auth_url"] %>/v3' \
+        --user_domain_name Default \
+        --project_domain_name Default \
         --monasca_url '<%= @monasca_api_url %>' \
         --user '<%= @agent_settings["user"] %>' \
         --dimensions '<%= @agent_dimensions.map{|k,v| "#{k}:#{v}"}.join(',') %>' \


### PR DESCRIPTION
This commit adds domain information to monasca-agent Keystone credentials. On
Pike, monasca-agent will otherwise attempt Keystone authentication without
specifying a domain for either user or project, which causes it to fail
authentication and thus prevents it from ever sending any metrics.