### PR TITLE
Add ceph monitoring

### DIFF
--- a/chef/cookbooks/monasca/providers/agent_plugin_ceph.rb
+++ b/chef/cookbooks/monasca/providers/agent_plugin_ceph.rb
@@ -1,0 +1,51 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "json"
+require "yaml"
+
+action :create do
+  # initialize the data structure if not available
+  node[:monasca] ||= {}
+  node[:monasca][:agent_plugin_config] ||= {}
+  node[:monasca][:agent_plugin_config][:ceph_instances] ||= {}
+
+  # add the hash with the given values
+  node[:monasca][:agent_plugin_config][:ceph_instances][new_resource.built_by] =
+    { "built_by" => new_resource.built_by,
+      "cluster_name" => new_resource.cluster_name,
+      "use_sudo" => new_resource.use_sudo }
+
+  ceph_instances = node[:monasca][:agent_plugin_config][:ceph_instances]
+
+  # be sure the package is installed. that way "/etc/monasca/agent/conf.d/" is available
+  # and also the user and group are there
+  package "openstack-monasca-agent"
+
+  # NOTE(toabctl): convert/parse first to/from json. Otherwise we have unwanted markers
+  # like "- !ruby/hash:Mash" in the yaml output
+  ceph_conf = JSON.parse({ "init_config" => nil,
+                           "instances" => ceph_instances.values }.to_json).to_yaml
+
+  # write http_check plugin config
+  file "/etc/monasca/agent/conf.d/ceph.yaml" do
+    content ceph_conf
+    owner node[:monasca][:agent][:user]
+    group node[:monasca][:agent][:group]
+    mode "0640"
+    notifies :restart, resources(service: node[:monasca][:agent][:agent_service_name]), :delayed
+  end
+end

--- a/chef/cookbooks/monasca/resources/agent_plugin_ceph.rb
+++ b/chef/cookbooks/monasca/resources/agent_plugin_ceph.rb
@@ -1,0 +1,24 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :built_by, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :cluster_name, kind_of: String, regex: /\A[-\w.]*\z/, required: true
+attribute :use_sudo, kind_of: [TrueClass, FalseClass], default: false
+
+attr_accessor :exists

--- a/chef/data_bags/crowbar/migrate/monasca/201_add_ceph_plugin_settings.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/201_add_ceph_plugin_settings.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  a["agent"]["monitor_ceph"] = ta["agent"]["monitor_ceph"] unless
+    a["agent"].key?("monitor_ceph")
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["agent"].delete("monitor_ceph") unless ta["agent"].key?("monitor_ceph")
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -38,6 +38,7 @@
         "ca_file": "",
         "log_dir": "/var/log/monasca-agent/",
         "log_level": "INFO",
+        "monitor_ceph": true,
         "monitor_libvirt": true,
         "statsd_port": 8125,
         "check_frequency": 15,
@@ -131,7 +132,7 @@
     "monasca": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
         "monasca-master": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -56,6 +56,7 @@
                 "ca_file": { "type": "str", "required": true },
                 "log_dir": { "type": "str", "required": true },
                 "log_level": { "type": "str", "required": true },
+                "monitor_ceph": { "type": "bool", "required": true },
                 "monitor_libvirt": { "type": "bool", "required": true },
                 "statsd_port": { "type": "int", "required": true },
                 "check_frequency": { "type": "int", "required": true },


### PR DESCRIPTION
This pull request adds:

* a monasca-agent check configuration resource provider for
* monasca-agent's ceph plugin
* the Monasca barclamp configuration option `monitor_ceph` that controls
  whether the Monasca agent should monitor Ceph.

Note: this code requires a companion change in crowbar-ceph that uses
      the resource provider added here.