### PR TITLE
[4.0] nova: Don't uselessly run "nova-manage db version"

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -85,8 +85,9 @@ execute "nova-manage db sync up to revision 329" do
   # We only do the sync the first time, and only if we're not doing HA or if we
   # are the founder of the HA cluster (so that it's really only done once).
   only_if do
-    !node[:nova][:db_synced] && (`nova-manage db version`.to_i < 329) &&
-      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node))
+    !node[:nova][:db_synced] &&
+      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
+      (`nova-manage db version`.to_i < 329)
   end
 end
 
@@ -99,8 +100,9 @@ execute "nova-manage db online_data_migrations" do
   ignore_failure true
   action :run
   only_if do
-    !node[:nova][:db_synced] && (`nova-manage db version`.to_i == 329) &&
-      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node))
+    !node[:nova][:db_synced] &&
+      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
+      (`nova-manage db version`.to_i == 329)
   end
 end
 


### PR DESCRIPTION
This can take several seconds on slow systems, and there's another
condition in the if statement after this one that can be false and that
doesn't require some program to run, so put this condition last.

(cherry picked from commit 00b13e017b8c976a4477d0d23799f9218026bd79)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1433