### PR TITLE
[4.0] rabbit: add mnesia dump log config

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -1,4 +1,10 @@
 [
+ {mnesia,
+  [
+   {dump_log_write_threshold, <%= node[:rabbitmq][:mnesia][:dump_log_write_threshold] %>},
+   {dump_log_time_threshold, <%= node[:rabbitmq][:mnesia][:dump_log_time_threshold] %>}
+  ]
+ },
  {rabbit,
   [
    {tcp_listeners, [

--- a/chef/data_bags/crowbar/migrate/rabbitmq/104_add_mnesia_dump_log.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/104_add_mnesia_dump_log.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["mnesia"] = ta["mnesia"] unless a["mnesia"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("mnesia") unless ta.key?("mnesia")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -46,6 +46,10 @@
         "rabbitmq-server": {
           "LimitNOFILE": null
         }
+      },
+      "mnesia": {
+        "dump_log_write_threshold": 100,
+        "dump_log_time_threshold": 180000
       }
     }
   },
@@ -53,7 +57,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 103,
+      "schema-revision": 104,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -87,6 +87,14 @@
                   "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
                 }
               }
+            },
+            "mnesia": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "dump_log_write_threshold": { "type": "int", "required": true},
+                "dump_log_time_threshold": { "type": "int", "required": true}
+              }
             }
           }
         }


### PR DESCRIPTION
As shown on big deployments, we sometimes get the warning
that mnesia is overloaded. This usually occurs when we are
dumping the log too fast and mnesia is receiving too many
messages so it cant catch up.

To fix this, we should increase the number of writes to the
transaction log before a dump is done (default is 100).
Together with this we also want to configure the maximum dump
log interval, in case the write treshold is set too high, this
will trigger a dump every X milliseconds, so we can be sure
that we are not losing anything if there is a period of low
writes or the treshold is set to high (default is 3 minutes)

Increasing the write treshold and reducing a bit the dump time
should help with mnesia being overloaded and prevent any
unintended consecuences from the overload.

(cherry picked from commit fb627e670737b6d103a3d487f907e0b47b585618)
Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1480