### PR TITLE
rabbitmq: Add more persistence for critical data

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -50,6 +50,29 @@ template "/etc/rabbitmq/rabbitmq.config" do
   notifies :restart, "service[rabbitmq-server]"
 end
 
+# create a file with definitions to load on start, to be 100% sure we always
+# start with a usable state
+template "/etc/rabbitmq/definitions.json" do
+  source "definitions.json.erb"
+  owner "root"
+  group node[:rabbitmq][:rabbitmq_group]
+  mode 0o640
+  variables(
+    json_user: node[:rabbitmq][:user].to_json,
+    # ideally we'd put a hash in the file, but the hash would change on each
+    # chef run and we don't want to rewrite the file all the time
+    json_password: node[:rabbitmq][:password].to_json,
+    json_vhost: node[:rabbitmq][:vhost].to_json,
+    trove_enabled: node[:rabbitmq][:trove][:enabled],
+    json_trove_user: node[:rabbitmq][:trove][:user].to_json,
+    json_trove_password: node[:rabbitmq][:trove][:password].to_json,
+    json_trove_vhost: node[:rabbitmq][:trove][:vhost].to_json,
+    ha_all_policy: cluster_enabled
+  )
+  # no notification to restart rabbitmq, as we still do changes with
+  # rabbitmqctl in the rabbit.rb recipe (this is less disruptive)
+end
+
 case node[:platform_family]
 when "suse"
   rabbitmq_plugins = "/usr/sbin/rabbitmq-plugins"

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -26,6 +26,17 @@ file node[:rabbitmq][:erlang_cookie_path] do
   group node[:rabbitmq][:rabbitmq_group]
 end
 
+# create file that will be sourced by OCF resource agent on promote
+template "/etc/rabbitmq/ocf-promote" do
+  source "ocf-promote.erb"
+  owner "root"
+  group "root"
+  mode 0o644
+  variables(
+    clustername: node[:rabbitmq][:clustername]
+  )
+end
+
 # Wait for all nodes to reach this point so we know that all nodes will have
 # all the required packages installed before we create the pacemaker
 # resources
@@ -42,6 +53,7 @@ pacemaker_primitive service_name do
   params ({
     "erlang_cookie" => node[:rabbitmq][:erlang_cookie],
     "pid_file" => pid_file,
+    "policy_file" => "/etc/rabbitmq/ocf-promote",
     "rmq_feature_health_check" => false,
     "rmq_feature_local_list_queues" => false,
     "default_vhost" => node[:rabbitmq][:vhost]

--- a/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
@@ -1,0 +1,61 @@
+{
+    "vhosts": [
+        {
+            "name": "/"
+        },
+<% if @trove_enabled -%>
+        {
+            "name": <%= @json_trove_vhost %>
+        },
+<% end -%>
+        {
+            "name": <%= @json_vhost %>
+        }
+    ],
+<% if @ha_all_policy -%>
+    "policies": [
+        {
+            "apply-to": "all",
+            "definition": {
+                "ha-mode": "all"
+            },
+            "name": "ha-all",
+            "pattern": "^(?!amq.).*",
+            "priority": 0,
+            "vhost": <%= @json_vhost %>
+        }
+    ],
+<% end -%>
+    "users": [
+<% if @trove_enabled -%>
+        {
+            "name": <%= @json_trove_user %>,
+            "password": <%= @json_trove_password %>,
+            "tags": ""
+        },
+<% end -%>
+        {
+            "name": <%= @json_user %>,
+            "password": <%= @json_password %>,
+            "tags": "management"
+        }
+    ],
+    "permissions": [
+<% if @trove_enabled -%>
+        {
+            "user": <%= @json_trove_user %>,
+            "vhost": <%= @json_trove_vhost %>,
+            "configure": ".*",
+            "read": ".*",
+            "write": ".*"
+        },
+<% end -%>
+        {
+            "user": <%= @json_user %>,
+            "vhost": <%= @json_vhost %>,
+            "configure": ".*",
+            "read": ".*",
+            "write": ".*"
+        }
+    ]
+}

--- a/chef/cookbooks/rabbitmq/templates/default/ocf-promote.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/ocf-promote.erb
@@ -1,0 +1,4 @@
+# What should be done on promote, and that could not be done through definitions.json
+
+# Ensure the cluster name is correctly set (as it cannot be set in rabbitmq.config)
+${OCF_RESKEY_ctl} set_cluster_name <%= @clustername %>

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -24,7 +24,8 @@
  ]},
  {rabbitmq_management,
   [
-   {listener, [{ip, "<%= node[:rabbitmq][:management_address] %>"}, {port, <%= node[:rabbitmq][:management_port] %>}]}
+   {listener, [{ip, "<%= node[:rabbitmq][:management_address] %>"}, {port, <%= node[:rabbitmq][:management_port] %>}]},
+   {load_definitions, "/etc/rabbitmq/definitions.json"}
   ]
  }
 ].


### PR DESCRIPTION
**rabbitmq: Create a definitions file to load on startup**
This ensures we always have the right user/password, vhost, policies,
etc. on startup.

The benefit is mostly visible with clustered rabbitmq, because in case
of bad failures, the OCF resource agent can reset everything, which
leads to a setup without the expected setup.

**rabbitmq: Set policy_file for OCF resource agent**

We use a file that is sourced from the OCF resource agent on promote to
ensure the cluster name is correctly set. This can matter when
everything has been completely reset after some critical failure.