### PR TITLE
[4.0]neutron[Cisco_ACI]: Backport from #1490

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -69,7 +69,8 @@ default[:neutron][:apic][:system_id] = "soc"
 default[:neutron][:apic][:hosts] = ""
 default[:neutron][:apic][:username] = "admin"
 default[:neutron][:apic][:password] = ""
-
+default[:neutron][:apic][:optimized_metadata] = true
+default[:neutron][:apic][:optimized_dhcp] = true
 default[:neutron][:apic][:opflex] = [{
   pod: "",
   nodes: [],

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -24,6 +24,9 @@ else
   neutron = node
 end
 
+use_apic_gbp = neutron[:neutron][:networking_plugin] == "ml2" &&
+  neutron[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
+
 # RDO package magic (non-standard packages)
 if node[:platform_family] == "rhel"
   net_core_pkgs=%w(kernel-*openstack* iproute-*el6ost.netns* iputils)
@@ -137,7 +140,8 @@ template neutron[:neutron][:config_file] do
       mtu_value: mtu_value,
       infoblox: infoblox_settings,
       ipam_driver: ipam_driver,
-      rpc_workers: neutron[:neutron][:rpc_workers]
+      rpc_workers: neutron[:neutron][:rpc_workers],
+      use_apic_gbp: use_apic_gbp
     )
 end
 

--- a/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
@@ -11,7 +11,8 @@ apic_name_mapping = use_name
 apic_clear_node_profiles = True
 enable_aci_routing = True
 apic_arp_flooding = True
-enable_optimized_metadata = True
+enable_optimized_metadata = <%= node[:neutron][:apic][:optimized_metadata] %>
+enable_optimized_dhcp = <%= node[:neutron][:apic][:optimized_dhcp] %>
 apic_provision_infra = True
 apic_provision_hostlinks = True
 <% @apic_switches.keys.each do |ip| -%>

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -64,7 +64,6 @@ username = <%= @keystone_settings['service_user'] %>
 password = <%= @keystone_settings['service_password'] %>
 
 <% end -%>
-
 [nova]
 region_name = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internal

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -53,6 +53,18 @@ project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings['admin_domain'] %>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
 
+<% if @use_apic_gbp -%>
+[apic_aim_auth]
+auth_plugin = v3password
+auth_url = <%= @keystone_settings['internal_auth_url'] %>
+user_domain_name = <%= @keystone_settings['admin_domain'] %>
+project_name = <%= @keystone_settings['service_tenant'] %>
+project_domain_name = <%= @keystone_settings['admin_domain'] %>
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
+
+<% end -%>
+
 [nova]
 region_name = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internal

--- a/chef/data_bags/crowbar/migrate/neutron/115_add_apic_optimized_dhcp_metadata.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/115_add_apic_optimized_dhcp_metadata.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  a["apic"]["optimized_metadata"] = ta["apic"]["optimized_metadata"] \
+    unless a["apic"].key? "optimized_metadata"
+  a["apic"]["optimized_dhcp"] = ta["apic"]["optimized_dhcp"] unless a["apic"].key? "optimized_dhcp"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["apic"].delete("optimized_metadata") unless ta["apic"].key? "optimized_metadata"
+  a["apic"].delete("optimized_dhcp") unless ta["apic"].key? "optimized_dhcp"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -45,6 +45,8 @@
         "system_id": "soc",
         "username": "admin",
         "password": "",
+        "optimized_metadata": true,
+        "optimized_dhcp": true,
         "opflex": [{
           "pod": "",
           "nodes" : [],
@@ -177,7 +179,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 114,
+      "schema-revision": 115,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -50,6 +50,8 @@
                       "system_id": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required": true },
                       "password": { "type" : "str", "required": true },
+                      "optimized_metadata": { "type" : "bool", "required" : true },
+                      "optimized_dhcp": { "type" : "bool", "required" : true },
                       "opflex": { "type": "seq", "required": true, "sequence": [ {
                         "type": "map", "required": true, "mapping": {
                           "pod": { "type" : "str", "required" : false },


### PR DESCRIPTION
This PR enables two features for Cisco ACI:
1. Allows usage of "apic_gbp" as ml2_mechanism_drivers and fixes the authentication for the latest version of ACI firmware + group-based-policy library combination.
2. Allows Crowbar configuration for enabling "optimized_metadata" and "optimized_dhcp" features for ACI. Until now these features were enabled by default. But since certain customer deployments wanted to test without enabling these features, it made sense to provide it as a configurable option. It was painful for the customer to change in the config file manually and avoid the chef-client from overriding the config. 

Note: The intended target of this PR is Cloud 7 and is updated here due to the standard process being followed for all PRs (master-update followed by cloud 7 backport). The tests were only done for Cloud 7 based deployments. 