### PR TITLE
Support neutron-dhcp-agent config snippets

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -26,6 +26,7 @@ default[:neutron][:config_file] = "/etc/neutron/neutron.conf.d/100-neutron.conf"
 default[:neutron][:lbaas_service_file] = "/etc/neutron/neutron-server.conf.d/100-neutron_service_lbaas.conf"
 default[:neutron][:lbaas_config_file] = "/etc/neutron/neutron.conf.d/110-neutron_lbaas.conf"
 default[:neutron][:l3_agent_config_file] = "/etc/neutron/neutron-l3-agent.conf.d/100-agent.conf"
+default[:neutron][:dhcp_agent_config_file] = "/etc/neutron/neutron-dhcp-agent.conf.d/100-neutron-dhcp-agent.conf"
 default[:neutron][:rpc_workers] = 1
 
 default[:neutron][:db][:database] = "neutron"

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -128,7 +128,7 @@ end
 
 dns_list = node[:dns][:forwarders].join(",")
 
-template "/etc/neutron/dhcp_agent.ini" do
+template node[:neutron][:dhcp_agent_config_file] do
   source "dhcp_agent.ini.erb"
   owner "root"
   group node[:neutron][:platform][:group]


### PR DESCRIPTION
Moved chef generated dhcp_agent.ini content to
/etc/neutron/neutron-dhcp-agent.conf.d/100-neutron-dhcp-agent.conf,
because the original /etc/neutron/dhcp_agent.ini has precedence
over config snippets in /etc/neutron/neutron-dhcp-agent.conf.d.