### PR TITLE
mariadb: Add expire_logs_days config option

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -51,7 +51,8 @@ unless node[:database][:galera_bootstrapped]
       variables(
         cluster_addresses: "gcomm://",
         sstuser: "root",
-        sstuser_password: ""
+        sstuser_password: "",
+        expire_logs_days: node[:database][:mysql][:expire_logs_days]
       )
     end
 
@@ -119,7 +120,8 @@ template "/etc/my.cnf.d/galera.cnf" do
   variables(
     cluster_addresses: cluster_addresses,
     sstuser: "sstuser",
-    sstuser_password: node[:database][:mysql][:sstuser_password]
+    sstuser_password: node[:database][:mysql][:sstuser_password],
+    expire_logs_days: node[:database][:mysql][:expire_logs_days]
   )
 end
 

--- a/chef/cookbooks/mysql/templates/default/galera.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera.cnf.erb
@@ -6,6 +6,7 @@ innodb_doublewrite=1
 query_cache_size=0
 wsrep_on=ON
 binlog_format=ROW
+expire_logs_days = <%= @expire_logs_days %>
 
 # SST method
 wsrep_sst_method = xtrabackup-v2

--- a/chef/cookbooks/mysql/templates/default/logging.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/logging.cnf.erb
@@ -2,6 +2,6 @@
 log_error=/var/log/mysql/mysql_error.log
 
 <% if @slow_query_logging_enabled -%>
-slow_query_log=1
-slow_query_log_file=/var/log/mysql/mysql_slow.log
+slow_query_log = 1
+slow_query_log_file = /var/log/mysql/mysql_slow.log
 <% end -%>

--- a/chef/data_bags/crowbar/migrate/database/104_add_expire_logs_days.rb
+++ b/chef/data_bags/crowbar/migrate/database/104_add_expire_logs_days.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["mysql"]["expire_logs_days"] = ta["mysql"]["expire_logs_days"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["mysql"].delete("expire_logs_days")
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/database/203_add_expire_logs_days.rb
+++ b/chef/data_bags/crowbar/migrate/database/203_add_expire_logs_days.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["mysql"]["expire_logs_days"] = ta["mysql"]["expire_logs_days"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["mysql"].delete("expire_logs_days")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -11,6 +11,7 @@
         "max_connections": 800,
         "tmp_table_size": 64,
         "max_heap_table_size": 64,
+        "expire_logs_days": 10,
         "ssl": {
           "enabled": false,
           "generate_certs": false,
@@ -47,7 +48,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -26,6 +26,7 @@
                 "max_connections": { "type": "int", "required": true },
                 "tmp_table_size": { "type": "int", "required": true },
                 "max_heap_table_size": { "type": "int", "required": true },
+                "expire_logs_days": { "type": "int", "required": true },
                 "ssl": {
                   "type": "map", "required": true, "mapping": {
                     "enabled": { "type": "bool", "required": true },

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -12,6 +12,7 @@
 
         = string_field %w(mysql datadir)
         = integer_field %w(mysql max_connections)
+        = integer_field %w(mysql expire_logs_days)
         = boolean_field %w(mysql slow_query_logging)
 
       %fieldset

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -26,6 +26,7 @@ en:
         mysql:
           datadir: 'Datadir'
           max_connections: 'Maximum Number of simultaneous Connections'
+          expire_logs_days: 'Number of days after the binary logs can be automatically removed'
           slow_query_logging: 'Slow Query Logging'
           ssl_header: 'SSL Support'
           ssl:


### PR DESCRIPTION
This commit makes the expire_logs_days option configurable via crowbar.
More information about the option can be found at
https://mariadb.com/kb/en/library/replication-and-binary-log-server-system-variables/#expire_logs_days.