### PR TITLE
[4.0] database: Hide mysql datadir setting in UI

### DIFF
--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -10,7 +10,6 @@
         %legend
           = t('.mysql_attributes')
 
-        = string_field %w(mysql datadir)
         = integer_field %w(mysql max_connections)
         = integer_field %w(mysql expire_logs_days)
         = boolean_field %w(mysql slow_query_logging)


### PR DESCRIPTION
It's really not a setting that people will likely change.

(cherry picked from commit 261e971b7365a909f305109837b26d9558389ad2)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1428