### PR TITLE
[4.0] nova: Fix problem with log permissions

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -87,7 +87,7 @@ execute "nova-manage db sync up to revision 329" do
   only_if do
     !node[:nova][:db_synced] &&
       (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
-      (`nova-manage db version`.to_i < 329)
+      (`nova-manage --log-file /dev/null db version`.to_i < 329)
   end
 end
 
@@ -102,7 +102,7 @@ execute "nova-manage db online_data_migrations" do
   only_if do
     !node[:nova][:db_synced] &&
       (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
-      (`nova-manage db version`.to_i == 329)
+      (`nova-manage --log-file /dev/null db version`.to_i == 329)
   end
 end
 


### PR DESCRIPTION
`nova-manage db version` in chef's condition is run as root and
touches /var/log/nova/nova-manage.log. With --log-file argument it
will not do it and save us some permission problems.

(cherry picked from commit b373cefdc0072ffc2756f58172a81e4f0ea66b79)

backport of #1481 