### PR TITLE
magnum: Use credential env to setup domain role

### DIFF
--- a/chef/cookbooks/magnum/recipes/setup.rb
+++ b/chef/cookbooks/magnum/recipes/setup.rb
@@ -72,7 +72,8 @@ unless node["magnum"]["trustee"]["domain_id"] && node["magnum"]["trustee"]["doma
       unless magnum_domain_role.include?('"admin"')
         create_magnum_domain_role = "#{openstack_command} role add --user #{magnum_domain_admin_id}"
         create_magnum_domain_role << " --domain #{magnum_domain_id} admin"
-        Mixlib::ShellOut.new(create_magnum_domain_role).run_command
+        Mixlib::ShellOut.new(create_magnum_domain_role,
+                             environment: env).run_command
       end
 
       dirty = false


### PR DESCRIPTION
In a1accbaf we switched out the credentials in the command flags for
environment variables, but we forgot to use the environment in one of
the magnum commands. This was causing the magnum domain admin to not
have a role in its own domain and causing our tests to fail when trying
to create a cluster template. This patch adds the environment setting to
the last mixlib call so that it works the same as the other shellouts.