### PR TITLE
nova: enable nested virt on Intel

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -109,6 +109,20 @@ case node[:nova][:libvirt_type]
               package "qemu-block-rbd"
             end
 
+            execute "enable kvm intel nested virt" do
+              command <<-SHELL
+                  grep -q nested /etc/modprobe.d/80-kvm-intel.conf ||
+                    echo "options kvm_intel nested=1" > /etc/modprobe.d/80-kvm-intel.conf
+                  ! grep -q N /sys/module/kvm_intel/parameters/nested ||
+                    /sbin/modprobe -r kvm_intel
+              SHELL
+              only_if do
+                node[:nova][:kvm][:nested_virt] &&
+                  `uname -r`.include?("default") &&
+                  system("grep -qw vmx /proc/cpuinfo")
+              end
+            end
+
             # load modules only when appropriate kernel is present
             execute "loading kvm modules" do
               command <<-EOF

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -76,6 +76,7 @@
         "secret_uuid": ""
       },
       "kvm": {
+        "nested_virt": false,
         "ksm_enabled": false,
         "disk_cachemodes": "network=writeback"
       },

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -134,6 +134,7 @@
             },
             "kvm": {
               "type": "map", "required": true, "mapping": {
+                "nested_virt": { "type": "bool", "required": false },
                 "ksm_enabled": { "type": "bool", "required": true },
                 "disk_cachemodes": { "type": "str", "required": true }
               }


### PR DESCRIPTION
because it defaults to off
but a lot of people rely on nested virt being available

While in https://fate.suse.com/320082 the virtualisation team
declined to promote nested virt to fully supported status for SLE12,
we are using this since 2012 in all kinds of places without problems.

same as #1261