### PR TITLE
galera: raise haproxy limit depending on max_connections (bsc#1068962)

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -334,6 +334,8 @@ haproxy_loadbalancer "galera" do
   address CrowbarPacemakerHelper.cluster_vip(node, "admin")
   port 3306
   mode "tcp"
+  # leave some room for pacemaker health checks
+  max_connections node[:database][:mysql][:max_connections] - 10
   options ["httpchk"]
   default_server "port 5555"
   stick ({ "on" => "dst" })


### PR DESCRIPTION
Without this, haproxy is always limiting us to 1000 connections, not
exposing the full capabilities if db connections is set to 1000. Also
if db connections is set  < 1000, this allows the openstack services
to exceed the number of db connections, causing db healthcheck to fail
and pacemaker to go nuts. always reserve some spare connections
to avoid this from happening.

Requires https://github.com/crowbar/crowbar-ha/pull/279 to be merged first.