### PR TITLE
monasca/nova: enable libvirt monitoring

### DIFF
--- a/chef/cookbooks/monasca/attributes/default.rb
+++ b/chef/cookbooks/monasca/attributes/default.rb
@@ -27,6 +27,7 @@ default[:monasca][:api][:bind_port] = 8070
 default[:monasca][:log_api][:bind_port] = 5607
 
 default[:monasca][:kibana][:bind_port] = 5601
+default[:monasca][:delegate_role] = "monasca-delegate"
 
 # agent default service settings
 default[:monasca][:agent]["user"] = "monasca-agent"

--- a/chef/cookbooks/monasca/providers/agent_plugin_libvirt.rb
+++ b/chef/cookbooks/monasca/providers/agent_plugin_libvirt.rb
@@ -1,0 +1,48 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "json"
+require "yaml"
+
+action :create do
+  config = {
+    "username" => new_resource.username,
+    "user_domain_name" => new_resource.user_domain_name,
+    "password" => new_resource.password,
+    "project_name" => new_resource.project_name,
+    "project_domain_name" => new_resource.project_domain_name,
+    "auth_url" => new_resource.auth_url,
+    "region_name" => new_resource.region_name
+  }.merge(node[:monasca][:agent][:plugins][:libvirt])
+
+  # be sure the package is installed. that way "/etc/monasca/agent/conf.d/" is available
+  # and also the user and group are there
+  package "openstack-monasca-agent"
+
+  # NOTE(toabctl): convert/parse first to/from json. Otherwise we have unwanted markers
+  # like "- !ruby/hash:Mash" in the yaml output
+  process_conf = JSON.parse({ "init_config" => config,
+                              "instances" => [] }.to_json).to_yaml
+
+  # write libvirt plugin config
+  file "/etc/monasca/agent/conf.d/libvirt.yaml" do
+    content process_conf
+    owner node[:monasca][:agent][:user]
+    group node[:monasca][:agent][:group]
+    mode "0640"
+    notifies :restart, resources(service: node[:monasca][:agent][:agent_service_name]), :delayed
+  end
+end

--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -123,7 +123,9 @@ template "/opt/monasca-installer/crowbar_vars.yml" do
     curator_actions: curator_actions.to_yaml.split("\n")[1..-1],
     curator_cron_config: [curator_cron_config].to_yaml.split("\n")[1..-1],
     curator_excluded_index: curator_excluded_index.to_yaml.split("\n")[1..-1],
-    elasticsearch_repo_dir: node[:monasca][:elasticsearch][:repo_dir].to_yaml.split("\n")[1..-1]
+    elasticsearch_repo_dir: node[:monasca][:elasticsearch][:repo_dir].to_yaml.split("\n")[1..-1],
+    monitor_libvirt: node[:monasca][:agent][:monitor_libvirt],
+    delegate_role: node[:monasca][:delegate_role]
   )
   notifies :run, "execute[run ansible]", :delayed
 end

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -161,6 +161,10 @@ end
 monasca_project = node[:monasca][:service_tenant]
 monasca_roles = node[:monasca][:service_roles]
 
+if node[:monasca][:agent][:monitor_libvirt]
+  monasca_roles.push node[:monasca][:delegate_role]
+end
+
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 register_auth_hash = {

--- a/chef/cookbooks/monasca/resources/agent_plugin_libvirt.rb
+++ b/chef/cookbooks/monasca/resources/agent_plugin_libvirt.rb
@@ -1,0 +1,28 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :username, kind_of: String, required: true
+attribute :password, kind_of: String, required: true
+attribute :project_name, kind_of: String, required: true
+attribute :auth_url, kind_of: String, required: true
+attribute :user_domain_name, kind_of: String, required: true
+attribute :project_domain_name, kind_of: String, required: true
+attribute :region_name, kind_of: String, required: true
+
+attr_accessor :exists

--- a/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
@@ -28,6 +28,10 @@ smtp_user: <%= @master_settings['smtp_user'] %>
 smtp_password: <%= @master_settings['smtp_password'] %>
 smtp_from_address: <%= @master_settings['smtp_from_address'] %>
 
+<%- if @monitor_libvirt %>
+delegated_authorized_roles: <%= @delegate_role %>
+<%- end %>
+
 memcached_listen_ip: <%= @monasca_net_ip %>
 kafka_host: <%= @monasca_net_ip %>
 kafka_hosts: "<%= @monasca_net_ip %>:9092"

--- a/chef/cookbooks/nova/recipes/role_nova_compute_kvm.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_kvm.rb
@@ -18,4 +18,5 @@ if CrowbarRoleRecipe.node_state_valid_for_role?(node, "nova", "nova-compute-kvm"
   include_recipe "nova::kvm"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+  include_recipe "nova::monitor_monasca"
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_qemu.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_qemu.rb
@@ -18,4 +18,5 @@ if CrowbarRoleRecipe.node_state_valid_for_role?(node, "nova", "nova-compute-qemu
   include_recipe "nova::qemu"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+  include_recipe "nova::monitor_monasca"
 end

--- a/chef/cookbooks/nova/recipes/role_nova_compute_xen.rb
+++ b/chef/cookbooks/nova/recipes/role_nova_compute_xen.rb
@@ -18,4 +18,5 @@ if CrowbarRoleRecipe.node_state_valid_for_role?(node, "nova", "nova-compute-xen"
   include_recipe "nova::xen"
   include_recipe "nova::compute"
   include_recipe "nova::monitor"
+  include_recipe "nova::monitor_monasca"
 end

--- a/chef/data_bags/crowbar/migrate/monasca/101_add_libvirt_plugin_settings.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/101_add_libvirt_plugin_settings.rb
@@ -1,0 +1,17 @@
+def upgrade(ta, td, a, d)
+  a["agent"]["monitor_libvirt"] = ta["agent"]["monitor_libvirt"] unless
+    a["agent"].key?("monitor_libvirt")
+
+  a["agent"]["plugins"] = ta["agent"]["plugins"] unless
+    a["agent"].key?("plugins")
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["agent"].delete("monitor_libvirt") unless ta["agent"].key?("monitor_libvirt")
+
+  a["agent"].delete("plugins") unless ta["agent"].key?("plugins")
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -10,10 +10,35 @@
           "service_tenant": "monasca",
           "service_role": "monasca-agent"
         },
+        "plugins" : {
+          "libvirt" : {
+            "cache_dir": "/dev/shm",
+            "customer_metadata": [
+              "scale_group",
+              "tenant_name"
+              ],
+            "disk_collection_period": 0,
+            "max_ping_concurrency": 8,
+            "metadata": [
+              "scale_group",
+              "tenant_name"
+              ],
+            "nova_refresh": 14400,
+            "ping_check": false,
+            "vm_cpu_check_enable": true,
+            "vm_disks_check_enable": true,
+            "vm_extended_disks_check_enable": false,
+            "vm_network_check_enable": true,
+            "vm_ping_check_enable": true,
+            "vm_probation": 300,
+            "vnic_collection_period": 0
+          }
+        },
         "insecure": true,
         "ca_file": "",
         "log_dir": "/var/log/monasca-agent/",
         "log_level": "INFO",
+        "monitor_libvirt": true,
         "statsd_port": 8125,
         "check_frequency": 15,
         "num_collector_threads": 1,
@@ -106,7 +131,7 @@
     "monasca": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
         "monasca-master": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -26,10 +26,37 @@
                     "service_role": { "type": "str", "required": false }
                   }
                 },
+                "plugins": {
+                  "required": true,
+                  "type": "map",
+                  "mapping": {
+                    "libvirt": {
+                      "required": true,
+                      "type": "map",
+                      "mapping": {
+                        "cache_dir": { "type": "str", "required": true },
+                        "customer_metadata": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
+                        "disk_collection_period": { "type": "int", "required": true },
+                        "max_ping_concurrency": { "type": "int", "required": true },
+                        "metadata": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
+                        "nova_refresh": { "type": "int", "required": true },
+                        "ping_check": { "type": "bool", "required": true },
+                        "vm_cpu_check_enable": { "type": "bool", "required": true },
+                        "vm_disks_check_enable": { "type": "bool", "required": true },
+                        "vm_extended_disks_check_enable": { "type": "bool", "required": true },
+                        "vm_network_check_enable": { "type": "bool", "required": true },
+                        "vm_ping_check_enable": { "type": "bool", "required": true },
+                        "vm_probation": { "type": "int", "required": true },
+                        "vnic_collection_period": { "type": "int", "required": true }
+                      }
+                    }
+                  }
+                },
                 "insecure": { "type": "bool", "required": true },
                 "ca_file": { "type": "str", "required": true },
                 "log_dir": { "type": "str", "required": true },
                 "log_level": { "type": "str", "required": true },
+                "monitor_libvirt": { "type": "bool", "required": true },
                 "statsd_port": { "type": "int", "required": true },
                 "check_frequency": { "type": "int", "required": true },
                 "num_collector_threads": { "type": "int", "required": true },

--- a/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
@@ -10,6 +10,7 @@
 
       = select_field %w(agent log_level), :collection => :agent_log_levels
       = integer_field %w(agent statsd_port)
+      = boolean_field %w(agent monitor_libvirt)
       = integer_field %w(agent check_frequency)
       = integer_field %w(agent num_collector_threads)
       = integer_field %w(agent pool_full_max_retries)

--- a/crowbar_framework/config/locales/monasca/en.yml
+++ b/crowbar_framework/config/locales/monasca/en.yml
@@ -35,6 +35,7 @@ en:
           insecure: 'Do you want insecure connection?'
           ca_file: 'Sets the path to the ca certs file if using certificates. Required only if insecure is set to False (ca_file)'
           log_level: 'Log level'
+          monitor_libvirt: 'Whether to monitor the libvirt process on compute nodes'
           statsd_port: 'Monasca Statsd port'
           check_frequency: 'Time to wait between collection runs (check_frequency)'
           num_collector_threads: 'Number of Collector Threads to run (num_collector_threads)'


### PR DESCRIPTION
This change enables Monasca's libvirt monitoring for compute nodes. This plugin
gathers various metrics on running VMs, such as their state, the tenant they
reside in, or their resource consumption. Change summary:

monasca:

* Added schema and, migrations and UI integration for libvirt agent plugin.
* Added resource/provider for generating libvirt agent plugin
  configuration.

nova:

* monitor_monasca: write libvirt agent plugin configuration on compute
  nodes.
* added monitor_monasca recipe for libvirt based compute nodes.

(cherry picked from commit e27d3ab2496cfc0958c4bb2a26648576fe40d754)