### PR TITLE
[4.0] rabbitmq: Increase timeouts for start/promote actions (bsc#1059532)

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -45,3 +45,6 @@ default[:rabbitmq][:erlang_cookie_path] = "/var/lib/rabbitmq/.erlang.cookie"
 # ha
 default[:rabbitmq][:ha][:enabled] = false
 default[:rabbitmq][:ha][:storage][:mode] = nil
+default[:rabbitmq][:ha][:op][:start][:timeout] = "300s"
+default[:rabbitmq][:ha][:op][:promote][:timeout] = "180s"
+default[:rabbitmq][:ha][:op][:monitor][:interval] = "10s"

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -16,9 +16,6 @@
 pid_file = "/var/run/rabbitmq/pid"
 
 agent_name = "ocf:rabbitmq:rabbitmq-server-ha"
-rabbitmq_op = {}
-rabbitmq_op["monitor"] = {}
-rabbitmq_op["monitor"]["interval"] = "10s"
 
 # set the shared rabbitmq cookie
 # cookie is automatically set during barclamp apply
@@ -49,7 +46,7 @@ pacemaker_primitive service_name do
     "rmq_feature_local_list_queues" => false,
     "default_vhost" => node[:rabbitmq][:vhost]
   })
-  op rabbitmq_op
+  op node[:rabbitmq][:ha][:op]
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end


### PR DESCRIPTION
When starting rabbitmq, especially if we are recovering from fencing,
the start could take a while as it needs to check for the tables
to be correct and/or reset the mnesia dir depending on the outcome, of
that check so the whole process could take much longer than the
default 60 seconds.

We also increase the promote timeout as it also needs to do some
internal checking for the master score and it could easily go over the
default timeout.

(cherry picked from commit 594853623315ba9be4c7563cda6e5a39dcf1293e)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1290