### PR TITLE
[4.0] keystone: Sync fernet keys when joining cluster

### DIFF
--- a/chef/cookbooks/keystone/templates/default/hacluster_sudoers.erb
+++ b/chef/cookbooks/keystone/templates/default/hacluster_sudoers.erb
@@ -1,0 +1,3 @@
+Defaults:hacluster !requiretty
+
+hacluster ALL = (root) NOPASSWD: /usr/bin/keystone-fernet-keys-push.sh

--- a/chef/cookbooks/keystone/templates/default/keystone-fernet-keys-push.sh
+++ b/chef/cookbooks/keystone/templates/default/keystone-fernet-keys-push.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+TARGETNODE=$1
+shift
+RSYNC_ARGS=$@
+test -z "$TARGETNODE" && { echo "usage: $0 <node-address> [extra rsync args]"; exit 1; }
+rsync -a --timeout=300 --delete-after $RSYNC_ARGS /etc/keystone/fernet-keys $TARGETNODE:/etc/keystone/

--- a/chef/cookbooks/keystone/templates/default/keystone-fernet-keys-sync.sh
+++ b/chef/cookbooks/keystone/templates/default/keystone-fernet-keys-sync.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+if [ -z "$CRM_alert_version" ]; then
+    echo "$0 must be run by Pacemaker version 1.1.15 or later"
+    exit 0
+fi
+
+# skip if alert is not triggered by node joining event
+[ "$CRM_alert_kind" = "node" -a "$CRM_alert_desc" = "member" ] || exit 0
+
+myname=$(uname -n)
+
+# skip if triggered on the re-joining node itself
+[ "$CRM_alert_node" = "$myname" ] && exit 0
+
+# sleep some random time (0-10s) to avoid all nodes hitting the new one at the same time
+sleep $(( $RANDOM % 11 ))
+
+# push keys to the joining node
+sudo /usr/bin/keystone-fernet-keys-push.sh $CRM_alert_node --ignore-existing


### PR DESCRIPTION
Newly (re)installed node will not have fernet keys causing failure
when starting keystone services. Cluster founder rotates the keys
and pushes new ones to cluster member on a regular basis.

This change creates pacemaker alert to notify all nodes about about
new member. Keys are then pushed to the new node from all other nodes
to the new node (with some random time offset).

not cherry-picked directly because of different attribute schema around `token_format`.

backport of #1474 

Preconditions:
https://github.com/crowbar/crowbar-core/pull/1457
https://github.com/crowbar/crowbar-ha/pull/288
https://github.com/crowbar/crowbar-ha/pull/289