### PR TITLE
nova: use oslo.cache memcache_pool by default for caching

### DIFF
--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -35,7 +35,7 @@ nova_metadata_insecure = <%= @nova_metadata_settings[:insecure] %>
 <% end %>
 
 [cache]
-backend = dogpile.cache.memcached
+backend = oslo_cache.memcache_pool
 enabled = true
 memcache_servers = <%= @memcached_servers.join(',') %>
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -101,7 +101,7 @@ pool_timeout = <%= node[:nova][:api_db][:pool_timeout] %>
 <% end %>
 
 [cache]
-backend = dogpile.cache.memcached
+backend = oslo_cache.memcache_pool
 enabled = true
 memcache_servers = <%= @memcached_servers.join(',') %>
 


### PR DESCRIPTION
This is the more production recommended setup especially for
eventlet/multithreaded services.