### PR TITLE
[4.0] ceilometer: fix hypervisor_inspector value for 'vmware' to be 'vsphere'

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -31,7 +31,7 @@ hypervisor_inspector = nil
 libvirt_type = nil
 if is_compute_agent
   if node.roles.include?("nova-compute-vmware")
-    hypervisor_inspector = "vmware"
+    hypervisor_inspector = "vsphere"
   else
     hypervisor_inspector = "libvirt"
     libvirt_type = node[:nova][:libvirt_type]

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -61,10 +61,10 @@ host_ip = <%= node[:nova][:vcenter][:host] rescue "" %>
 host_port = <%= node[:nova][:vcenter][:port] rescue "443" %>
 host_username = <%= node[:nova][:vcenter][:user] rescue "" %>
 host_password = <%= node[:nova][:vcenter][:password] rescue "" %>
-<% if @hypervisor_inspector == "vmware" && !node[:nova][:vcenter][:ca_file].empty? -%>
+<% if @hypervisor_inspector == "vsphere" && !node[:nova][:vcenter][:ca_file].empty? -%>
 ca_file = <%= node[:nova][:vcenter][:ca_file] -%>
 <% end -%>
-<% if @hypervisor_inspector == "vmware" && node[:nova][:vcenter][:insecure] -%>
+<% if @hypervisor_inspector == "vsphere" && node[:nova][:vcenter][:insecure] -%>
 insecure = <%= node[:nova][:vcenter][:insecure] %>
 <% end -%>
 


### PR DESCRIPTION
Corrects the hypervisor_inspector value for 'vmware' to be 'vsphere' instead of 'vmware'. Without this, the ceilometer compute polling agent running on vmware role compute nodes is not working.

More info: https://github.com/openstack/ceilometer/blob/stable/newton/setup.cfg#L234

(cherry picked from commit a870a5d80fc8cdf39f877df7a730a3f3e65802cb)