### PR TITLE
Revert ha service restarts

### DIFF
--- a/chef/cookbooks/postgresql/recipes/server_redhat.rb
+++ b/chef/cookbooks/postgresql/recipes/server_redhat.rb
@@ -86,7 +86,7 @@ end
 
 service "postgresql" do
   service_name node["postgresql"]["server"]["service_name"]
-  supports restart: true, status: true, reload: true, restart_crm_resource: true
+  supports restart: true, status: true, reload: true
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -70,8 +70,7 @@ bash "enabling rabbit management" do
 end
 
 service "rabbitmq-server" do
-  supports restart: true, start: true, stop: true, status: true, \
-           restart_crm_resource: true, pacemaker_resource_name: "rabbitmq"
+  supports restart: true, start: true, stop: true, status: true
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end


### PR DESCRIPTION
Originally, crowbar could not restart the postgresql or rabbitmq resource agents. We "fixed" this so that crowbar could properly manage it, but this is really not a safe thing to do for HA services. This PR reverts those commits so that we go back to the original behavior. We don't make either postgresql or rabbitmq highly configurable so neither the original changes nor this revert will have a significant impact on users.

See also this discussion: https://github.com/crowbar/crowbar-openstack/pull/974#pullrequestreview-53856237