### PR TITLE
[4.0] horizon: use Grafana 4

### DIFF
--- a/chef/cookbooks/horizon/files/default/grafana-monasca.json
+++ b/chef/cookbooks/horizon/files/default/grafana-monasca.json
@@ -1,4822 +1,6026 @@
 {
-  "id": "sid-14393838984416185642089112666",
-  "title": "SUSE OpenStack Cloud Monitoring",
-  "originalTitle": "SUSE OpenStack Cloud Monitoring",
-  "tags": [],
-  "style": "dark",
-  "timezone": "utc",
-  "editable": true,
-  "hideControls": false,
-  "sharedCrosshair": false,
-  "rows": [
+  "__requires": [
     {
-      "title": "Monasca Health - metrics",
-      "height": "100px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "Metrics API",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 19,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "component",
-              "condition_value": "monasca-api"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "9",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "10",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "11",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "12",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "0.0,0.2,1.0",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Threshold Engine",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 44,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-thresh"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Persister",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 21,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "component",
-              "condition_value": "monasca-persister"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Metrics DB",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 51,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "influxd"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Notification Engine",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 42,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-notification"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        }
-      ],
-      "showTitle": true
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.1.0"
     },
     {
-      "title": "Monasca Health - Logs",
-      "height": "100px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "Log API",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 20,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "component",
-              "condition_value": "monasca-log-api"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Log Transformer",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 54,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-transformer"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Log Metrics",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 102,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-metrics"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Log Persister",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 53,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-persister"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Log DB",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 33,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "elasticsearch.cluster_status",
-              "condition_filter": true,
-              "condition_key": "",
-              "condition_value": ""
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "9",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Kibana",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 22,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "component",
-              "condition_value": "kibana"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        }
-      ],
-      "showTitle": true
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
     },
     {
-      "title": "Monasca Health - Common",
-      "height": "100px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "Kafka",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 38,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "kafka.Kafka"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "ZooKeeper",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 48,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "org.apache.zookeeper.server"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Storm - Nimbus",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 52,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "storm.daemon.nimbus"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "Storm - Supervisor",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 55,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "storm.daemon.supervisor"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        },
-        {
-          "title": "MariaDB",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 66,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "mysqld"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "1",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "0",
-              "op": "=",
-              "text": "DOWN"
-            },
-            {
-              "value": "2",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "3",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "4",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "5",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "6",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "7",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "8",
-              "op": "=",
-              "text": "UP"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(225, 40, 40, 0.59)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(71, 212, 59, 0.4)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          }
-        }
-      ],
-      "showTitle": true
+      "type": "datasource",
+      "id": "monasca-datasource",
+      "name": "Monasca",
+      "version": "1.0.0"
     },
     {
-      "title": "System resources",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 23,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": 100,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "cpu.percent",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "cpu.user_perc",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "cpu.system_perc",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "cpu.wait_perc",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Memory usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 24,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "mem.total_mb",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "mem.used_mb",
-              "period": "",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "mem.swap_total_mb",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "mem.swap_used_mb",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "mem.used_cache",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "Disk usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 25,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": 100,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "disk.space_used_perc",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "System load",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 26,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "load.avg_1_min",
-              "period": "",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Network Monitoring",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "Network usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 61,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "bps",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "net.in_bytes_sec",
-              "merge": true,
-              "dimensions": "",
-              "period": "",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "net.out_bytes_sec",
-              "merge": true,
-              "dimensions": "",
-              "period": "",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "monitoring"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Metrics API",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 63,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-api"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 64,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-api"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 65,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-api"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Threshold Engine",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 73,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-thresh"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 74,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-thresh"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 95,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "storm.daemon.nimbus"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "period": "",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "storm.daemon.supervisor"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "storm.daemon.worker"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Persister",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 67,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-persister"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 68,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-persister"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 69,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-persister"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Metrics DB",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 76,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "influxd"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 77,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "influxd"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 78,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "influxd"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Notification Engine",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 70,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-notification"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 71,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-notification"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 72,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-notification"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Log API",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 79,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-api"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 80,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-api"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 81,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-api"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Processing time",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 103,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "s",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "monasca.log.processing_time_ms"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Publish time",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 104,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "s",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "monasca.log.publish_time_ms"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": ""
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Log Transformer",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 85,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-transformer"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 86,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-transformer"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 87,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-transformer"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Log Metrics",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 105,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-metrics"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 106,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-metrics"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 107,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-metrics"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Log Persister",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 82,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-persister"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 83,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-persister"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 84,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "monasca-log-persister"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Log DB",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "Storage size",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 31,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "bytes",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "null",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "elasticsearch.store.size"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Open file descriptors",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 56,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "elasticsearch.process.open_fd",
-              "condition_filter": true,
-              "condition_key": ""
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Kibana",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "Response time",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 36,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "ms",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "kibana.resp_time_avg_ms"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "kibana.resp_time_max_ms"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Requests per second",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 37,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "kibana.req_sec"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "Kafka",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 60,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "kafka.Kafka"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 59,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "kafka.Kafka"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "leftYAxisLabel": "MB",
-          "links": []
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 89,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "kafka.Kafka"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Consumer lag",
-          "error": false,
-          "span": 12,
-          "editable": true,
-          "type": "graph",
-          "id": 58,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "kafka.consumer_lag"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "ZooKeeper",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 90,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "org.apache.zookeeper.server"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 91,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "org.apache.zookeeper.server"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 92,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "org.apache.zookeeper.server"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Outstanding bytes",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 57,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "zookeeper.outstanding_bytes"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Connections count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 49,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "zookeeper.connections_count"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Timings",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 47,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "s",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "zookeeper.avg_latency_sec"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "zookeeper.max_latency_sec"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "zookeeper.min_latency_sec"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    },
-    {
-      "title": "MariaDB",
-      "height": "250px",
-      "editable": true,
-      "collapse": true,
-      "panels": [
-        {
-          "title": "CPU usage",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 96,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.cpu_perc",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "mysqld"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "Allocated memory",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 97,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.mem.rss_mbytes",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "mysqld"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "PID count",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "id": 98,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "process.pid_count",
-              "condition_filter": true,
-              "condition_key": "process_name",
-              "condition_value": "mysqld"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
+      "type": "panel",
+      "id": "natel-discrete-panel",
+      "name": "Discrete",
+      "version": "0.0.6"
     }
   ],
-  "nav": [
-    {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
-    }
-  ],
-  "time": {
-    "from": "now-1h",
-    "to": "now"
-  },
-  "templating": {
-    "list": [],
-    "enable": false
-  },
   "annotations": {
     "enable": false,
     "list": []
   },
-  "refresh": "30s",
-  "version": 6,
-  "hideAllLegends": false
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": "100px",
+      "panels": [
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "height": "",
+          "highlightOnMouseover": true,
+          "id": 109,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 25,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "component",
+                  "value": "monasca-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Metrics API",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 108,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-thresh"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Threshold Engine",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 110,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "component",
+                  "value": "monasca-persister"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Persister",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 111,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "influxd"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Metrics DB",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 112,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-notification"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Notification Engine",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Monasca Health - metrics",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "100px",
+      "panels": [
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 115,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "component",
+                  "value": "monasca-log-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Log API",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 116,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-transformer"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Log Transformer",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 117,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-metrics"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Log Metrics",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 118,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-persister"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Log Persister",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 119,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "elasticsearch.cluster_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Log DB",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "",
+              "value": ""
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 120,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "component",
+                  "value": "kibana"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Kibana",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Monasca Health - Logs",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "100px",
+      "panels": [
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 121,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "kafka.Kafka"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Kafka",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 122,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "org.apache.zookeeper.server"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Zookeeper",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 123,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "storm.daemon.nimbus"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Storm - Nimbus",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 124,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "storm.daemon.supervisor"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Storm - Supervisor",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 125,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "mysqld"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "MariaDB",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Monasca Health - Common",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 23,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "cpu.percent",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "cpu.user_perc",
+              "period": "300",
+              "refId": "B",
+              "series": "cpu.user_perc",
+              "target": ""
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "cpu.system_perc",
+              "period": "300",
+              "refId": "C",
+              "series": "cpu.system_perc",
+              "target": ""
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "cpu.wait_perc",
+              "period": "300",
+              "refId": "D",
+              "series": "cpu.wait_perc",
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 24,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "group": false,
+              "hide": false,
+              "metric": "mem.total_mb",
+              "period": "300",
+              "refId": "A",
+              "series": "mem.total_mb"
+            },
+            {
+              "aggregator": "none",
+              "alias": "",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.used_mb",
+              "period": "300",
+              "refId": "B",
+              "series": "mem.used_mb",
+              "target": ""
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.swap_total_mb",
+              "period": "300",
+              "refId": "C",
+              "series": "mem.swap_total_mb",
+              "target": ""
+            },
+            {
+              "aggregator": "avg",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.swap_used_mb",
+              "period": "300",
+              "refId": "D",
+              "series": "mem.swap_used_mb",
+              "target": ""
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.used_cache",
+              "period": "300",
+              "refId": "E",
+              "series": "mem.used_cache",
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Memory usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 25,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "disk.space_used_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "disk.space_used_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Disk usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 26,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "load.avg_1_min",
+              "period": "300",
+              "refId": "A",
+              "series": "load.avg_1_min"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "System load",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "System resources",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 61,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "merge": true,
+              "metric": "net.in_bytes_sec",
+              "period": "300",
+              "refId": "A",
+              "series": "net.in_bytes_sec"
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "service",
+              "condition_value": "monitoring",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "monitoring"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "merge": true,
+              "metric": "net.out_bytes_sec",
+              "period": "300",
+              "refId": "B",
+              "series": "net.out_bytes_sec",
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Network usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bps",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Network Monitoring",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 63,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-api",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-api"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 64,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-api",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-api"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 65,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-api",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-api"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Metrics API",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 73,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-thresh",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-thresh"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 74,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-thresh",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-thresh"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 95,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@process_name",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "storm.daemon.nimbus",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "storm.daemon.nimbus"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            },
+            {
+              "aggregator": "none",
+              "alias": "@process_name",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "storm.daemon.supervisor",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "storm.daemon.supervisor"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "B",
+              "series": "process.pid_count",
+              "target": ""
+            },
+            {
+              "aggregator": "none",
+              "alias": "@process_name",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "storm.daemon.worker",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "storm.daemon.worker"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "C",
+              "series": "process.pid_count",
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Threshold Engine",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 67,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-persister",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-persister"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 68,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-persister",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-persister"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 69,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-persister",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-persister"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Persister",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 76,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "influxd",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "influxd"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 77,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "influxd",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "influxd"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 78,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "influxd",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "influxd"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Metrics DB",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 70,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-notification",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-notification"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 71,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-notification",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-notification"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 72,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-notification",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-notification"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Notification Engine",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 79,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-api",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-api"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 80,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-api",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-api"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 81,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-api",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "monasca.log.processing_time_ms",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 103,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "monasca.log.processing_time_ms",
+              "period": "300",
+              "refId": "A",
+              "series": "monasca.log.processing_time_ms"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Processing time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 104,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "monasca.log.publish_time_ms",
+              "period": "300",
+              "refId": "A",
+              "series": "monasca.log.publish_time_ms"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Publish time",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": "",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Log API",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 85,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-transformer",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-transformer"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 86,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-transformer",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-transformer"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 87,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-transformer",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-transformer"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Log Transformer",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 105,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-metrics",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-metrics"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 106,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "avg",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-metrics",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-metrics"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 107,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-metrics",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-metrics"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Log Metrics",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 82,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-persister",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-persister"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 83,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-persister",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-persister"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 84,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "monasca-log-persister",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "monasca-log-persister"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Log Persister",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 31,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "elasticsearch.store.size",
+              "period": "300",
+              "refId": "A",
+              "series": "elasticsearch.store.size"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Storage size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 56,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "elasticsearch.process.open_fd",
+              "period": "300",
+              "refId": "A",
+              "series": "elasticsearch.process.open_fd"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Open file descriptors",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Log DB",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 36,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "kibana.resp_time_avg_ms",
+              "period": "300",
+              "refId": "A",
+              "series": "kibana.resp_time_avg_ms"
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "kibana.resp_time_max_ms",
+              "period": "300",
+              "refId": "B",
+              "series": "kibana.resp_time_max_ms",
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Response time",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 37,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "kibana.req_sec",
+              "period": "300",
+              "refId": "A",
+              "series": "kibana.req_sec"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Requests per second",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Kibana",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 60,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "kafka.Kafka",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "kafka.Kafka"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 59,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "kafka.Kafka",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "kafka.Kafka"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 89,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "kafka.Kafka",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "kafka.Kafka"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 58,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "kafka.consumer_lag",
+              "period": "300",
+              "refId": "A",
+              "series": "kafka.consumer_lag"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Consumer lag",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Kafka",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 90,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "org.apache.zookeeper.server",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "org.apache.zookeeper.server"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 91,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "org.apache.zookeeper.server",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "org.apache.zookeeper.server"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 92,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "org.apache.zookeeper.server",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "org.apache.zookeeper.server"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 57,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "zookeeper.outstanding_bytes",
+              "period": "300",
+              "refId": "A",
+              "series": "zookeeper.outstanding_bytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Outstanding bytes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 49,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "zookeeper.connections_count",
+              "period": "300",
+              "refId": "A",
+              "series": "zookeeper.connections_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Connections count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 47,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "zookeeper.avg_latency_sec",
+              "period": "300",
+              "refId": "A",
+              "series": "zookeeper.avg_latency_sec"
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "zookeeper.max_latency_sec",
+              "period": "300",
+              "refId": "B",
+              "series": "zookeeper.max_latency_sec",
+              "target": ""
+            },
+            {
+              "aggregator": "none",
+              "column": "value",
+              "dimensions": [],
+              "error": "",
+              "function": "none",
+              "metric": "zookeeper.min_latency_sec",
+              "period": "300",
+              "refId": "C",
+              "series": "zookeeper.min_latency_sec",
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Timings",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "ZooKeeper",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 96,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "mysqld",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "mysqld"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.cpu_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "process.cpu_perc"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 97,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "mysqld",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "mysqld"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.mem.rss_mbytes",
+              "period": "300",
+              "refId": "A",
+              "series": "process.mem.rss_mbytes"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Allocated memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "MB",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 98,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "aggregator": "none",
+              "column": "value",
+              "condition_filter": true,
+              "condition_key": "process_name",
+              "condition_value": "mysqld",
+              "dimensions": [
+                {
+                  "key": "process_name",
+                  "value": "mysqld"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "process.pid_count",
+              "period": "300",
+              "refId": "A",
+              "series": "process.pid_count"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PID count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "MariaDB",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "enable": false,
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "timezone": "utc",
+  "title": "SUSE OpenStack Cloud Monitoring: Monasca",
+  "version": 0
 }

--- a/chef/cookbooks/horizon/files/default/grafana-openstack.json
+++ b/chef/cookbooks/horizon/files/default/grafana-openstack.json
@@ -1,822 +1,4231 @@
 {
-  "id": "sid-14394701277644387945359960469",
-  "title": "SUSE OpenStack Cloud Monitoring",
-  "originalTitle": "SUSE OpenStack Cloud Monitoring",
-  "tags": [],
-  "style": "dark",
-  "timezone": "utc",
-  "editable": true,
-  "hideControls": false,
-  "sharedCrosshair": false,
-  "rows": [
+  "__requires": [
     {
-      "title": "OpenStack Health",
-      "height": "100px",
-      "editable": true,
-      "collapse": false,
-      "collapsable": true,
-      "panels": [
-        {
-          "title": "compute (Nova)",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 1,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "max",
-              "merge": true,
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "compute-api"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          },
-          "height": "100"
-        },
-        {
-          "title": "networking (Neutron)",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 4,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "max",
-              "merge": true,
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "network-api"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          },
-          "height": "100"
-        },
-        {
-          "title": "image-service (Glance)",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 5,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "max",
-              "merge": true,
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "image-api"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          },
-          "height": "100"
-        },
-        {
-          "title": "block-storage (Cinder)",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 7,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "max",
-              "merge": true,
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "volume-api"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          },
-          "height": "100"
-        },
-        {
-          "title": "object-storage (Swift)",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 8,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "max",
-              "merge": true,
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "object-store-api"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          },
-          "height": "100"
-        },
-        {
-          "title": "identity-service (Keystone)",
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "singlestat",
-          "id": 12,
-          "links": [],
-          "maxDataPoints": 100,
-          "interval": null,
-          "targets": [
-            {
-              "function": "max",
-              "merge": true,
-              "column": "value",
-              "series": "http_status",
-              "condition_filter": true,
-              "condition_key": "service",
-              "condition_value": "identity-api"
-            }
-          ],
-          "cacheTimeout": null,
-          "format": "none",
-          "prefix": "",
-          "postfix": "",
-          "nullText": null,
-          "valueMaps": [
-            {
-              "value": "0",
-              "op": "=",
-              "text": "UP"
-            },
-            {
-              "value": "1",
-              "op": "=",
-              "text": "DOWN"
-            }
-          ],
-          "nullPointMode": "connected",
-          "valueName": "current",
-          "prefixFontSize": "50%",
-          "valueFontSize": "80%",
-          "postfixFontSize": "50%",
-          "thresholds": "-1.0,0.2,0.8",
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "sparkline": {
-            "show": false,
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "fillColor": "rgba(31, 118, 189, 0.18)"
-          },
-          "height": "100"
-        }
-      ],
-      "notice": false,
-      "showTitle": true
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.1.0"
     },
     {
-      "title": "System Resources",
-      "height": "250px",
-      "editable": true,
-      "collapse": false,
-      "collapsable": true,
-      "panels": [
-        {
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "percent",
-            "none"
-          ],
-          "grid": {
-            "max": null,
-            "min": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)",
-            "leftMax": 100,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null
-          },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true,
-            "rightSide": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "null",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true,
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "cpu.percent",
-              "condition_filter": false,
-              "alias": ""
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "cpu.wait_perc"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "cpu.system_perc"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "cpu.user_perc"
-            }
-          ],
-          "aliasColors": {},
-          "title": "CPU usage",
-          "id": 2,
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": ""
-        },
-        {
-          "title": "Memory usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 13,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "none"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)",
-            "thresholdLine": false
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true,
-            "rightSide": false
-          },
-          "nullPointMode": "null",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "mem.total_mb",
-              "merge": false,
-              "dimensions": ""
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "mem.swap_used_mb"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "mem.used_mb"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "mem.swap_total_mb"
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "mem.used_cache"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "MB"
-        },
-        {
-          "title": "Disk usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 14,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "percent",
-            "short"
-          ],
-          "grid": {
-            "leftMax": 100,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true,
-            "rightSide": false,
-            "sortDesc": null,
-            "sort": null
-          },
-          "nullPointMode": "null",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "series": "disk.space_used_perc",
-              "condition_filter": true,
-              "condition_key": "mount_point",
-              "condition_value": "/"
-           }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "System load",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 15,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "null",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "load.avg_1_min"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "notice": false,
-      "showTitle": true
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
     },
     {
-      "title": "Network monitoring",
-      "height": "250px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "Network usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 16,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "bps",
-            "short"
-          ],
-          "grid": {
-            "leftMax": null,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "alignAsTable": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "targets": [
-            {
-              "function": "none",
-              "column": "value",
-              "series": "net.in_bytes_sec",
-              "merge": true,
-              "dimensions": ""
-            },
-            {
-              "target": "",
-              "function": "none",
-              "column": "value",
-              "merge": true,
-              "dimensions": "",
-              "series": "net.out_bytes_sec"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ],
-      "showTitle": true
-    }
-  ],
-  "nav": [
+      "type": "datasource",
+      "id": "monasca-datasource",
+      "name": "Monasca",
+      "version": "1.0.0"
+    },
     {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
+      "type": "panel",
+      "id": "natel-discrete-panel",
+      "name": "Discrete",
+      "version": "0.0.6"
     }
   ],
-  "time": {
-    "from": "now-1h",
-    "to": "now"
-  },
-  "templating": {
-    "list": [],
-    "enable": false
-  },
   "annotations": {
     "enable": false,
     "list": []
   },
-  "refresh": "30s",
-  "version": 6,
-  "hideAllLegends": false
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": 60,
+      "panels": [
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 17,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "compute-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Compute (Nova)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 18,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "network-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Networking (Neutron)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 19,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "image-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Image (Glance)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 20,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "volume-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Volume (Cinder)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 21,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "volume-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Block Storage (Cinder)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 22,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "object-store-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Object Storage (Swift)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 23,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "identity-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Identity (Keystone)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 24,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "orchestration-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Orchestration (Heat)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 25,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "data-processing-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Data Processing (Sahara)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 26,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "key-manager-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Key Manager (Barbican)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 27,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "share-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Share (Manila)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 28,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "service",
+                  "value": "container-infra-api"
+                },
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "http_status",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Containers (Magnum)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "OpenStack Health",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 34,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.total_mb",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "mem.total_mb",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Memory (Total)",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decmbytes",
+              "label": "",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 37,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.used_mb",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "mem.used_mb",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Memory (Used)",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decmbytes",
+              "label": "",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 35,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.swap_total_mb",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "mem.swap_total_mb",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Swap (Total)",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decmbytes",
+              "label": "",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 36,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.swap_used_mb",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "mem.swap_used_mb",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Swap (Used)",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decmbytes",
+              "label": "",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 38,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "mem.used_cache",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "mem.used_cache",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Cache",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decmbytes",
+              "label": "",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Memory Usage",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 260,
+      "panels": [
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "cpu.percent",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "cpu.percent",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Percentage",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": "",
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 29,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "cpu.wait_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "cpu.wait_perc",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Wait",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": "",
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 30,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "cpu.system_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "cpu.system_perc",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "System",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": "",
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 32,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "load.avg_1_min",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "load.avg_1_min",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "System Load",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": "",
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 31,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "cpu.user_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "cpu.user_perc",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "User",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": "",
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "CPU Usage",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 16,
+      "panels": [
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "height": "400px",
+          "id": 33,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "disk.space_used_perc",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "disk.space_used_perc",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Root File System",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": "",
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Disk Usage",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 39,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "net.in_bytes_sec",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "net.in_bytes_sec",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Bytes/s (inbound)",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "Bps",
+              "label": "",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "default",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": null
+          },
+          "id": 40,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "loadingEditor": false,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "column": "value",
+              "condition_filter": false,
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "function": "none",
+              "metric": "net.out_bytes_sec",
+              "period": "300",
+              "refId": "A",
+              "series": "cpu.percent"
+            },
+            {
+              "aggregator": "avg",
+              "alias": "Average (all hosts)",
+              "dimensions": [],
+              "error": "",
+              "group": false,
+              "metric": "net.out_bytes_sec",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Bytes/s (outbound)",
+          "tooltip": {
+            "query_as_alias": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "Bps",
+              "label": "",
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "none",
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "zerofill": true
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Network monitoring",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "decimals": null,
+          "fill": 1,
+          "id": 59,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [],
+              "error": "",
+              "group": true,
+              "metric": "nova.vm.total_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total VMs",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "decimals": null,
+          "fill": 1,
+          "id": 60,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [],
+              "error": "",
+              "group": true,
+              "metric": "nova.vm.blocked_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Blocked",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "decimals": null,
+          "fill": 1,
+          "id": 61,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [],
+              "error": "",
+              "group": true,
+              "metric": "nova.vm.crashed_count",
+              "period": "300",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Crashed",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "decimals": null,
+          "fill": 1,
+          "id": 62,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [],
+              "error": "",
+              "group": true,
+              "metric": "nova.vm.nostate_count",
+              "period": "300",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "No State",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "decimals": null,
+          "fill": 1,
+          "id": 63,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [],
+              "error": "",
+              "group": true,
+              "metric": "nova.vm.paused_count",
+              "period": "300",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Paused",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "decimals": null,
+          "fill": 1,
+          "id": 64,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [],
+              "error": "",
+              "group": true,
+              "metric": "nova.vm.running_count",
+              "period": "300",
+              "refId": "F"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Running",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "decimals": null,
+          "fill": 1,
+          "id": 65,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [],
+              "error": "",
+              "group": true,
+              "metric": "nova.vm.suspended_count",
+              "period": "300",
+              "refId": "E"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Suspended",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "decimals": null,
+          "fill": 1,
+          "id": 66,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [],
+              "error": "",
+              "group": true,
+              "metric": "nova.vm.shutoff_count",
+              "period": "300",
+              "refId": "H"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Shut off/Nova suspend",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "VM Graphs",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 250,
+      "panels": [
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 58,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 25,
+          "showLegend": true,
+          "showLegendNames": true,
+          "showLegendPercent": false,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "nova.vm.total_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 22,
+          "title": "Total VMs",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(202, 31, 31, 0)",
+          "colorMaps": [],
+          "display": "timeline",
+          "extendLastValue": true,
+          "height": "",
+          "highlightOnMouseover": true,
+          "id": 51,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [
+            {
+              "type": "dashboard"
+            }
+          ],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 25,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": false,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "nova.vm.running_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 22,
+          "title": "Running",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 52,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 25,
+          "showLegend": true,
+          "showLegendNames": true,
+          "showLegendPercent": false,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "nova.vm.blocked_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 22,
+          "title": "Blocked",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 53,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 25,
+          "showLegend": true,
+          "showLegendNames": true,
+          "showLegendPercent": false,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "nova.vm.nostate_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 22,
+          "title": "No State",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 54,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 25,
+          "showLegend": true,
+          "showLegendNames": true,
+          "showLegendPercent": false,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "nova.vm.crashed_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 22,
+          "title": "Crashed",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 55,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 25,
+          "showLegend": true,
+          "showLegendNames": true,
+          "showLegendPercent": false,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "nova.vm.paused_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 22,
+          "title": "Paused",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 56,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 25,
+          "showLegend": true,
+          "showLegendNames": true,
+          "showLegendPercent": false,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "nova.vm.shuttingdown_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 22,
+          "title": "Shutting down",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 57,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 25,
+          "showLegend": true,
+          "showLegendNames": true,
+          "showLegendPercent": false,
+          "showLegendValues": true,
+          "span": 4,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "nova.vm.shutoff_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 22,
+          "title": "Shut off / Nova suspended",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "VM Counts",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 250,
+      "panels": [
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 41,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "ceph.cluster.osds.total_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "OSDs (total)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "1"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 42,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "ceph.cluster.osds.up_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "OSDs (up)",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "ALL UP"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "OSD(s) DOWN"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 43,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "OSD(s) DOWN",
+              "to": "1000"
+            }
+          ],
+          "rowHeight": 50,
+          "showDistinctCount": false,
+          "showLegend": true,
+          "showLegendCounts": false,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendTime": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "ceph.cluster.osds.down_count",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "OSD Health",
+          "type": "natel-discrete-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "ALL UP",
+              "value": "0"
+            }
+          ],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        },
+        {
+          "backgroundColor": "rgba(128, 128, 128, 0.1)",
+          "colorMaps": [
+            {
+              "color": "rgb(0, 255, 0)",
+              "text": "OK"
+            },
+            {
+              "color": "rgb(255, 255, 0)",
+              "text": "WARN"
+            },
+            {
+              "color": "rgb(255, 0, 0)",
+              "text": "ERROR"
+            }
+          ],
+          "display": "timeline",
+          "extendLastValue": true,
+          "highlightOnMouseover": true,
+          "id": 44,
+          "legendSortBy": "-ms",
+          "lineColor": "rgba(128, 128, 128, 1.0)",
+          "links": [],
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "metricNameColor": "#000000",
+          "rangeMaps": [],
+          "rowHeight": 50,
+          "showLegend": true,
+          "showLegendNames": true,
+          "showLegendPercent": true,
+          "showLegendValues": true,
+          "span": 3,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "group": false,
+              "metric": "ceph.cluster.quorum_size",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "textSize": 24,
+          "title": "Quorum Size",
+          "type": "natel-discrete-panel",
+          "valueMaps": [],
+          "valueTextColor": "#000000",
+          "writeAllValues": false,
+          "writeLastValue": true,
+          "writeMetricNames": false
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Ceph Health",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "fill": 1,
+          "id": 46,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "dimensions": [],
+              "error": "",
+              "metric": "ceph.cluster.total_used_bytes",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Used Storage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "fill": 1,
+          "id": 48,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "dimensions": [],
+              "error": "",
+              "metric": "ceph.cluster.total_avail_bytes",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Available Storage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "fill": 1,
+          "id": 47,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "dimensions": [],
+              "error": "",
+              "metric": "ceph.cluster.utilization_perc",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Storage Utilization (%)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "fill": 1,
+          "id": 49,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "ceph.osd.utilization_perc",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "OSD Utilization (%)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "default",
+          "fill": 1,
+          "id": 50,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "none",
+              "alias": "@hostname",
+              "dimensions": [
+                {
+                  "key": "hostname",
+                  "value": "$all"
+                }
+              ],
+              "error": "",
+              "metric": "ceph.osd.used_bytes",
+              "period": "300",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "OSD Utilization (bytes)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Ceph Storage",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "enable": false,
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "timezone": "utc",
+  "title": "SUSE OpenStack Cloud Monitoring: OpenStack",
+  "version": 0
 }

--- a/chef/cookbooks/horizon/providers/grafana_datasource.rb
+++ b/chef/cookbooks/horizon/providers/grafana_datasource.rb
@@ -1,0 +1,142 @@
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "json"
+require "net/http"
+require "openssl"
+require "uri"
+
+action :create do
+  connection = _build_connection(new_resource)
+  datasources = list_data_sources(connection)
+
+  datasource = find_data_source_by_name(new_resource.name, datasources)
+
+  payload = _datasource_payload(new_resource)
+
+  send_datasource(connection, payload) if datasource.nil?
+
+  if !datasource.nil? && datasource_diff?(datasource, payload)
+    payload["id"] = datasource["id"]
+    send_datasource(connection, payload)
+  end
+end
+
+def list_data_sources(conn)
+  path = ::File.join(conn["base_path"], "/api/datasources")
+  resp = conn["http"].request_get(path, conn["headers"])
+
+  return JSON.parse(resp.read_body) if resp.is_a?(Net::HTTPOK)
+
+  log_message = "Could not retrieve list of Grafana data sources"
+  _raise_error(resp, log_message, "list_data_sources()")
+end
+
+def find_data_source_by_name(name, data_sources)
+  data_sources.each do |data_source|
+    return data_source if data_source["name"] == name
+  end
+
+  nil
+end
+
+def send_datasource(conn, payload)
+  method = "POST"
+  path = ::File.join(conn["base_path"], "/api/datasources")
+
+  if payload["id"]
+    path = ::File.join(path, payload["id"].to_s)
+    method = "PUT"
+  end
+
+  headers = { "Content-Type" => "application/json" }.merge(conn["headers"])
+
+  resp = conn["http"].send_request(method, path, JSON.generate(payload), headers)
+
+  return if resp.is_a?(Net::HTTPOK)
+
+  log_message = "Could not update data source #{payload["name"]}"
+  _raise_error(resp, log_message, "send_datasource()")
+end
+
+def datasource_diff?(api, resource)
+  res = false
+  resource.each_key do |k|
+    if resource[k].is_a?(Hash)
+      res = datasource_diff?(api[k], resource[k])
+      break if res == true
+    end
+
+    unless api.key?(k) && (api[k] == resource[k])
+      res = true
+      break
+    end
+  end
+
+  res
+end
+
+def _build_connection(new_resource)
+  uri = URI(new_resource.grafana_url)
+
+  # Need to require net/https so that Net::HTTP gets monkey-patched
+  # to actually support SSL:
+  require "net/https" if uri.scheme.start_with?("https")
+
+  # Construct authentication headers
+  auth_headers = Net::HTTP::Get.new(new_resource.grafana_url)
+  auth_headers.basic_auth(new_resource.user_name, new_resource.password)
+  headers = { "Authorization" => auth_headers["authorization"] }
+
+  # Construct the http object
+  http = Net::HTTP.new(uri.host, uri.port)
+
+  http.use_ssl = true if uri.scheme.start_with?("https")
+  http.verify_mode = OpenSSL::SSL::VERIFY_NONE if new_resource.insecure
+
+  {
+    "base_path" => new_resource.grafana_url,
+    "http" => http,
+    "headers" => headers
+  }
+end
+
+def _datasource_payload(new_resource)
+  {
+    "url" => new_resource.proxy_url,
+    "access" => "direct",
+    "isDefault" => new_resource.is_default,
+    "withCredentials" => false,
+    "jsonData" => {
+      "useHorizonProxy" => true,
+      "token" => "",
+      "keystoneAuth" => false,
+      "authMode" => "Horizon"
+    },
+    "name" => new_resource.name,
+    "type" => "monasca-datasource"
+  }
+end
+
+def _log_error(resp, msg)
+  Chef::Log.error(msg)
+  Chef::Log.error("Response Code: #{resp.code}") if resp
+  Chef::Log.error("Response Message: #{resp.message}") if resp
+end
+
+def _raise_error(resp, msg, calling_function)
+  _log_error(resp, msg)
+  new_resource.updated_by_last_action(false)
+  raise "#{msg} in provider function #{calling_function}"
+end

--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -12,9 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 monasca_server = node_search_with_cache("roles:monasca-server").first
+monasca_master = node_search_with_cache("roles:monasca-master").first
+monasca_host = MonascaUiHelper.monasca_admin_host(monasca_server)
+grafana_password = monasca_master[:monasca][:master][:database_grafana_password]
+
+# Used for creating data source
+grafana_base_url = ::File.join(MonascaUiHelper.dashboard_local_url(node), "/grafana")
+
+# Used to check whether Grafana is alive
+grafana_service_url = MonascaUiHelper.grafana_service_url(node)
+
+ha_enabled = node[:horizon][:ha][:enabled]
+
 if monasca_server.nil?
   Chef::Log.warn("No monasca-server found.")
+  return
+end
+
+if monasca_master.nil?
+  Chef::Log.warn("No monasca-master found.")
   return
 end
 
@@ -22,6 +40,7 @@ template "/srv/www/openstack-dashboard/openstack_dashboard/"\
          "local/local_settings.d/_80_monasca_ui_settings.py" do
   source "_80_monasca_ui_settings.py.erb"
   variables(
+    endpoint_region: keystone_settings["endpoint_region"],
     kibana_enabled: true,
     kibana_host: MonascaUiHelper.monasca_public_host(monasca_server)
   )
@@ -31,34 +50,73 @@ template "/srv/www/openstack-dashboard/openstack_dashboard/"\
   notifies :reload, resources(service: "apache2")
 end
 
-package "grafana-apache" do
+package "grafana" do
   action :install
-  notifies :reload, resources(service: "apache2")
 end
 
-template "/srv/www/grafana/config.js" do
-  source "grafana-config.js"
+template "/etc/grafana/grafana.ini" do
+  source "grafana.ini.erb"
   variables(
-    api_url: MonascaUiHelper.api_public_url(monasca_server)
+    database_host: monasca_host,
+    grafana_password: grafana_password
   )
   owner "root"
-  group "www"
-  mode "0644"
-  notifies :reload, resources(service: "apache2")
+  group "grafana"
+  mode "0640"
 end
 
-cookbook_file "/srv/www/grafana/app/dashboards/openstack.json" do
-  source "grafana-openstack.json"
-  owner "root"
-  group "root"
-  mode "0644"
-  notifies :reload, resources(service: "apache2")
+service "grafana-server" do
+  supports status: true, restart: true, start: true, stop: true
+  action [:enable, :start]
+  subscribes :restart, resources(template: "/etc/grafana/grafana.ini")
 end
 
-cookbook_file "/srv/www/grafana/app/dashboards/monasca.json" do
+["monasca-grafana-datasource", "grafana-natel-discrete-panel",
+ "grafana-monasca-ui-drilldown"].each do |pkg|
+  package pkg do
+    action :install
+    notifies :restart, resources(service: "grafana-server")
+  end
+end
+
+cookbook_file "/var/lib/grafana/dashboards/monasca.json" do
   source "grafana-monasca.json"
   owner "root"
   group "root"
   mode "0644"
-  notifies :reload, resources(service: "apache2")
+  notifies :restart, resources(service: "grafana-server")
+end
+
+cookbook_file "/var/lib/grafana/dashboards/openstack.json" do
+  source "grafana-openstack.json"
+  owner "root"
+  group "root"
+  mode "0644"
+  notifies :restart, resources(service: "grafana-server")
+end
+
+# Grafana takes a few seconds from startup until it's actually listening, so
+# we'll need to wait for it:
+execute "grafana listening?" do
+  command "while true; do sleep 5; curl -s #{grafana_service_url} > /dev/null && break; done"
+  timeout 60
+  # We'll end up triggering this twice: once immediately because we also need
+  # to notify the horizon_grafana_datasource if the grafana-server resource
+  # hasn't changed and once if it is triggered by grafana-server. In the latter
+  # case the first invocation will fail for a clean slate deployment because
+  # grafana-server isn't running, yet. Hence we need to check the service's
+  # status here.
+  only_if { system("systemctl status grafana-server > /dev/null") }
+  subscribes :run, resources(service: "grafana-server")
+end
+
+horizon_grafana_datasource "Monasca (Crowbar)" do
+  action :nothing
+  is_default true
+  user_name "admin"
+  password grafana_password
+  grafana_url grafana_base_url
+  proxy_url "../monitoring/proxy/"
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  subscribes :create, resources(execute: "grafana listening?"), :immediately
 end

--- a/chef/cookbooks/horizon/resources/grafana_datasource.rb
+++ b/chef/cookbooks/horizon/resources/grafana_datasource.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :name, regex: /[^\n]/, required: true
+attribute :is_default, required: false, default: false
+attribute :insecure, required: false, default: true
+attribute :user_name, kind_of: String, required: true
+attribute :password, kind_of: String, required: true
+attribute :grafana_url, kind_of: String, required: true
+attribute :proxy_url, kind_of: String, required: true

--- a/chef/cookbooks/horizon/templates/default/_80_monasca_ui_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/_80_monasca_ui_settings.py.erb
@@ -33,12 +33,15 @@ MONITORING_SERVICE_TYPE = getattr(
     settings, 'MONITORING_SERVICE_TYPE', 'monitoring'
 )
 
+GRAFANA_URL = { '<%= @endpoint_region %>': "/grafana" }
 
 # Grafana button titles/file names (global across all projects):
 GRAFANA_LINKS = [
-    {'title': 'Dashboard', 'fileName': 'openstack.json'},
-    {'title': 'Monasca Health', 'fileName': 'monasca.json'}
+        {'title': 'Dashboard', 'path': '/grafana/dashboard/file/openstack.json?orgId=1', 'raw': True},
+        {'title': 'Monasca Health', 'path': '/grafana/dashboard/file/monasca.json?orgId=1', 'raw': True}
 ]
+
+SHOW_GRAFANA_HOME = False
 
 DEFAULT_LINKS = GRAFANA_LINKS
 DASHBOARDS = getattr(settings, 'GRAFANA_LINKS', GRAFANA_LINKS)

--- a/chef/cookbooks/horizon/templates/default/grafana.ini.erb
+++ b/chef/cookbooks/horizon/templates/default/grafana.ini.erb
@@ -1,0 +1,401 @@
+##################### Grafana Configuration Example #####################
+#
+# Everything has defaults so you only need to uncomment things you want to
+# change
+
+# possible values : production, development
+; app_mode = production
+
+# instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
+; instance_name = ${HOSTNAME}
+
+#################################### Paths ####################################
+[paths]
+# Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
+#
+;data = /var/lib/grafana
+#
+# Directory where grafana can store logs
+#
+;logs = /var/log/grafana
+#
+# Directory where grafana will automatically scan and look for plugins
+#
+;plugins = /var/lib/grafana/plugins
+
+#
+#################################### Server ####################################
+[server]
+# Protocol (http or https)
+;protocol = http
+
+# The ip address to bind to, empty will bind to all interfaces
+;http_addr =
+
+# The http port  to use
+;http_port = 3000
+
+# The public facing domain name used to access grafana from a browser
+;domain = localhost
+
+# Redirect to correct domain if host header does not match domain
+# Prevents DNS rebinding attacks
+;enforce_domain = false
+
+# The full public facing url you use in browser, used for redirects and emails
+# If you use reverse proxy and sub path specify full url (with sub path)
+root_url = %(protocol)s://%(domain)s/grafana
+
+# Log web requests
+;router_logging = false
+
+# the path relative working path
+;static_root_path = public
+
+# enable gzip
+;enable_gzip = false
+
+# https certs & key file
+;cert_file =
+;cert_key =
+
+#################################### Database ####################################
+[database]
+# You can configure the database connection by specifying type, host, name, user and password
+# as seperate properties or as on string using the url propertie.
+
+# Either "mysql", "postgres" or "sqlite3", it's your choice
+type = mysql
+host = <%= @database_host %>:3306
+name = grafana
+user = grafana
+password = <%= @grafana_password %>
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+
+# Use either URL or the previous fields to configure the database
+# Example: mysql://user:secret@host:port/database
+;url =
+
+# For "postgres" only, either "disable", "require" or "verify-full"
+;ssl_mode = disable
+
+# For "sqlite3" only, path relative to data_path setting
+;path = grafana.db
+
+# Max conn setting default is 0 (mean not set)
+;max_conn =
+;max_idle_conn =
+;max_open_conn =
+
+
+#################################### Session ####################################
+[session]
+# Either "memory", "file", "redis", "mysql", "postgres", default is "file"
+;provider = file
+
+# Provider config options
+# memory: not have any config yet
+# file: session dir path, is relative to grafana data_path
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+# mysql: go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`
+# postgres: user=a password=b host=localhost port=5432 dbname=c sslmode=disable
+;provider_config = sessions
+
+# Session cookie name
+;cookie_name = grafana_sess
+
+# If you use session in https only, default is false
+;cookie_secure = false
+
+# Session life time, default is 86400
+;session_life_time = 86400
+
+#################################### Data proxy ###########################
+[dataproxy]
+
+# This enables data proxy logging, default is false
+;logging = false
+
+
+#################################### Analytics ####################################
+[analytics]
+# Server reporting, sends usage counters to stats.grafana.org every 24 hours.
+# No ip addresses are being tracked, only simple counters to track
+# running instances, dashboard and error counts. It is very helpful to us.
+# Change this option to false to disable reporting.
+;reporting_enabled = true
+
+# Set to false to disable all checks to https://grafana.net
+# for new vesions (grafana itself and plugins), check is used
+# in some UI views to notify that grafana or plugin update exists
+# This option does not cause any auto updates, nor send any information
+# only a GET request to http://grafana.net to get latest versions
+;check_for_updates = true
+
+# Google Analytics universal tracking code, only enabled if you specify an id here
+;google_analytics_ua_id =
+
+#################################### Security ####################################
+[security]
+# default admin user, created on startup
+;admin_user = admin
+
+# default admin password, can be changed before first start of grafana,  or in profile settings
+admin_password = <%= @grafana_password %>
+
+# used for signing
+;secret_key = SW2YcwTIb9zpOOhoPsMm
+
+# Auto-login remember days
+;login_remember_days = 7
+;cookie_username = grafana_user
+;cookie_remember_name = grafana_remember
+
+# disable gravatar profile images
+;disable_gravatar = false
+
+# data source proxy whitelist (ip_or_domain:port separated by spaces)
+;data_source_proxy_whitelist =
+
+[snapshots]
+# snapshot sharing options
+;external_enabled = true
+;external_snapshot_url = https://snapshots-origin.raintank.io
+;external_snapshot_name = Publish to snapshot.raintank.io
+
+# remove expired snapshot
+;snapshot_remove_expired = true
+
+# remove snapshots after 90 days
+;snapshot_TTL_days = 90
+
+#################################### Users ####################################
+[users]
+# disable user signup / registration
+allow_sign_up = false
+
+# Allow non admin users to create organizations
+;allow_org_create = true
+
+# Set to true to automatically assign new users to the default organization (id 1)
+;auto_assign_org = true
+
+# Default role new users will be automatically assigned (if disabled above is set to true)
+;auto_assign_org_role = Viewer
+
+# Background text for the user field on the login page
+;login_hint = email or username
+
+# Default UI theme ("dark" or "light")
+;default_theme = dark
+
+[auth]
+# Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
+;disable_login_form = false
+
+#################################### Anonymous Auth ##########################
+[auth.anonymous]
+# enable anonymous access
+enabled = true
+
+# specify organization name that should be used for unauthenticated users
+org_name = Main Org.
+
+# specify role for unauthenticated users
+org_role = Viewer
+
+#################################### Github Auth ##########################
+[auth.github]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://github.com/login/oauth/authorize
+;token_url = https://github.com/login/oauth/access_token
+;api_url = https://api.github.com/user
+;team_ids =
+;allowed_organizations =
+
+#################################### Google Auth ##########################
+[auth.google]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_client_id
+;client_secret = some_client_secret
+;scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+;auth_url = https://accounts.google.com/o/oauth2/auth
+;token_url = https://accounts.google.com/o/oauth2/token
+;api_url = https://www.googleapis.com/oauth2/v1/userinfo
+;allowed_domains =
+
+#################################### Generic OAuth ##########################
+[auth.generic_oauth]
+;enabled = false
+;name = OAuth
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://foo.bar/login/oauth/authorize
+;token_url = https://foo.bar/login/oauth/access_token
+;api_url = https://foo.bar/user
+;team_ids =
+;allowed_organizations =
+
+#################################### Grafana.net Auth ####################
+[auth.grafananet]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email
+;allowed_organizations =
+
+#################################### Auth Proxy ##########################
+[auth.proxy]
+;enabled = false
+;header_name = X-WEBAUTH-USER
+;header_property = username
+;auto_sign_up = true
+;ldap_sync_ttl = 60
+;whitelist = 192.168.1.1, 192.168.2.1
+
+#################################### Basic Auth ##########################
+[auth.basic]
+;enabled = true
+
+#################################### Auth LDAP ##########################
+[auth.ldap]
+;enabled = false
+;config_file = /etc/grafana/ldap.toml
+;allow_sign_up = true
+
+#################################### SMTP / Emailing ##########################
+[smtp]
+;enabled = false
+;host = localhost:25
+;user =
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+;password =
+;cert_file =
+;key_file =
+;skip_verify = false
+;from_address = admin@grafana.localhost
+;from_name = Grafana
+
+[emails]
+;welcome_email_on_sign_up = false
+
+#################################### Logging ##########################
+[log]
+# Either "console", "file", "syslog". Default is console and  file
+# Use space to separate multiple modes, e.g. "console file"
+;mode = console file
+
+# Either "trace", "debug", "info", "warn", "error", "critical", default is "info"
+;level = info
+
+# optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+;filters =
+
+
+# For "console" mode only
+[log.console]
+;level =
+
+# log line format, valid options are text, console and json
+;format = console
+
+# For "file" mode only
+[log.file]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# This enables automated log rotate(switch of following options), default is true
+;log_rotate = true
+
+# Max line number of single file, default is 1000000
+;max_lines = 1000000
+
+# Max size shift of single file, default is 28 means 1 << 28, 256MB
+;max_size_shift = 28
+
+# Segment log daily, default is true
+;daily_rotate = true
+
+# Expired days of log file(delete after max days), default is 7
+;max_days = 7
+
+[log.syslog]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+;network =
+;address =
+
+# Syslog facility. user, daemon and local0 through local7 are valid.
+;facility =
+
+# Syslog tag. By default, the process' argv[0] is used.
+;tag =
+
+
+#################################### AMQP Event Publisher ##########################
+[event_publisher]
+;enabled = false
+;rabbitmq_url = amqp://localhost/
+;exchange = grafana_events
+
+;#################################### Dashboard JSON files ##########################
+[dashboards.json]
+enabled = true
+path = /var/lib/grafana/dashboards
+
+#################################### Alerting ############################
+[alerting]
+# Disable alerting engine & UI features
+;enabled = true
+# Makes it possible to turn off alert rule execution but alerting UI is visible
+;execute_alerts = true
+
+#################################### Internal Grafana Metrics ##########################
+# Metrics available at HTTP API Url /api/metrics
+[metrics]
+# Disable / Enable internal metrics
+;enabled           = true
+
+# Publish interval
+;interval_seconds  = 10
+
+# Send internal metrics to Graphite
+[metrics.graphite]
+# Enable by setting the address setting (ex localhost:2003)
+;address =
+;prefix = prod.grafana.%(instance_name)s.
+
+#################################### Internal Grafana Metrics ##########################
+# Url used to to import dashboards directly from Grafana.net
+[grafana_net]
+;url = https://grafana.net
+
+#################################### External image storage ##########################
+[external_image_storage]
+# Used for uploading images to public servers so they can be included in slack/email messages.
+# you can choose between (s3, webdav)
+;provider =
+
+[external_image_storage.s3]
+;bucket_url =
+;access_key =
+;secret_key =
+
+[external_image_storage.webdav]
+;url =
+;username =
+;password =

--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -46,8 +46,9 @@
     DocumentRoot <%= @horizon_dir %>
     Alias /media <%= @horizon_dir %>/media
     Alias /static <%= @horizon_dir %>/static
-    <% if @grafana_available %>
-    Alias /grafana /srv/www/grafana
+    <% unless @grafana_url.empty? %>
+    ProxyPass "/grafana" "<%= @grafana_url %>"
+    ProxyPassReverse "/grafana" "<%= @grafana_url %>"
     <% end %>
 
     Timeout 120
@@ -57,7 +58,7 @@
         ExpiresActive on
         ExpiresDefault "access plus 1 month"
     </Location>
-    <% if @grafana_available %>
+    <% unless @grafana_url.empty? %>
     <Location /grafana>
         Require all granted
     </Location>


### PR DESCRIPTION
This commit adds support for Grafana 4 to the Horizon barclamp.
This allows us to switch from our local Grafana 1.5 fork to
upstream Grafana 4 for the Monasca metrics dashboards.

It makes the following changes:

* Configure and deploy standalone grafana service
* Enable mod_proxy in Apache if monasca is active.
* Create a ProxyPass path on the Apache server to transparently
  proxy requests to standalone Grafana
* Add resource/provider for creating Grafana datasource
* Use grafana_datasource resource to create default Grafana data
  source.
* Add Grafana 4 compatible Monasca dashboard.
* Add Grafana 4 compatible dashboard for OpenStack metrics.
* Add Ceph monitoring panels to OpenStack dashboards
* Install Discrete Grafana panel plugin
* Adjust GRAFANA_LINKS
* Adjust alarm drilldown links for Grafana 4.

(cherry picked from commit cdc0d812e0b79ccb61f06d3d3ba3a64b0e15c258)