### PR TITLE
[4.0] neutron: fix additional external nets on compute nodes

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -181,7 +181,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
 
     if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
       external_networks = ["nova_floating"]
-      external_networks.concat(node[:neutron][:additional_external_networks])
+      external_networks.concat(neutron[:neutron][:additional_external_networks])
       ext_physnet_map = NeutronHelper.get_neutron_physnets(node, external_networks)
       external_networks.each do |net|
         ext_iface = node[:crowbar_wall][:network][:nets][net].last
@@ -214,7 +214,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
 
     if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
       external_networks = ["nova_floating"]
-      external_networks.concat(node[:neutron][:additional_external_networks])
+      external_networks.concat(neutron[:neutron][:additional_external_networks])
       ext_physnet_map = NeutronHelper.get_neutron_physnets(node, external_networks)
       external_networks.each do |net|
         ext_iface = node[:crowbar_wall][:network][:nets][net].last


### PR DESCRIPTION
(backports #1411)

On compute nodes, the `additional_external_networks` barclamp attribute used to configure custom neutron external networks was improperly taken from the local chef node instead of the remote 'neutron-network' node.

When used in combination with a DVR enabled setup, which requires the external networks to be present on compute nodes too, this mishap basically caused the custom external networks to be unreachable without a clear error indication in the neutron logs.

Fixes: [bsc#1066171](https://bugzilla.suse.com/show_bug.cgi?id=1066171)
