### PR TITLE
Lib{lxc,libxl,qemu} logrotate (bsc#1062760)

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -80,6 +80,24 @@ case node[:nova][:libvirt_type]
         notifies :create, "ruby_block[restart_libvirtd]", :immediately
       end
 
+      logr_virttype = {
+        "kvm" =>"qemu",
+        "qemu"=>"qemu",
+        "lxc" =>"lxc",
+        "xen" =>"libxl",
+      }
+
+      logr_confname = logr_virttype[node[:nova][:libvirt_type]]
+      template "/etc/logrotate.d/libvirtd.#{logr_confname}" do
+        source "libvirtd.logrotate.erb"
+        group "root"
+        owner "root"
+        mode "0644"
+        variables(
+          logdir: logr_confname
+        )
+      end
+
       case node[:nova][:libvirt_type]
         when "kvm", "qemu"
           package "qemu"

--- a/chef/cookbooks/nova/templates/default/libvirtd.logrotate.erb
+++ b/chef/cookbooks/nova/templates/default/libvirtd.logrotate.erb
@@ -1,0 +1,8 @@
+/var/log/libvirt/<%= @logdir %>/*.log {
+        weekly
+        missingok
+        rotate 4
+        compress
+        delaycompress
+        copytruncate
+}


### PR DESCRIPTION
nova: logrotate config to move weekly log to separate dir

the logrotate conf provided by package will not rotate old files if they
are 0< and <100k, which is almost always for a short lived vm.
Also the since the logs are not periodically moved to different buckets,
the folder can sometimes grow to contain hundreds of small log files

edit:
the two commits highlight the difference between the original file
and the changes I am making to the file. Will squash them once the PR is
ready to be merged.