### PR TITLE
[4.0] rabbitmq: do not create the erlang cookie file on cluster deployment

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -40,7 +40,6 @@ default[:rabbitmq][:mnesiadir] = nil
 
 default[:rabbitmq][:cluster] = false
 default[:rabbitmq][:clustername] = "rabbit@#{node[:hostname]}"
-default[:rabbitmq][:erlang_cookie_path] = "/var/lib/rabbitmq/.erlang.cookie"
 
 # ha
 default[:rabbitmq][:ha][:enabled] = false

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -20,15 +20,6 @@ rabbitmq_op = {}
 rabbitmq_op["monitor"] = {}
 rabbitmq_op["monitor"]["interval"] = "10s"
 
-# set the shared rabbitmq cookie
-# cookie is automatically set during barclamp apply
-# on the apply_role_pre_chef_call method
-file node[:rabbitmq][:erlang_cookie_path] do
-  content node[:rabbitmq][:erlang_cookie]
-  owner node[:rabbitmq][:rabbitmq_user]
-  group node[:rabbitmq][:rabbitmq_group]
-end
-
 # Wait for all nodes to reach this point so we know that all nodes will have
 # all the required packages installed before we create the pacemaker
 # resources


### PR DESCRIPTION
There should be no need to create the erlang cookie file for rabbit on
cluster deployments as the pacemaker resource agent already creates
it for us.

(cherry picked from commit ffe2732e464667f1fb3907cf9e4d2554b63f809b)