### PR TITLE
glance: fix loading glance metadefs to database

### DIFF
--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -74,7 +74,7 @@ ruby_block "mark node for glance db_sync" do
     node.save
   end
   action :nothing
-  subscribes :create, "execute[glance-manage db sync]", :immediately
+  subscribes :create, "execute[glance-manage db_load_metadefs]", :immediately
 end
 
 crowbar_pacemaker_sync_mark "create-glance_database" if ha_enabled


### PR DESCRIPTION
Fixes an error from the previous PR #1284 , which introduced
loading glance metadefs into the glance database: the 'glance-manage
db_load_metadefs' block is never executed because the ruby_block
that ensures single execution is triggered too quickly.