### PR TITLE
Rework "new backend" UI for cinder and manila

### DIFF
--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -221,15 +221,15 @@
       %div#cinder_backends
         = t(".volumes.loading_text")
 
-      %fieldset
-        %legend
-          = t(".volumes.addheader")
-
-        = select_field %w(volumes backend_driver), :collection => :volume_driver_for_cinder
-        = string_field %w(volumes backend_name)
-
-        %div.form-group.pull-left
-          %input(id='add_cinder_backend' class="form-control" type="button" value="Add Backend")
+      %ul.list-group
+        %li.list-group-item.active
+          %h3.list-group-item-heading
+            = t(".volumes.addheader")
+            .form-group.pull-right
+              %input(id='add_cinder_backend' class="form-control btn-default" type="button" value="Add Backend")
+        %li.list-group-item
+          = select_field %w(volumes backend_driver), :collection => :volume_driver_for_cinder
+          = string_field %w(volumes backend_name)
 
     %fieldset
       %legend

--- a/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
@@ -102,15 +102,15 @@
       %div#manila_backends
         = t(".shares.loading_text")
 
-      %fieldset
-        %legend
-          = t(".shares.addheader")
-
-        = select_field %w(shares backend_driver), :collection => :share_driver_for_manila
-        = string_field %w(shares backend_name)
-
-        %div.form-group.pull-left
-          %input(id='add_manila_backend' class="form-control" type="button" value="Add Backend")
+      %ul.list-group
+        %li.list-group-item.active
+          %h3.list-group-item-heading
+            = t(".shares.addheader")
+            .form-group.pull-right
+              %input(id='add_manila_backend' class="form-control btn-default" type="button" value="Add Backend")
+        %li.list-group-item
+          = select_field %w(shares backend_driver), :collection => :share_driver_for_manila
+          = string_field %w(shares backend_name)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/cinder/en.yml
+++ b/crowbar_framework/config/locales/cinder/en.yml
@@ -28,7 +28,7 @@ en:
         volumes:
           "0":
             backend_driver: 'Type of Volume'
-          addheader: 'Add new Cinder Backend'
+          addheader: 'New Backend'
           backend_name: 'Name for Backend'
           backend_driver: 'Type of Volume'
           loading_text: 'Loading Backends...'

--- a/crowbar_framework/config/locales/manila/en.yml
+++ b/crowbar_framework/config/locales/manila/en.yml
@@ -26,7 +26,7 @@ en:
         keystone_instance: 'Keystone'
         glance_instance: 'Glance'
         shares:
-          addheader: 'Add new Manila Backend'
+          addheader: 'New Backend'
           listheader: 'Share backends'
           backend_name: 'Name for Backend'
           backend_driver: 'Type of Share'


### PR DESCRIPTION
Use the same way of presenting the new backend as the way used for
existing backends, instead of displaying this as a new section.

Old UI:
![old add backend](https://user-images.githubusercontent.com/1758783/32882902-0ef8dcfc-cab6-11e7-80ec-34a61daee44e.png)

New UI:
![new add backend](https://user-images.githubusercontent.com/1758783/32882912-15e33ecc-cab6-11e7-8327-a6e6fe3f03c8.png)
