### PR TITLE
tempest: Fix SSL with self-signed certificates

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -53,6 +53,7 @@ login_url = <%= @horizon_protocol %>://<%= @horizon_host %>/auth/login/
 endpoint_type = internalURL
 
 [heat_plugin]
+disable_ssl_certificate_validation = <%= @ssl_insecure ? 'true' : 'false' %>
 username = <%= @comp_user %>
 password = <%= @comp_pass %>
 admin_username = <%= @keystone_settings['admin_user'] %>


### PR DESCRIPTION
It seems the heat_plugin needs the "disable_ssl_certificate_validation"
setting as well. See:

http://git.openstack.org/cgit/openstack/heat/tree/heat_integrationtests/common/config.py?h=stable/pike#n82