### PR TITLE
keystone: generate SSL files before starting WSGI services

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -72,6 +72,18 @@ ruby_block "set origin for apache2 restart" do
   action :nothing
 end
 
+if node[:keystone][:api][:protocol] == "https"
+  ssl_setup "setting up ssl for keystone" do
+    generate_certs node[:keystone][:ssl][:generate_certs]
+    certfile node[:keystone][:ssl][:certfile]
+    keyfile node[:keystone][:ssl][:keyfile]
+    group node[:keystone][:group]
+    fqdn node[:fqdn]
+    cert_required node[:keystone][:ssl][:cert_required]
+    ca_certs node[:keystone][:ssl][:ca_certs]
+  end
+end
+
 if node[:keystone][:frontend] == "uwsgi"
 
   service "keystone" do
@@ -138,7 +150,9 @@ elsif node[:keystone][:frontend] == "apache"
     ssl_enable node[:keystone][:api][:protocol] == "https"
     ssl_certfile node[:keystone][:ssl][:certfile]
     ssl_keyfile node[:keystone][:ssl][:keyfile]
-    ssl_cacert node[:keystone][:ssl][:ca_certs]
+    if node[:keystone][:ssl][:cert_required]
+      ssl_cacert node[:keystone][:ssl][:ca_certs]
+    end
   end
 
   apache_site "keystone-public.conf" do
@@ -159,7 +173,9 @@ elsif node[:keystone][:frontend] == "apache"
     ssl_enable node[:keystone][:api][:protocol] == "https"
     ssl_certfile node[:keystone][:ssl][:certfile]
     ssl_keyfile node[:keystone][:ssl][:keyfile]
-    ssl_cacert node[:keystone][:ssl][:ca_certs]
+    if node[:keystone][:ssl][:cert_required]
+      ssl_cacert node[:keystone][:ssl][:ca_certs]
+    end
   end
 
   apache_site "keystone-admin.conf" do
@@ -356,17 +372,6 @@ end
 
 if ha_enabled
   crowbar_pacemaker_sync_mark "create-keystone_db_sync"
-end
-
-if node[:keystone][:api][:protocol] == "https"
-  ssl_setup "setting up ssl for keystone" do
-    generate_certs node[:keystone][:ssl][:generate_certs]
-    certfile node[:keystone][:ssl][:certfile]
-    keyfile node[:keystone][:ssl][:keyfile]
-    group node[:keystone][:group]
-    fqdn node[:fqdn]
-    ca_certs node[:keystone][:ssl][:ca_certs]
-  end
 end
 
 if ha_enabled


### PR DESCRIPTION
The SSL file setup needs to be performed before the keystone
WSGI services are started, otherwise they fail the following
apache log error during the restart of the apache service:

```
start_apache2[27198]: AH00526: Syntax error on line 12 of /etc/apache2/vhosts.d/keystone-public.conf:
start_apache2[27198]: SSLCertificateFile: file '/etc/keystone/ssl/certs/signing_cert.pem' does not exist or is empty
systemd[1]: apache2.service: Main process exited, code=exited, status=1/FAILURE
```

```
start_apache2[27312]: AH00526: Syntax error on line 12 of /etc/apache2/vhosts.d/keystone-admin.conf:
start_apache2[27312]: SSLCertificateFile: file '/etc/keystone/ssl/certs/signing_cert.pem' does not exist or is empty
systemd[1]: apache2.service: Main process exited, code=exited, status=1/FAILURE

```

Prior to Pike, the keystone certificate/key files were generated
during the installation of the openstack-keystone package, which
is the reason why this inconsistency wasn't triggered. The Pike
package no longer contains this logic, so the keystone services rely on
having these SSL files generated by the keystone cookbook.

This PR should bring the [SOC8 SSL Jenkins job](https://ci.suse.de/view/Cloud/view/Cloud8/job/cloud-mkcloud8-job-ssl-x86_64/) back to its natural green colour.