### PR TITLE
chef: add name to metadata and remove recommends

### DIFF
--- a/chef/cookbooks/aodh/metadata.rb
+++ b/chef/cookbooks/aodh/metadata.rb
@@ -1,3 +1,4 @@
+name "aodh"
 maintainer "Crowbar project"
 maintainer_email "crowbar@googlegroups.com"
 license "Apache 2.0"

--- a/chef/cookbooks/ceilometer/metadata.rb
+++ b/chef/cookbooks/ceilometer/metadata.rb
@@ -1,3 +1,4 @@
+name "ceilometer"
 maintainer "User Unknown"
 maintainer_email "Unknown@Sample.com"
 license "Apache 2.0"
@@ -12,5 +13,3 @@ depends "database"
 depends "crowbar-openstack"
 depends "crowbar-pacemaker"
 depends "utils"
-
-recommends "hyperv"

--- a/chef/cookbooks/heat/metadata.rb
+++ b/chef/cookbooks/heat/metadata.rb
@@ -1,3 +1,4 @@
+name "heat"
 maintainer "User Unknown"
 maintainer_email "crowbar@dell.com"
 license "Apache 2.0"

--- a/chef/cookbooks/horizon/metadata.rb
+++ b/chef/cookbooks/horizon/metadata.rb
@@ -1,3 +1,4 @@
+name "horizon"
 maintainer "User Unknown"
 maintainer_email "Unknown@Sample.com"
 license "Apache 2.0"

--- a/chef/cookbooks/memcached/metadata.rb
+++ b/chef/cookbooks/memcached/metadata.rb
@@ -1,3 +1,4 @@
+name "memcached"
 maintainer "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license "Apache 2.0"

--- a/chef/cookbooks/mysql/metadata.rb
+++ b/chef/cookbooks/mysql/metadata.rb
@@ -1,3 +1,4 @@
+name "mysql"
 maintainer "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license "Apache 2.0"

--- a/chef/cookbooks/nova/metadata.rb
+++ b/chef/cookbooks/nova/metadata.rb
@@ -16,5 +16,3 @@ depends "memcached"
 depends "nagios"
 depends "neutron"
 depends "utils"
-
-recommends "hyperv"

--- a/chef/cookbooks/rabbitmq/metadata.rb
+++ b/chef/cookbooks/rabbitmq/metadata.rb
@@ -1,3 +1,4 @@
+name "rabbitmq"
 maintainer "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license "Apache 2.0"

--- a/chef/cookbooks/swift/metadata.rb
+++ b/chef/cookbooks/swift/metadata.rb
@@ -15,6 +15,7 @@
 #
 # Author: andi abes
 #
+name "swift"
 maintainer "Dell, Inc."
 maintainer_email "crowbar@dell.com"
 license "Apache 2.0"

--- a/chef/cookbooks/tempest/metadata.rb
+++ b/chef/cookbooks/tempest/metadata.rb
@@ -1,3 +1,4 @@
+name "tempest"
 maintainer "Dell Inc."
 maintainer_email "agordeev@mirantis.com"
 license "All rights reserved"


### PR DESCRIPTION
There is no reason to not have the name in all the cookbooks metadata
and it collides when using tools as some tools use the metadata name for
identification instead of just resorting to the directory name.

Plus it makes all cookbooks have the similar base metadata

Also removes 2 instances of recommends in the metadata as they are
useless. recommends and suggests do nothing on anything related to
chef-client or chef-server and they are deprecated due to this[0]

[0] https://chef.github.io/chef-rfc/rfc085-remove-unused-metadata.html