### PR TITLE
[4.0] rabbitmq: Use pause_minority setting to deal with partitions better

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -20,6 +20,9 @@
                  {certfile, "<%= node[:rabbitmq][:ssl][:certfile] %>"},
                  {keyfile, "<%= node[:rabbitmq][:ssl][:keyfile] %>"}]},
 <% end -%>
+<% if @cluster_enabled -%>
+   {cluster_partition_handling, <%= @cluster_partition_handling %>},
+<% end -%>
    {disk_free_limit, 50000000}
  ]},
  {rabbitmq_management,


### PR DESCRIPTION
We do care about data integrity, and the default setting is "ignore"
which can result in inconsistencies when the partition is over.

For two-node clusters, "pause_minority" doesn't work as it would require
the two nodes to always be up, which prevents any maintenance on a node.
But pacemaker should help here (with the fencing), so we keep the default
behavior and we don't add any safety net at the rabbitmq level.

See https://www.rabbitmq.com/partitions.html for more details

(cherry picked from commit a4aaeccc1ffcf480dcde14ccd1b430e1621e6f98)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1477