### PR TITLE
monasca: use exit status from monasca-setup

### DIFF
--- a/chef/cookbooks/monasca/templates/default/monasca-reconfigure-server.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-reconfigure-server.erb
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # This script is a monasca-setup wrapper that configures monasca-agent on the
 # monasca-server node. On the monasca-server node chef will _not_ touch the
 # agent configuration directly. Instead, it will run this script.

--- a/chef/cookbooks/monasca/templates/default/monasca-reconfigure.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-reconfigure.erb
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # if you use that script, the chef settings
 # will be overwritten and after the next chef-client run, the settings
 # from monasca-reconfigure will be overwritten. So DO NOT USE IT!


### PR DESCRIPTION
Currently monasca-reconfigure just forges on if one of its monasca-setup
invocations fails. This commit changes both monasca-setup scripts to run
with -e so they abort with a non-zero exit status if monasca-setup exits
non-zero.