### PR TITLE
[4.0] nova: add HA rate limiting options to raw template

### DIFF
--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -29,6 +29,7 @@ haproxy_loadbalancer "nova-api" do
   port node[:nova][:ports][:api]
   use_ssl node[:nova][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "api")
+  rate_limit node[:nova][:ha_rate_limit]["nova-api"]
   action :nothing
 end.run_action(:create)
 
@@ -37,6 +38,7 @@ haproxy_loadbalancer "nova-metadata" do
   port node[:nova][:ports][:metadata]
   use_ssl node[:nova][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "metadata")
+  rate_limit node[:nova][:ha_rate_limit]["nova-metadata"]
   action :nothing
 end.run_action(:create)
 
@@ -46,6 +48,7 @@ if node[:nova][:use_novnc]
     port node[:nova][:ports][:novncproxy]
     use_ssl node[:nova][:novnc][:ssl][:enabled]
     servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "novncproxy")
+    rate_limit node[:nova][:ha_rate_limit]["nova-novncproxy"]
     action :nothing
   end.run_action(:create)
 end
@@ -58,6 +61,7 @@ if node[:nova][:use_serial]
       "nova",
       "nova-controller",
       "serialproxy")
+    rate_limit node[:nova][:ha_rate_limit]["nova-serialproxy"]
     action :nothing
   end.run_action(:create)
 end

--- a/chef/data_bags/crowbar/migrate/nova/119_add_rate_limit.rb
+++ b/chef/data_bags/crowbar/migrate/nova/119_add_rate_limit.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ha_rate_limit"] = ta["ha_rate_limit"] unless a.key? "ha_rate_limit"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ha_rate_limit") unless ta.key? "ha_rate_limit"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -152,6 +152,12 @@
         "vendordata": {
           "json": "{}"
         }
+      },
+      "ha_rate_limit": {
+        "nova-api": 0,
+        "nova-metadata": 0,
+        "nova-novncproxy": 0,
+        "nova-serialproxy": 0
       }
     }
   },
@@ -159,7 +165,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 118,
+      "schema-revision": 119,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -231,6 +231,14 @@
                   }
                 }
               }
+            },
+            "ha_rate_limit": {
+              "type": "map", "required": true, "mapping": {
+                "nova-api": { "type": "int", "required": true },
+                "nova-metadata": { "type": "int", "required": true },
+                "nova-novncproxy": { "type": "int", "required": true },
+                "nova-serialproxy": { "type": "int", "required": true }
+              }
             }
           }
         }


### PR DESCRIPTION
Adds HA rate limiting options to the raw template for the different
services that depend from nova. Defaults to 0 as the values, which means
no rate limiting

(cherry picked from commit ffcc557fcc85888b95d058de7e72d315ba0008f6)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1233