### PR TITLE
[4.0] nova: fix wrong attribute

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -526,7 +526,7 @@ class NovaService < OpenstackServiceObject
 
     # by this point its safe to assume that we can skip the node as nothing has changed on it
     # same attributes, same roles so skip it
-    @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node_name}")
+    @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node}")
     true
   end
 


### PR DESCRIPTION
Using the wrong attribute name node_name instead of node

(cherry picked from commit 98dcf36d622350884ac5c52c66a38ced5bc3c668)

backport-of: https://github.com/crowbar/crowbar-openstack/pull/1454