### PR TITLE
[4.0] memcached: increase max connections limit

### DIFF
--- a/chef/cookbooks/memcached/attributes/default.rb
+++ b/chef/cookbooks/memcached/attributes/default.rb
@@ -2,6 +2,7 @@ default[:memcached][:memory] = 64
 default[:memcached][:port] = 11211
 default[:memcached][:listen] = "0.0.0.0"
 default[:memcached][:daemonize] = true
+default[:memcached][:max_connections] = 4096
 
 case node[:platform_family]
 when "suse"

--- a/chef/cookbooks/memcached/recipes/default.rb
+++ b/chef/cookbooks/memcached/recipes/default.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+service_name = "memcached"
+
 case node[:platform_family]
 when "suse", "rhel"
   package "memcached" do
@@ -30,11 +32,11 @@ when "debian"
   end
 end
 
-service "memcached" do
+service service_name do
   action :nothing
   supports status: true, start: true, stop: true, restart: true
 end
-utils_systemd_service_restart "memcached"
+utils_systemd_service_restart service_name
 
 template "/etc/memcached.conf" do
   case node[:platform_family]
@@ -52,7 +54,8 @@ template "/etc/memcached.conf" do
     listen: node[:memcached][:listen],
     user: node[:memcached][:user],
     port: node[:memcached][:port],
-    memory: node[:memcached][:memory]
+    memory: node[:memcached][:memory],
+    max_connections: node[:memcached][:max_connections]
   )
   notifies :restart, resources(service: "memcached"), :immediately
 end

--- a/chef/cookbooks/memcached/templates/default/memcached.conf.erb
+++ b/chef/cookbooks/memcached/templates/default/memcached.conf.erb
@@ -39,6 +39,7 @@ logfile /var/log/memcached.log
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 # -c 1024
+-c <%= @max_connections %>
 
 # Lock down all paged memory. Consult with the README and homepage before you do this
 # -k

--- a/chef/cookbooks/memcached/templates/default/memcached.sysconfig.erb
+++ b/chef/cookbooks/memcached/templates/default/memcached.sysconfig.erb
@@ -10,7 +10,7 @@
 #
 # see man 1 memcached for more
 #
-MEMCACHED_PARAMS="<%= @daemonize ? "-d" : "" %> -m <%= @memory %> -l <%= @listen %> -p <%= @port %>"
+MEMCACHED_PARAMS="<%= @daemonize ? "-d" : "" %> -m <%= @memory %> -l <%= @listen %> -p <%= @port %> -c <%= @max_connections %>"
 
 ## Path:        Network/WWW/Memcached
 ## Description: username memcached should run as


### PR DESCRIPTION
In a big deployment, the default connections limit for memcached is too
low (1024) so its easy to reach it.
Increase the max connections limit for memcached to 4096 which should be
enough to deal with big deployments.

(cherry picked from commit 530420f5efe413e880d8b93e13193336a707d31f)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1372