### PR TITLE
[4.0] nova: Fix issues related to the use of skip_unchanged_nodes

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -266,7 +266,6 @@ class NovaService < OpenstackServiceObject
 
   def apply_role_pre_chef_call(old_role, role, all_nodes)
     @logger.debug("Nova apply_role_pre_chef_call: entering #{all_nodes.inspect}")
-    return if all_nodes.empty?
 
     unless hyperv_available?
       role.override_attributes["nova"]["elements"]["nova-compute-hyperv"] = []

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -272,7 +272,12 @@ class NovaService < OpenstackServiceObject
     end
 
     controller_elements, controller_nodes, ha_enabled = role_expand_elements(role, "nova-controller")
-    reset_sync_marks_on_clusters_founders(controller_elements)
+    # Only reset sync marks if we are really applying on all controller nodes;
+    # if we are not, then we clearly do not intend to have some sync between
+    # them during the chef run
+    if Set.new(controller_nodes & all_nodes) == Set.new(controller_nodes)
+      reset_sync_marks_on_clusters_founders(controller_elements)
+    end
     Openstack::HA.set_controller_role(controller_nodes) if ha_enabled
 
     vip_networks = ["admin", "public"]


### PR DESCRIPTION
**nova: Fix apply with skip_unchanged_nodes**
When there's absolutely no node impacted by the "apply" thanks to
skip_unchanged_nodes, then we hit some old micro-optimization in
apply_role_pre_chef_call that was not intended to be used that way: we
skip the whole method.

Unfortunately, we do need to run the method even with
skip_unchanged_nodes because we need to ensure that attributes, like the
HA related ones, are set.

**nova: Do not reset sync marks uselessly with skip_unchanged_nodes**
If skip_unchanged_nodes results in some control nodes to be skipped,
then we don't want to reset the sync marks as we will not run chef
through the apply. If we do the reset, then we will rely on periodic
chef runs to set the sync marks, which will take time to converge as
there's no guarantee that the periodic chef runs on the control nodes
are happening at the same time.

Backport of https://github.com/crowbar/crowbar-openstack/pull/1459