### PR TITLE
keystone: Fix updated password check (bsc#1060687)

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -592,8 +592,8 @@ register_auth_hash = { user: node[:keystone][:admin][:username],
 
 updated_password = node[:keystone][:admin][:updated_password]
 
-unless updated_password.empty? ||
-    updated_password.nil? ||
+unless updated_password.nil? ||
+    updated_password.empty? ||
     updated_password == node[:keystone][:admin][:password]
 
   if !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)


### PR DESCRIPTION
Without this patch, when the keystone barclamp checks the
updated_password field it first checks for emptiness and then for
nilness. This is incorrect because .nil? is defined on all objects but
.empty? is only defined on iterables, so a value of nil would cause an
error in the first check instead of being caught by the second check.
This patch switches the order to fix this.

This wasn't noticed before because the schema defines the default value
of updated_password as an empty string. This would only be noticed if
the schema wasn't migrated properly. In any case, it's still better form
to check in this order.

(cherry picked from commit c341a5fb90fc6126ee95c8a511dd58b57b9e67bc)