### PR TITLE
[4.0] postgresql/rabbitmq: Fix drbd setup to monitor master and slaves

### DIFF
--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -75,10 +75,16 @@ if node[:database][:ha][:storage][:mode] == "drbd"
   drbd_params = {}
   drbd_params["drbd_resource"] = drbd_resource
 
+  drbd_op = {}
+  drbd_op["monitor"] = [
+    { "interval" => "15s" },
+    { "interval" => "10s", "role" => "Master" }
+  ]
+
   pacemaker_primitive drbd_primitive do
     agent "ocf:linbit:drbd"
     params drbd_params
-    op postgres_op
+    op drbd_op
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end

--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -103,10 +103,16 @@ if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
   drbd_params = {}
   drbd_params["drbd_resource"] = drbd_resource
 
+  drbd_op = {}
+  drbd_op["monitor"] = [
+    { "interval" => "15s" },
+    { "interval" => "10s", "role" => "Master" }
+  ]
+
   pacemaker_primitive drbd_primitive do
     agent "ocf:linbit:drbd"
     params drbd_params
-    op rabbitmq_op
+    op drbd_op
     action :update
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end


### PR DESCRIPTION
As explained in [1][2], we need to set a different monitor interval for the
slaves and the master, otherwise one of them won't be monitored.

[1] https://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/_monitoring_multi_state_resources.html
[2] https://www.linbit.com/en/drbd-monitor-intervals/

Requires https://github.com/crowbar/crowbar-ha/pull/283

Backport of https://github.com/crowbar/crowbar-openstack/pull/1464