### PR TITLE
neutron: Fixes for ACI integration with SOC7 (backport from #1323)

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -70,6 +70,9 @@ if node.roles.include?("nova-compute-kvm")
   include_recipe "neutron::common_config"
 
   # Agent configurations for Cisco APIC driver
+  # The ACI setup for OpenStack releases before Pike use "of_interface" options
+  # set to "ovs-ofctl". This option has been deprecated in Pike and removed
+  # from this config file for Pike. It is still included in Newton (Cloud7)
   agent_config_path = "/etc/neutron/plugins/ml2/openvswitch_agent.ini"
   template agent_config_path do
     cookbook "neutron"
@@ -80,8 +83,11 @@ if node.roles.include?("nova-compute-kvm")
     variables(
       ml2_type_drivers: ml2_type_drivers,
       tunnel_types: "",
+      enable_tunneling: false,
       use_l2pop: false,
       dvr_enabled: false,
+      of_interface: "ovs-ofctl",
+      ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
       bridge_mappings: ""
     )
   end

--- a/chef/cookbooks/neutron/recipes/cisco_apic_support.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_support.rb
@@ -21,7 +21,7 @@ if node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
 end
 
 aciswitches = node[:neutron][:apic][:apic_switches].to_hash
-template "/etc/neutron/plugins/ml2/ml2_conf_cisco_apic.ini" do
+template "/etc/neutron/neutron-server.conf.d/100-ml2_conf_cisco_apic.ini.conf" do
   cookbook "neutron"
   source "ml2_conf_cisco_apic.ini.erb"
   mode "0640"

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -3,10 +3,11 @@
 <% unless @tunnel_types.empty? -%>
 tunnel_types = <%= @tunnel_types.join(",") %>
 <% end -%>
-<% if @use_l2pop -%>
-l2_population = True
+<% if @ml2_type_drivers.include?("cisco_apic_ml2") || @ml2_type_drivers.include?("apic_gbp") -%>
+enable_tunneling = <%= @enable_tunneling %>
 <% end -%>
 <% if @use_l2pop -%>
+l2_population = True
 arp_responder = True
 <% end -%>
 <% if @dvr_enabled -%>
@@ -16,7 +17,7 @@ enable_distributed_routing = True
 tunnel_csum = True
 <% end -%>
 [ovs]
-<% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
+<% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") && !@ml2_type_drivers.include?("opflex") -%>
 tunnel_bridge = br-tunnel
 <% end -%>
 ovsdb_interface = <%= @ovsdb_interface %>


### PR DESCRIPTION
This commit fixes minor issues encountered while testing ACI
integration with SUSE OpenStack Cloud 7. The ACI changes were
so far only being tested for Cloud 6 on the Cisco Lab.
Also recent changes in the crowbar framework caused failures while
applying the barclamp by enabling APIC as the ML2 backend.
The fixes include:
 - config setting for of_interface
 - modified path for linking ml2_conf_cisco_apic.ini
These changes were tested with Cloud7 on the Cisco ACI lab for L2 and L3
functionality and also shared with the Sales Engineering team.
So the commit needs to be merged with Cloud7 so PTFs can be
generated if required by customers wanting to upgrade from
Cloud6 to Cloud7.

(cherry picked from commit b495b6f5312a1823566e530db1195001b2611138)