### PR TITLE
tempest: remove world-readable permission from tempest.conf

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -482,7 +482,7 @@ end
 
 template "/etc/tempest/tempest.conf" do
   source "tempest.conf.erb"
-  mode 0644
+  mode 0o640
   variables(
     lazy {
       {


### PR DESCRIPTION
This is probably not a good idea, it contains passwords.