### PR TITLE
rabbitmq: Use pause_minority setting to deal with partitions better

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -24,6 +24,16 @@ cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
 crm_resource_stop_cmd = cluster_enabled ? "force-demote" : "force-stop"
 crm_resource_start_cmd = cluster_enabled ? "force-promote" : "force-start"
 
+cluster_partition_handling = if cluster_enabled
+  if CrowbarPacemakerHelper.num_corosync_nodes(node) > 2
+    "pause_minority"
+  else
+    "ignore"
+  end
+else
+  "unused"
+end
+
 package "rabbitmq-server"
 package "rabbitmq-server-plugins" if node[:platform_family] == "suse"
 
@@ -47,6 +57,10 @@ template "/etc/rabbitmq/rabbitmq.config" do
   owner "root"
   group "root"
   mode 0644
+  variables(
+    cluster_enabled: cluster_enabled,
+    cluster_partition_handling: cluster_partition_handling
+  )
   notifies :restart, "service[rabbitmq-server]"
 end
 

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -20,6 +20,9 @@
                  {certfile, "<%= node[:rabbitmq][:ssl][:certfile] %>"},
                  {keyfile, "<%= node[:rabbitmq][:ssl][:keyfile] %>"}]},
 <% end -%>
+<% if @cluster_enabled -%>
+   {cluster_partition_handling, <%= @cluster_partition_handling %>},
+<% end -%>
    {disk_free_limit, 50000000}
  ]},
  {rabbitmq_management,


### PR DESCRIPTION
We do care about data integrity, and the default setting is "ignore"
which can result in inconsistencies when the partition is over.

For two-node clusters, it could be argued that this wouldn't work nicely
as this more or less means that as soon as there's a partition, rabbitmq
stop working. But pacemaker should help here (with the fencing) and it's
really better to fail than to have inconsistencies later on.

See https://www.rabbitmq.com/partitions.html for more details