### PR TITLE
[4.0] nova: use the proper vars for serialproxy

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -242,8 +242,8 @@ kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 enabled = <%= @serial_enabled ? "True" : "False" %>
 base_url = ws://<%= @serialproxy_public_host %>:<%= node[:nova][:ports][:serialproxy] %>/
 proxyclient_address = <%= node[:nova][:my_ip] %>
-serialproxy_host = 0.0.0.0
-serialproxy_port = 6083
+serialproxy_host = <%= @bind_host %>
+serialproxy_port = <%= @bind_port_serialproxy %>
 
 [ssl]
 <%= "ca_file = #{@ssl_ca_file}" if @ssl_cert_required %>


### PR DESCRIPTION
We were leaving the default hardcoded values for serialproxy which could
collide with haproxy if deployed on HA as both will try to use the same
ports.

(cherry picked from commit 2f8b1d3b8f5ef0774cf7acddc58b5e36a4a3aab3)