### PR TITLE
rabbitmq: Change default HA to non-clustered

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -82,6 +82,7 @@ usermod -u #{static_uid} -g #{static_gid} rabbitmq;
 chown -R rabbitmq:rabbitmq /var/lib/rabbitmq;
 chown rabbitmq:rabbitmq /var/run/rabbitmq /var/log/rabbitmq;
 chown rabbitmq:rabbitmq /var/run/rabbitmq/pid /var/log/rabbitmq/*.log* || :;
+chgrp rabbitmq /etc/rabbitmq/definitions.json;
 EOC
   # Make any error in the commands fatal
   flags "-e"

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -22,7 +22,7 @@
       "client": {
         "heartbeat_timeout": 10
       },
-      "cluster": true,
+      "cluster": false,
       "ha": {
         "storage": {
           "mode": "shared",


### PR DESCRIPTION
While there's been quite some work on the clustered rabbitmq, it is
safer to keep the default with the old non-clustered way of doing HA for 
the stable branch.

People can still enable the feature if desired.