### PR TITLE
database: Fix schema migrations for backend specific attributes (bsc#…

### DIFF
--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -198,4 +198,11 @@ class DatabaseService < PacemakerServiceObject
 
     @logger.debug("Database apply_role_pre_chef_call: leaving")
   end
+
+  def post_schema_migration_callback(proposal, role)
+    return if role.nil?
+    sql_engine = role.default_attributes["database"]["sql_engine"]
+    role.default_attributes[sql_engine] = role.default_attributes["database"][sql_engine]
+    role.save
+  end
 end


### PR DESCRIPTION
…1058876)

As the backend cookbooks where taken from upstream originally they
expect their attributes to live at the top level of the attribute
hierarchy instead of below the "database" namespace, where the barclamp
manages them. To make that work we usually copy those attributes to the
top level in DatabaseService.apply_role_pre_chef_call(). This however
does not work for schema migrations that introduce new attribute to the
barclamp. This commit addresses that by make use of the new
post_schema_migration_callback() to copy the attributes during a
schema migration.

Closes: https://bugzilla.suse.com/show_bug.cgi?id=1058876

This requires: https://github.com/crowbar/crowbar-core/pull/1355

Provides an alternative to https://github.com/crowbar/crowbar-openstack/pull/1314