### PR TITLE
nova: reduce excessive node searches on compute role nodes

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -300,42 +300,30 @@ elsif !node[:nova]["use_shared_instance_storage"]
   end
 end
 
-# Create and distribute ssh keys for nova user on all compute nodes
-
-# if for some reason, we only have one of the two keys, we recreate the keys
-# (no need to check the case where public key doesn't exist, as the execute
-# resource deals with that)
-if ::File.exist?("#{node[:nova][:home_dir]}/.ssh/id_rsa.pub") && !::File.exist?("#{node[:nova][:home_dir]}/.ssh/id_rsa")
-  file "#{node[:nova][:home_dir]}/.ssh/id_rsa.pub" do
-    action :delete
-  end
-end
-
-execute "Create Nova SSH key" do
-  command "su #{node[:nova][:user]} -c \"ssh-keygen -q -t rsa  -P '' -f '#{node[:nova][:home_dir]}/.ssh/id_rsa'\""
-  creates "#{node[:nova][:home_dir]}/.ssh/id_rsa.pub"
-  only_if { ::File.exist?(node[:nova][:home_dir]) }
-end
-
-ruby_block "nova_read_ssh_public_key" do
-  block do
-    service_ssh_key = File.read("#{node[:nova][:home_dir]}/.ssh/id_rsa.pub")
-    if node[:nova][:service_ssh_key] != service_ssh_key
-      node.set[:nova][:service_ssh_key] = service_ssh_key
-      node.save
-    end
-  end
-  only_if { ::File.exist?("#{node[:nova][:home_dir]}/.ssh/id_rsa.pub") }
+directory "#{node[:nova][:home_dir]}/.ssh" do
+  mode 0o700
+  owner node[:nova][:user]
+  action :create
+  recursive true
 end
 
 ssh_auth_keys = ""
-compute_nodes = node_search_with_cache("roles:nova-compute-#{node[:nova][:libvirt_type]}")
-compute_nodes.each do |n|
-  ssh_auth_keys += n[:nova][:service_ssh_key]
-end
-
 if node["roles"].include?("nova-compute-zvm")
   ssh_auth_keys += node[:nova][:zvm][:zvm_xcat_ssh_key]
+end
+
+unless node[:nova][:compute_remotefs_sshkey].empty?
+  # Create and distribute ssh keys for nova user on all compute nodes
+  file "#{node[:nova][:home_dir]}/.ssh/id_ed25519" do
+    mode 0o600
+    owner node[:nova][:user]
+    content "#{node[:nova][:compute_remotefs_sshkey]}\n"
+  end
+
+  ssh_auth_keys += %x[cat <<EOF | ssh-keygen -y -f /dev/stdin
+  #{node[:nova][:compute_remotefs_sshkey]}
+  EOF
+  ].chomp
 end
 
 file "#{node[:nova][:home_dir]}/.ssh/authorized_keys" do
@@ -344,7 +332,6 @@ file "#{node[:nova][:home_dir]}/.ssh/authorized_keys" do
 end
 
 # enable or disable the ksm setting (performance)
-
 template "/etc/default/qemu-kvm" do
   source "qemu-kvm.erb"
   variables({

--- a/chef/data_bags/crowbar/migrate/nova/120_add_remotefs_sshkey.rb
+++ b/chef/data_bags/crowbar/migrate/nova/120_add_remotefs_sshkey.rb
@@ -1,0 +1,20 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "compute_remotefs_sshkey"
+    a["compute_remotefs_sshkey"] = %x[
+      t=$(mktemp)
+      rm -f $t
+      ssh-keygen -q -t ed25519 -N "" -f $t
+      cat $t
+      rm -f $t ${t}.pub
+    ]
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "compute_remotefs_sshkey"
+    a.delete("compute_remotefs_sshkey")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -24,6 +24,7 @@
       "cross_az_attach": true,
       "create_default_flavors": true,
       "image_cache_manager_interval": -1,
+      "compute_remotefs_sshkey": "",
       "migration": {
         "network": "admin"
       },
@@ -165,7 +166,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 119,
+      "schema-revision": 120,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -31,6 +31,7 @@
             "cross_az_attach": { "type": "bool", "required": true },
             "create_default_flavors": { "type": "bool", "required": true },
             "image_cache_manager_interval": { "type": "int", "required": true },
+            "compute_remotefs_sshkey": { "type": "str", "required": true },
             "migration": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -191,6 +191,13 @@ class NovaService < OpenstackServiceObject
     base["attributes"]["nova"]["neutron_metadata_proxy_shared_secret"] = random_password
 
     base["attributes"]["nova"]["ec2-api"]["db"]["password"] = random_password
+    base["attributes"]["nova"]["compute_remotefs_sshkey"] = %x[
+      t=$(mktemp)
+      rm -f $t
+      ssh-keygen -q -t ed25519 -N "" -f $t
+      cat $t
+      rm -f $t ${t}.pub
+    ]
 
     @logger.debug("Nova create_proposal: exiting")
     base


### PR DESCRIPTION
This was only a marginal security feature to begin with, as
you could just copy the other instance ssh key with one hop
more. Created a followup card to make this more secure.

(cherry picked from commit ae1345b916848af7bade0e170c05b0159ba61d55)

Backport of #648 648