### PR TITLE
memcached: Make config non-HA-aware (bsc#1038223)

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -147,9 +147,7 @@ end
 node.normal[:apache][:listen_ports_crowbar] ||= {}
 node.normal[:apache][:listen_ports_crowbar][:aodh] = { plain: [bind_port] }
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "aodh-server") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance("aodh-server")
 

--- a/chef/cookbooks/barbican/recipes/common.rb
+++ b/chef/cookbooks/barbican/recipes/common.rb
@@ -93,13 +93,7 @@ end
 
 crowbar_pacemaker_sync_mark "create-barbican_database" if ha_enabled
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:barbican][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "barbican-controller")
-  else
-    [node]
-  end
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance("barbican") if node["roles"].include?("barbican-controller")
 

--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -3,9 +3,7 @@ include_recipe "apache2"
 is_controller = node["roles"].include?("ceilometer-server")
 ha_enabled = node[:ceilometer][:ha][:server][:enabled]
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "ceilometer-server") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance("ceilometer-server") if is_controller
 

--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -118,13 +118,7 @@ if need_shared_lock_path
   include_recipe "crowbar-openstack::common"
 end
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:cinder][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "cinder-controller")
-  else
-    [node]
-  end
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance("cinder") if node["roles"].include?("cinder-controller")
 

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -41,9 +41,7 @@ else
 end
 
 # use memcached as a cache backend for ec2-api-metadata
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "ec2-api") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance "ec2-api"
 

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -43,9 +43,7 @@ ironics = node_search_with_cache("roles:ironic-server") || []
 network_settings = GlanceHelper.network_settings(node)
 
 ha_enabled = node[:glance][:ha][:enabled]
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "glance-server") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 glance_stores = node.default[:glance][:glance_stores].dup
 glance_stores += ["vmware"] unless node[:glance][:vsphere][:host].empty?

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -13,10 +13,7 @@ end
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 network_settings = GlanceHelper.network_settings(node)
 
-ha_enabled = node[:glance][:ha][:enabled]
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "glance-server") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance("glance")
 

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -102,9 +102,7 @@ if node[:heat][:api][:protocol] == "https"
   end
 end
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "heat-server") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 memcached_instance("heat-server")
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -382,9 +382,7 @@ else
 end
 
 # We're going to use memcached as a cache backend for Django
-memcached_locations = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "horizon-server") : [node]
-)
+memcached_locations = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance "openstack-dashboard"
 

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -57,9 +57,7 @@ node.normal[:apache][:listen_ports_crowbar][:keystone] = { admin: [bind_admin_po
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(node, node[:keystone][:api][:protocol] == "https", ha_enabled)
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "keystone-server") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance "keystone"
 

--- a/chef/cookbooks/magnum/recipes/common.rb
+++ b/chef/cookbooks/magnum/recipes/common.rb
@@ -21,9 +21,7 @@ network_settings = MagnumHelper.network_settings(node)
 
 ha_enabled = node[:magnum][:ha][:enabled]
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "magnum-server") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 memcached_instance("magnum-server")
 
 include_recipe "database::client"

--- a/chef/cookbooks/manila/recipes/common.rb
+++ b/chef/cookbooks/manila/recipes/common.rb
@@ -109,13 +109,7 @@ cinder_insecure = CrowbarOpenStackHelper.insecure(cinder_config)
 enabled_share_protocols = ["NFS", "CIFS"]
 enabled_share_protocols << ["CEPHFS"] if ManilaHelper.has_cephfs_share? node
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:manila][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "manila-server")
-  else
-    [node]
-  end
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance("manila") if node["roles"].include?("manila-server")
 

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -66,9 +66,7 @@ end
 keystone_settings = KeystoneHelper.keystone_settings(neutron, @cookbook_name)
 
 ha_enabled = node[:neutron][:ha][:server][:enabled]
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "neutron-server") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance("neutron-server") if is_neutron_server
 

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -87,9 +87,7 @@ glance_insecure = CrowbarOpenStackHelper.insecure(glance_config) || keystone_set
 Chef::Log.info("Glance server at #{glance_server_host}")
 
 # use memcached as a cache backend for nova-novncproxy
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  api_ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "nova-controller") : [node]
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance "nova" if is_controller
 

--- a/chef/cookbooks/sahara/recipes/common.rb
+++ b/chef/cookbooks/sahara/recipes/common.rb
@@ -42,13 +42,7 @@ nova_insecure = CrowbarOpenStackHelper.insecure(nova_config)
 
 use_ceilometer = !Barclamp::Config.load("openstack", "ceilometer").empty?
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:sahara][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "sahara-server")
-  else
-    [node]
-  end
-)
+memcached_servers = MemcachedHelper.get_memcached_servers([node])
 
 memcached_instance("sahara") if node["roles"].include?("sahara-server")
 


### PR DESCRIPTION
Without this patch, when deployed in an HA configuration, all of the
barclamps set their cache servers to all of the memcached servers in the
cluster in lexicographical order. This is not actually an optimal way to
configure memcached servers since if part of the cluster is down, the
memcached servers living on it will be inaccessible. python-memcached is
not tied to pacemaker and has no way of knowing that, so it passes the
entire list to python-memcached which attempts to connect to each server
serially, not attempting the next one until the first times out. The
effect is that any query to the OpenStack service will take a very long
time if the first memcached server in the list is down.

This patch fixes the issue by only using the local memcached server
instead of using all in the cluster. This also adjusts the
get_memcached_servers helper method to only accept one node as input
since, knowing what we now know, we're unlikely to need more than one.
The get_memcached_servers method was implemented while updating the
barclamps to prevent deprecation warnings emitted by keystonemiddleware
in Ocata[1] and was mimicking old behavior used to set the cache servers
for keystone and nova.

[1] https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html