### PR TITLE
neutron: Fix deprecated nova_metadata_ip option

### DIFF
--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -1,7 +1,6 @@
 [DEFAULT]
 <% unless @nova_metadata_settings.empty? %>
-# Change to nova_metadata_host after Pike is required
-nova_metadata_ip = <%= @nova_metadata_settings[:host] %>
+nova_metadata_host = <%= @nova_metadata_settings[:host] %>
 metadata_proxy_shared_secret = <%= @nova_metadata_settings[:shared_secret] %>
 nova_metadata_protocol = <%= @nova_metadata_settings[:protocol] %>
 nova_metadata_insecure = <%= @nova_metadata_settings[:insecure] %>


### PR DESCRIPTION
The nova_metadata_ip option is deprecated in favor of the
new nova_metadata_host option because it reflects better
that the option accepts an IP address and also a DNS name. [1]

This change was originally included in #1229, but then later was
reverted in #1245 because it was braking the (then Ocata based)
Devel:Cloud:8.
This PR reverts commit 416c1bb99f9b289e7a4a2c920eeafa5fb6da8ec5 
(#1245) in effect bringing back these suppressed changes.

More information:
[1] https://docs.openstack.org/releasenotes/neutron/pike.html#deprecation-notes
