### PR TITLE
neutron: use service account for neutron-l3-ha service

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -35,7 +35,7 @@ if use_l3_agent
     owner "root"
     group "root"
     mode "0600"
-    content keystone_settings["admin_password"]
+    content keystone_settings["service_password"]
     # Our Chef is apparently too old for this :-/
     #sensitive true
     action :create
@@ -70,8 +70,8 @@ if use_l3_agent
                                                                    insecure_flag do |env|
       env["OS_AUTH_URL"] = os_auth_url_v2
       env["OS_REGION_NAME"] = keystone_settings["endpoint_region"]
-      env["OS_TENANT_NAME"] = keystone_settings["admin_tenant"]
-      env["OS_USERNAME"] = keystone_settings["admin_user"]
+      env["OS_TENANT_NAME"] = keystone_settings["service_project"]
+      env["OS_USERNAME"] = keystone_settings["service_user"]
     end
 
     file "/etc/neutron/neutron-l3-ha-service.yaml" do


### PR DESCRIPTION
Update the neutron barclamp to use the neutron service user credentials for the neutron-l3-ha/neutron-ha-tool service.

The neutron-l3-ha service was previously configured to use the admin user, which:
 1. is not necessary - the neutron service user is more  appropriate
 2. is problematic during a keystone admin password update, because it takes some time for the new admin password to reach the neutron barclamps in the chef-run, which means the neutron-l3-ha service may be triggered and run with the old admin password value and ultimately fail.