### PR TITLE
nova: fix SSL configuration for nova-placement

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -326,7 +326,8 @@ template node[:nova][:placement_config_file] do
   keystone_settings: keystone_settings,
   placement_database_connection: placement_database_connection,
   placement_service_user: node["nova"]["placement_service_user"],
-  placement_service_password: node["nova"]["placement_service_password"]
+  placement_service_password: node["nova"]["placement_service_password"],
+  placement_service_insecure: node[:nova][:ssl][:insecure]
   )
 end
 

--- a/chef/cookbooks/nova/recipes/placement_api.rb
+++ b/chef/cookbooks/nova/recipes/placement_api.rb
@@ -108,6 +108,12 @@ crowbar_openstack_wsgi "WSGI entry for nova-placement-api" do
   daemon_process "nova-placement-api"
   user node[:nova][:user]
   group node[:nova][:group]
+  ssl_enable node[:nova][:ssl][:enabled]
+  ssl_certfile node[:nova][:ssl][:certfile]
+  ssl_keyfile node[:nova][:ssl][:keyfile]
+  if node[:nova][:ssl][:cert_required]
+    ssl_cacert node[:nova][:ssl][:ca_certs]
+  end
 end
 
 apache_site "nova-placement-api.conf" do

--- a/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
@@ -8,6 +8,7 @@ auth_type = password
 username = <%= @placement_service_user %>
 password = <%= @placement_service_password %>
 os_interface = internal
+insecure = <%= @placement_service_insecure %>
 
 <% if @placement_database_connection -%>
 [placement_database]


### PR DESCRIPTION
Add the missing SSL parameters to the WSGI configuration for the
nova-placement API service, when SSL is enabled for nova . Also
add the missing [placement]/insecure configuration option to the
nova placement configuration file.

This changeset is required to have nova work properly when SSL is
enabled. Without it, nova-scheduler reports the following error while
trying to contact nova-placement during the creation of a server instance:

```
2017-09-26 09:24:19.684 32469 WARNING keystoneauth.identity.generic.base [req-89ea9888-e1ad-4745-8983-da096309d386 1c3e6c5446e7440e80ca98813f8099ed ff30a0242f8a4ab68f19c49ae2ed1ba1 - default default] Failed to discover available identity versions when contacting https://d52-54-77-77-01-01.virtual.cloud.suse.de:35357. Attempting to parse version from URL.: ConnectFailure: Unable to establish connection to https://d52-54-77-77-01-01.virtual.cloud.suse.de:35357: HTTPSConnectionPool(host='d52-54-77-77-01-01.virtual.cloud.suse.de', port=35357): Max retries exceeded with url: / (Caused by SSLError(SSLError("bad handshake: Error([('SSL routines', 'ssl3_get_server_certificate', 'certificate verify failed')],)",),))
2017-09-26 09:24:19.685 32469 WARNING nova.scheduler.client.report [req-89ea9888-e1ad-4745-8983-da096309d386 1c3e6c5446e7440e80ca98813f8099ed ff30a0242f8a4ab68f19c49ae2ed1ba1 - default default] Discovering suitable URL for placement API failed.: DiscoveryFailure: Could not determine a suitable URL for the plugin
```

This PR, in addition to #1317, should bring the SOC8 SSL Jenkins job back to its natural green colour.
