### PR TITLE
neutron-l3-ha-service: tweak timeouts

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -247,9 +247,9 @@ default[:neutron][:ha][:ports][:server] = 5530
 default[:neutron][:ha][:neutron_l3_ha_resource][:op][:monitor][:interval] = "10s"
 
 default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:status][:terminate] = 300
-default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:status][:kill] = 120
+default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:status][:kill] = 50
 default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:router_migration][:terminate] = 1800
-default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:router_migration][:kill] = 120
+default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:router_migration][:kill] = 50
 default[:neutron][:ha][:neutron_l3_ha_service][:hatool][:program] = "/usr/bin/neutron-ha-tool"
 default[:neutron][:ha][:neutron_l3_ha_service][:hatool][:env] = {}
 default[:neutron][:ha][:neutron_l3_ha_service][:seconds_to_sleep_between_checks] = 10


### PR DESCRIPTION
We found out that default timeouts for neutron-l3-ha-service were bigger
than Pacemaker default timeout (60s). This lead to a situation where we
tried to gracefully shutdown the service, but since we allowed that much
time, Pacemaker kicked in and fenced the node.

Since Pacemaker will call systemd service to stop the l3-service + tool,
we are reducing the time systemd takes to send a kill signal. Now
systemd will kill the l3-service + tool before Pacemaker tries to fence
the node.

Pacemaker timeout is configured to 60s. We want systemd to send the kill
signal at 55s. The systemd timeout is calculated as the maximum
l3-service :kill timeout + 5s. That's why we are changing the :kill
timeouts to 50s.