### PR TITLE
ceilometer: add configurable API timeout attribute (bsc#1064060)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -221,6 +221,7 @@ crowbar_openstack_wsgi "WSGI entry for ceilometer-api" do
   if node[:ceilometer][:ssl][:cert_required]
     ssl_cacert node[:ceilometer][:ssl][:ca_certs]
   end
+  timeout node[:ceilometer][:api][:timeout]
 end
 
 apache_site "ceilometer-api.conf" do

--- a/chef/cookbooks/crowbar-openstack/providers/wsgi.rb
+++ b/chef/cookbooks/crowbar-openstack/providers/wsgi.rb
@@ -66,6 +66,7 @@ action :create do
         ssl_certfile: current_resource.ssl_certfile,
         ssl_keyfile: current_resource.ssl_keyfile,
         ssl_cacert: current_resource.ssl_cacert,
+        timeout: current_resource.timeout,
         access_log: current_resource.access_log,
         error_log: current_resource.error_log,
         apache_log_dir: node[:apache][:log_dir],
@@ -112,6 +113,8 @@ def load_current_resource
   @current_resource.ssl_certfile(@new_resource.ssl_certfile)
   @current_resource.ssl_keyfile(@new_resource.ssl_keyfile)
   @current_resource.ssl_cacert(@new_resource.ssl_cacert)
+
+  @current_resource.timeout(@new_resource.timeout)
 
   @current_resource.access_log(_get_access_log)
   @current_resource.error_log(_get_error_log)

--- a/chef/cookbooks/crowbar-openstack/resources/wsgi.rb
+++ b/chef/cookbooks/crowbar-openstack/resources/wsgi.rb
@@ -20,6 +20,8 @@ attribute :ssl_certfile, kind_of: String, default: nil
 attribute :ssl_keyfile, kind_of: String, default: nil
 attribute :ssl_cacert, kind_of: String, default: nil
 
+attribute :timeout, kind_of: Integer, default: nil
+
 attribute :access_log, kind_of: String, default: nil
 attribute :error_log, kind_of: String, default: nil
 

--- a/chef/cookbooks/crowbar-openstack/templates/default/vhost-wsgi.conf.erb
+++ b/chef/cookbooks/crowbar-openstack/templates/default/vhost-wsgi.conf.erb
@@ -12,6 +12,10 @@ Listen <%= @bind_host %>:<%= @bind_port %>
     LimitRequestBody <%= @limit_request_body %>
 <% end %>
 
+<% if @timeout %>
+    Timeout <%= @timeout %>
+<% end %>
+
 <% if @ssl_enable %>
     SSLEngine on
     SSLCertificateFile <%= @ssl_certfile %>

--- a/chef/data_bags/crowbar/migrate/ceilometer/202_add_api_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/202_add_api_timeout.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["api"]["timeout"] = ta["api"]["timeout"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["api"].delete("timeout")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -18,7 +18,8 @@
       "memcache_secret_key": "",
       "api": {
         "protocol": "http",
-        "port": 8777
+        "port": 8777,
+        "timeout": 120
       },
       "db": {
         "password": "",
@@ -43,7 +44,7 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-central": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-ceilometer.schema
+++ b/chef/data_bags/crowbar/template-ceilometer.schema
@@ -30,7 +30,8 @@
               "required": true,
               "mapping": {
                 "protocol": { "type": "str", "required": true },
-                "port": { "type": "int", "required": true }
+                "port": { "type": "int", "required": true },
+                "timeout": { "type": "int", "required": true }
               }
             },
             "db": {


### PR DESCRIPTION
When ceilometer works with a large database, the ceilometer-api takes a longer time to respond to client requests. This leads to Gateway Timeout errors.
    
This commit makes the ceilometer-api wsgi timeout value configurable through the raw barclamp attribute 'api.timeout', which has a default value of 2 minutes.

Fixes: [bsc#1064060](https://bugzilla.suse.com/show_bug.cgi?id=1064060)
Also fixes: [bsc#1061197 (partially)](https://bugzilla.suse.com/show_bug.cgi?id=1061197), [bsc#1046787 (partially)](https://bugzilla.suse.com/show_bug.cgi?id=1046787), [bsc#1064088](https://bugzilla.suse.com/show_bug.cgi?id=1064088)

