### PR TITLE
neutron: Add option to force metadata-proxy

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -31,6 +31,7 @@ default[:neutron][:lbaas_config_file] = "/etc/neutron/neutron.conf.d/110-neutron
 default[:neutron][:l3_agent_config_file] = "/etc/neutron/neutron-l3-agent.conf.d/100-agent.conf"
 default[:neutron][:metadata_agent_config_file] = "/etc/neutron/neutron-metadata-agent.conf.d/100-metadata_agent.conf"
 default[:neutron][:rpc_workers] = 1
+default[:neutron][:force_metadata] = false
 
 default[:neutron][:db][:database] = "neutron"
 default[:neutron][:db][:user] = "neutron"

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -152,6 +152,7 @@ template node[:neutron][:dhcp_agent_config_file] do
     dhcp_driver: "neutron.agent.linux.dhcp.Dnsmasq",
     dhcp_domain: node[:neutron][:dhcp_domain],
     enable_isolated_metadata: "True",
+    force_metadata: node[:neutron][:force_metadata],
     enable_metadata_network: "False",
     nameservers: dns_list
   )

--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -3,6 +3,7 @@ interface_driver = <%= @interface_driver %>
 resync_interval = <%= @resync_interval %>
 dhcp_driver = <%= @dhcp_driver %>
 enable_isolated_metadata = <%= @enable_isolated_metadata %>
+force_metadata = <%= @force_metadata %>
 enable_metadata_network = <%= @enable_metadata_network %>
 dhcp_domain = <%= @dhcp_domain %>
 <% if @nameservers -%>

--- a/chef/data_bags/crowbar/migrate/neutron/114_add_force_metadata.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/114_add_force_metadata.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["force_metadata"] = ta["force_metadata"] unless a.key? "force_metadata"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("force_metadata") unless ta.key? "force_metadata"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -168,14 +168,15 @@
       },
       "ha_rate_limit": {
         "neutron-server": 0
-      }
+      },
+      "force_metadata": false
     }
   },
   "deployment": {
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 113,
+      "schema-revision": 114,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -207,7 +207,8 @@
                       "type": "map", "required": true, "mapping": {
                         "neutron-server": { "type": "int", "required": true }
                       }
-                    }
+                    },
+                    "force_metadata": { "type": "bool", "required": true }
               }}
      }},
     "deployment": { "type": "map", "required": true,


### PR DESCRIPTION
In some cases dhcp agent disables metadata-proxy service for networks which don't have proper routed access to metadata service.
Exposed option enables users to force enabling metadata-proxy for all networks.