### PR TITLE
nova: use the proper vars for serialproxy

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -262,8 +262,8 @@ rpc_conn_pool_size = 64
 enabled = <%= @serial_enabled ? "True" : "False" %>
 base_url = ws://<%= @serialproxy_public_host %>:<%= node[:nova][:ports][:serialproxy] %>/
 proxyclient_address = <%= node[:nova][:my_ip] %>
-serialproxy_host = 0.0.0.0
-serialproxy_port = 6083
+serialproxy_host = <%= @bind_host %>
+serialproxy_port = <%= @bind_port_serialproxy %>
 
 [trusted_computing]
 <% if @has_itxt %>


### PR DESCRIPTION
We were leaving the default hardcoded values for serialproxy which could
collide with haproxy if deployed on HA as both will try to use the same
ports.