### PR TITLE
database: Rename all mysql folders to mariadb

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -18,8 +18,8 @@
 #
 
 default["mysql"]["bind_address"]              = node["ipaddress"]
-default["mysql"]["tmpdir"]                    = "/var/lib/mysqltmp"
-default["mysql"]["datadir"]                   = "/var/lib/mysql"
+default["mysql"]["tmpdir"]                    = "/var/lib/mariadbtmp"
+default["mysql"]["datadir"]                   = "/var/lib/mariadb"
 
 if attribute?("ec2")
   default["mysql"]["ec2_path"]                = "/mnt/mysql"

--- a/chef/cookbooks/mysql/metadata.rb
+++ b/chef/cookbooks/mysql/metadata.rb
@@ -29,7 +29,7 @@ attribute "mysql/bind_address",
 attribute "mysql/datadir",
           display_name: "MySQL Data Directory",
           description: "Location of mysql databases",
-          default: "/var/lib/mysql"
+          default: "/var/lib/mariadb"
 
 attribute "mysql/ec2_path",
           display_name: "MySQL EC2 Path",

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -5,7 +5,7 @@
     "database": {
       "sql_engine": "mysql",
       "mysql": {
-        "datadir": "/var/lib/mysql",
+        "datadir": "/var/lib/mariadb",
         "slow_query_logging": true,
         "innodb_buffer_pool_size": 256,
         "max_connections": 800,


### PR DESCRIPTION
This commit changes /var/lib/mysql(tmp) to /var/lib/mariadb(tmp). The
goal of this commit is make the mariadb integration more aligned with
the 10.2 release which depricates the use of the mysql string.