### PR TITLE
[4.0] keystone: Set cache/memcache_socket_timeout = 1

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -15,6 +15,7 @@ driver = <%= node[:keystone][:assignment][:driver] %>
 backend = oslo_cache.memcache_pool
 enabled = True
 memcache_servers = <%= @memcached_servers.join(',') %>
+memcache_socket_timeout = 1
 
 [database]
 connection = <%= @sql_connection %>


### PR DESCRIPTION
The default is 3 seconds, which is very high. When one memcached server
goes down, then every connection pool for memcached (in each process, on
each node) need to identify that this server is down, and that has some
dramatic impact on performance.

Lowering this to 1 second, while still being a reasonable value, helps
quite a bit. I would even consider lowering this to 0.25, but oslo.cache
doesn't support float values there (see
https://bugs.launchpad.net/oslo.cache/+bug/1731921).

Helps with https://bugzilla.suse.com/show_bug.cgi?id=1038223

(cherry picked from commit 1c2bfed21f6e58643a82880c89356bbc7336e2a1)

Partial backport of https://github.com/crowbar/crowbar-openstack/pull/1429 (the other commit is not relevant for stable/4.0)