### PR TITLE
barbican: Removes unreferenced monitor interval

### DIFF
--- a/chef/cookbooks/barbican/attributes/default.rb
+++ b/chef/cookbooks/barbican/attributes/default.rb
@@ -41,7 +41,6 @@ default[:barbican][:ha][:enabled] = false
 default[:barbican][:ha][:ports][:api] = 5621
 
 # pacemaker definitions
-default[:barbican][:ha][:api][:op][:monitor][:interval] = "10s"
 default[:barbican][:ha][:worker][:op][:monitor][:interval] = "10s"
 default[:barbican][:ha][:keystone_listener][:op][:monitor][:interval] = "10s"
 default[:barbican][:ha][:worker][:agent] = "systemd:openstack-barbican-worker"


### PR DESCRIPTION
Removes unreferenced pacemaker monitor interval from the barbican
cookbook
Follow up to the code removal in 722dfb098aed3fa503b7f41f07627b90a5914d4a