### PR TITLE
nova: fix ratelimit migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/nova/205_add_rate_limit.rb
+++ b/chef/data_bags/crowbar/migrate/nova/205_add_rate_limit.rb
@@ -1,9 +1,13 @@
 def upgrade(ta, td, a, d)
   a["ha_rate_limit"] = ta["ha_rate_limit"] unless a.key? "ha_rate_limit"
+  a["ha_rate_limit"]["nova-placement-api"] = ta["ha_rate_limit"]["nova-placement-api"] \
+    unless a["ha_rate_limit"].key? "nova-placement-api"
   return a, d
 end
 
 def downgrade(ta, td, a, d)
+  a["ha_rate_limit"].delete("nova-placement-api") \
+    unless ta["ha_rate_limit"].key? "nova-placement-api"
   a.delete("ha_rate_limit") unless ta.key? "ha_rate_limit"
   return a, d
 end


### PR DESCRIPTION
As we have backported the migration onto 4.0 branch but on 4.0 the
placement api does not exists, we could end up with a situation in which
the ha_rate_limit key exists in an environment but the
nova-placement-api inside that attribute is missing, so lets make sure
that we check for that case and update it if its missing.

Do-Not-Merge-Until: https://github.com/crowbar/crowbar-openstack/pull/1281