### PR TITLE
rabbitmq: allow to add extra users to rabbit

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -67,7 +67,8 @@ template "/etc/rabbitmq/definitions.json" do
     json_trove_user: node[:rabbitmq][:trove][:user].to_json,
     json_trove_password: node[:rabbitmq][:trove][:password].to_json,
     json_trove_vhost: node[:rabbitmq][:trove][:vhost].to_json,
-    ha_all_policy: cluster_enabled
+    ha_all_policy: cluster_enabled,
+    extra_users: node[:rabbitmq][:users]
   )
   # no notification to restart rabbitmq, as we still do changes with
   # rabbitmqctl in the rabbit.rb recipe (this is less disruptive)

--- a/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
@@ -34,6 +34,13 @@
             "tags": ""
         },
 <% end -%>
+<% @extra_users.each do |user, pass| -%>
+        {
+            "name": "<%= user %>",
+            "password": "<%= pass %>",
+            "tags": ""
+        },
+<% end -%>
         {
             "name": <%= @json_user %>,
             "password": <%= @json_password %>,
@@ -49,6 +56,15 @@
             "read": ".*",
             "write": ".*"
         },
+<% end -%>
+<% @extra_users.each do |user, pass| -%>
+        {
+          "user": <%= user %>,
+          "vhost": <%= @json_vhost %>,
+          "configure": ".*",
+          "read": ".*",
+          "write": ".*"
+        }
 <% end -%>
         {
             "user": <%= @json_user %>,

--- a/chef/data_bags/crowbar/migrate/rabbitmq/202_add_extra_users.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/202_add_extra_users.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["extra_users"] = ta["extra_users"] unless a["extra_users"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("extra_users") unless ta.key?("extra_users")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -46,7 +46,8 @@
         "rabbitmq-server": {
           "LimitNOFILE": null
         }
-      }
+      },
+      "extra_users": [ ]
     }
   },
   "deployment": {

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -87,6 +87,11 @@
                   "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
                 }
               }
+            },
+            "extra_users": {
+              "type": "seq",
+              "required": false,
+              "sequence": [ { "type": "str" } ]
             }
           }
         }

--- a/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
@@ -6,6 +6,9 @@
     = string_field :vhost
     = integer_field :port
     = string_field :user
+    = array_string_field :extra_users, :only_comma => true
+    %span.help-block
+      = t('.extra_users_hint')
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/rabbitmq/en.yml
+++ b/crowbar_framework/config/locales/rabbitmq/en.yml
@@ -48,6 +48,8 @@ en:
               device: 'Name of Block Device or NFS Mount Specification'
               fstype: 'Filesystem Type'
               options: 'Mount Options'
+        extra_users: 'Extra users to create.'
+        extra_users_hint: 'A comma-separated list of extra users to create. This users will have all privileges for the default vhost and will be tagged as management.'
       validation:
         unknown_mode: 'Unknown mode for HA storage: %{storage_mode}.'
         no_device: 'No device specified for shared storage.'


### PR DESCRIPTION
with the introduction of the definitions file it looks like
rabbit will disregard any existing users when restarting,
using the defintions file as the blank slate to start from.

This gets in the middle of having any extra users for other
tasks like monitoring and there is no mechanism to add users.

This PR adds an extra field to crowbar to add a list of users
that will get written into the definitions file, allowing
us to specify extra users to be created