### PR TITLE
nova: Don't uselessly run "nova-manage db version"

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -137,8 +137,9 @@ execute "nova-manage db sync up to revision 329" do
   # We only do the sync the first time, and only if we're not doing HA or if we
   # are the founder of the HA cluster (so that it's really only done once).
   only_if do
-    !node[:nova][:db_synced] && (`nova-manage db version`.to_i < 329) &&
-      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node))
+    !node[:nova][:db_synced] &&
+      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
+      (`nova-manage db version`.to_i < 329)
   end
 end
 
@@ -151,8 +152,9 @@ execute "nova-manage db online_data_migrations" do
   ignore_failure true
   action :run
   only_if do
-    !node[:nova][:db_synced] && (`nova-manage db version`.to_i == 329) &&
-      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node))
+    !node[:nova][:db_synced] &&
+      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
+      (`nova-manage db version`.to_i == 329)
   end
 end
 


### PR DESCRIPTION
This can take several seconds on slow systems, and there's another
condition in the if statement after this one that can be false and that
doesn't require some program to run, so put this condition last.