### PR TITLE
Extend DB sync timeouts  (bsc#1060421)

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -258,7 +258,7 @@ ha_enabled = node[:neutron][:ha][:server][:enabled]
 crowbar_pacemaker_sync_mark "wait sync mark for neutron db sync" do
   mark "neutron_db_sync"
   action :wait
-  timeout 120
+  timeout 300
   only_if { ha_enabled }
 end
 

--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -27,7 +27,7 @@ db_settings = fetch_database_settings
 
 crowbar_pacemaker_sync_mark "wait-nova_database" do
   # the db sync is very slow for nova
-  timeout 120
+  timeout 300
   only_if { ha_enabled }
 end
 


### PR DESCRIPTION
It looks like it takes just above 3 minutes to complete using mysql/galera, so we need to raise limits.