### PR TITLE
[4.0] barbican: Fixes misspelling of keystone-listener

### DIFF
--- a/chef/cookbooks/barbican/recipes/ha.rb
+++ b/chef/cookbooks/barbican/recipes/ha.rb
@@ -50,7 +50,7 @@ if node[:pacemaker][:clone_stateless_services]
 
   services =
     if node[:barbican][:enable_keystone_listener]
-      ["worker", "keystone-listner"]
+      ["worker", "keystone-listener"]
     else
       ["worker"]
     end


### PR DESCRIPTION
Fixes misspelling of keystone-listener in barbican services list

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1444