### PR TITLE
nova: enable default filters explicitly along with additonal filters …

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -327,6 +327,9 @@ use_baremetal_filters = true
 <% if @has_itxt %>
 available_filters = nova.scheduler.filters.standard_filters
 enabled_filters = RetryFilter,AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,TrustedFilter
+<% else %>
+available_filters = nova.scheduler.filters.all_filters
+enabled_filters = RetryFilter,AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,SameHostFilter,DifferentHostFilter
 <% end %>
 <% unless @track_instance_changes %>
 track_instance_changes = false


### PR DESCRIPTION
…for tempest tests

Tracking down the following tempest test failure:
```
tempest.api.compute.admin.test_servers_on_multinodes.ServersOnMultiNodesTest.test_create_servers_on_sam
e_host
```
Since SameHostFilter is not enabled in nova.conf, even though the tempest test
makes create server call with hints set to:
```
{ same_host: "..." }
```
The same host hint is ignored and nova scheduler schedules the instance creation on any
compute host. (See [1] to for more on filters)

This change enables default set of filters by setting them explicitly
in the nova.conf property file and also enables
SameHostFilter and DifferentHostFilter for tempest tests.

[1] https://docs.openstack.org/nova/latest/user/filter-scheduler.html