### PR TITLE
Require SSL connection to database if MariaDB SSL is configured

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -40,6 +40,7 @@ database_user "grant database access for aodh database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/barbican/recipes/common.rb
+++ b/chef/cookbooks/barbican/recipes/common.rb
@@ -89,6 +89,7 @@ database_user "grant database access for #{@cookbook_name} database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -95,6 +95,7 @@ else
       host "%"
       privileges db_settings[:privs]
       provider db_settings[:user_provider]
+      require_ssl db_settings[:connection][:ssl][:enabled]
       action :grant
       only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/cinder/recipes/sql.rb
+++ b/chef/cookbooks/cinder/recipes/sql.rb
@@ -56,6 +56,7 @@ database_user "grant database access for cinder database user" do
     host "%"
     privileges db_settings[:privs]
     provider db_settings[:user_provider]
+    require_ssl db_settings[:connection][:ssl][:enabled]
     action :grant
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/database/libraries/provider_database_mysql.rb
+++ b/chef/cookbooks/database/libraries/provider_database_mysql.rb
@@ -74,13 +74,22 @@ class Chef
         end
 
         def client
-          @client ||= Mysql2::Client.new(
+          client_options = {
             host: new_resource.connection[:host],
             socket: new_resource.connection[:socket],
             username: new_resource.connection[:username],
             password: new_resource.connection[:password],
             port: new_resource.connection[:port]
-          )
+          }
+          if new_resource.connection[:ssl][:enabled]
+            if new_resource.connection[:ssl][:insecure]
+              client_options[:sslverify] = false
+            else
+              client_options[:sslverify] = true
+              client_options[:sslca] = new_resource.connection[:ssl][:ca_certs]
+            end
+          end
+          @client ||= Mysql2::Client.new(client_options)
         end
 
         def close_client

--- a/chef/cookbooks/database/libraries/provider_database_mysql_user.rb
+++ b/chef/cookbooks/database/libraries/provider_database_mysql_user.rb
@@ -113,13 +113,22 @@ class Chef
         private
 
         def client
-          @client ||= Mysql2::Client.new(
+          client_options = {
             host: new_resource.connection[:host],
             socket: new_resource.connection[:socket],
             username: new_resource.connection[:username],
             password: new_resource.connection[:password],
             port: new_resource.connection[:port]
-          )
+          }
+          if new_resource.connection[:ssl][:enabled]
+            if new_resource.connection[:ssl][:insecure]
+              client_options[:sslverify] = false
+            else
+              client_options[:sslverify] = true
+              client_options[:sslca] = new_resource.connection[:ssl][:ca_certs]
+            end
+          end
+          @client ||= Mysql2::Client.new(client_options)
         end
 
         def close_client

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -79,6 +79,7 @@ database_user "grant database access for #{@cookbook_name} database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -58,6 +58,7 @@ database_user "grant database access for glance database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -51,6 +51,7 @@ database_user "grant database access for heat database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -333,6 +333,11 @@ database_user "create dashboard database user" do
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
+# We do not require SSL connectopn for horizon user in case of insecure DB setup,
+# because horizon's django uses a library (MySQLdb) that does not support insecure connection.
+database_ssl = db_settings[:connection][:ssl][:enabled] &&
+  !db_settings[:connection][:ssl][:insecure]
+
 database_user "grant database access for dashboard database user" do
     connection db_settings[:connection]
     database_name node[:horizon][:db][:database]
@@ -341,14 +346,14 @@ database_user "grant database access for dashboard database user" do
     host "%"
     privileges db_settings[:privs]
     provider db_settings[:user_provider]
-    require_ssl db_settings[:connection][:ssl][:enabled]
+    require_ssl database_ssl
     action :grant
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-horizon_database" if ha_enabled
 
-db_settings = {
+django_db_settings = {
   "ENGINE" => django_db_backend,
   "NAME" => "'#{node[:horizon][:db][:database]}'",
   "USER" => "'#{node[:horizon][:db][:user]}'",
@@ -356,6 +361,8 @@ db_settings = {
   "HOST" => "'#{db_settings[:address]}'",
   "default-character-set" => "'utf8'"
 }
+
+db_ca_certs = database_ssl ? db_settings[:connection][:ssl][:ca_certs] : ""
 
 glance_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "glance"))
 cinder_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "cinder"))
@@ -446,7 +453,8 @@ template local_settings do
     || sahara_insecure \
     || manila_insecure \
     || ceilometer_insecure,
-    db_settings: db_settings,
+    db_settings: django_db_settings,
+    db_ca_certs: db_ca_certs,
     timezone: (node[:provisioner][:timezone] rescue "UTC") || "UTC",
     use_ssl: node[:horizon][:apache][:ssl],
     password_validator_regex: node[:horizon][:password_validator][:regex],

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -341,6 +341,7 @@ database_user "grant database access for dashboard database user" do
     host "%"
     privileges db_settings[:privs]
     provider db_settings[:user_provider]
+    require_ssl db_settings[:connection][:ssl][:enabled]
     action :grant
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -227,6 +227,13 @@ DATABASES = {
         <% @db_settings.sort_by { |key, value| key }.each do |key,value| -%>
         '<%= key %>': <%= value %>,
         <% end -%>
+        <% unless @db_ca_certs.empty? %>
+        'OPTIONS': {
+            'ssl': {
+                'ca': '<%= @db_ca_certs %>'
+            }
+        }
+        <% end %>
     },
 }
 

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -45,6 +45,7 @@ database_user "grant database access for ironic database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
 end
 

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -217,6 +217,7 @@ database_user "grant database access for keystone database user" do
     host "%"
     privileges db_settings[:privs]
     provider db_settings[:user_provider]
+    require_ssl db_settings[:connection][:ssl][:enabled]
     action :grant
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/magnum/recipes/sql.rb
+++ b/chef/cookbooks/magnum/recipes/sql.rb
@@ -54,6 +54,7 @@ database_user "grant database access for magnum database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || is_cluster_founder }
 end

--- a/chef/cookbooks/manila/recipes/sql.rb
+++ b/chef/cookbooks/manila/recipes/sql.rb
@@ -36,6 +36,7 @@ database_user "grant database access for manila database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -72,6 +72,7 @@ unless node[:database][:galera_bootstrapped]
     db_connection[:host] = "localhost"
     db_connection[:username] = "root"
     db_connection[:password] = ""
+    db_connection[:ssl] = {}
 
     service "mysql-temp start" do
       service_name mysql_service_name

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -164,6 +164,7 @@ db_connection = db_settings[:connection].dup
 db_connection[:host] = "localhost"
 db_connection[:username] = "root"
 db_connection[:password] = node[:database][:mysql][:server_root_password]
+db_connection[:ssl] = {}
 
 unless node[:database][:database_bootstrapped]
   database_user "create db_maker database user" do
@@ -206,7 +207,7 @@ unless node[:database][:database_bootstrapped]
       "TRIGGER"
     ]
     provider db_settings[:user_provider]
-    require_ssl db_connection[:ssl][:enabled]
+    require_ssl node[:mysql][:ssl][:enabled]
     action :grant
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -206,6 +206,7 @@ unless node[:database][:database_bootstrapped]
       "TRIGGER"
     ]
     provider db_settings[:user_provider]
+    require_ssl db_connection[:ssl][:enabled]
     action :grant
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/neutron/recipes/database.rb
+++ b/chef/cookbooks/neutron/recipes/database.rb
@@ -63,6 +63,7 @@ props.each do |prop|
     host "%"
     privileges db_settings[:privs]
     provider db_settings[:user_provider]
+    require_ssl db_settings[:connection][:ssl][:enabled]
     action :grant
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -59,6 +59,7 @@ end
     host "%"
     privileges db_settings[:privs]
     provider db_settings[:user_provider]
+    require_ssl db_settings[:connection][:ssl][:enabled]
     action :grant
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
@@ -82,6 +83,7 @@ database_user "grant privileges to the #{node[:nova][:db][:user]} database user"
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/sahara/recipes/sql.rb
+++ b/chef/cookbooks/sahara/recipes/sql.rb
@@ -52,6 +52,7 @@ database_user "grant database access for sahara database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/trove/recipes/sql.rb
+++ b/chef/cookbooks/trove/recipes/sql.rb
@@ -47,5 +47,6 @@ database_user "grant database access for trove database user" do
   host "%"
   privileges db_settings[:privs]
   provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
 end


### PR DESCRIPTION
With this settings, non-SSL access is forbidden for the affected
users.

This is based on @s-t-e-v-e-n-k patch. 

**NOTE**: 
 - db_maker access does not work for insecure connection, requires this fix in rubygem-mysql2:
 https://github.com/brianmario/mysql2/pull/889
 - currently present in our rubygem package