### PR TITLE
swift: make default replicas count match storage node count

### DIFF
--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -114,6 +114,7 @@ class SwiftService < OpenstackServiceObject
         "swift-ring-compute"    => [controller[:fqdn]],
         "swift-storage"         => storage_nodes.map { |x| x[:fqdn] }
       }
+      base["attributes"]["swift"]["replicas"] = [[storage_nodes.length, 3].min, 1].max
     end
 
     @logger.fatal("swift create_proposal: exiting")


### PR DESCRIPTION
The current default swift replica count value is 3, which results
in a "Replica count of 3.0 requires more than 2 devices" failure
when the swift barclamp is deployed by mkcloud on setups with 3
nodes.

This commit extends that behavior by computing the default value
of the replicas count automatically based on the number of
swift-storage nodes using the formula:

   min(1, max(`no-swift-storage-nodes`, 3))

This fix is meant mainly to fix [the DVR SOC8 Jenkins job](https://ci.suse.de/view/Cloud/view/Cloud8/job/cloud-mkcloud8-job-dvr-x86_64/), which
is currently broken.