### PR TITLE
horizon: Explicit set REST_API_REQUIRED_SETTINGS (bsc#1046616)

### DIFF
--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -57,6 +57,13 @@ OPENSTACK_HYPERVISOR_FEATURES = {
     'requires_keypair': False,
 }
 
+# explicitly set this (bsc#1046616)
+# SOC6 wrote to local_settings.py which means the file gets not updated
+# via an rpm package update.
+REST_API_REQUIRED_SETTINGS = ['OPENSTACK_HYPERVISOR_FEATURES',
+                              'LAUNCH_INSTANCE_DEFAULTS',
+                              'OPENSTACK_IMAGE_FORMATS']
+
 OPENSTACK_NEUTRON_NETWORK = {
     'enable_router': True,
     'enable_quotas': True,


### PR DESCRIPTION
SOC6 updated local_settings.py via Crowbar. Because of that, the file will
not be updated during a RPM package update (due to "config(noreplace)").
So explicitly set REST_API_REQUIRED_SETTINGS to get the correct settings.

Note: This fix is not needed for SOC8 because SOC7 will put the config
file into local_settings.d/ as a snippet. So local_settings.py will be
updated (if no user edited the file manually) during a SOC7->SOC8 update.