### PR TITLE
[4.0] rabbitmq: Improvements for clustered HA

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -48,8 +48,11 @@ default[:rabbitmq][:ha][:storage][:mode] = nil
 default[:rabbitmq][:ha][:op][:start][:timeout] = "300s"
 default[:rabbitmq][:ha][:op][:promote][:timeout] = "180s"
 default[:rabbitmq][:ha][:op][:monitor][:interval] = "10s"
-default[:rabbitmq][:ha][:clustered_op][:start][:timeout] = "300s"
-default[:rabbitmq][:ha][:clustered_op][:promote][:timeout] = "180s"
+default[:rabbitmq][:ha][:clustered_op][:start][:timeout] = "360s"
+default[:rabbitmq][:ha][:clustered_op][:stop][:timeout] = "120s"
+default[:rabbitmq][:ha][:clustered_op][:promote][:timeout] = "120s"
+default[:rabbitmq][:ha][:clustered_op][:demote][:timeout] = "120s"
+default[:rabbitmq][:ha][:clustered_op][:notify][:timeout] = "180s"
 default[:rabbitmq][:ha][:clustered_op][:monitor] = [
-  { interval: "10s" }, { interval: "11s", role: "Master" }
+  { interval: "30s" }, { interval: "27s", role: "Master" }
 ]

--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -48,3 +48,8 @@ default[:rabbitmq][:ha][:storage][:mode] = nil
 default[:rabbitmq][:ha][:op][:start][:timeout] = "300s"
 default[:rabbitmq][:ha][:op][:promote][:timeout] = "180s"
 default[:rabbitmq][:ha][:op][:monitor][:interval] = "10s"
+default[:rabbitmq][:ha][:clustered_op][:start][:timeout] = "300s"
+default[:rabbitmq][:ha][:clustered_op][:promote][:timeout] = "180s"
+default[:rabbitmq][:ha][:clustered_op][:monitor] = [
+  { interval: "10s" }, { interval: "11s", role: "Master" }
+]

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -58,7 +58,7 @@ pacemaker_primitive service_name do
     "rmq_feature_local_list_queues" => false,
     "default_vhost" => node[:rabbitmq][:vhost]
   })
-  op node[:rabbitmq][:ha][:op]
+  op node[:rabbitmq][:ha][:clustered_op]
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -59,6 +59,11 @@ pacemaker_primitive service_name do
     "default_vhost" => node[:rabbitmq][:vhost]
   })
   op node[:rabbitmq][:ha][:clustered_op]
+  meta ({
+    "migration-threshold" => "10",
+    "failure-timeout" => "30s",
+    "resource-stickiness" => "100"
+  })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end


### PR DESCRIPTION
First commit ensures that we monitor both the master and the slaves.

Second commit adjusts the resource configuration to match what is documented upstream.

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1463