### PR TITLE
[4.0] database: Show Insecure SSL flag in the UI

### DIFF
--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -23,6 +23,7 @@
           = boolean_field %w(mysql ssl generate_certs)
           = string_field %w(mysql ssl certfile)
           = string_field %w(mysql ssl keyfile)
+          = boolean_field %w(mysql ssl insecure)
           = string_field %w(mysql ssl ca_certs)
 
     #postgresql_container


### PR DESCRIPTION
(cherry picked from commit 32bca13ff4e64820802969e6d0585b431d1a551d)

backport of https://github.com/crowbar/crowbar-openstack/pull/1313