### PR TITLE
ceilometer: add separate polling configuration file

### DIFF
--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -105,3 +105,6 @@ service_region_name= <%= @keystone_settings['endpoint_region'] %>
 
 [publisher_notifier]
 metering_topic=metering
+
+[polling]
+cfg_file=/etc/ceilometer/pipeline.yaml


### PR DESCRIPTION
In Ocata use of pipeline.yaml for polling by ceilometer
polling agent was deprecated. Instead it is recommended
to add a separate polling section in ceilometer config
file and set cfg_file to a new file called polling.yaml
(See [1] [2] Ocata and Pike release notes)

This is preferred method because it allows to define
a set of meters that can be polled which is different
from meters that are collected via notifications.

The structure of the polling.yaml is similar to
pipeline.yaml but only requires fields necessary for
polling that is interval (polling interval) and
list of patterns for source meters.

[1] Ceilometer Ocata Release Notes:
    https://docs.openstack.org/releasenotes/ceilometer/ocata.html

[2] Ceilometer Pike Release Notes:
    https://docs.openstack.org/releasenotes/ceilometer/pike.html