### PR TITLE
Tempest: Make subnetpool test not skip

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -348,6 +348,7 @@ neutron_api_extensions = [
   "subnet_allocation",
   "subnet-service-types",
   "tag",
+  "subnet_allocation",
 ].join(",")
 
 unless neutrons[0].nil?


### PR DESCRIPTION
Recently defcore added the test: tempest.api.network.test_subnetpools_extensions.SubnetPoolsTestJSON
to the 2017.09 guidelines.
But with our default tempest config this test is skipped because of the missing neutron api extention

Now the test will be run as part of the tempest full.