### PR TITLE
[4.0] memcached: Make config non-HA-aware (bsc#1038223)

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -209,17 +209,8 @@ crowbar_pacemaker_sync_mark "create-keystone_database" if ha_enabled
 
 sql_connection = fetch_database_connection_string(node[:keystone][:db])
 
-if ha_enabled
-  memcached_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "keystone-server")
-  memcached_servers = memcached_nodes.map do |n|
-    node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
-    "#{node_admin_ip}:#{n[:memcached][:port]}"
-  end
-else
-  node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  memcached_servers = ["#{node_admin_ip}:#{node[:memcached][:port]}"]
-end
-memcached_servers.sort!
+node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+memcached_servers = ["#{node_admin_ip}:#{node[:memcached][:port]}"]
 
 # we have to calculate max_active_keys for fernet token provider
 # http://docs.openstack.org/admin-guide/identity-fernet-token-faq.html# \

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -86,17 +86,8 @@ glance_insecure = CrowbarOpenStackHelper.insecure(glance_config) || keystone_set
 Chef::Log.info("Glance server at #{glance_server_host}")
 
 # use memcached as a cache backend for nova-novncproxy
-if api_ha_enabled
-  memcached_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "nova-controller")
-  memcached_servers = memcached_nodes.map do |n|
-    node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
-    "#{node_admin_ip}:#{n[:memcached][:port] rescue node[:memcached][:port]}"
-  end
-else
-  node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  memcached_servers = ["#{node_admin_ip}:#{node[:memcached][:port]}"]
-end
-memcached_servers.sort!
+node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+memcached_servers = ["#{node_admin_ip}:#{node[:memcached][:port]}"]
 
 directory "/etc/nova" do
    mode 0755


### PR DESCRIPTION
Without this patch, the keystone and nova barclamps set their cache
servers to all of the memcached servers in the cluster in
lexicographical order. This is not actually an optimal way to configure
memcached servers since if part of the cluster is down, the memcached
servers living on it will be inaccessible. The python-memcached backend
is not tied to pacemaker and has no way of knowing that the server is
down, so it attempts to connect to each server serially, not attempting
the next one until the first times out. The effect is that any query to
the OpenStack service will take a very long time. This patch fixes the
issue by only using the local memcached server for keystonemiddleware
instead of using all in the cluster. This means every controller in the
cluster will use only its own memcached server, similar to how it would
work if it was using an in-process cache.