### PR TITLE
Set socket_timeout for memcached connections to 1s

### DIFF
--- a/chef/cookbooks/aodh/templates/default/aodh.conf.erb
+++ b/chef/cookbooks/aodh/templates/default/aodh.conf.erb
@@ -27,6 +27,7 @@ auth_type = password
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:aodh][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/barbican/templates/default/barbican.conf.erb
+++ b/chef/cookbooks/barbican/templates/default/barbican.conf.erb
@@ -43,3 +43,4 @@ service_token_roles = admin
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:barbican][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -35,6 +35,7 @@ auth_type = password
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:ceilometer][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -291,6 +291,7 @@ service_token_roles = admin
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:cinder][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 
 [oslo_concurrency]
 <% if @need_shared_lock_path -%>

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -79,6 +79,7 @@ auth_type = password
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:glance][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -34,6 +34,7 @@ auth_type = password
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:glance][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -128,6 +128,7 @@ user_domain_name = <%= @keystone_settings['admin_domain'] %>
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:heat][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -67,6 +67,7 @@ service_token_roles = admin
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:ironic][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 
 [neutron]
 auth_type=password

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -12,6 +12,7 @@ driver = <%= node[:keystone][:assignment][:driver] %>
 backend = oslo_cache.memcache_pool
 enabled = True
 memcache_servers = <%= @memcached_servers.join(',') %>
+memcache_socket_timeout = 1
 
 [database]
 connection = <%= @sql_connection %>

--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -56,6 +56,7 @@ auth_type = password
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:magnum][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -57,6 +57,7 @@ service_token_roles = admin
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:manila][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 
 [neutron]
 url=<%= @neutron_protocol%>://<%= @neutron_server_host%>:<%= @neutron_server_port%>

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -54,6 +54,7 @@ user_domain_name = <%= @keystone_settings['admin_domain'] %>
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:neutron][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -179,6 +179,7 @@ user_domain_name = <%= @keystone_settings["admin_domain"] %>
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:nova][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 service_token_roles_required = true
 service_token_roles = admin
 

--- a/chef/cookbooks/sahara/templates/default/sahara.conf.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara.conf.erb
@@ -44,6 +44,7 @@ service_token_roles = admin
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:sahara][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 
 [neutron]
 api_insecure = <%= @neutron_insecure %>

--- a/chef/cookbooks/trove/templates/default/trove.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove.conf.erb
@@ -72,6 +72,7 @@ service_token_roles = admin
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:trove][:memcache_secret_key] %>
+memcache_pool_socket_timeout = 1
 
 [oslo_messaging_rabbit]
 amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>


### PR DESCRIPTION
The default is 3 seconds, which is very high. When one memcached server
goes down, then every connection pool for memcached (in each process, on
each node) need to identify that this server is down, and that has some
dramatic impact on performance.

Lowering this to 1 second, while still being a reasonable value, helps
quite a bit. I would even consider lowering this to 0.25, but oslo.cache
doesn't support float values there (see
https://bugs.launchpad.net/oslo.cache/+bug/1731921).

Helps with https://bugzilla.suse.com/show_bug.cgi?id=1038223