### PR TITLE
cinder,nova: use default key manager instead of barbican

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -264,6 +264,7 @@ max_over_subscription_ratio = <%= volume[volume['backend_driver']]['max_over_sub
 
 [key_manager]
 <% unless node[:cinder][:keymgr_fixed_key].empty? -%>
+api_class = cinder.keymgr.conf_key_mgr.ConfKeyManager
 fixed_key = <%= node[:cinder][:keymgr_fixed_key].each_byte.map { |b| b.to_s(16) }.join %>
 <% end -%>
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -160,6 +160,7 @@ user_domain_name = <%= @keystone_settings['admin_domain'] %>
 
 [key_manager]
 <% unless @keymgr_fixed_key.empty? %>
+api_class = nova.keymgr.conf_key_mgr.ConfKeyManager
 fixed_key = <%= @keymgr_fixed_key.each_byte.map { |b| b.to_s(16) }.join %>
 <% end %>
 


### PR DESCRIPTION
Starting with Ocata, as part of the migration to castellan as
an external key manager interface lib, the default key manager
was changed from ConfKeyManager - the nova internal fixed-key,
insecure key manager - to Barbican [1]. This change isn't explicitly
documented in the release notes and creates a default dependency
between nova/cinder and Barbican. As currently nova/cinder have
not yet been fully integrated with Barbican, the encrypted volume
support is broken.

This is only a quick fix that brings back the ability to create
and manage encrypted volumes by switching back to the key
manager that was used before Ocata. It also fixes the following
tempest test cases:

 tempest.scenario.test_encrypted_cinder_volumes.TestEncryptedCinderVolumes.test_encrypted_cinder_volumes_cryptsetup  tempest.scenario.test_encrypted_cinder_volumes.TestEncryptedCinderVolumes.test_encrypted_cinder_volumes_luks  tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_boot_server_from_encrypted_volume_luks

More info:
  - Castellan as a key manager lib: https://specs.openstack.org/openstack/nova-specs/specs/newton/implemented/use-castellan-key-manager.html

NOTE: a separate PR actually integrates barbican with cinder & nova - #1299