### PR TITLE
neutron: Fix config snippet support for metering agent

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -29,6 +29,7 @@ default[:neutron][:lbaas_agent_config_file] = "/etc/neutron/neutron-lbaasv2-agen
 default[:neutron][:lbaas_config_file] = "/etc/neutron/neutron.conf.d/110-neutron_lbaas.conf"
 default[:neutron][:l3_agent_config_file] = "/etc/neutron/neutron-l3-agent.conf.d/100-agent.conf"
 default[:neutron][:metadata_agent_config_file] = "/etc/neutron/neutron-metadata-agent.conf.d/100-metadata_agent.conf"
+default[:neutron][:metering_agent_config_file] = "/etc/neutron/neutron-metering-agent.conf.d/100-metering_agent.conf"
 default[:neutron][:rpc_workers] = 1
 
 default[:neutron][:db][:database] = "neutron"


### PR DESCRIPTION
Because the metering agent is started with an explicit "--config-file
/etc/neutron/metadata_agent.ini" flag, options in this file will override
everything that is being set in config snippets.

So do not generate /etc/neutron/metadata_agent.ini (instead empty it), but
instead a config snippet.

This wasn't done as part of 654c0ea1 because the neutron package was missing a
/etc/neutron/neutron-metering-agent.conf.d directory back then.