### PR TITLE
[stable/4.0] Use httpchk in haproxy for galera

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -19,7 +19,7 @@
 
 resource_agent = "ocf:heartbeat:galera"
 
-["galera-3-wsrep-provider", "mariadb-tools", "xtrabackup", "socat"].each do |p|
+["galera-3-wsrep-provider", "mariadb-tools", "xtrabackup", "socat", "galera-python-clustercheck"].each do |p|
   package p
 end
 
@@ -40,7 +40,7 @@ end
 unless node[:database][:galera_bootstrapped]
   if CrowbarPacemakerHelper.is_cluster_founder?(node)
     # To bootstrap for the first time, start galera on one node
-    # to set up the seed sst user.
+    # to set up the seed sst and monitoring users.
 
     template "temporary bootstrap /etc/my.cnf.d/galera.cnf" do
       path "/etc/my.cnf.d/galera.cnf"
@@ -95,6 +95,15 @@ unless node[:database][:galera_bootstrapped]
       host "localhost"
       provider db_settings[:user_provider]
       action :grant
+    end
+
+    database_user "create haproxy and galera monitoring user" do
+      connection db_connection
+      username "monitoring"
+      password ""
+      host "%"
+      provider db_settings[:user_provider]
+      action :create
     end
 
     service "mysql-temp stop" do
@@ -238,6 +247,59 @@ crowbar_pacemaker_sync_mark "sync-database_root_password" do
   revision node[:database]["crowbar-revision"]
 end
 
+# Configuration files for galera-python-clustercheck
+template "/etc/galera-python-clustercheck/galera-python-clustercheck.conf" do
+  source "galera-python-clustercheck.conf.erb"
+  owner "galera-python-clustercheck"
+  group "mysql"
+  mode "0640"
+  variables(
+    node_address: Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+  )
+end
+
+template "/etc/galera-python-clustercheck/my.cnf" do
+  source "galera-python-clustercheck-my.cnf.erb"
+  owner "galera-python-clustercheck"
+  group "mysql"
+  mode "0640"
+  variables(
+    node_address: Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+  )
+end
+
+# Start galera-clustercheck which serves the cluster state as http return codes
+# on port 5555
+transaction_objects = []
+service_name = "galera-python-clustercheck"
+
+pacemaker_primitive service_name do
+  agent "systemd:#{service_name}"
+  action :update
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+transaction_objects.push("pacemaker_primitive[#{service_name}]")
+
+clone_name = "cl-#{service_name}"
+pacemaker_clone clone_name do
+  rsc service_name
+  meta CrowbarPacemakerHelper.clone_meta(node, remote: false)
+  action :update
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+transaction_objects.push("pacemaker_clone[#{clone_name}]")
+
+clone_location_name = openstack_pacemaker_controller_only_location_for clone_name
+transaction_objects << "pacemaker_location[#{clone_location_name}]"
+
+pacemaker_transaction "clustercheck" do
+  cib_objects transaction_objects
+  action :commit_new
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
 include_recipe "crowbar-pacemaker::haproxy"
 
 ha_servers = CrowbarPacemakerHelper.haproxy_servers_for_service(
@@ -261,7 +323,8 @@ haproxy_loadbalancer "galera" do
   address CrowbarPacemakerHelper.cluster_vip(node, "admin")
   port 3306
   mode "tcp"
-  options ["mysql-check user monitoring"]
+  options ["httpchk"]
+  default_server "port 5555"
   stick ({ "on" => "dst" })
   servers ha_servers
   action :nothing

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -176,16 +176,6 @@ unless node[:database][:database_bootstrapped]
     only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
-  database_user "create haproxy and galera monitoring user" do
-    connection db_connection
-    username "monitoring"
-    password ""
-    host "%"
-    provider db_settings[:user_provider]
-    action :create
-    only_if { ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-
   database_user "grant db_maker access" do
     connection db_connection
     username "db_maker"

--- a/chef/cookbooks/mysql/templates/default/galera-python-clustercheck-my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera-python-clustercheck-my.cnf.erb
@@ -1,0 +1,3 @@
+[client]
+user=monitoring
+host=<%= @node_address %>

--- a/chef/cookbooks/mysql/templates/default/galera-python-clustercheck.conf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera-python-clustercheck.conf.erb
@@ -1,0 +1,16 @@
+# Options:
+#   -h, --help            show this help message and exit
+#   -a AWD, --available-when-donor=AWD
+#                         Available when donor [default: 0]
+#   -r, --disable-when-readonly
+#                         Disable when read_only flag is set (desirable when
+#                         wanting to take a node out of the cluster wihtout
+#                         desync) [default: False]
+#   -c CACHE, --cache-time=CACHE
+#                         Cache the last response for N seconds [default: 1]
+#   -f CNF, --conf=CNF    MySQL Config file to use [default: ~/.my.cnf]
+#   -p PORT, --port=PORT  Port to listen on [default: 8000]
+#   -6, --ipv6            Listen to ipv6 only (disabled ipv4) [default: False]
+#   -4 IPV4, --ipv4=IPV4  Listen to ipv4 on this address [default: 0.0.0.0]
+
+GALERA_PYTHON_CLUSTERCHECK_OPTIONS="--conf=/etc/galera-python-clustercheck/my.cnf -p 5555 -4 <%= @node_address %>"


### PR DESCRIPTION
By using a script provided in the galera-python-clustercheck package we
are able to ensure a node is in sync with the galera cluster rather
than the previously superficial check of just ensuring mysql is running.

Install the package and configure it to use the monitoring user.

This requires a change to crowbar-ha in PR #256 to allow extending
the haproxy pacemaker group.

(cherry picked from commit 9efe0aac04167a4d7efa77a93f3e4392df148710)