### PR TITLE
database: Only add pacemaker timeouts if not exists

### DIFF
--- a/chef/data_bags/crowbar/migrate/database/204_add_pacemaker_timeouts.rb
+++ b/chef/data_bags/crowbar/migrate/database/204_add_pacemaker_timeouts.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["mysql"]["ha"] = ta["mysql"]["ha"]
+  a["mysql"].key?("ha") || a["mysql"]["ha"] = ta["mysql"]["ha"]
   return a, d
 end
 


### PR DESCRIPTION
We backported the original commit which means that the ha values can
already exist. In the current implementation we should override the
settings.