### PR TITLE
mariadb: Make HA op timeouts configurable

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -37,4 +37,3 @@ default[:mysql][:ha][:ports][:admin_port] = 3306
 # in pacemamker
 default[:mysql][:ha][:op][:monitor][:interval] = "20s"
 default[:mysql][:ha][:op][:monitor][:role]     = "Master"
-default[:mysql][:ha][:op][:promote][:timeout]  = "300s"

--- a/chef/data_bags/crowbar/migrate/database/204_add_pacemaker_timeouts.rb
+++ b/chef/data_bags/crowbar/migrate/database/204_add_pacemaker_timeouts.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["mysql"]["ha"] = ta["mysql"]["ha"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["mysql"].delete("ha")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -19,6 +19,22 @@
           "certfile": "/etc/mysql/ssl/certs/signing_cert.pem",
           "keyfile": "/etc/mysql/ssl/private/signing_key.pem",
           "ca_certs": "/etc/mysql/ssl/certs/ca.pem"
+        },
+        "ha": {
+          "op": {
+            "start": {
+              "timeout": "60s"
+            },
+            "stop": {
+              "timeout": "60s"
+            },
+            "promote": {
+              "timeout": "300s"
+            },
+            "demote": {
+              "timeout": "60s"
+            }
+          }
         }
       },
       "postgresql": {
@@ -48,7 +64,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -36,6 +36,34 @@
                     "keyfile": { "type" : "str", "required" : true },
                     "ca_certs": { "type" : "str", "required" : true }
                   }
+                },
+                "ha": {
+                  "type": "map", "required": true, "mapping": {
+                    "op": {
+                      "type": "map", "required": true, "mapping": {
+                        "start": {
+                          "type": "map", "required": true, "mapping": {
+                            "timeout": { "type" : "str", "required" : true }
+                          }
+                        },
+                        "stop": {
+                          "type": "map", "required": true, "mapping": {
+                            "timeout": { "type" : "str", "required" : true }
+                          }
+                        },
+                        "promote": {
+                          "type": "map", "required": true, "mapping": {
+                            "timeout": { "type" : "str", "required" : true }
+                          }
+                        },
+                        "demote": {
+                          "type": "map", "required": true, "mapping": {
+                            "timeout": { "type" : "str", "required" : true }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },


### PR DESCRIPTION
In big deployments it might be required to adapt the timeouts according
to the deployments. This change allows the operator to specify the
timeouts which fit best.