### PR TITLE
galera: Turn boostrap timeout into a proposal attribute

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -191,7 +191,7 @@ end
 # "wsrep_local_state_comment" status variable on all cluster nodes to reach
 # the "Synced" state, before continuing with the rest of the recipe.
 ruby_block "wait galera bootstrap" do
-  seconds = 300
+  seconds = node[:database][:mysql][:bootstrap_timeout]
   block do
     require "timeout"
     begin
@@ -224,6 +224,9 @@ ruby_block "mark node for galera bootstrap" do
 end
 
 crowbar_pacemaker_sync_mark "sync-database_boostrapped" do
+  # to be on the safe side we need to wait at least as long as the other nodes might
+  # need for bootstrapping (see the 'ruby_block "wait galera bootstrap"' above)
+  timeout node[:database][:mysql][:bootstrap_timeout] + 10
   revision node[:database]["crowbar-revision"]
 end
 

--- a/chef/data_bags/crowbar/migrate/database/206_add_bootstrap_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/database/206_add_bootstrap_timeout.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["mysql"]["bootstrap_timeout"] = ta["mysql"]["bootstrap_timeout"] unless a["mysql"]["bootstap_timeout"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["mysql"].delete("bootstrap_timeout") unless ta["mysql"].key?("bootstrap_timeout")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -12,6 +12,7 @@
         "tmp_table_size": 64,
         "max_heap_table_size": 64,
         "expire_logs_days": 10,
+        "bootstrap_timeout": 600,
         "ssl": {
           "enabled": false,
           "generate_certs": false,
@@ -69,7 +70,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 205,
+      "schema-revision": 206,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -27,6 +27,7 @@
                 "tmp_table_size": { "type": "int", "required": true },
                 "max_heap_table_size": { "type": "int", "required": true },
                 "expire_logs_days": { "type": "int", "required": true },
+                "bootstrap_timeout": { "type": "int", "required": true },
                 "ssl": {
                   "type": "map", "required": true, "mapping": {
                     "enabled": { "type": "bool", "required": true },


### PR DESCRIPTION
Some system (especially with a huge amount of RAM) need more time for
bootstrapping. Increase the default timeout and make it configurable as
a barclamp attribute.

