### PR TITLE
horizon: Fix apache cipher suite

### DIFF
--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -26,7 +26,7 @@
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
-    SSLCipherSuite DEFAULT_SUSE
+    SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
     SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>


### PR DESCRIPTION
It seems that the DEFAULT_SUSE macro is not defined in the version of
openssl present for SLES SP1, and results in apache being unable to
start. Verbosely define the cipher suite list instead.