### PR TITLE
[4.0] nova: get pub key from file instead of stdin

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -320,10 +320,7 @@ unless node[:nova][:compute_remotefs_sshkey].empty?
     content "#{node[:nova][:compute_remotefs_sshkey]}\n"
   end
 
-  ssh_auth_keys += %x[cat <<EOF | ssh-keygen -y -f /dev/stdin
-  #{node[:nova][:compute_remotefs_sshkey]}
-  EOF
-  ].chomp
+  ssh_auth_keys += %x[ssh-keygen -y -f "#{node[:nova][:home_dir]}/.ssh/id_ed25519"].chomp
 end
 
 file "#{node[:nova][:home_dir]}/.ssh/authorized_keys" do


### PR DESCRIPTION
backport from https://github.com/crowbar/crowbar-openstack/pull/1379

We found in some situations that when generating a public ssh key from a
private key using stdin, the ssh-keygen command would fail. In those
situations it helps to read the private from the file it was just
writen in the previous code block.

(cherry picked from commit 12b7b58fdc78b2596cef6b4625e9d34e70382e80)

