### PR TITLE
neutron: fix HA neutron-agents_before_ha timeout

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -432,13 +432,26 @@ end
 #   action :nothing
 # end
 #
-# If this runs simulatiously on multiple nodes (e.g. in a HA setup). It might
-# be that one node creates the router after the other did the "not_if" check.
-# In that case the router will be created twice (as it is perfectly fine to
-# have multiple routers with the same name). To avoid this race-condition we
-# make sure that the post_install_conf recipe is only executed on a single node
-# of the cluster.
-if node[:neutron][:create_default_networks] && \
-    (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node))
-  include_recipe "neutron::post_install_conf"
+if node[:neutron][:create_default_networks]
+  # If this runs simulatiously on multiple nodes (e.g. in a HA setup). It might
+  # be that one node creates the router after the other did the "not_if" check.
+  # In that case the router will be created twice (as it is perfectly fine to
+  # have multiple routers with the same name). To avoid this race-condition we
+  # make sure that the post_install_conf recipe is only executed on a single node
+  # of the cluster.
+  if !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)
+    include_recipe "neutron::post_install_conf"
+  end
+
+  # All non-founder nodes should wait until the founder node is done
+  # evaluating if the default networks need to be created, as this can
+  # take a long time. Otherwise, the founder node will be delayed and
+  # might produce pacemaker sync timeouts in other recipes where such
+  # a big delay isn't expected (e.g. the network_agents recipe).
+  crowbar_pacemaker_sync_mark "wait sync mark for neutron default networks" do
+    mark "neutron_default_networks"
+    action :wait
+    timeout 180
+    only_if { ha_enabled }
+  end
 end


### PR DESCRIPTION
Lately, running openstack CLI commands takes a long time due to
the fact that the CLI data model needs to be loaded from an increasing
number of python packages. This has a negative impact on cookbook
recipes that make extensive use of the openstack CLI, one of which
is the post_install neutron recipe, which evaluates the need to create
and then conditionally creates default objects (networks, routers).

Based on Jenkins HA job logs, an openstack CLI command can take up to
10-15 seconds to complete, which means the founder node is kept
busy for up to 100-150 seconds while evaluating the need to create
these default objects. This delay needs to be addressed in the
neutron cookbook, otherwise it may negatively impact other cookbooks
that are not prepared to handle that long of a delay.

This has been currently seen happening in the SOC8 HA Jenkins jobs (e.g. [cloud-mkcloud8-job-ha-compute-x86_64](https://ci.suse.de/job/openstack-mkcloud/86605/) )