### PR TITLE
ceilometer: add no-op events pipeline

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -124,3 +124,12 @@ template "/etc/ceilometer/pipeline.yaml" do
     notifies :restart, "service[swift-proxy]"
   end
 end
+
+template "/etc/ceilometer/event_pipeline.yaml" do
+  source "event_pipeline.yaml.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+  notifies :restart, "service[nova-compute]" if is_compute_agent
+  notifies :restart, "service[swift-proxy]" if is_swift_proxy
+end

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -186,6 +186,7 @@ service "ceilometer-agent-notification" do
   action [:enable, :start]
   subscribes :restart, resources(template: node[:ceilometer][:config_file])
   subscribes :restart, resources("template[/etc/ceilometer/pipeline.yaml]")
+  subscribes :restart, resources("template[/etc/ceilometer/event_pipeline.yaml]")
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
 utils_systemd_service_restart "ceilometer-agent-notification" do

--- a/chef/cookbooks/ceilometer/templates/default/event_pipeline.yaml.erb
+++ b/chef/cookbooks/ceilometer/templates/default/event_pipeline.yaml.erb
@@ -1,0 +1,12 @@
+---
+sources:
+    - name: event_source
+      events:
+          - "!*"
+      sinks:
+          - event_sink
+sinks:
+    - name: event_sink
+      transformers:
+      publishers:
+          - file://


### PR DESCRIPTION
Before pike you could turn event publishing pipeline
off by removing /etc/ceilometer/event_pipeline.yaml,
but in pike it now defaults to
pipeline/data/event_pipeline.yaml as a fallback
location (see https://review.openstack.org/#/c/441734/)

Since there is no way to turn off event publishing, this
workaround creates a  pipeline which matches no events, which
is a no-op.

Also filed upstream bug https://bugs.launchpad.net/ceilometer/+bug/1720021