### PR TITLE
nova: set executor_thread_pool_size back to default

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -336,7 +336,7 @@ haproxy_loadbalancer "galera" do
   mode "tcp"
   # leave some room for pacemaker health checks
   max_connections node[:database][:mysql][:max_connections] - 10
-  options ["httpchk"]
+  options ["httpchk", "clitcpka"]
   default_server "port 5555"
   stick ({ "on" => "dst" })
   servers ha_servers

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -60,7 +60,6 @@ debug = <%= node[:nova][:debug] %>
 log_dir = /var/log/nova
 use_syslog = <%= node[:nova][:use_syslog] ? 'True' : 'False' %>
 use_stderr = false
-executor_thread_pool_size = 256
 transport_url = <%= @rabbit_settings[:url] %>
 control_exchange = nova
 <% if @libvirt_type.eql?('zvm') %>
@@ -259,7 +258,8 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end %>
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
-rpc_conn_pool_size = 64
+# consider making configurable or even lower it
+rpc_conn_pool_size = 32
 
 [serial_console]
 enabled = <%= @serial_enabled ? "True" : "False" %>


### PR DESCRIPTION
We raised this to a high value to workaround a scalability
issue in icehouse, but we don't need this anymore with newton+ it
seems. this higher value cloggs up a large amount of resources
without seeing a whole lot of performance benefit.