### PR TITLE
tempest: readd img_dir and ami/ari/aki_img_file options

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -142,7 +142,11 @@ instance_type = <%= @heat_flavor_ref %>
 lock_path = /var/run/tempest
 
 [scenario]
+img_dir = <%= @tempest_path %>/etc/cirros/
 img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-disk.img
+ami_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-blank.img
+ari_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-initrd
+aki_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-vmlinuz
 
 [service_available]
 neutron = true


### PR DESCRIPTION
The img_dir, ami_img_file, ari_img_file and aki_img_file
options from the scenario group are still being used by
some test cases:

  scenario.test_minimum_basic.TestMinimumBasicScenario.*
  scenario.test_encrypted_cinder_volumes.TestEncryptedCinderVolumes.*

, which fail unless these configuration options are supplied.

These options were removed during the Ocata update in #1167.

More info:
 - tempest configuration doc: https://github.com/openstack/tempest/blob/17.0.0/doc/source/configuration.rst#images