### PR TITLE
Add *.log file for apache logrotate(bsc#1071317)

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -181,6 +181,13 @@ elsif node[:keystone][:frontend] == "apache"
   apache_site "keystone-admin.conf" do
     enable true
   end
+
+  template "/etc/logrotate.d/apache2-all" do
+    source "apache.logrotate.erb"
+    mode 0o644
+    owner "root"
+    group "root"
+  end
 end
 
 db_settings = fetch_database_settings

--- a/chef/cookbooks/keystone/templates/default/apache.logrotate.erb
+++ b/chef/cookbooks/keystone/templates/default/apache.logrotate.erb
@@ -1,0 +1,13 @@
+/var/log/apache2/*.log {
+    compress
+    dateext
+    maxage 365
+    rotate 99
+    size=+4096k
+    notifempty
+    missingok
+    create 644 root root
+    postrotate
+     /etc/init.d/apache2 reload
+    endscript
+}


### PR DESCRIPTION
Currently only the apache access and error logs are rotated by logrotate but /var/log/apache
also contains access and error logs from keystone, ceilometer, barbican and other services which
are not rotated. This adds another file whichh rotates all the log files in the apache directory.