### PR TITLE
[4.0] neutron: Bump gc_thresh2 and gc_thresh3 sysctl

### DIFF
--- a/chef/cookbooks/neutron/files/default/sysctl-neighbour-table-overflow.conf
+++ b/chef/cookbooks/neutron/files/default/sysctl-neighbour-table-overflow.conf
@@ -1,3 +1,3 @@
 net.ipv4.neigh.default.gc_thresh1=1024
-net.ipv4.neigh.default.gc_thresh2=2048
-net.ipv4.neigh.default.gc_thresh3=4096
+net.ipv4.neigh.default.gc_thresh2=4096
+net.ipv4.neigh.default.gc_thresh3=8192


### PR DESCRIPTION
On very large deployments, we hit limits in the ARP table again, so
let's bump the settings again. We don't bump gc_thresh1 as it's about
the minimum number of entries to keep and the value there is already
high.

For original background on these settings, see 0583a0c9.

(cherry picked from commit 3dd21ea62ac152e40bfdfee4b8e25a528c82a79f)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1430