### PR TITLE
[4.0] Set heartbeat_timeout_threshold to improve recovery when one rabbitmq node goes down

### DIFF
--- a/chef/cookbooks/aodh/templates/default/aodh.conf.erb
+++ b/chef/cookbooks/aodh/templates/default/aodh.conf.erb
@@ -46,3 +46,4 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/cookbooks/barbican/templates/default/barbican.conf.erb
+++ b/chef/cookbooks/barbican/templates/default/barbican.conf.erb
@@ -23,6 +23,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [queue]
 

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -80,3 +80,4 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -316,6 +316,7 @@ rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [ssl]
 ca_file = <%= node[:cinder][:ssl][:ca_certs] if node[:cinder][:api][:protocol] == 'https' && node[:cinder][:ssl][:cert_required] %>

--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -202,6 +202,7 @@ class CrowbarOpenStackHelper
           cluster: false,
           durable_queues: false,
           ha_queues: false,
+          heartbeat_timeout: rabbit[:rabbitmq][:client][:heartbeat_timeout],
           pacemaker_resource: "rabbitmq"
         }
 
@@ -250,6 +251,7 @@ class CrowbarOpenStackHelper
             cluster: true,
             durable_queues: true,
             ha_queues: true,
+            heartbeat_timeout: rabbit[:rabbitmq][:client][:heartbeat_timeout],
             pacemaker_resource: "ms-rabbitmq"
           }
           Chef::Log.info("RabbitMQ cluster found")

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -26,8 +26,10 @@ s3_use_ssl = true
 
 [database]
 connection = <%= @database_connection %>
+
 [oslo_concurrency]
 lock_path = /var/run/ec2-api
+
 [oslo_messaging_rabbit]
 <% if @rabbit_settings[:cluster] -%>
 amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>
@@ -37,6 +39,8 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
+
 [keystone_authtoken]
 auth_type = password
 auth_uri = <%= @keystone_settings['public_auth_url'] %>

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -93,6 +93,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [paste_deploy]
 <% if node[:glance][:enable_caching] and node[:glance][:use_cachemanagement] -%>

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -45,6 +45,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [paste_deploy]
 flavor = keystone

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -151,3 +151,4 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -57,6 +57,15 @@ cleaning_network_uuid=<%= @ironic_net_id %>
 [oslo_concurrency]
 lock_path=/var/run/ironic
 
+[oslo_messaging_rabbit]                                                                                                                
+amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>                                                                         
+rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>                                                                                 
+ssl = <%= @rabbit_settings[:use_ssl] %>                                                                                                
+<% if @rabbit_settings[:client_ca_certs] -%>                                                                                           
+kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>                                                                         
+<% end -%>                                                                                                                             
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
+
 [pxe]
 tftp_server=<%= @tftp_ip %>
 tftp_root=<%= @tftproot %>

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -112,6 +112,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [oslo_policy]
 policy_file = <%= node[:keystone][:policy_file] %>

--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -82,6 +82,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [oslo_policy]
 policy_file = /etc/magnum/policy.json

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -89,6 +89,7 @@ rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 #############################################################################
 #############################################################################

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -80,6 +80,7 @@ rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [ssl]
 <% if @ssl_cert_required -%>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -237,6 +237,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [serial_console]
 enabled = <%= @serial_enabled ? "True" : "False" %>

--- a/chef/cookbooks/sahara/templates/default/sahara.conf.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara.conf.erb
@@ -60,3 +60,4 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/cookbooks/trove/templates/default/trove-conductor.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove-conductor.conf.erb
@@ -26,3 +26,4 @@ rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/cookbooks/trove/templates/default/trove-taskmanager.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove-taskmanager.conf.erb
@@ -77,3 +77,4 @@ rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/cookbooks/trove/templates/default/trove.conf.erb
+++ b/chef/cookbooks/trove/templates/default/trove.conf.erb
@@ -78,3 +78,4 @@ rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/data_bags/crowbar/migrate/rabbitmq/103_heartbeat_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/103_heartbeat_timeout.rb
@@ -1,0 +1,16 @@
+def upgrade(ta, td, a, d)
+  a["client"] ||= {}
+  unless a["client"]["heartbeat_timeout"]
+    a["client"]["heartbeat_timeout"] = ta["client"]["heartbeat_timeout"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta.key?("client")
+    a["client"].delete("heartbeat_timeout") unless ta["client"].key?("heartbeat_timeout")
+  else
+    a.delete("client")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -19,6 +19,9 @@
         "ca_certs": "/etc/rabbitmq/ssl/certs/ca.pem",
         "client_ca_certs": "/etc/ssl/certs/rabbitca.pem"
       },
+      "client": {
+        "heartbeat_timeout": 10
+      },
       "cluster": true,
       "ha": {
         "storage": {
@@ -50,7 +53,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 103,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -30,6 +30,13 @@
                 "client_ca_certs": { "type" : "str", "required" : true }
               }
             },
+            "client" : {
+              "type": "map",
+              "required": true,
+              "mapping" : {
+                "heartbeat_timeout": { "type": "int", "required": true }
+              }
+            },
             "cluster": { "type": "bool", "required": true },
             "ha" : {
               "type": "map",


### PR DESCRIPTION
This will be used to configure the heartbeat timeout for clients
connecting to rabbitmq. See https://www.rabbitmq.com/heartbeats.html for
details about heartbeats.

The default used by oslo.messaging is 60 seconds, which is extremely
high. There are various recommendations out there, the rabbitmq website
has two different ranges: 5-20s [1] and 8-20s [2]. Another
recommendation is 6-12s. 10s is within these ranges, so it's a good pick
for now. Some setups may want to be more aggressive here, hence the
attribute to allow this.

[1] https://www.rabbitmq.com/heartbeats.html
[2] https://www.rabbitmq.com/networking.html
[3] http://openstack-qe-guy.blogspot.fr/2015/11/rabbitmq-best-practices.html

Backport of https://github.com/crowbar/crowbar-openstack/pull/1434