### PR TITLE
rabbitmq: Set "clone-max" for the ms-rabbitmq resource

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -62,6 +62,7 @@ pacemaker_ms ms_name do
   rsc service_name
   meta ({
     "master-max" => "1",
+    "clone-max" => CrowbarPacemakerHelper.cluster_nodes(node).size,
     "master-node-max" => "1",
     "ordered" => "false",
     "interleave" => "false",


### PR DESCRIPTION
By setting this to the number of "real" cluster nodes (non-remote) we
avoid having the resource listed as "Stopped" on remote nodes
(compute-ha) in the crm status output.

See https://github.com/crowbar/crowbar-openstack/pull/1265