### PR TITLE
[4.0] database: Expose max_connections and slow_query_logging in UI

### DIFF
--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -11,6 +11,8 @@
           = t('.mysql_attributes')
 
         = string_field %w(mysql datadir)
+        = integer_field %w(mysql max_connections)
+        = boolean_field %w(mysql slow_query_logging)
 
       %fieldset
         %legend

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -25,6 +25,8 @@ en:
         mysql_attributes: 'MariaDB Options'
         mysql:
           datadir: 'Datadir'
+          max_connections: 'Maximum Number of simultaneous Connections'
+          slow_query_logging: 'Slow Query Logging'
           ssl_header: 'SSL Support'
           ssl:
             enabled: 'Enable SSL'


### PR DESCRIPTION
This commit makes max_connections and slow_query_logging configurable
via the UI.

(cherry picked from commit 29b1aa63c798654a28ffbb88187c29a34c4aa5de)