### PR TITLE
rabbitmq: remove slash from default vhost

### DIFF
--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -7,7 +7,7 @@
       "port": 5672,
       "password": "",
       "user": "nova",
-      "vhost": "/nova",
+      "vhost": "nova",
       "ssl": {
         "enabled": false,
         "port": 5671,
@@ -40,7 +40,7 @@
         "enabled": false,
         "password": "",
         "user": "trove",
-        "vhost": "/trove"
+        "vhost": "trove"
       },
       "resource_limits": {
         "rabbitmq-server": {


### PR DESCRIPTION
For some reason we set the default vhost for rabbit to
contain a slash. Its not that its worng but it makes no sense
to include a slash in the name and it makes it seem like the
slash is required for a vhost, but its not. Plus we end up with
rabbit urls with 2 slashes at the end wich further confuses
the proper way of writing them (i.e. guest:guest@IP:5672//nova)

So this sets the normal name minus slash to the nova+trove vhosts