### PR TITLE
barbican: reorder config creation and initial db sync 

### DIFF
--- a/chef/cookbooks/barbican/recipes/common.rb
+++ b/chef/cookbooks/barbican/recipes/common.rb
@@ -32,6 +32,33 @@ public_host = CrowbarHelper.get_host_for_public_url(node,
 
 database_connection = fetch_database_connection_string(node[:barbican][:db])
 
+memcached_servers = MemcachedHelper.get_memcached_servers(
+  if node[:barbican][:ha][:enabled]
+    CrowbarPacemakerHelper.cluster_nodes(node, "barbican-controller")
+  else
+    [node]
+  end
+)
+
+memcached_instance("barbican") if node["roles"].include?("barbican-controller")
+
+template node[:barbican][:config_file] do
+  source "barbican.conf.erb"
+  owner "root"
+  group node[:barbican][:group]
+  mode 0o640
+  variables(
+    database_connection: database_connection,
+    kek: node[:barbican][:kek],
+    keystone_listener: node[:barbican][:enable_keystone_listener],
+    host_href: "#{barbican_protocol}://#{public_host}:#{node[:barbican][:api][:bind_port]}",
+    rabbit_settings: fetch_rabbitmq_settings,
+    keystone_settings: KeystoneHelper.keystone_settings(node, @cookbook_name),
+    memcached_servers: memcached_servers
+  )
+  notifies :reload, resources(service: "apache2")
+end
+
 crowbar_pacemaker_sync_mark "wait-barbican_database" if ha_enabled
 
 # Create the Barbican Database
@@ -69,7 +96,7 @@ end
 execute "barbican-manage db upgrade" do
   user node[:barbican][:user]
   group node[:barbican][:group]
-  command "barbican-manage db upgrade -d #{database_connection} -v head "
+  command "barbican-manage db upgrade -v head"
   # We only do the sync the first time, and only if we're not doing HA or if we
   # are the founder of the HA cluster (so that it's really only done once).
   only_if do
@@ -92,30 +119,3 @@ ruby_block "mark node for barbican db_sync" do
 end
 
 crowbar_pacemaker_sync_mark "create-barbican_database" if ha_enabled
-
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:barbican][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "barbican-controller")
-  else
-    [node]
-  end
-)
-
-memcached_instance("barbican") if node["roles"].include?("barbican-controller")
-
-template node[:barbican][:config_file] do
-  source "barbican.conf.erb"
-  owner "root"
-  group node[:barbican][:group]
-  mode 0640
-  variables(
-    database_connection: database_connection,
-    kek: node[:barbican][:kek],
-    keystone_listener: node[:barbican][:enable_keystone_listener],
-    host_href: "#{barbican_protocol}://#{public_host}:#{node[:barbican][:api][:bind_port]}",
-    rabbit_settings: fetch_rabbitmq_settings,
-    keystone_settings: KeystoneHelper.keystone_settings(node, @cookbook_name),
-    memcached_servers: memcached_servers
-  )
-  notifies :reload, resources(service: "apache2")
-end


### PR DESCRIPTION
By creating the config file before running the initial database sync be
can remove the addtional db connection parameter from the "barbican db
upgrade" call. Which brings the recipe more in sync with how we do
things in the other barclamps.

It also avoid a shell escaping issues with db_connection uri that
contain special character like '&' that would cause issues on the
shell. (e.g. for ssl enabled MariaDB we add some ssl parameters to it
via "&ssl...=")

This should fix the current failures in the ssl CI jobs e.g.: https://ci.suse.de/job/openstack-mkcloud/88868/parsed_console/