### PR TITLE
[4.0] mysql: tune innodb log size / writeback

### DIFF
--- a/chef/cookbooks/mysql/templates/default/tuning.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/tuning.cnf.erb
@@ -1,5 +1,7 @@
 [mysqld]
 innodb_buffer_pool_size = <%= @innodb_buffer_pool_size %>M
+innodb_log_file_size = <%= [8, @innodb_buffer_pool_size / 4].max %>M
+innodb_flush_method = O_DIRECT
 
 max_connections = <%= @max_connections %>
 tmp_table_size = <%= @tmp_table_size %>M


### PR DESCRIPTION
We're already raising innodb_buffer_pool_size, and log_file_size should
be scaled accordingly (typical recommendation is 25% of the buffer pool
size which is what we're doing here). Also tune writeback to O_DIRECT
as this is what upstream is doing:

https://git.openstack.org/cgit/openstack/openstack-ansible-galera_server/tree/templates/my.cnf.j2#n80
(cherry picked from commit f12daf1464d21c08f3773965b8cfdb827582b7a3)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1325