### PR TITLE
keystone: store old admin password in node attr for update

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -475,6 +475,39 @@ end
 
 keystone_insecure = node["keystone"]["api"]["protocol"] == "https" && node[:keystone][:ssl][:insecure]
 
+register_auth_hash = { user: node[:keystone][:admin][:username],
+                       password: node[:keystone][:admin][:password],
+                       project: node[:keystone][:admin][:project] }
+
+old_password = node[:keystone][:admin][:old_password]
+old_register_auth_hash = register_auth_hash.clone
+old_register_auth_hash[:password] = old_password
+
+keystone_register "update admin password" do
+  protocol node[:keystone][:api][:protocol]
+  insecure keystone_insecure
+  host my_admin_host
+  port node[:keystone][:api][:admin_port]
+  auth old_register_auth_hash
+  user_name node[:keystone][:admin][:username]
+  user_password node[:keystone][:admin][:password]
+  project_name node[:keystone][:admin][:project]
+  action :add_user
+  only_if do
+    node[:keystone][:bootstrap] &&
+      (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
+      old_password && !old_password.empty? &&
+      old_password != node[:keystone][:admin][:password]
+  end
+end
+
+ruby_block "backup current admin password on node attributes" do
+  block do
+    node.set[:keystone][:admin][:old_password] = node[:keystone][:admin][:password]
+    node.save
+  end
+end
+
 # Creates admin user, admin role and admin project
 execute "keystone-manage bootstrap" do
   command "keystone-manage bootstrap \
@@ -494,39 +527,6 @@ execute "keystone-manage bootstrap" do
   end
 end
 
-register_auth_hash = { user: node[:keystone][:admin][:username],
-                       password: node[:keystone][:admin][:password],
-                       project: node[:keystone][:admin][:project] }
-
-updated_password = node[:keystone][:admin][:updated_password]
-
-unless updated_password.nil? ||
-    updated_password.empty? ||
-    updated_password == node[:keystone][:admin][:password]
-
-  if !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)
-    keystone_register "update admin password" do
-      protocol node[:keystone][:api][:protocol]
-      insecure keystone_insecure
-      host my_admin_host
-      port node[:keystone][:api][:admin_port]
-      auth register_auth_hash
-      user_name node[:keystone][:admin][:username]
-      user_password updated_password
-      project_name node[:keystone][:admin][:project]
-      action :nothing
-    end.run_action(:add_user)
-  end
-
-  ruby_block "update admin password on node attributes" do
-    block do
-      node.set[:keystone][:admin][:password] = updated_password
-      node.save
-      register_auth_hash[:password] = updated_password
-    end
-    action :nothing
-  end.run_action(:create)
-end
 
 # Silly wake-up call - this is a hack; we use retries because the server was
 # just (re)started, and might not answer on the first try

--- a/chef/data_bags/crowbar/migrate/keystone/204_remove_updated_password.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/204_remove_updated_password.rb
@@ -1,0 +1,14 @@
+def upgrade(ta, td, a, d)
+  a["admin"].delete("updated_password")
+  nodes = NodeObject.find("roles:keystone-server")
+  nodes.each do |node|
+    node[:keystone][:admin][:old_password] = node[:keystone][:admin][:password]
+    node.save
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["admin"]["updated_password"] = ta["admin"]["updated_password"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -40,8 +40,7 @@
       "admin": {
         "project": "admin",
         "username": "admin",
-        "password": "crowbar",
-        "updated_password": ""
+        "password": "crowbar"
       },
       "service": {
         "project": "service",
@@ -174,7 +173,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -45,8 +45,7 @@
                     "admin": { "type": "map", "required": true, "mapping": {
                       "project": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required" : true },
-                      "password": { "type" : "str", "required" : true },
-                      "updated_password": { "type" : "str", "required" : false }
+                      "password": { "type" : "str", "required" : true }
                     }},
                     "service": { "type": "map", "required": true, "mapping": {
                       "project": { "type" : "str", "required" : true },

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -152,26 +152,6 @@ class KeystoneService < OpenstackServiceObject
     @logger.debug("Keystone apply_role_pre_chef_call: leaving")
   end
 
-  def update_proposal_status(inst, status, message, bc = @bc_name)
-    @logger.debug("update_proposal_status: enter #{inst} #{bc} #{status} #{message}")
-
-    prop = Proposal.where(barclamp: bc, name: inst).first
-    unless prop.nil?
-      prop["deployment"][bc]["crowbar-status"] = status
-      prop["deployment"][bc]["crowbar-failed"] = message
-      # save the updated_password into the password field to update the raw_view
-      if status == "success" && !prop["attributes"][bc]["admin"]["updated_password"].blank?
-        prop["attributes"][bc]["admin"]["password"] = prop["attributes"][bc]["admin"]["updated_password"]
-      end
-      res = prop.save
-    else
-      res = true
-    end
-
-    @logger.debug("update_proposal_status: exit #{inst} #{bc} #{status} #{message}")
-    res
-  end
-
   def apply_role_post_chef_call(old_role, role, all_nodes)
     @logger.debug("Keystone apply_role_post_chef_call: entering #{all_nodes.inspect}")
 

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -14,12 +14,7 @@
 
       = string_field %w(default project)
       = string_field %w(admin username)
-      - if @proposal.active?
-        = password_field %w(admin updated_password)
-        .alert.alert-info
-          = t('.admin.updated_password_hint')
-      - else
-        = password_field %w(admin password)
+      = password_field %w(admin password)
 
       = boolean_field %w(default create_user),
         "data-showit" => "true",

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -31,8 +31,6 @@ en:
         admin:
           username: 'Administrator Username'
           password: 'Administrator Password'
-          updated_password: 'Update Administrator Password'
-          updated_password_hint: 'Changing the admin password directly in OpenStack its not supported. You can change the admin password directly using this field.'
         ssl_header: 'SSL Support'
         api:
           protocol: 'Protocol'


### PR DESCRIPTION
Use a node attribute to store a backup copy of the admin password, to be used when the admin password is changed.
This replaces the previous method of managing the admin password change through a dedicated UI `updated_password` attribute and allows the user to change the password by simply modifying the regular `password` UI attribute.
    
The advantage of having a backup copy of the admin password in the node attributes is that the new password value is immediately available after a password change, even during the chef compilation phase. The implications of this:
 - the new password value can immediately be used by all recipes during the chef compilation phase, which removes the need of having to deal with a password change scenario in every openstack cookbook using keystone for authentication
 - reconfiguring keystone with the new password doesn't need to happen in the compilation phase anymore. Doing it in the convergence phase, at the same time as everything else, removes this unnecessary exception from the keystone cookbook and aligns everything together better
