### PR TITLE
nova: fix wrong attribute

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -529,7 +529,7 @@ class NovaService < OpenstackServiceObject
 
     # by this point its safe to assume that we can skip the node as nothing has changed on it
     # same attributes, same roles so skip it
-    @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node_name}")
+    @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node}")
     true
   end
 


### PR DESCRIPTION
Using the wrong attribute name node_name instead of node