### PR TITLE
[4.0] neutron: fix fwaas_v1 configuration (bsc#1064057)

### DIFF
--- a/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
@@ -11,3 +11,9 @@ periodic_interval = <%= @periodic_interval %>
 periodic_fuzzy_delay = <%= @periodic_fuzzy_delay %>
 debug = <%= @debug ? "True" : "False" %>
 [AGENT]
+extensions = fwaas
+
+[fwaas]
+agent_version = v1
+driver = iptables
+enabled = True


### PR DESCRIPTION
(backport of #1386)

The FWaaS configuration driven by the neutron barclamp was missing the following L3 agent configuration options:

```
[AGENT]
extensions = fwaas

[fwaas]
agent_version = v1
driver = iptables
enabled = True

```
Because of this, configured fwaas instances were stuck in a PENDING_UPDATE state.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1064057

More info:
 - https://docs.openstack.org/ocata/networking-guide/fwaas-v1-scenario.html
 - https://bugs.launchpad.net/neutron/+bug/1635180
