### PR TITLE
[4.0] rakefile: avoid doing the syntaxcheck on vendor dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,7 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   RSpec::Core::RakeTask.new(:spec)
 
   task :syntaxcheck do
-    system("for f in `find -name \*.rb`; do echo -n \"Syntaxcheck $f: \"; ruby -wc $f || exit $? ; done")
+    system("for f in `find -not -path './vendor*' -name \*.rb`; do echo -n \"Syntaxcheck $f: \"; ruby -wc $f || exit $? ; done")
     exit $?.exitstatus
   end
 


### PR DESCRIPTION
Looks like travis installs all gems to the vendor dir,
that means that the syntaxcheck will check all the ruby files
under that directory, slowing down the travis work for no reason.

This removes any rb files coming from under the vendor directory

(cherry picked from commit 1259a87bd6908ef6528fdfb52f1035a2a857e017)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1076