### PR TITLE
neutron: Fix config snippet support for neutron agents

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -23,9 +23,12 @@ default[:neutron][:dns_domain] = "openstack.local"
 default[:neutron][:networking_plugin] = "ml2"
 default[:neutron][:additional_external_networks] = []
 default[:neutron][:config_file] = "/etc/neutron/neutron.conf.d/100-neutron.conf"
+default[:neutron][:dhcp_agent_config_file] = "/etc/neutron/neutron-dhcp-agent.conf.d/100-dhcp_agent.conf"
 default[:neutron][:lbaas_service_file] = "/etc/neutron/neutron-server.conf.d/100-neutron_service_lbaas.conf"
+default[:neutron][:lbaas_agent_config_file] = "/etc/neutron/neutron-lbaasv2-agent.conf.d/100-lbaas_agent.conf"
 default[:neutron][:lbaas_config_file] = "/etc/neutron/neutron.conf.d/110-neutron_lbaas.conf"
 default[:neutron][:l3_agent_config_file] = "/etc/neutron/neutron-l3-agent.conf.d/100-agent.conf"
+default[:neutron][:metadata_agent_config_file] = "/etc/neutron/neutron-metadata-agent.conf.d/100-metadata_agent.conf"
 default[:neutron][:rpc_workers] = 1
 
 default[:neutron][:db][:database] = "neutron"

--- a/chef/cookbooks/neutron/definitions/neutron_metadata.rb
+++ b/chef/cookbooks/neutron/definitions/neutron_metadata.rb
@@ -57,7 +57,7 @@ define :neutron_metadata,
 
   keystone_settings = KeystoneHelper.keystone_settings(neutron, @cookbook_name)
 
-  template "/etc/neutron/metadata_agent.ini" do
+  template node[:neutron][:metadata_agent_config_file] do
     source "metadata_agent.ini.erb"
     owner "root"
     group node[:neutron][:platform][:group]
@@ -80,7 +80,7 @@ define :neutron_metadata,
     service node[:neutron][:platform][:metadata_agent_name] do
       action [:enable, :start]
       subscribes :restart, resources(template: node[:neutron][:config_file])
-      subscribes :restart, resources("template[/etc/neutron/metadata_agent.ini]")
+      subscribes :restart, resources(template: node[:neutron][:metadata_agent_config_file])
       provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
       if nova_compute_ha_enabled
         supports no_crm_maintenance_mode: true

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -128,7 +128,7 @@ end
 
 dns_list = node[:dns][:forwarders].join(",")
 
-template "/etc/neutron/dhcp_agent.ini" do
+template node[:neutron][:dhcp_agent_config_file] do
   source "dhcp_agent.ini.erb"
   owner "root"
   group node[:neutron][:platform][:group]
@@ -147,7 +147,7 @@ end
 
 if node[:neutron][:use_lbaas] &&
     [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
-  template "/etc/neutron/lbaas_agent.ini" do
+  template node[:neutron][:lbaas_agent_config_file] do
     source "lbaas_agent.ini.erb"
     owner "root"
     group node[:neutron][:platform][:group]
@@ -210,7 +210,7 @@ if node[:neutron][:use_lbaas] &&
     action [:enable, :start]
     subscribes :restart, resources(template: node[:neutron][:config_file])
     subscribes :restart, resources(template: node[:neutron][:lbaas_config_file])
-    subscribes :restart, resources("template[/etc/neutron/lbaas_agent.ini]")
+    subscribes :restart, resources(template: node[:neutron][:lbaas_agent_config_file])
     provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
   end
   utils_systemd_service_restart lbaas_agent do
@@ -234,7 +234,7 @@ service node[:neutron][:platform][:dhcp_agent_name] do
   supports status: true, restart: true
   action [:enable, :start]
   subscribes :restart, resources(template: node[:neutron][:config_file])
-  subscribes :restart, resources("template[/etc/neutron/dhcp_agent.ini]")
+  subscribes :restart, resources(template: node[:neutron][:dhcp_agent_config_file])
   provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
 end
 utils_systemd_service_restart node[:neutron][:platform][:dhcp_agent_name] do


### PR DESCRIPTION
Because the dhcp/lbaasv2/metadata agents are started with an explicit
"--config-file /etc/neutron/$foo_agent.ini" flag, options in this file
will override everything that is being set in config snippets.

So do not generate /etc/neutron/$foo_agent.ini files, but instead config
snippets.

Co-Authored-By: Tom Patzig <tom.patzig@sap.com>