### PR TITLE
Add HA rate limiting options to raw template to neutron and cinder

### DIFF
--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -29,6 +29,7 @@ haproxy_loadbalancer "cinder-api" do
   port node[:cinder][:api][:bind_port]
   use_ssl (node[:cinder][:api][:protocol] == "https")
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "cinder", "cinder-controller", "api")
+  rate_limit node[:cinder][:ha_rate_limit]["cinder-api"]
   action :nothing
 end.run_action(:create)
 

--- a/chef/cookbooks/neutron/recipes/server_ha.rb
+++ b/chef/cookbooks/neutron/recipes/server_ha.rb
@@ -20,6 +20,7 @@ haproxy_loadbalancer "neutron-server" do
   port node[:neutron][:api][:service_port]
   use_ssl (node[:neutron][:api][:protocol] == "https")
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "neutron", "neutron-server", "server")
+  rate_limit node[:neutron][:ha_rate_limit]["neutron-server"]
   action :nothing
 end.run_action(:create)
 

--- a/chef/data_bags/crowbar/migrate/cinder/204_add_rate_limit.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/204_add_rate_limit.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ha_rate_limit"] = ta["ha_rate_limit"] unless a.key? "ha_rate_limit"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ha_rate_limit") unless ta.key? "ha_rate_limit"
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/neutron/205_add_rate_limit.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/205_add_rate_limit.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ha_rate_limit"] = ta["ha_rate_limit"] unless a.key? "ha_rate_limit"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ha_rate_limit") unless ta.key? "ha_rate_limit"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -155,6 +155,9 @@
         "password": "",
         "user": "cinder",
         "database": "cinder"
+      },
+      "ha_rate_limit": {
+        "cinder-api": 0
       }
     }
   },
@@ -162,7 +165,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]
@@ -186,4 +189,3 @@
     }
   }
 }
-

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -324,6 +324,11 @@
                 "user": { "type": "str", "required": true },
                 "database": { "type": "str", "required": true }
               }
+            },
+            "ha_rate_limit": {
+              "type": "map", "required": true, "mapping": {
+                "cinder-api": { "type": "int", "required": true }
+              }
             }
           }
         }

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -164,6 +164,9 @@
           "wapi_version": "2.2.2",
           "wapi_max_results": -1000
           }
+      },
+      "ha_rate_limit": {
+        "neutron-server": 0
       }
     }
   },
@@ -171,7 +174,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 204,
+      "schema-revision": 205,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -201,6 +201,11 @@
                           }]
                         }
                       }
+                    },
+                    "ha_rate_limit": {
+                      "type": "map", "required": true, "mapping": {
+                        "neutron-server": { "type": "int", "required": true }
+                      }
                     }
               }}
      }},


### PR DESCRIPTION
Adds HA rate limiting options to the raw template for the different
services that depend from neutron and cinder. Defaults to 0 as the values, which means
no rate limiting