### PR TITLE
neutron, nova: Revert use of Restart= for ovs and nfs

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -43,7 +43,6 @@ service node[:network][:ovs_service] do
   supports status: true, restart: true
   action [:start, :enable]
 end
-utils_systemd_service_restart node[:network][:ovs_service]
 
 if node.roles.include?("neutron-network")
   # Explicitly stop and disable l3 and metadata agents if APIC is

--- a/chef/cookbooks/neutron/recipes/vmware_support.rb
+++ b/chef/cookbooks/neutron/recipes/vmware_support.rb
@@ -48,7 +48,6 @@ service node[:network][:ovs_service] do
   supports status: true, restart: true
   action [:start, :enable]
 end
-utils_systemd_service_restart node[:network][:ovs_service]
 
 node[:neutron][:platform][:nsx_pkgs].each { |p| package p }
 

--- a/chef/cookbooks/nova/recipes/instances.rb
+++ b/chef/cookbooks/nova/recipes/instances.rb
@@ -29,7 +29,6 @@ if node[:nova]["setup_shared_instance_storage"]
     enabled true
     action [:enable, :start]
   end
-  utils_systemd_service_restart "nfs-kernel-server"
 
   admin_net = Barclamp::Inventory.get_network_by_type(node, "admin")
 


### PR DESCRIPTION
These services are oneshot, and this is not compatible.

This is not visible in our CI, due to the fact that the code path is
only used for some exotic configuration.

(cherry picked from commit 28cf45c4519f43bab7a004fa3c7e16006c9d7250)