### PR TITLE
keystone: Fix updating admin password

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -67,10 +67,6 @@ end
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(
   node, node[:aodh][:api][:protocol] == "https", ha_enabled)
@@ -82,7 +78,7 @@ keystone_register "register aodh user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -94,7 +90,7 @@ keystone_register "give aodh user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -107,7 +103,7 @@ keystone_register "register aodh service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "aodh"
   service_type "alarming"
   service_description "Openstack Telemetry Alarming Service"
@@ -122,7 +118,7 @@ keystone_register "register aodh endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "aodh"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{aodh_protocol}://#{my_public_host}:#{aodh_port}"

--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -57,9 +57,6 @@ admin_host = CrowbarHelper.get_host_for_admin_url(node, node[:barbican][:ha][:en
 public_host = CrowbarHelper.get_host_for_public_url(node,
                                                     barbican_protocol == "https",
                                                     node[:barbican][:ha][:enabled])
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
 
 crowbar_pacemaker_sync_mark "wait-barbican_register" if ha_enabled
 
@@ -68,7 +65,7 @@ keystone_register "barbican api wakeup keystone" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -78,7 +75,7 @@ keystone_register "register barbican service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "barbican"
   service_type "key-manager"
   service_description "Openstack Barbican - Key and Secret Management Service"
@@ -90,7 +87,7 @@ keystone_register "register barbican endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "barbican"
   service_type "key-manager"
   endpoint_region keystone_settings["endpoint_region"]
@@ -105,7 +102,7 @@ keystone_register "register barbican user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -117,7 +114,7 @@ keystone_register "give barbican user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -235,16 +235,12 @@ end
 
 crowbar_pacemaker_sync_mark "wait-ceilometer_register" if ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "ceilometer wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -253,7 +249,7 @@ keystone_register "register ceilometer user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -265,7 +261,7 @@ keystone_register "give ceilometer user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -279,7 +275,7 @@ unless swift_middlewares.empty?
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth register_auth_hash
+    auth lazy { node[:keystone][:admin][:credentials] }
     user_name keystone_settings["service_user"]
     project_name keystone_settings["service_tenant"]
     role_name "ResellerAdmin"
@@ -293,7 +289,7 @@ keystone_register "register ceilometer service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "ceilometer"
   service_type "metering"
   service_description "Openstack Telemetry Service"
@@ -305,7 +301,7 @@ keystone_register "register ceilometer endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "ceilometer"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{ceilometer_protocol}://#{my_public_host}:#{node[:ceilometer][:api][:port]}"

--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -33,16 +33,12 @@ my_public_host = CrowbarHelper.get_host_for_public_url(node, node[:cinder][:api]
 
 crowbar_pacemaker_sync_mark "wait-cinder_register"
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "cinder api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -51,7 +47,7 @@ keystone_register "register cinder user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -63,7 +59,7 @@ keystone_register "give cinder user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -75,7 +71,7 @@ keystone_register "register cinder service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "cinder"
   service_type "volume"
   service_description "Openstack Cinder Service"
@@ -87,7 +83,7 @@ keystone_register "register cinder endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "cinder"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{cinder_protocol}://"\
@@ -104,7 +100,7 @@ keystone_register "register cinder service v2" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "cinderv2"
   service_type "volumev2"
   service_description "Openstack Cinder Service V2"
@@ -116,7 +112,7 @@ keystone_register "register cinder endpoint v2" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "cinderv2"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{cinder_protocol}://"\
@@ -133,7 +129,7 @@ keystone_register "register cinder service v3" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "cinderv3"
   service_type "volumev3"
   service_description "Openstack Cinder Service V3"
@@ -145,7 +141,7 @@ keystone_register "register cinder endpoint v3" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "cinderv3"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{cinder_protocol}://"\

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -88,10 +88,6 @@ crowbar_pacemaker_sync_mark "create-ec2_api_database" if ha_enabled
 rabbit_settings = fetch_rabbitmq_settings "nova"
 keystone_settings = KeystoneHelper.keystone_settings(node, "nova")
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(node, ssl_enabled, ha_enabled)
 
@@ -102,7 +98,7 @@ keystone_register "register ec2 user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -114,7 +110,7 @@ keystone_register "give ec2 user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -127,7 +123,7 @@ keystone_register "register ec2-api service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "ec2-api"
   service_type "ec2"
   service_description "EC2 Compatibility Layer"
@@ -139,7 +135,7 @@ keystone_register "register ec2-api endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "ec2-api"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{api_protocol}://#{my_public_host}:#{ec2_api_port}"
@@ -154,7 +150,7 @@ keystone_register "register ec2-metadata service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "ec2-metadata"
   service_type "ec2"
   service_description "EC2 Compatibility Layer"
@@ -166,7 +162,7 @@ keystone_register "register ec2-metadata endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "ec2-metadata"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{api_protocol}://#{my_public_host}:#{ec2_metadata_port}"

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -139,16 +139,12 @@ glance_protocol = node[:glance][:api][:protocol]
 
 crowbar_pacemaker_sync_mark "wait-glance_register_service" if ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "register glance service" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "glance"
   service_type "image"
   service_description "Openstack Glance Service"
@@ -160,7 +156,7 @@ keystone_register "register glance endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "glance"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{glance_protocol}://#{endpoint_public_ip}:#{api_port}"

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -76,16 +76,12 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 crowbar_pacemaker_sync_mark "wait-glance_register_user" if ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project:  keystone_settings["admin_project"] }
-
 keystone_register "glance wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -94,7 +90,7 @@ keystone_register "register glance user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -106,7 +102,7 @@ keystone_register "give glance user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -118,16 +118,12 @@ db_connection = fetch_database_connection_string(node[:heat][:db])
 
 crowbar_pacemaker_sync_mark "wait-heat_register" if ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "heat wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -136,7 +132,7 @@ keystone_register "register heat user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -148,7 +144,7 @@ keystone_register "give heat user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -160,7 +156,7 @@ keystone_register "add heat stack user role" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   role_name "heat_stack_user"
   action :add_role
 end
@@ -171,7 +167,7 @@ node[:heat][:trusts_delegated_roles].each do |role|
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth register_auth_hash
+    auth lazy { node[:keystone][:admin][:credentials] }
     role_name role
     action :add_role
   end
@@ -181,7 +177,7 @@ node[:heat][:trusts_delegated_roles].each do |role|
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth register_auth_hash
+    auth lazy { node[:keystone][:admin][:credentials] }
     user_name keystone_settings["admin_user"]
     project_name keystone_settings["default_tenant"]
     role_name role
@@ -280,7 +276,7 @@ bash "register heat domain" do
   EOF
   environment ({
     "OS_USERNAME" => keystone_settings["admin_user"],
-    "OS_PASSWORD" => keystone_settings["admin_password"],
+    "OS_PASSWORD" => node[:keystone][:admin][:password],
     "OS_TENANT_NAME" => keystone_settings["admin_tenant"],
     "OS_AUTH_URL" => "#{keystone_settings['protocol']}://#{keystone_settings['internal_url_host']}:#{keystone_settings['service_port']}/v3",
     "OS_REGION_NAME" => keystone_settings["endpoint_region"],
@@ -294,7 +290,7 @@ keystone_register "register Heat CloudFormation Service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "heat-cfn"
   service_type "cloudformation"
   service_description "Heat CloudFormation Service"
@@ -306,7 +302,7 @@ keystone_register "register heat Cfn endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "heat-cfn"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{node[:heat][:api][:protocol]}://#{my_public_host}:#{node[:heat][:api][:cfn_port]}/v1"
@@ -321,7 +317,7 @@ keystone_register "register Heat Service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "heat"
   service_type "orchestration"
   service_description "Heat Service"
@@ -333,7 +329,7 @@ keystone_register "register heat endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "heat"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{node[:heat][:api][:protocol]}://"\
@@ -355,7 +351,7 @@ ruby_block "get stack user domain" do
     url = "#{keystone_settings["protocol"]}://#{keystone_settings["internal_url_host"]}"
     url << ":#{keystone_settings["service_port"]}/v3"
     env = "OS_USERNAME='#{keystone_settings["admin_user"]}' "
-    env << "OS_PASSWORD='#{keystone_settings["admin_password"]}' "
+    env << "OS_PASSWORD='#{node[:keystone][:admin][:password]}' "
     env << "OS_PROJECT_NAME='#{keystone_settings["admin_tenant"]}' "
     env << "OS_AUTH_URL='#{url}' "
     env << "OS_REGION_NAME='#{keystone_settings["endpoint_region"]}' "

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -93,16 +93,12 @@ my_public_host = CrowbarHelper.get_host_for_public_url(node, false)
 
 db_connection = fetch_database_connection_string(node[:ironic][:db])
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "ironic wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -111,7 +107,7 @@ keystone_register "register ironic service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "ironic"
   service_type "baremetal"
   service_description "Ironic baremetal provisioning service"
@@ -127,7 +123,7 @@ keystone_register "register ironic endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "ironic"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL public_endpoint
@@ -141,7 +137,7 @@ keystone_register "register ironic user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -153,7 +149,7 @@ keystone_register "give ironic user admin role in service tenant" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"

--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -31,16 +31,12 @@ my_public_host = CrowbarHelper.get_host_for_public_url(
 
 crowbar_pacemaker_sync_mark "wait-magnum_register" if ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "magnum api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -49,7 +45,7 @@ keystone_register "register magnum user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -61,7 +57,7 @@ keystone_register "give magnum user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -73,7 +69,7 @@ keystone_register "register magnum service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "magnum"
   service_type "container-infra"
   service_description "Container Infrastructure Management Service"
@@ -85,7 +81,7 @@ keystone_register "register magnum endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "magnum"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{magnum_protocol}://"\

--- a/chef/cookbooks/manila/recipes/api.rb
+++ b/chef/cookbooks/manila/recipes/api.rb
@@ -33,16 +33,12 @@ my_public_host = CrowbarHelper.get_host_for_public_url(
 
 crowbar_pacemaker_sync_mark "wait-manila_register"
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "manila api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -51,7 +47,7 @@ keystone_register "register manila user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -63,7 +59,7 @@ keystone_register "give manila user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -75,7 +71,7 @@ keystone_register "register manila service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "manila"
   service_type "share"
   service_description "Openstack Manila shared filesystem service"
@@ -87,7 +83,7 @@ keystone_register "register manila endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "manila"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{manila_protocol}://"\
@@ -105,7 +101,7 @@ keystone_register "register manila service v2" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "manilav2"
   service_type "sharev2"
   service_description "Openstack Manila shared filesystem service V2"
@@ -117,7 +113,7 @@ keystone_register "register manila endpoint v2" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "manilav2"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{manila_protocol}://"\

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -15,18 +15,12 @@
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-register_auth_hash = {
-  user: keystone_settings["admin_user"],
-  password: keystone_settings["admin_password"],
-  project: keystone_settings["admin_project"]
-}
-
 keystone_register "monasca api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -35,7 +29,7 @@ keystone_register "register monasca api user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -47,7 +41,7 @@ keystone_register "give monasca api user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -59,7 +53,7 @@ keystone_register "register monasca api service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "monasca"
   service_type "monitoring"
   service_description "Monasca monitoring service"
@@ -71,7 +65,7 @@ keystone_register "register monasca api endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "monasca"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL MonascaHelper.api_public_url(node)
@@ -85,7 +79,7 @@ keystone_register "register logs service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "logs"
   service_type "logs"
   service_description "Monasca logs service"
@@ -97,7 +91,7 @@ keystone_register "register logs endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "logs"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL MonascaHelper.log_api_public_url(node, "v3.0")
@@ -111,7 +105,7 @@ keystone_register "register logs_v2 service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "logs_v2"
   service_type "logs_v2"
   service_description "Monasca logs_v2 service"
@@ -123,7 +117,7 @@ keystone_register "register logs_v2 endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "logs_v2"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL MonascaHelper.log_api_public_url(node, "v2.0")
@@ -137,7 +131,7 @@ keystone_register "register logs-search service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "logs-search"
   service_type "logs-search"
   service_description "Monasca logs-search service"
@@ -149,7 +143,7 @@ keystone_register "register logs-search endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "logs-search"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL MonascaHelper.logs_search_public_url(node)
@@ -174,7 +168,7 @@ keystone_register "monasca:common wakeup keystone" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -183,7 +177,7 @@ keystone_register "monasca:common create project #{monasca_project} for monasca"
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   project_name monasca_project
   action :add_project
 end
@@ -194,7 +188,7 @@ monasca_roles.each do |role|
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth register_auth_hash
+    auth lazy { node[:keystone][:admin][:credentials] }
     role_name role
     action :add_role
   end
@@ -206,7 +200,7 @@ keystone_register "give admin user admin role in monasca tenant" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["admin_user"]
   project_name monasca_project
   role_name "admin"
@@ -219,7 +213,7 @@ keystone_register "give admin user monasca-user role in monasca tenant" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["admin_user"]
   project_name monasca_project
   role_name "monasca-user"
@@ -240,7 +234,7 @@ unless agents_settings.empty?
       insecure keystone_settings["insecure"]
       host keystone_settings["internal_url_host"]
       port keystone_settings["admin_port"]
-      auth register_auth_hash
+      auth lazy { node[:keystone][:admin][:credentials] }
       user_name as["service_user"]
       user_password as["service_password"]
       project_name as["service_tenant"]
@@ -252,7 +246,7 @@ unless agents_settings.empty?
       insecure keystone_settings["insecure"]
       host keystone_settings["internal_url_host"]
       port keystone_settings["admin_port"]
-      auth register_auth_hash
+      auth lazy { node[:keystone][:admin][:credentials] }
       user_name as["service_user"]
       project_name as["service_tenant"]
       role_name as["service_role"]

--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -25,16 +25,12 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 crowbar_pacemaker_sync_mark "wait-neutron_register" if ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "neutron api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -43,7 +39,7 @@ keystone_register "register neutron user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -55,7 +51,7 @@ keystone_register "give neutron user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -67,7 +63,7 @@ keystone_register "register neutron service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "neutron"
   service_type "network"
   service_description "Openstack Neutron Service"
@@ -79,7 +75,7 @@ keystone_register "register neutron endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "neutron"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{neutron_protocol}://#{my_public_host}:#{api_port}/"

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -37,16 +37,12 @@ api_protocol = node[:nova][:ssl][:enabled] ? "https" : "http"
 
 crowbar_pacemaker_sync_mark "wait-nova_register" if api_ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "nova api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -55,7 +51,7 @@ keystone_register "register nova user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -67,7 +63,7 @@ keystone_register "give nova user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -79,7 +75,7 @@ keystone_register "register nova service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "nova"
   service_type "compute"
   service_description "Openstack Nova Service"
@@ -91,7 +87,7 @@ keystone_register "register nova_legacy service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "nova_legacy"
   service_type "compute_legacy"
   service_description "Openstack Nova Compute Service (Legacy 2.0)"
@@ -103,7 +99,7 @@ keystone_register "register nova endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "nova"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{api_protocol}://"\
@@ -120,7 +116,7 @@ keystone_register "register nova_legacy endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "nova_legacy"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{api_protocol}://"\

--- a/chef/cookbooks/nova/recipes/placement_api.rb
+++ b/chef/cookbooks/nova/recipes/placement_api.rb
@@ -36,16 +36,12 @@ api_protocol = node[:nova][:ssl][:enabled] ? "https" : "http"
 
 crowbar_pacemaker_sync_mark "wait-nova-placement_register" if api_ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "register placement user '#{node["nova"]["placement_service_user"]}'" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name node["nova"]["placement_service_user"]
   user_password node["nova"]["placement_service_password"]
   project_name keystone_settings["service_tenant"]
@@ -57,7 +53,7 @@ keystone_register "give placement user '#{node["nova"]["placement_service_user"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name node["nova"]["placement_service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -69,7 +65,7 @@ keystone_register "register placement service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "placement"
   service_type "placement"
   service_description "Openstack Placement Service"
@@ -81,7 +77,7 @@ keystone_register "register placement endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "placement"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{api_protocol}://#{public_api_host}:#{api_port}"

--- a/chef/cookbooks/sahara/recipes/api.rb
+++ b/chef/cookbooks/sahara/recipes/api.rb
@@ -28,10 +28,6 @@ my_public_host = CrowbarHelper.get_host_for_public_url(
   node, node[:sahara][:api][:protocol] == "https", ha_enabled
 )
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 crowbar_pacemaker_sync_mark "wait-sahara_register" if ha_enabled
 
 keystone_register "sahara api wakeup keystone" do
@@ -39,7 +35,7 @@ keystone_register "sahara api wakeup keystone" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -48,7 +44,7 @@ keystone_register "register sahara user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -60,7 +56,7 @@ keystone_register "give sahara user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -72,7 +68,7 @@ keystone_register "register sahara service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "sahara"
   service_type "data-processing"
   service_description "Openstack Sahara - Data Processing"
@@ -84,7 +80,7 @@ keystone_register "register sahara endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "sahara"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{sahara_protocol}://#{my_public_host}:#{sahara_port}/v1.1/%(tenant_id)s"

--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -39,16 +39,12 @@ service_tenant = node[:swift][:dispersion][:service_tenant]
 service_user = node[:swift][:dispersion][:service_user]
 service_password = node[:swift][:dispersion][:service_password]
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "swift dispersion wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -57,7 +53,7 @@ keystone_register "create tenant #{service_tenant} for dispersion" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   project_name service_tenant
   action :add_project
 end
@@ -67,7 +63,7 @@ keystone_register "add #{service_user}:#{service_tenant} user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name service_user
   user_password service_password
   project_name service_tenant
@@ -79,7 +75,7 @@ keystone_register "add #{service_user}:#{service_tenant} user admin role" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name service_user
   role_name "admin"
   project_name service_tenant

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -165,16 +165,12 @@ case proxy_config[:auth_method]
 
      crowbar_pacemaker_sync_mark "wait-swift_register" if ha_enabled
 
-     register_auth_hash = { user: keystone_settings["admin_user"],
-                            password: keystone_settings["admin_password"],
-                            project: keystone_settings["admin_project"] }
-
      keystone_register "swift proxy wakeup keystone" do
        protocol keystone_settings["protocol"]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
        port keystone_settings["admin_port"]
-       auth register_auth_hash
+       auth lazy { node[:keystone][:admin][:credentials] }
        action :wakeup
      end
 
@@ -185,7 +181,7 @@ case proxy_config[:auth_method]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
        port keystone_settings["admin_port"]
-       auth register_auth_hash
+       auth lazy { node[:keystone][:admin][:credentials] }
        role_name role
        action :add_role
      end
@@ -195,7 +191,7 @@ case proxy_config[:auth_method]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
        port keystone_settings["admin_port"]
-       auth register_auth_hash
+       auth lazy { node[:keystone][:admin][:credentials] }
        user_name keystone_settings["service_user"]
        user_password keystone_settings["service_password"]
        project_name keystone_settings["service_tenant"]
@@ -207,7 +203,7 @@ case proxy_config[:auth_method]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
        port keystone_settings["admin_port"]
-       auth register_auth_hash
+       auth lazy { node[:keystone][:admin][:credentials] }
        user_name keystone_settings["service_user"]
        project_name keystone_settings["service_tenant"]
        role_name "admin"
@@ -218,7 +214,7 @@ case proxy_config[:auth_method]
        protocol keystone_settings["protocol"]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
-       auth register_auth_hash
+       auth lazy { node[:keystone][:admin][:credentials] }
        port keystone_settings["admin_port"]
        service_name "swift"
        service_type "object-store"
@@ -230,7 +226,7 @@ case proxy_config[:auth_method]
        protocol keystone_settings["protocol"]
        insecure keystone_settings["insecure"]
        host keystone_settings["internal_url_host"]
-       auth register_auth_hash
+       auth lazy { node[:keystone][:admin][:credentials] }
        port keystone_settings["admin_port"]
        endpoint_service "swift"
        endpoint_region keystone_settings["endpoint_region"]

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -44,16 +44,12 @@ tempest_magnum_settings = node[:tempest][:magnum]
 # heat (orchestration)
 tempest_heat_settings = node[:tempest][:heat]
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "tempest tempest wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -62,7 +58,7 @@ keystone_register "create tenant #{tempest_comp_tenant} for tempest" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   project_name tempest_comp_tenant
   action :add_project
 end
@@ -109,7 +105,7 @@ users.each do |user|
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth register_auth_hash
+    auth lazy { node[:keystone][:admin][:credentials] }
     user_name user["name"]
     user_password user["pass"]
     project_name tempest_comp_tenant
@@ -122,7 +118,7 @@ roles.each do |role|
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth register_auth_hash
+    auth lazy { node[:keystone][:admin][:credentials] }
     role_name role
     action :add_role
   end
@@ -133,7 +129,7 @@ end
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth register_auth_hash
+    auth lazy { node[:keystone][:admin][:credentials] }
     user_name user["name"]
     role_name user["role"]
     project_name tempest_comp_tenant
@@ -145,7 +141,7 @@ end
     insecure keystone_settings["insecure"]
     host keystone_settings["internal_url_host"]
     port keystone_settings["admin_port"]
-    auth register_auth_hash
+    auth lazy { node[:keystone][:admin][:credentials] }
     user_name user["name"]
     project_name tempest_comp_tenant
     action :add_ec2
@@ -158,7 +154,7 @@ keystone_register "add #{keystone_settings['admin_user']}:#{tempest_comp_tenant}
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["admin_user"]
   role_name "admin"
   project_name tempest_comp_tenant

--- a/chef/cookbooks/trove/recipes/api.rb
+++ b/chef/cookbooks/trove/recipes/api.rb
@@ -71,16 +71,12 @@ object_store_url, object_store_insecure =
 
 crowbar_pacemaker_sync_mark "wait-trove_register" if ha_enabled
 
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
 keystone_register "trove api wakeup keystone" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   action :wakeup
 end
 
@@ -89,7 +85,7 @@ keystone_register "register trove user" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
@@ -101,7 +97,7 @@ keystone_register "give trove user access" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
@@ -113,7 +109,7 @@ keystone_register "register trove service" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   service_name "trove"
   service_type "database"
   service_description "Openstack Trove database service"
@@ -125,7 +121,7 @@ keystone_register "register trove endpoint" do
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
   port keystone_settings["admin_port"]
-  auth register_auth_hash
+  auth lazy { node[:keystone][:admin][:credentials] }
   endpoint_service "trove"
   endpoint_region keystone_settings["endpoint_region"]
   endpoint_publicURL "#{trove_protocol}://"\


### PR DESCRIPTION
If the keystone admin password is updated through the keystone barclamp,
the change happens at converge time and the chef node object is also
updated at converge time. This does not help other recipes that have
already evaluated the auth hash at compile time. This patch ensures the
update stores the entire credentials hash on the node object, and then
uses the lazy syntax to evaluate that value at converge time so that an
update to the password during the keystone proposal run will propagate
to the other proposals.