### PR TITLE
[4.0] all: Make systemd restart services on failures

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -231,6 +231,9 @@ service "aodh-evaluator" do
   subscribes :restart, resources(template: node[:aodh][:config_file])
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "aodh-evaluator" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 service "aodh-notifier" do
   service_name node[:aodh][:notifier][:service_name]
@@ -239,6 +242,9 @@ service "aodh-notifier" do
   subscribes :restart, resources(template: node[:aodh][:config_file])
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "aodh-notifier" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 service "aodh-listener" do
   service_name node[:aodh][:listener][:service_name]
@@ -246,6 +252,9 @@ service "aodh-listener" do
   action [:enable, :start]
   subscribes :restart, resources(template: node[:aodh][:config_file])
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
+end
+utils_systemd_service_restart "aodh-listener" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
 end
 
 if ha_enabled

--- a/chef/cookbooks/barbican/recipes/keystone-listener.rb
+++ b/chef/cookbooks/barbican/recipes/keystone-listener.rb
@@ -31,3 +31,7 @@ service "openstack-barbican-keystone-listener" do
   action [:disable, :stop] unless node[:barbican][:enable_keystone_listener]
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "openstack-barbican-keystone-listener" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+  only_if { node[:barbican][:enable_keystone_listener] }
+end

--- a/chef/cookbooks/barbican/recipes/worker.rb
+++ b/chef/cookbooks/barbican/recipes/worker.rb
@@ -28,3 +28,6 @@ service "openstack-barbican-worker" do
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "openstack-barbican-worker" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end

--- a/chef/cookbooks/ceilometer/recipes/agent.rb
+++ b/chef/cookbooks/ceilometer/recipes/agent.rb
@@ -41,3 +41,7 @@ service "ceilometer-agent-compute" do
     action [:disable, :stop]
   end
 end
+utils_systemd_service_restart "ceilometer-agent-compute" do
+  action :enable
+  only_if { is_compute }
+end

--- a/chef/cookbooks/ceilometer/recipes/central.rb
+++ b/chef/cookbooks/ceilometer/recipes/central.rb
@@ -32,6 +32,9 @@ service "ceilometer-agent-central" do
   subscribes :restart, resources("template[/etc/ceilometer/pipeline.yaml]")
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
+utils_systemd_service_restart "ceilometer-agent-central" do
+  action ha_enabled ? :disable : :enable
+end
 
 if ha_enabled
   log "HA support for ceilometer-central is enabled"

--- a/chef/cookbooks/ceilometer/recipes/mongodb.rb
+++ b/chef/cookbooks/ceilometer/recipes/mongodb.rb
@@ -42,6 +42,9 @@ service mongo_service do
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
+utils_systemd_service_restart mongo_service do
+  action ha_enabled ? :disable : :enable
+end
 
 if ha_enabled
   crowbar_pacemaker_sync_mark "wait-mongodb_service"

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -174,6 +174,9 @@ service "ceilometer-collector" do
   subscribes :restart, resources("template[/etc/ceilometer/pipeline.yaml]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "ceilometer-collector" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 service "ceilometer-agent-notification" do
   service_name node[:ceilometer][:agent_notification][:service_name]
@@ -182,6 +185,9 @@ service "ceilometer-agent-notification" do
   subscribes :restart, resources(template: node[:ceilometer][:config_file])
   subscribes :restart, resources("template[/etc/ceilometer/pipeline.yaml]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
+end
+utils_systemd_service_restart "ceilometer-agent-notification" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
 end
 
 service "ceilometer-api" do

--- a/chef/cookbooks/cinder/definitions/cinder_service.rb
+++ b/chef/cookbooks/cinder/definitions/cinder_service.rb
@@ -21,4 +21,7 @@ define :cinder_service, use_pacemaker_provider: false do
     subscribes :restart, resources(template: node[:cinder][:config_file])
     provider Chef::Provider::CrowbarPacemakerService if params[:use_pacemaker_provider]
   end
+  utils_systemd_service_restart cinder_service_name do
+    action params[:use_pacemaker_provider] ? :disable : :enable
+  end
 end

--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -287,6 +287,7 @@ service "tgt" do
     restart_command "stop tgt; start tgt"
   end
 end
+utils_systemd_service_restart "tgt"
 
 volume_elements = node[:cinder][:elements]["cinder-volume"]
 ha_enabled = CrowbarPacemakerHelper.cluster_enabled?(node) &&

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -207,17 +207,26 @@ service "openstack-ec2-api-api" do
   subscribes :restart, resources(template: node[:nova]["ec2-api"][:config_file])
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "openstack-ec2-api-api" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 service "openstack-ec2-api-metadata" do
   action [:enable, :start]
   subscribes :restart, resources(template: node[:nova]["ec2-api"][:config_file])
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "openstack-ec2-api-metadata" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 service "openstack-ec2-api-s3" do
   action [:enable, :start]
   subscribes :restart, resources(template: node[:nova]["ec2-api"][:config_file])
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
+end
+utils_systemd_service_restart "openstack-ec2-api-s3" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
 end
 
 if ha_enabled

--- a/chef/cookbooks/glance/definitions/glance_service.rb
+++ b/chef/cookbooks/glance/definitions/glance_service.rb
@@ -16,4 +16,7 @@ define :glance_service do
     subscribes :restart, resources(template: node[:glance][short_name][:config_file])
     provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
   end
+  utils_systemd_service_restart glance_name do
+    action use_crowbar_pacemaker_service ? :disable : :enable
+  end
 end

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -452,6 +452,9 @@ service "heat-engine" do
   subscribes :restart, resources("template[/etc/heat/heat.conf.d/100-heat.conf]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "heat-engine" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 template "/etc/heat/loadbalancer.template" do
   source "loadbalancer.template.erb"
@@ -469,6 +472,9 @@ service "heat-api" do
   subscribes :restart, resources("template[/etc/heat/heat.conf.d/100-heat.conf]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "heat-api" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 service "heat-api-cfn" do
   service_name node[:heat][:api_cfn][:service_name]
@@ -477,6 +483,9 @@ service "heat-api-cfn" do
   subscribes :restart, resources("template[/etc/heat/heat.conf.d/100-heat.conf]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart "heat-api-cfn" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 service "heat-api-cloudwatch" do
   service_name node[:heat][:api_cloudwatch][:service_name]
@@ -484,6 +493,9 @@ service "heat-api-cloudwatch" do
   action [:enable, :start]
   subscribes :restart, resources("template[/etc/heat/heat.conf.d/100-heat.conf]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
+end
+utils_systemd_service_restart "heat-api-cloudwatch" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
 end
 
 if ha_enabled

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -191,12 +191,18 @@ service "ironic-api" do
   action [:enable, :start]
   subscribes :restart, resources(template: node[:ironic][:config_file])
 end
+utils_systemd_service_restart "ironic-api" do
+  action :enable
+end
 
 service "ironic-conductor" do
   service_name node[:ironic][:conductor][:service_name]
   supports status: true, restart: true
   action [:enable, :start]
   subscribes :restart, resources(template: node[:ironic][:config_file])
+end
+utils_systemd_service_restart "ironic-conductor" do
+  action :enable
 end
 
 execute "ironic-dbsync" do

--- a/chef/cookbooks/ironic/recipes/tftp.rb
+++ b/chef/cookbooks/ironic/recipes/tftp.rb
@@ -79,6 +79,7 @@ if node[:platform_family] == "suse"
       action ["disable", "stop"]
     end
   end
+  # No need for utils_systemd_service_restart: it's handled in the template already
 
   bash "reload systemd after tftp.service update" do
     code "systemctl daemon-reload"

--- a/chef/cookbooks/ironic/templates/default/tftp.service.erb
+++ b/chef/cookbooks/ironic/templates/default/tftp.service.erb
@@ -4,3 +4,4 @@ Description=Tftp Server
 [Service]
 Type=simple
 ExecStart=/usr/sbin/in.tftpd -u tftp -s <%= @tftproot %> -m <%= @map_file %> -L -a <%= @ironic_ip %>
+Restart=on-failure

--- a/chef/cookbooks/magnum/definitions/magnum_service.rb
+++ b/chef/cookbooks/magnum/definitions/magnum_service.rb
@@ -14,4 +14,7 @@ define :magnum_service, use_pacemaker_provider: false do
     provider Chef::Provider::CrowbarPacemakerService \
                if params[:use_pacemaker_provider]
   end
+  utils_systemd_service_restart magnum_service_name do
+    action params[:use_pacemaker_provider] ? :disable : :enable
+  end
 end

--- a/chef/cookbooks/manila/definitions/manila_service.rb
+++ b/chef/cookbooks/manila/definitions/manila_service.rb
@@ -14,4 +14,7 @@ define :manila_service, use_pacemaker_provider: false do
     provider Chef::Provider::CrowbarPacemakerService \
                if params[:use_pacemaker_provider]
   end
+  utils_systemd_service_restart manila_service_name do
+    action params[:use_pacemaker_provider] ? :disable : :enable
+  end
 end

--- a/chef/cookbooks/memcached/definitions/memcached_instance.rb
+++ b/chef/cookbooks/memcached/definitions/memcached_instance.rb
@@ -27,6 +27,7 @@ define :memcached_instance do
     service "memcached" do
       action [:enable, :start]
     end
+    utils_systemd_service_restart "memcached"
   else
     runit_service "memcached-#{params[:name]}" do
       template_name "memcached"

--- a/chef/cookbooks/memcached/metadata.rb
+++ b/chef/cookbooks/memcached/metadata.rb
@@ -5,6 +5,7 @@ description "Installs memcached and provides a define to set up an instance of m
 long_description IO.read(File.join(File.dirname(__FILE__), "README.rdoc"))
 version "0.10.4"
 depends "runit"
+depends "utils"
 
 recipe "memcached", "Installs and configures memcached"
 

--- a/chef/cookbooks/memcached/recipes/default.rb
+++ b/chef/cookbooks/memcached/recipes/default.rb
@@ -34,6 +34,7 @@ service "memcached" do
   action :nothing
   supports status: true, start: true, stop: true, restart: true
 end
+utils_systemd_service_restart "memcached"
 
 template "/etc/memcached.conf" do
   case node[:platform_family]

--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -61,6 +61,10 @@ if node["roles"].include?("monasca-server")
     action [:enable, :start]
     # provider Chef::Provider::CrowbarPacemakerService if ha_enabled
   end
+  utils_systemd_service_restart agent_settings[:agent_service_name] do
+    # action ha_enabled ? :disable : :enable
+    action :enable
+  end
 
   monasca_agent_plugin_elastic "elasticsearch checks" do
     built_by "agent.rb"
@@ -129,6 +133,10 @@ service agent_settings[:agent_service_name] do
   # provider Chef::Provider::CrowbarPacemakerService if ha_enabled
   subscribes :restart, resources(template: "/etc/monasca/agent/agent.yaml")
   subscribes :restart, resources(template: "/etc/monasca/agent/supervisor.conf")
+end
+utils_systemd_service_restart agent_settings[:agent_service_name] do
+  # action ha_enabled ? :disable : :enable
+  action :enable
 end
 
 ##########################################################

--- a/chef/cookbooks/monasca/recipes/log_agent.rb
+++ b/chef/cookbooks/monasca/recipes/log_agent.rb
@@ -87,5 +87,6 @@ service "openstack-monasca-log-agent" do
   supports status: true, restart: true, start: true, stop: true
   action [:enable, :start]
 end
+utils_systemd_service_restart "openstack-monasca-log-agent"
 
 node.save

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -60,6 +60,9 @@ service "mysql" do
   action :enable
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
+utils_systemd_service_restart "mysql" do
+  action ha_enabled ? :disable : :enable
+end
 
 directory node[:mysql][:tmpdir] do
   owner "mysql"

--- a/chef/cookbooks/neutron/definitions/neutron_metadata.rb
+++ b/chef/cookbooks/neutron/definitions/neutron_metadata.rb
@@ -100,5 +100,8 @@ define :neutron_metadata,
         supports status: true, restart: true
       end
     end
+    utils_systemd_service_restart node[:neutron][:platform][:metadata_agent_name] do
+      action use_crowbar_pacemaker_service ? :disable : :enable
+    end
   end
 end

--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -43,6 +43,7 @@ service node[:network][:ovs_service] do
   supports status: true, restart: true
   action [:start, :enable]
 end
+utils_systemd_service_restart node[:network][:ovs_service]
 
 if node.roles.include?("neutron-network")
   # Explicitly stop and disable l3 and metadata agents if APIC is
@@ -63,6 +64,7 @@ if node.roles.include?("nova-compute-kvm")
   service "lldpd" do
     action [:enable, :start]
   end
+  utils_systemd_service_restart "lldpd"
 
   # include neutron::common_config only now, after we've installed packages
   include_recipe "neutron::common_config"
@@ -118,9 +120,11 @@ if node.roles.include?("nova-compute-kvm")
     action [:enable, :start]
     subscribes :restart, resources("template[#{agent_config_path}]")
   end
+  utils_systemd_service_restart "neutron-opflex-agent"
 
   service "agent-ovs" do
     action [:enable, :start]
     subscribes :restart, resources("template[#{opflex_agent_conf}]")
   end
+  utils_systemd_service_restart "agent-ovs"
 end

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -315,6 +315,9 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       supports status: true, restart: true
     end
   end
+  utils_systemd_service_restart neutron_agent do
+    action use_crowbar_pacemaker_service ? :disable : :enable
+  end
 
   # L3 agent
   if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
@@ -350,6 +353,9 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       else
         supports status: true, restart: true
       end
+    end
+    utils_systemd_service_restart node[:neutron][:platform][:l3_agent_name] do
+      action use_crowbar_pacemaker_service ? :disable : :enable
     end
   end
 end

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -198,6 +198,9 @@ service node[:neutron][:platform][:metering_agent_name] do
   subscribes :restart, resources("template[/etc/neutron/metering_agent.ini]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart node[:neutron][:platform][:metering_agent_name] do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 if node[:neutron][:use_lbaas] &&
     [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
@@ -210,6 +213,9 @@ if node[:neutron][:use_lbaas] &&
     subscribes :restart, resources("template[/etc/neutron/lbaas_agent.ini]")
     provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
   end
+  utils_systemd_service_restart lbaas_agent do
+    action use_crowbar_pacemaker_service ? :disable : :enable
+  end
 elsif node[:neutron][:use_lbaas] &&
     node[:neutron][:lbaasv2_driver] == "f5"
   service node[:neutron][:platform][:f5_agent_name] do
@@ -219,6 +225,9 @@ elsif node[:neutron][:use_lbaas] &&
     subscribes :restart, resources("template[/etc/neutron/services/f5/f5-openstack-agent.ini]")
     provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
   end
+  utils_systemd_service_restart node[:neutron][:platform][:f5_agent_name] do
+    action use_crowbar_pacemaker_service ? :disable : :enable
+  end
 end
 
 service node[:neutron][:platform][:dhcp_agent_name] do
@@ -227,6 +236,9 @@ service node[:neutron][:platform][:dhcp_agent_name] do
   subscribes :restart, resources(template: node[:neutron][:config_file])
   subscribes :restart, resources("template[/etc/neutron/dhcp_agent.ini]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
+end
+utils_systemd_service_restart node[:neutron][:platform][:dhcp_agent_name] do
+  action use_crowbar_pacemaker_service ? :disable : :enable
 end
 
 if ha_enabled

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -399,6 +399,9 @@ service node[:neutron][:platform][:service_name] do
   end
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
+utils_systemd_service_restart node[:neutron][:platform][:service_name] do
+  action use_crowbar_pacemaker_service ? :disable : :enable
+end
 
 if node[:neutron][:use_infoblox]
   service node[:neutron][:platform][:infoblox_agent_name] do
@@ -406,6 +409,9 @@ if node[:neutron][:use_infoblox]
     action [:enable, :start]
     subscribes :restart, resources(template: node[:neutron][:config_file])
     provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
+  end
+  utils_systemd_service_restart node[:neutron][:platform][:infoblox_agent_name] do
+    action use_crowbar_pacemaker_service ? :disable : :enable
   end
 end
 

--- a/chef/cookbooks/neutron/recipes/vmware_dvs_agents.rb
+++ b/chef/cookbooks/neutron/recipes/vmware_dvs_agents.rb
@@ -37,3 +37,4 @@ service agent_service_name do
   subscribes :restart, resources(template: node[:neutron][:config_file])
   subscribes :restart, resources(template: agent_config_path)
 end
+utils_systemd_service_restart agent_service_name

--- a/chef/cookbooks/neutron/recipes/vmware_support.rb
+++ b/chef/cookbooks/neutron/recipes/vmware_support.rb
@@ -48,6 +48,7 @@ service node[:network][:ovs_service] do
   supports status: true, restart: true
   action [:start, :enable]
 end
+utils_systemd_service_restart node[:network][:ovs_service]
 
 node[:neutron][:platform][:nsx_pkgs].each { |p| package p }
 

--- a/chef/cookbooks/nova/definitions/nova_package.rb
+++ b/chef/cookbooks/nova/definitions/nova_package.rb
@@ -59,4 +59,7 @@ define :nova_package, enable: true, use_pacemaker_provider: false, restart_crm_r
 
     provider Chef::Provider::CrowbarPacemakerService if params[:use_pacemaker_provider]
   end
+  utils_systemd_service_restart nova_name do
+    action params[:use_pacemaker_provider] ? :disable : :enable
+  end
 end

--- a/chef/cookbooks/nova/recipes/instances.rb
+++ b/chef/cookbooks/nova/recipes/instances.rb
@@ -29,6 +29,7 @@ if node[:nova]["setup_shared_instance_storage"]
     enabled true
     action [:enable, :start]
   end
+  utils_systemd_service_restart "nfs-kernel-server"
 
   admin_net = Barclamp::Inventory.get_network_by_type(node, "admin")
 

--- a/chef/cookbooks/nova/recipes/vncproxy.rb
+++ b/chef/cookbooks/nova/recipes/vncproxy.rb
@@ -47,6 +47,9 @@ if node[:nova][:use_novnc]
     subscribes :restart, resources(template: node[:nova][:config_file]), :delayed
     provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
   end
+  utils_systemd_service_restart "nova-novncproxy" do
+    action use_crowbar_pacemaker_service ? :disable : :enable
+  end
 end
 
 if node[:nova][:use_serial]
@@ -60,6 +63,9 @@ if node[:nova][:use_serial]
     subscribes :restart, resources(template: node[:nova][:config_file]), :delayed
     provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
   end
+  utils_systemd_service_restart "nova-serialproxy" do
+    action use_crowbar_pacemaker_service ? :disable : :enable
+  end
 end
 
 service "nova-consoleauth" do
@@ -68,4 +74,7 @@ service "nova-consoleauth" do
   action [:enable, :start]
   subscribes :restart, resources(template: node[:nova][:config_file]), :delayed
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
+end
+utils_systemd_service_restart "nova-consoleauth" do
+  action use_crowbar_pacemaker_service ? :disable : :enable
 end

--- a/chef/cookbooks/postgresql/metadata.rb
+++ b/chef/cookbooks/postgresql/metadata.rb
@@ -21,3 +21,4 @@ end
 end
 
 depends "openssl"
+depends "utils"

--- a/chef/cookbooks/postgresql/recipes/server_debian.rb
+++ b/chef/cookbooks/postgresql/recipes/server_debian.rb
@@ -37,3 +37,4 @@ service "postgresql" do
   supports restart: true, status: true, reload: true
   action [:enable, :start]
 end
+utils_systemd_service_restart "postgresql"

--- a/chef/cookbooks/postgresql/recipes/server_redhat.rb
+++ b/chef/cookbooks/postgresql/recipes/server_redhat.rb
@@ -88,10 +88,10 @@ service "postgresql" do
   service_name node["postgresql"]["server"]["service_name"]
   supports restart: true, status: true, reload: true, restart_crm_resource: true
   action [:enable, :start]
-  provider Chef::Provider::CrowbarPacemakerService if node[:database][:ha][:enabled]
+  provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
 utils_systemd_service_restart "postgresql" do
-  action node[:database][:ha][:enabled] ? :disable : :enable
+  action ha_enabled ? :disable : :enable
 end
 
 template "/etc/cron.daily/postgresql-logs" do

--- a/chef/cookbooks/postgresql/recipes/server_redhat.rb
+++ b/chef/cookbooks/postgresql/recipes/server_redhat.rb
@@ -90,6 +90,9 @@ service "postgresql" do
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if node[:database][:ha][:enabled]
 end
+utils_systemd_service_restart "postgresql" do
+  action node[:database][:ha][:enabled] ? :disable : :enable
+end
 
 template "/etc/cron.daily/postgresql-logs" do
   source "cron-postgresql-logs.erb"

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -75,3 +75,6 @@ service "rabbitmq-server" do
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if node[:rabbitmq][:ha][:enabled]
 end
+utils_systemd_service_restart "rabbitmq-server" do
+  action node[:rabbitmq][:ha][:enabled] ? :disable : :enable
+end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -73,8 +73,8 @@ service "rabbitmq-server" do
   supports restart: true, start: true, stop: true, status: true, \
            restart_crm_resource: true, pacemaker_resource_name: "rabbitmq"
   action [:enable, :start]
-  provider Chef::Provider::CrowbarPacemakerService if node[:rabbitmq][:ha][:enabled]
+  provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
 utils_systemd_service_restart "rabbitmq-server" do
-  action node[:rabbitmq][:ha][:enabled] ? :disable : :enable
+  action ha_enabled ? :disable : :enable
 end

--- a/chef/cookbooks/sahara/definitions/sahara_service.rb
+++ b/chef/cookbooks/sahara/definitions/sahara_service.rb
@@ -27,4 +27,7 @@ define :sahara_service do
     subscribes :restart, resources(template: node[:sahara][:config_file])
     provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
   end
+  utils_systemd_service_restart sahara_service_name do
+    action use_crowbar_pacemaker_service ? :disable : :enable
+  end
 end

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -332,6 +332,10 @@ if node[:swift][:frontend]=="native"
     # Do not even try to start the daemon if we don't have the ring yet
     only_if { ::File.exist? "/etc/swift/object.ring.gz" }
   end
+  utils_systemd_service_restart "swift-proxy" do
+    action use_crowbar_pacemaker_service ? :disable : :enable
+    only_if { ::File.exist? "/etc/swift/object.ring.gz" }
+  end
 elsif node[:swift][:frontend]=="uwsgi"
 
   service "swift-proxy" do

--- a/chef/cookbooks/swift/recipes/rsync.rb
+++ b/chef/cookbooks/swift/recipes/rsync.rb
@@ -46,6 +46,8 @@ if node[:platform_family] == "rhel"
   service "xinetd" do
     action [:start, :enable]
   end
+  utils_systemd_service_restart "xinetd"
+
   cookbook_file "/etc/xinetd.d/rsync" do
     source "rsync_xinetd"
     notifies :restart, resources(service: "xinetd")
@@ -55,5 +57,6 @@ else
     action [:enable, :start]
     service_name "rsyncd" if node[:platform_family] == "suse"
   end
+  utils_systemd_service_restart "rsync"
 end
 

--- a/chef/cookbooks/swift/recipes/storage.rb
+++ b/chef/cookbooks/swift/recipes/storage.rb
@@ -114,6 +114,9 @@ if (!compute_nodes.nil? and compute_nodes.length > 0 )
       end
       only_if { ::File.exist? "/etc/swift/#{ring}.ring.gz" }
     end
+    utils_systemd_service_restart svc do
+      only_if { ::File.exist? "/etc/swift/#{ring}.ring.gz" }
+    end
   end
 end
 

--- a/chef/cookbooks/trove/definitions/trove_service.rb
+++ b/chef/cookbooks/trove/definitions/trove_service.rb
@@ -14,4 +14,7 @@ define :trove_service, use_pacemaker_provider: false do
     provider Chef::Provider::CrowbarPacemakerService \
                if params[:use_pacemaker_provider]
   end
+  utils_systemd_service_restart trove_service_name do
+    action params[:use_pacemaker_provider] ? :disable : :enable
+  end
 end


### PR DESCRIPTION
This offers some automatic recovery, which is nice. It turns out it's
also recommended by systemd documentation, in case a service is
long-running, which is the case here.

It's worth mentioning that in the past, the periodic chef-client has
been providing this, to some extent. But this means the recovery could
take up to 15 minutes.

This is of course disabled when a service is managed by Pacemaker, as we
do not want to have systemd interfere with Pacemaker in that case.

Depends on https://github.com/crowbar/crowbar-core/pull/1332
Backport of https://github.com/crowbar/crowbar-openstack/pull/1287