### PR TITLE
[4.0] mysql: Further config file tuning based on mysqltuner suggestions

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -56,7 +56,8 @@ unless node[:database][:galera_bootstrapped]
         sstuser: "root",
         sstuser_password: "",
         expire_logs_days: node[:database][:mysql][:expire_logs_days],
-        node_address: node_address
+        node_address: node_address,
+        wsrep_slave_threads: node[:database][:mysql][:wsrep_slave_threads]
       )
     end
 
@@ -136,7 +137,8 @@ template "/etc/my.cnf.d/galera.cnf" do
     sstuser: "sstuser",
     sstuser_password: node[:database][:mysql][:sstuser_password],
     expire_logs_days: node[:database][:mysql][:expire_logs_days],
-    node_address: node_address
+    node_address: node_address,
+    wsrep_slave_threads: node[:database][:mysql][:wsrep_slave_threads]
   )
 end
 

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -127,6 +127,8 @@ template "/etc/my.cnf.d/tuning.cnf" do
   mode "0640"
   variables(
     innodb_buffer_pool_size: node[:database][:mysql][:innodb_buffer_pool_size],
+    innodb_flush_log_at_trx_commit: node[:database][:mysql][:innodb_flush_log_at_trx_commit],
+    innodb_buffer_pool_instances: node[:database][:mysql][:innodb_buffer_pool_instances],
     max_connections: node[:database][:mysql][:max_connections],
     tmp_table_size: node[:database][:mysql][:tmp_table_size],
     max_heap_table_size: node[:database][:mysql][:max_heap_table_size]

--- a/chef/cookbooks/mysql/templates/default/galera.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera.cnf.erb
@@ -8,7 +8,9 @@ wsrep_on=ON
 binlog_format=ROW
 expire_logs_days = <%= @expire_logs_days %>
 
-wsrep_provider_options = "gmcast.listen_addr=tcp://<%= @node_address %>:4567"
+wsrep_slave_threads = <%= @wsrep_slave_threads %>
+# values recommended by mysqltuner.pl
+wsrep_provider_options = "gmcast.listen_addr=tcp://<%= @node_address %>:4567;gcs.fc_limit = <%= @wsrep_slave_threads * 5 %>;gcs.fc_factor = 0.8"
 
 # SST method
 wsrep_sst_method = xtrabackup-v2

--- a/chef/cookbooks/mysql/templates/default/tuning.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/tuning.cnf.erb
@@ -1,11 +1,18 @@
 [mysqld]
 innodb_buffer_pool_size = <%= @innodb_buffer_pool_size %>M
 innodb_log_file_size = <%= [8, @innodb_buffer_pool_size / 4].max %>M
+innodb_buffer_pool_instances = <%= @innodb_buffer_pool_instances %>
+
 innodb_flush_method = O_DIRECT
+
+# 0 should bring better performance but has slight risk of losing some logs
+innodb_flush_log_at_trx_commit = <%= @innodb_flush_log_at_trx_commit %>
 
 max_connections = <%= @max_connections %>
 tmp_table_size = <%= @tmp_table_size %>M
 max_heap_table_size = <%= @max_heap_table_size %>M
+
+skip_name_resolve = 1
 
 # FIXME: Remove after MariaDB 10.2.X switch (new default is auto)
 thread_cache_size = <%= node['mysql']['tunable']['thread_cache_size'] %>

--- a/chef/data_bags/crowbar/migrate/database/107_add_more_tuning.rb
+++ b/chef/data_bags/crowbar/migrate/database/107_add_more_tuning.rb
@@ -1,0 +1,23 @@
+def upgrade(ta, td, a, d)
+  unless a["mysql"]["innodb_flush_log_at_trx_commit"]
+    a["mysql"]["innodb_flush_log_at_trx_commit"] = ta["mysql"]["innodb_flush_log_at_trx_commit"]
+  end
+  unless a["mysql"]["innodb_buffer_pool_instances"]
+    a["mysql"]["innodb_buffer_pool_instances"] = ta["mysql"]["innodb_buffer_pool_instances"]
+  end
+  unless a["mysql"]["wsrep_slave_threads"]
+    a["mysql"]["wsrep_slave_threads"] = ta["mysql"]["wsrep_slave_threads"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["mysql"].key?("innodb_flush_log_at_trx_commit")
+    a["mysql"].delete("innodb_flush_log_at_trx_commit")
+  end
+  unless ta["mysql"].key?("innodb_buffer_pool_instances")
+    a["mysql"].delete("innodb_buffer_pool_instances")
+  end
+  a["mysql"].delete("wsrep_slave_threads") unless ta["mysql"].key?("wsrep_slave_threads")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -8,11 +8,14 @@
         "datadir": "/var/lib/mysql",
         "slow_query_logging": true,
         "innodb_buffer_pool_size": 256,
+        "innodb_flush_log_at_trx_commit": 1,
+        "innodb_buffer_pool_instances": 1,
         "max_connections": 800,
         "tmp_table_size": 64,
         "max_heap_table_size": 64,
         "expire_logs_days": 10,
         "bootstrap_timeout": 600,
+        "wsrep_slave_threads" : 1,
         "ssl": {
           "enabled": false,
           "generate_certs": false,
@@ -70,7 +73,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 106,
+      "schema-revision": 107,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -23,11 +23,14 @@
                 "datadir": { "type": "str", "required": true },
                 "slow_query_logging": { "type": "bool", "required": true },
                 "innodb_buffer_pool_size": { "type": "int", "required": true },
+                "innodb_flush_log_at_trx_commit": { "type": "int", "required": true },
+                "innodb_buffer_pool_instances": { "type": "int", "required": true },
                 "max_connections": { "type": "int", "required": true },
                 "tmp_table_size": { "type": "int", "required": true },
                 "max_heap_table_size": { "type": "int", "required": true },
                 "expire_logs_days": { "type": "int", "required": true },
                 "bootstrap_timeout": { "type": "int", "required": true },
+                "wsrep_slave_threads": { "type": "int", "required": true },
                 "ssl": {
                   "type": "map", "required": true, "mapping": {
                     "enabled": { "type": "bool", "required": true },


### PR DESCRIPTION
mysqltuner suggests some configuration changes for better performance,
but they might not be best for everyone. So we add new proposal
variables for the users to tune the config.

- InnoDB flush log at each commit might be disabled.
- For wsrep_slave_threads, documentation says
  "as a rough guideline consider using twice the number of CPU cores"
  but that might not make sense for single writer setup we're offering.
  So let's keep the default and let user decide
- gcs.limit should be equal to 5 * wsrep_slave_threads (mysqltuner.pl)
- skip_name_resolve to avoid DNS resolution on connection.

(cherry picked from commit cf8ff9d8cf78439b371c37f1994bd762e137e336)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1410