### PR TITLE
neutron-l3-ha-service: don't capture SIGTERM

### DIFF
--- a/spec/neutron_l3_ha_service_spec.rb
+++ b/spec/neutron_l3_ha_service_spec.rb
@@ -531,12 +531,10 @@ describe "neutron-l3-ha-service" do
       subprocess = Subprocess.new @ruby, @service_path, @settings_path
       subprocess.start
       sleep_workaround_for_subprocess
-      sleep 1 # Let it run for a while
-      subprocess.send_signal "TERM"
       result = subprocess.wait 0.1
 
-      expect(result.error).to include "HATOOL-CALL --l3-agent-check --quiet"
-      expect(result.error).to include "HATOOL-CALL --l3-agent-migrate --now --retry"
+      expect(result.output).to include "HATOOL-CALL --l3-agent-check --quiet"
+      expect(result.output).to include "HATOOL-CALL --l3-agent-migrate --now --retry"
 
       expect(result.exit_status).to eq 0
     end


### PR DESCRIPTION
The service captures SIGTERM when migrating routers from dead agents.
This is a process that can take long time and can prevent Pacemaker to
properly shutdown the service leading to node fencing.

This change delegates the SIGTERM handling to neutron-ha-tool, which
does so in a per router basis instead of for the whole batch.

Reference: https://bugzilla.suse.com/show_bug.cgi?id=1059530