### PR TITLE
pacemaker: created openstack_pacemaker_primitive

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/central_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/central_ha.rb
@@ -25,7 +25,7 @@ rabbit_settings = fetch_rabbitmq_settings
 transaction_objects = []
 
 service_name = "ceilometer-central"
-pacemaker_primitive service_name do
+openstack_pacemaker_primitive service_name do
   agent node[:ceilometer][:ha][:central][:agent]
   op node[:ceilometer][:ha][:central][:op]
   action :update

--- a/chef/cookbooks/cinder/recipes/volume_ha.rb
+++ b/chef/cookbooks/cinder/recipes/volume_ha.rb
@@ -24,7 +24,7 @@ crowbar_pacemaker_sync_mark "wait-cinder_volume_ha_resources"
 transaction_objects = []
 
 service_name = "cinder-volume"
-pacemaker_primitive service_name do
+openstack_pacemaker_primitive service_name do
   agent node[:cinder][:ha][:volume_ra]
   op node[:cinder][:ha][:op]
   action :update

--- a/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_clone_for_transaction.rb
+++ b/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_controller_clone_for_transaction.rb
@@ -27,7 +27,7 @@ define :openstack_pacemaker_controller_clone_for_transaction,
 
   fake_params = {}
 
-  pacemaker_primitive primitive_name do
+  openstack_pacemaker_primitive primitive_name do
     agent agent
     op op
     # do not inherit params from the definition; yes, they get inherited if not

--- a/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_primitive.rb
+++ b/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_primitive.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+define :openstack_pacemaker_primitive,
+    agent: nil,
+    params: {},
+    op: {},
+    action: [] do
+  primitive_name = params[:name]
+  agent = params[:agent]
+  op = params[:op]
+  action = params[:action]
+
+  fake_params = {}
+
+  unless op["monitor"].nil? || op["monitor"]["on-fail"].nil?
+    op_defaults = CrowbarPacemakerHelper.op_defaults(node)
+    op["monitor"] = op["monitor"].merge("on-fail" => op_defaults["monitor"]["on-fail"])
+  end
+
+  pacemaker_primitive primitive_name do
+    agent agent
+    params fake_params
+    op op
+    action action
+  end
+
+end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -436,7 +436,7 @@ if node[:keystone][:token_format] == "fernet"
   service_transaction_objects = []
 
   keystone_fernet_primitive = "keystone-fernet-rotate"
-  pacemaker_primitive keystone_fernet_primitive do
+  openstack_pacemaker_primitive keystone_fernet_primitive do
     agent node[:keystone][:ha][:fernet][:agent]
     params({
       "target" => "/var/lib/keystone/keystone-fernet-rotate",

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -139,7 +139,7 @@ crowbar_pacemaker_sync_mark "wait-database_ha_resources" do
   revision node[:database]["crowbar-revision"]
 end
 
-pacemaker_primitive service_name do
+openstack_pacemaker_primitive service_name do
   agent resource_agent
   params({
     "enable_creation" => true,

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -234,7 +234,7 @@ end
 if use_l3_agent
   # Remove old resource
   ha_tool_primitive_name = "neutron-ha-tool"
-  pacemaker_primitive ha_tool_primitive_name do
+  openstack_pacemaker_primitive ha_tool_primitive_name do
     agent node[:neutron][:ha][:network][:ha_tool_ra]
     action [:stop, :delete]
     only_if "crm configure show #{ha_tool_primitive_name}"
@@ -261,7 +261,7 @@ if use_l3_agent
   ha_service_transaction_objects = []
   ha_service_primitive_name = "neutron-l3-ha-service"
 
-  pacemaker_primitive ha_service_primitive_name do
+  openstack_pacemaker_primitive ha_service_primitive_name do
     agent "systemd:neutron-l3-ha-service"
     op node[:neutron][:ha][:neutron_l3_ha_resource][:op]
     action :update

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -110,7 +110,7 @@ end
 
 if node[:platform_family] == "suse" && old_remote_nodes.empty?
   virtlogd_primitive = "virtlogd-compute"
-  pacemaker_primitive virtlogd_primitive do
+  openstack_pacemaker_primitive virtlogd_primitive do
     agent "systemd:virtlogd"
     op nova[:nova][:ha][:op]
     action :update
@@ -121,7 +121,7 @@ if node[:platform_family] == "suse" && old_remote_nodes.empty?
 end
 
 libvirtd_primitive = "libvirtd-compute"
-pacemaker_primitive libvirtd_primitive do
+openstack_pacemaker_primitive libvirtd_primitive do
   agent "systemd:libvirtd"
   op nova[:nova][:ha][:op]
   action :update
@@ -135,7 +135,7 @@ when "ml2"
   # neutron_agent & neutron_agent_ra are empty for plugins like cisco_apic_ml2 and apic_gbp
   unless neutron_agent.empty? || neutron_agent_ra.empty?
     neutron_agent_primitive = "#{neutron_agent.sub(/^openstack-/, "")}-compute"
-    pacemaker_primitive neutron_agent_primitive do
+    openstack_pacemaker_primitive neutron_agent_primitive do
       agent neutron_agent_ra
       op neutron[:neutron][:ha][:network][:op]
       action :update
@@ -148,7 +148,7 @@ end
 
 if neutron[:neutron][:use_dvr]
   l3_agent_primitive = "neutron-l3-agent-compute"
-  pacemaker_primitive l3_agent_primitive do
+  openstack_pacemaker_primitive l3_agent_primitive do
     agent neutron[:neutron][:ha][:network][:l3_ra]
     op neutron[:neutron][:ha][:network][:op]
     action :update
@@ -158,7 +158,7 @@ if neutron[:neutron][:use_dvr]
   compute_transaction_objects << "pacemaker_primitive[#{l3_agent_primitive}]"
 
   metadata_agent_primitive = "neutron-metadata-agent-compute"
-  pacemaker_primitive metadata_agent_primitive do
+  openstack_pacemaker_primitive metadata_agent_primitive do
     agent neutron[:neutron][:ha][:network][:metadata_ra]
     op neutron[:neutron][:ha][:network][:op]
     action :update
@@ -169,7 +169,7 @@ if neutron[:neutron][:use_dvr]
 end
 
 nova_primitive = "nova-compute"
-pacemaker_primitive nova_primitive do
+openstack_pacemaker_primitive nova_primitive do
   agent "ocf:openstack:NovaCompute"
   params ({
     "auth_url"       => internal_auth_url_v2,
@@ -229,7 +229,7 @@ end
 controller_transaction_objects = []
 
 evacuate_primitive = "nova-evacuate"
-pacemaker_primitive evacuate_primitive do
+openstack_pacemaker_primitive evacuate_primitive do
   agent "ocf:openstack:NovaEvacuate"
   params ({
     "auth_url"       => internal_auth_url_v2,
@@ -270,7 +270,7 @@ hostmap = remote_nodes.map do |remote_node|
 end.sort.join(";")
 
 fence_primitive = "fence-nova"
-pacemaker_primitive fence_primitive do
+openstack_pacemaker_primitive fence_primitive do
   agent "stonith:fence_compute"
   params ({
     "pcmk_host_map"  => hostmap,

--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -49,7 +49,7 @@ end
 
 transaction_objects = []
 
-pacemaker_primitive vip_primitive do
+openstack_pacemaker_primitive vip_primitive do
   agent "ocf:heartbeat:IPaddr2"
   params ({
     "ip" => ip_addr
@@ -77,7 +77,7 @@ transaction_objects << "pacemaker_primitive[#{vip_primitive}]"
 # of through the IP address). So we're still monitoring what we want, although
 # in two different steps -- and strictly speaking, we're not monitoring the
 # fact that the database is listening on the IP address.
-pacemaker_primitive service_name do
+openstack_pacemaker_primitive service_name do
   agent agent_name
   op postgres_op
   action :update

--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -75,7 +75,7 @@ if node[:database][:ha][:storage][:mode] == "drbd"
   drbd_params = {}
   drbd_params["drbd_resource"] = drbd_resource
 
-  pacemaker_primitive drbd_primitive do
+  openstack_pacemaker_primitive drbd_primitive do
     agent "ocf:linbit:drbd"
     params drbd_params
     op postgres_op
@@ -102,7 +102,7 @@ if node[:database][:ha][:storage][:mode] == "drbd"
   transaction_objects << "pacemaker_location[#{location_name}]"
 end
 
-pacemaker_primitive fs_primitive do
+openstack_pacemaker_primitive fs_primitive do
   agent "ocf:heartbeat:Filesystem"
   params fs_params
   op postgres_op

--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -103,7 +103,7 @@ if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
   drbd_params = {}
   drbd_params["drbd_resource"] = drbd_resource
 
-  pacemaker_primitive drbd_primitive do
+  openstack_pacemaker_primitive drbd_primitive do
     agent "ocf:linbit:drbd"
     params drbd_params
     op rabbitmq_op
@@ -130,7 +130,7 @@ if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
   storage_transaction_objects << "pacemaker_location[#{ms_location_name}]"
 end
 
-pacemaker_primitive fs_primitive do
+openstack_pacemaker_primitive fs_primitive do
   agent "ocf:heartbeat:Filesystem"
   params fs_params
   op rabbitmq_op
@@ -239,7 +239,7 @@ end # ruby_block
 
 service_transaction_objects = []
 
-pacemaker_primitive admin_vip_primitive do
+openstack_pacemaker_primitive admin_vip_primitive do
   agent "ocf:heartbeat:IPaddr2"
   params ({
     "ip" => admin_ip_addr
@@ -251,7 +251,7 @@ end
 service_transaction_objects << "pacemaker_primitive[#{admin_vip_primitive}]"
 
 if node[:rabbitmq][:listen_public]
-  pacemaker_primitive public_vip_primitive do
+  openstack_pacemaker_primitive public_vip_primitive do
     agent "ocf:heartbeat:IPaddr2"
     params ({
       "ip" => public_ip_addr
@@ -266,7 +266,7 @@ if node[:rabbitmq][:listen_public]
   #       constraints before we can stop and delete the primitive.
 end
 
-pacemaker_primitive service_name do
+openstack_pacemaker_primitive service_name do
   agent agent_name
   params ({
     "nodename" => node[:rabbitmq][:nodename]
@@ -341,7 +341,7 @@ end
 
 # When listen_public is disabled remove the VIP primitive for rabbitmq
 unless node[:rabbitmq][:listen_public]
-  pacemaker_primitive public_vip_primitive do
+  openstack_pacemaker_primitive public_vip_primitive do
     agent "ocf:heartbeat:IPaddr2"
     action [:stop, :delete]
     only_if "crm configure show #{public_vip_primitive}"

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -36,7 +36,7 @@ crowbar_pacemaker_sync_mark "wait-rabbitmq_ha_resources"
 transaction_objects = []
 
 service_name = "rabbitmq"
-pacemaker_primitive service_name do
+openstack_pacemaker_primitive service_name do
   agent agent_name
   # nodename is empty so that we explicitly depend on the config files
   params ({


### PR DESCRIPTION
Depends on: https://github.com/crowbar/crowbar-ha/pull/262

This change is meant to provide a default value for pacemaker ops. In
particular we are interested in providing a default for 'op on-fail'
actions.

With Pacemaker we are not able to configure such behavior. The approach
here is to provide a wrapper definition around pacemaker_primitive that
can read that default value from the Pacemaker barclamp. For that reason
this change depends on a pull request in the crowbar-ha repository
addressing this.