### PR TITLE
neutron-l3-ha-service: fix logging (bsc#1059460)

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -254,3 +254,4 @@ default[:neutron][:ha][:neutron_l3_ha_service][:hatool][:program] = "/usr/bin/ne
 default[:neutron][:ha][:neutron_l3_ha_service][:hatool][:env] = {}
 default[:neutron][:ha][:neutron_l3_ha_service][:seconds_to_sleep_between_checks] = 10
 default[:neutron][:ha][:neutron_l3_ha_service][:max_errors_tolerated] = 10
+default[:neutron][:ha][:neutron_l3_ha_service][:log_file] = "/var/log/neutron/neutron-l3-ha-service.log"

--- a/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
+++ b/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
@@ -27,6 +27,10 @@ class HAToolLog
     end
     @logger
   end
+
+  def self.set_file(file_path)
+    @logger = Logger.new(file_path, "daily") unless file_path.nil?
+  end
 end
 
 def main
@@ -35,6 +39,7 @@ def main
   service_options = ServiceOptions.load ARGV[0]
   ha_functions = HAFunctions.new(service_options)
   error_counter = ErrorCounter.new service_options.max_errors_tolerated
+  HAToolLog.set_file(service_options.log_file)
 
   while true
     status = ha_functions.check_l3_agents

--- a/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
+++ b/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
@@ -235,13 +235,15 @@ class ServiceOptions
   attr_reader :hatool
   attr_reader :seconds_to_sleep_between_checks
   attr_reader :max_errors_tolerated
+  attr_reader :log_file
 
-  def initialize(status_timeout, router_migration_timeout, hatool_options, sleep_time, max_errors_tolerated)
+  def initialize(status_timeout, router_migration_timeout, hatool_options, sleep_time, max_errors_tolerated, log_file)
     @status_timeout = status_timeout
     @router_migration_timeout = router_migration_timeout
     @hatool = hatool_options
     @seconds_to_sleep_between_checks = sleep_time
     @max_errors_tolerated = max_errors_tolerated
+    @log_file = log_file
   end
 
   def self.load(path)
@@ -252,7 +254,8 @@ class ServiceOptions
         TimeoutOptions.from_hash(data["timeouts"]["router_migration"]),
         HAToolOptions.from_hash(data["hatool"]),
         data["seconds_to_sleep_between_checks"].to_i,
-        data["max_errors_tolerated"].to_i
+        data["max_errors_tolerated"].to_i,
+        data["log_file"]
       )
     end
   end

--- a/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
+++ b/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
@@ -28,7 +28,7 @@ class HAToolLog
     @logger
   end
 
-  def self.set_file(file_path)
+  def self.file=(file_path)
     @logger = Logger.new(file_path, "daily") unless file_path.nil?
   end
 end
@@ -39,7 +39,7 @@ def main
   service_options = ServiceOptions.load ARGV[0]
   ha_functions = HAFunctions.new(service_options)
   error_counter = ErrorCounter.new service_options.max_errors_tolerated
-  HAToolLog.set_file(service_options.log_file)
+  HAToolLog.file = service_options.log_file
 
   while true
     status = ha_functions.check_l3_agents
@@ -242,25 +242,25 @@ class ServiceOptions
   attr_reader :max_errors_tolerated
   attr_reader :log_file
 
-  def initialize(status_timeout, router_migration_timeout, hatool_options, sleep_time, max_errors_tolerated, log_file)
-    @status_timeout = status_timeout
-    @router_migration_timeout = router_migration_timeout
-    @hatool = hatool_options
-    @seconds_to_sleep_between_checks = sleep_time
-    @max_errors_tolerated = max_errors_tolerated
-    @log_file = log_file
+  def initialize(params = {})
+    @status_timeout = params.fetch(:status_timeout)
+    @router_migration_timeout = params.fetch(:router_migration_timeout)
+    @hatool = params.fetch(:hatool_options)
+    @seconds_to_sleep_between_checks = params.fetch(:sleep_time)
+    @max_errors_tolerated = params.fetch(:max_errors_tolerated)
+    @log_file = params.fetch(:log_file)
   end
 
   def self.load(path)
     File.open path do |file|
       data = YAML.load file.read
       ServiceOptions.new(
-        TimeoutOptions.from_hash(data["timeouts"]["status"]),
-        TimeoutOptions.from_hash(data["timeouts"]["router_migration"]),
-        HAToolOptions.from_hash(data["hatool"]),
-        data["seconds_to_sleep_between_checks"].to_i,
-        data["max_errors_tolerated"].to_i,
-        data["log_file"]
+        status_timeout: TimeoutOptions.from_hash(data["timeouts"]["status"]),
+        router_migration_timeout: TimeoutOptions.from_hash(data["timeouts"]["router_migration"]),
+        hatool_options: HAToolOptions.from_hash(data["hatool"]),
+        sleep_time: data["seconds_to_sleep_between_checks"].to_i,
+        max_errors_tolerated: data["max_errors_tolerated"].to_i,
+        log_file: data["log_file"]
       )
     end
   end

--- a/spec/neutron_l3_ha_service_spec.rb
+++ b/spec/neutron_l3_ha_service_spec.rb
@@ -524,7 +524,7 @@ describe ErrorCounter do
   end
 end
 
-def make_config(tmpdir, log_file=nil)
+def make_config(tmpdir, log_file = nil)
   config = {
     "timeouts" => {
       "status" => {
@@ -546,7 +546,7 @@ def make_config(tmpdir, log_file=nil)
     "max_errors_tolerated" => "10"
   }
 
-  config.update({"log_file" => log_file}) unless log_file.nil?
+  config.update("log_file" => log_file) unless log_file.nil?
 
   tmpdir.write_file "settings.yml", config.to_yaml
 end

--- a/spec/neutron_l3_ha_service_spec.rb
+++ b/spec/neutron_l3_ha_service_spec.rb
@@ -120,7 +120,49 @@ describe ServiceOptions do
       service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
       expect(service_options.hatool.insecure).to eq false
     end
+
+    it "log_file is nil by default" do
+      service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
+      expect(service_options.log_file).to eq nil
+    end
   end
+
+  context "valid settings file" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        @tmpdir = tmpdir
+        tmpdir.write_file "settings.yml", {
+          "timeouts" => {
+            "status" => {
+              "terminate" => 1,
+              "kill" => 2
+            },
+            "router_migration" => {
+              "terminate" => 5,
+              "kill" => 6
+            }
+          },
+          "hatool" => {
+            "program" => "path-to-hatool",
+            "env" => {
+              "some-key" => "some-value"
+            },
+            "insecure" => "false"
+          },
+          "seconds_to_sleep_between_checks" => "10",
+          "max_errors_tolerated" => "13",
+          "log_file" => "something"
+        }.to_yaml
+        example.run
+      end
+    end
+
+    it "log_file is loaded" do
+      service_options = ServiceOptions.load(@tmpdir.path_for("settings.yml"))
+      expect(service_options.log_file).to eq "something"
+    end
+  end
+
 end
 
 describe TimeoutOptions do

--- a/spec/neutron_l3_ha_service_spec.rb
+++ b/spec/neutron_l3_ha_service_spec.rb
@@ -524,8 +524,8 @@ describe ErrorCounter do
   end
 end
 
-def make_config(tmpdir)
-  tmpdir.write_file "settings.yml", {
+def make_config(tmpdir, log_file=nil)
+  config = {
     "timeouts" => {
       "status" => {
         "terminate" => 1,
@@ -544,10 +544,55 @@ def make_config(tmpdir)
     },
     "seconds_to_sleep_between_checks" => "10",
     "max_errors_tolerated" => "10"
-  }.to_yaml
+  }
+
+  config.update({"log_file" => log_file}) unless log_file.nil?
+
+  tmpdir.write_file "settings.yml", config.to_yaml
 end
 
 describe "neutron-l3-ha-service" do
+  context "explicit log file specified" do
+    around do |example|
+      with_tmpdir do |tmpdir|
+        @hatool_path = tmpdir.write_script "fake-hatool", <<-EOF.gsub(/^\s+/, "")
+        #!#{ruby_bin}
+        puts (["HATOOL-CALL"] + ARGV).join(" ")
+        if ARGV.include? "--help"
+          puts "--retry"
+          exit 0
+        end
+        exit 2 if ARGV.include? "--l3-agent-check"
+        EOF
+
+        @log_path = tmpdir.path_for("somelogfile")
+        @settings_path = make_config tmpdir, @log_path
+        @tmpdir = tmpdir
+        @ruby = File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])
+        @service_path = "chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb"
+        example.run
+      end
+    end
+
+    it "logs to specified file" do
+      subprocess = Subprocess.new @ruby, @service_path, @settings_path
+      subprocess.start
+      sleep_workaround_for_subprocess
+      sleep 1 # Let it run for a while
+      subprocess.send_signal "TERM"
+      result = subprocess.wait 0.1
+
+      log_file_content = File.read(@log_path)
+      expect(log_file_content).to include "HATOOL-CALL --l3-agent-check --quiet"
+      expect(log_file_content).to include "HATOOL-CALL --l3-agent-migrate --now --retry"
+
+      expect(result.error).to eq ""
+      expect(result.output).to eq ""
+
+      expect(result.exit_status).to eq 0
+    end
+  end
+
   context "hatool reports dead agents" do
     around do |example|
       with_tmpdir do |tmpdir|


### PR DESCRIPTION
The neutron-l3-ha-service will log to:
`/var/log/neutron/neutron-l3-ha-service.log`
With a daily rotation, to avoid polluting messages