### PR TITLE
keystone: increase keystone_register timeout

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -469,7 +469,7 @@ crowbar_pacemaker_sync_mark "sync-keystone_before_register" if ha_enabled
 
 crowbar_pacemaker_sync_mark "wait-keystone_register" do
   # keystone_register might be slow
-  timeout 90
+  timeout 150
   only_if { ha_enabled }
 end
 


### PR DESCRIPTION
Increase the timeout of the keystone_register sync mark
from 90 to 150 seconds, to fix the timeout errors occurring
during the deployment of the keystone barclamp in HA configurations.

This fixes some of the HA failures occurring intermittently in the cloud 8 HA
Jenkins jobs (e.g. [cloud-mkcloud8-job-ha-compute-x86_64 #88028](https://ci.suse.de/job/openstack-mkcloud/88028/) - during which, the time it took the founder node to configure the keystone resources was ~ 110 sec)