### PR TITLE
[4.0] mysql: Use fqdn for database hostname when using SSL

### DIFF
--- a/chef/cookbooks/database/libraries/crowbar.rb
+++ b/chef/cookbooks/database/libraries/crowbar.rb
@@ -19,9 +19,9 @@ module CrowbarDatabaseHelper
     use_ssl = node[:database][:sql_engine] == "mysql" && node[:database][:mysql][:ssl][:enabled]
     if node[:database][:ha][:enabled]
       vhostname = get_ha_vhostname(node)
-      use_ssl ? vhostname : CrowbarPacemakerHelper.cluster_vip(node, "admin", vhostname)
+      use_ssl ? "#{vhostname}.#{node[:domain]}" : CrowbarPacemakerHelper.cluster_vip(node, "admin", vhostname)
     else
-      use_ssl ? node[:hostname] : Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+      use_ssl ? node[:fqdn] : Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
     end
   end
 end


### PR DESCRIPTION
Certificates are usually issued for the FQDN not just the hostname.

(cherry picked from commit 102d79ce3cee46150be722e1e8cea93720467828)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1306