### PR TITLE
crowbar-pacemaker: clone restarts by default

### DIFF
--- a/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_clone_for_transaction.rb
+++ b/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_clone_for_transaction.rb
@@ -26,6 +26,9 @@ define :openstack_pacemaker_controller_clone_for_transaction,
   raise "No agent specified for #{primitive_name}!" if agent.nil?
 
   fake_params = {}
+  unless op["monitor"].nil?
+    op["monitor"] = op["monitor"].merge("on-fail" => "restart")
+  end
 
   pacemaker_primitive primitive_name do
     agent agent


### PR DESCRIPTION
When STONITH is enabled in a cluster, the default behavior for the
primitives is to fence the node on failure. This is a desirable behavior
for stateful services because it can lead to a corrupt state. On
stateless services (those that we can clone) fencing may be a too
intrusive action. We are setting the default action for clones to
restart instead of [implicit] fencing.