### PR TITLE
[4.0] ceilometer: configurable default_api_return_limit

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -78,6 +78,7 @@ template node[:ceilometer][:config_file] do
       libvirt_type: libvirt_type,
       metering_time_to_live: metering_time_to_live,
       event_time_to_live: event_time_to_live,
+      default_api_return_limit: node[:ceilometer][:api][:default_return_limit]
     )
     if is_compute_agent
       notifies :restart, "service[nova-compute]"

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -13,6 +13,9 @@ transport_url = <%= @rabbit_settings[:url] %>
 [collector]
 workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 
+[api]
+default_api_return_limit = <%= @default_api_return_limit %>
+
 [database]
 metering_time_to_live = <%= @metering_time_to_live %>
 event_time_to_live = <%= @event_time_to_live %>

--- a/chef/data_bags/crowbar/migrate/ceilometer/106_add_default_api_return_limit.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/106_add_default_api_return_limit.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["api"]["default_return_limit"] = ta["api"]["default_return_limit"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["api"].delete("default_return_limit")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -19,7 +19,8 @@
       "api": {
         "protocol": "http",
         "port": 8777,
-        "timeout": 120
+        "timeout": 120,
+        "default_return_limit": 1000
       },
       "db": {
         "password": "",
@@ -44,7 +45,7 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 105,
+      "schema-revision": 106,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-central": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-ceilometer.schema
+++ b/chef/data_bags/crowbar/template-ceilometer.schema
@@ -31,7 +31,8 @@
               "mapping": {
                 "protocol": { "type": "str", "required": true },
                 "port": { "type": "int", "required": true },
-                "timeout": { "type": "int", "required": true }
+                "timeout": { "type": "int", "required": true },
+                "default_return_limit": { "type": "int", "required": true }
               }
             },
             "db": {


### PR DESCRIPTION
(backports #1409)

The ceilometer admin dashboard in horizon doesn't specify a limit for the number of entries returned by ceilometer API calls, in which case the `[api]/default_api_return_limit` configuration option is used to limit the number of returned entries.
The default value of this option is 100, which may be too small in cases where the ceilometer database has a large number of entries (meters, samples, etc).

Making this option configurable as a raw attribute gives the crowbar admin another parameter that can be used to adjust ceilometer to larger environments.

Fixes [bsc#1046787](https://bugzilla.suse.com/show_bug.cgi?id=1046787)