### PR TITLE
keystone: Sync fernet keys when joining cluster

### DIFF
--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -71,3 +71,26 @@ if node[:keystone][:frontend] == "apache" && node[:pacemaker][:clone_stateless_s
 
   crowbar_pacemaker_sync_mark "create-keystone_ha_resources"
 end
+
+template "/usr/bin/keystone-fernet-keys-sync.sh" do
+  source "keystone-fernet-keys-sync.sh"
+  owner "root"
+  group "root"
+  mode "0755"
+end
+
+# handler scripts are run by hacluster user so sudo configuration is needed
+# if the handler needs to rsync to other nodes using root's keys
+template "/etc/sudoers.d/keystone-fernet-keys-sync" do
+  source "hacluster_sudoers.erb"
+  owner "root"
+  group "root"
+  mode "0440"
+end
+
+# on founder: create/delete pacemaker alert
+pacemaker_alert "keystone-fernet-keys-sync" do
+  handler "/usr/bin/keystone-fernet-keys-sync.sh"
+  action node[:keystone][:token_format] == "fernet" ? :create : :delete
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -384,15 +384,21 @@ if node[:keystone][:token_format] == "fernet"
   # To be sure that rsync package is installed
   package "rsync"
   crowbar_pacemaker_sync_mark "sync-keystone_install_rsync" if ha_enabled
+
+  template "/usr/bin/keystone-fernet-keys-push.sh" do
+    source "keystone-fernet-keys-push.sh"
+    owner "root"
+    group "root"
+    mode "0755"
+  end
+
   rsync_command = ""
   if ha_enabled
     cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node)
     cluster_nodes.map do |n|
       next if node.name == n.name
       node_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
-      rsync_command += \
-        "rsync -a --timeout=300 --delete-after /etc/keystone/fernet-keys " \
-        "#{node_address}:/etc/keystone/; "
+      rsync_command += "/usr/bin/keystone-fernet-keys-push.sh #{node_address}; "
     end
     raise "No other cluster members found" if rsync_command.empty?
   end

--- a/chef/cookbooks/keystone/templates/default/hacluster_sudoers.erb
+++ b/chef/cookbooks/keystone/templates/default/hacluster_sudoers.erb
@@ -1,0 +1,3 @@
+Defaults:hacluster !requiretty
+
+hacluster ALL = (root) NOPASSWD: /usr/bin/keystone-fernet-keys-push.sh

--- a/chef/cookbooks/keystone/templates/default/keystone-fernet-keys-push.sh
+++ b/chef/cookbooks/keystone/templates/default/keystone-fernet-keys-push.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+TARGETNODE=$1
+shift
+RSYNC_ARGS=$@
+test -z "$TARGETNODE" && { echo "usage: $0 <node-address> [extra rsync args]"; exit 1; }
+rsync -a --timeout=300 --delete-after $RSYNC_ARGS /etc/keystone/fernet-keys $TARGETNODE:/etc/keystone/

--- a/chef/cookbooks/keystone/templates/default/keystone-fernet-keys-sync.sh
+++ b/chef/cookbooks/keystone/templates/default/keystone-fernet-keys-sync.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+if [ -z "$CRM_alert_version" ]; then
+    echo "$0 must be run by Pacemaker version 1.1.15 or later"
+    exit 0
+fi
+
+# skip if alert is not triggered by node joining event
+[ "$CRM_alert_kind" = "node" -a "$CRM_alert_desc" = "member" ] || exit 0
+
+myname=$(uname -n)
+
+# skip if triggered on the re-joining node itself
+[ "$CRM_alert_node" = "$myname" ] && exit 0
+
+# sleep some random time (0-10s) to avoid all nodes hitting the new one at the same time
+sleep $(( $RANDOM % 11 ))
+
+# push keys to the joining node
+sudo /usr/bin/keystone-fernet-keys-push.sh $CRM_alert_node --ignore-existing


### PR DESCRIPTION
Newly (re)installed node will not have fernet keys causing failure
when starting keystone services. Cluster founder rotates the keys
and pushes new ones to cluster member on a regular basis.

This change creates pacemaker alert to notify founder about new node.
Keys are then pushed from founder to the node.

Preconditions:
~~https://github.com/crowbar/crowbar-core/pull/1451~~
~~https://github.com/crowbar/crowbar-ha/pull/285~~
~~https://github.com/crowbar/crowbar-ha/pull/284~~
~~https://github.com/crowbar/crowbar-ha/pull/287~~