### PR TITLE
neutron: Backport from #1495

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -116,6 +116,11 @@ if node.roles.include?("nova-compute-kvm")
     )
   end
 
+  # Explicitly link the opflex-agent-ovs.conf
+  link "/etc/opflex-agent-ovs/opflex-agent-ovs.conf" do
+    to "/etc/opflex-agent-ovs/conf.d/10-opflex-agent-ovs.conf"
+  end
+
   neutron_metadata do
     use_cisco_apic_ml2_driver true
     neutron_node_object neutron

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -141,6 +141,12 @@ template neutron[:neutron][:config_file] do
     )
 end
 
+if node[:platform_family] == "suse"
+  link "/etc/neutron/neutron.conf" do
+    to node[:neutron][:config_file]
+  end
+end
+
 if neutron[:neutron][:use_lbaas]
   interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
   if neutron[:neutron][:networking_plugin] == "ml2" &&


### PR DESCRIPTION
This change explicitly links the config files neutron.conf
and opflex-agent-conf to the override location at
/etc/neutron/neutron.conf.d/*-neutron.conf and
/etc/opflex-agent-ovs/conf.d/*-opflex-agent-ovs.conf.
The missing soft-links were discovered while testing for
in L3 services with ACI backend which failed.

(cherry picked from commit 1b3fb1885a188409753636a3d3219289c726528d)