### PR TITLE
barbican: complete integration as key manager with cinder & nova

### DIFF
--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -124,6 +124,16 @@ keystone_register "give barbican user access" do
   action :add_access
 end
 
+keystone_register "add barbican creator user role" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  role_name "creator"
+  action :add_role
+end
+
 crowbar_pacemaker_sync_mark "create-barbican_register" if ha_enabled
 
 if node[:barbican][:ha][:enabled]

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -263,8 +263,13 @@ max_over_subscription_ratio = <%= volume[volume['backend_driver']]['max_over_sub
 <% end -%>
 
 [key_manager]
+<% if @barbican_settings.any? -%>
+api_class = castellan.key_manager.barbican_key_manager.BarbicanKeyManager
+<% else -%>
+api_class = nova.keymgr.conf_key_mgr.ConfKeyManager
 <% unless node[:cinder][:keymgr_fixed_key].empty? -%>
 fixed_key = <%= node[:cinder][:keymgr_fixed_key].each_byte.map { |b| b.to_s(16) }.join %>
+<% end -%>
 <% end -%>
 
 [database]
@@ -313,3 +318,13 @@ key_file = <%= node[:cinder][:ssl][:keyfile] if node[:cinder][:api][:protocol] =
 
 [volumes]
 backups_enabled = false
+
+<% unless @barbican_settings.empty? %>
+[barbican]
+barbican_endpoint = <%= @barbican_settings[:protocol] %>://<%= @barbican_settings[:host] %>:<%= @barbican_settings[:port] %>
+barbican_api_version = v1
+auth_endpoint = <%= @keystone_settings['internal_auth_url'] %>
+<% unless @barbican_settings[:protocol].nil? -%>
+verify_ssl = <%= @barbican_settings[:insecure] %>
+<% end -%>
+<% end %>

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -266,7 +266,7 @@ max_over_subscription_ratio = <%= volume[volume['backend_driver']]['max_over_sub
 <% if @barbican_settings.any? -%>
 api_class = castellan.key_manager.barbican_key_manager.BarbicanKeyManager
 <% else -%>
-api_class = nova.keymgr.conf_key_mgr.ConfKeyManager
+api_class = cinder.keymgr.conf_key_mgr.ConfKeyManager
 <% unless node[:cinder][:keymgr_fixed_key].empty? -%>
 fixed_key = <%= node[:cinder][:keymgr_fixed_key].each_byte.map { |b| b.to_s(16) }.join %>
 <% end -%>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -159,9 +159,15 @@ user_domain_name = <%= @keystone_settings['admin_domain'] %>
 <% end %>
 
 [key_manager]
+<% if @barbican_settings.any? -%>
+api_class = castellan.key_manager.barbican_key_manager.BarbicanKeyManager
+<% else -%>
+api_class = nova.keymgr.conf_key_mgr.ConfKeyManager
 <% unless @keymgr_fixed_key.empty? %>
 fixed_key = <%= @keymgr_fixed_key.each_byte.map { |b| b.to_s(16) }.join %>
 <% end %>
+<% end -%>
+
 
 [keystone_authtoken]
 auth_type = password
@@ -333,3 +339,13 @@ track_instance_changes = false
 
 [notifications]
 notify_on_state_change = vm_and_task_state
+
+<% unless @barbican_settings.empty? %>
+[barbican]
+barbican_endpoint = <%= @barbican_settings[:protocol] %>://<%= @barbican_settings[:host] %>:<%= @barbican_settings[:port] %>
+barbican_api_version = v1
+auth_endpoint = <%= @keystone_settings['internal_auth_url'] %>
+<% unless @barbican_settings[:protocol].nil? -%>
+verify_ssl = <%= @barbican_settings[:insecure] %>
+<% end -%>
+<% end %>

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -165,6 +165,11 @@ keystone_register "add #{keystone_settings['admin_user']}:#{tempest_comp_tenant}
   action :add_access
 end
 
+# Add the creator role to all tempest users to enable them to
+# create encrypted volumes
+barbican = search(:node, "roles:barbican-controller").first
+tempest_roles = barbican.nil? ? "" : "creator"
+
 # Create directories that we need
 ["", "bin", "etc", "etc/certs", "etc/cirros"].each do |subdir|
   directory "#{node[:tempest][:tempest_path]}/#{subdir}" do
@@ -565,7 +570,8 @@ template "/etc/tempest/tempest.conf" do
         # magnum (container) settings
         magnum_settings: tempest_magnum_settings,
         # heat (orchestration) settings
-        heat_settings: tempest_heat_settings
+        heat_settings: tempest_heat_settings,
+        tempest_roles: tempest_roles
       }
     }
   )

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -13,6 +13,7 @@ admin_username = <%= @keystone_settings['admin_user'] %>
 admin_project_name = <%= @keystone_settings['default_tenant'] %>
 admin_password = <%= @keystone_settings['admin_password'] %>
 admin_domain_name = Default
+tempest_roles = <%= @tempest_roles %>
 
 [aws]
 ec2_url = <%= @ec2_protocol %>://<%= @ec2_host %>:<%= @ec2_port %>/


### PR DESCRIPTION
Update the nova [3] and cinder [2] barclamps to properly configure
barbican as a key manager when barbican is deployed [1].

When barbican is used as a key manager, all non-admin users are required
to have the creator role to create secrets and, as a direct consequence,
to create and manage encrypted volumes [4].
The tempest barclamp also needs to be updated to add the creator role
to all tempest users [5], otherwise encrypted volume test cases will fail.

More info:
- [1] key manager volume encryption configuration - https://docs.openstack.org/cinder/pike/configuration/block-storage/volume-encryption.html
- [2] cinder configuration options for barbican - https://docs.openstack.org/cinder/pike/configuration/block-storage/samples/cinder.conf.html
- [3] nova configuration options for barbican - https://docs.openstack.org/nova/pike/configuration/sample-config.html
- [4] RBAC for barbican - https://github.com/cloudkeep/barbican/wiki/Role-Based-Access-Control
- [5] tempest creator role being added for barbican in devstack - http://git.openstack.org/cgit/openstack/barbican/commit/?id=54accd42b3ec23d6fdbf87b79048f378dabf6839

