### PR TITLE
neutron: Complete renaming to dns_domain

### DIFF
--- a/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
@@ -6,7 +6,7 @@
     = instance_field :database
     = instance_field :keystone
     = instance_field :rabbitmq
-    = string_field :dhcp_domain
+    = string_field :dns_domain
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -30,7 +30,7 @@ en:
         database_instance: 'Database Instance'
         rabbitmq_instance: 'RabbitMQ Instance'
         keystone_instance: 'Keystone Instance'
-        dhcp_domain: 'DHCP Domain'
+        dns_domain: 'DNS Domain'
         plugin_header: 'Networking Plugin'
         networking_plugin: 'Plugin'
         ml2_type_drivers: 'Modular Layer 2 type drivers'


### PR DESCRIPTION
dhcp_domain got renamed to dns_domain in 05eb713d, but the UI was not
updated.