### PR TITLE
rabbitmq: Fix HA with shared storage

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -82,6 +82,7 @@ usermod -u #{static_uid} -g #{static_gid} rabbitmq;
 chown -R rabbitmq:rabbitmq /var/lib/rabbitmq;
 chown rabbitmq:rabbitmq /var/run/rabbitmq /var/log/rabbitmq;
 chown rabbitmq:rabbitmq /var/run/rabbitmq/pid /var/log/rabbitmq/*.log* || :;
+chgrp rabbitmq /etc/rabbitmq/definitions.json;
 EOC
   # Make any error in the commands fatal
   flags "-e"


### PR DESCRIPTION
The /etc/rabbitmq/definitions.json file is not readable by the rabbitmq
group, since we change the GID of that group when using shared storage.