### PR TITLE
neutron: Fix conditional statement in template.

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -81,6 +81,7 @@ if node.roles.include?("nova-compute-kvm")
     mode "0640"
     variables(
       ml2_type_drivers: ml2_type_drivers,
+      ml2_mech_drivers: ml2_mech_drivers,
       tunnel_types: "",
       enable_tunneling: false,
       use_l2pop: false,
@@ -111,7 +112,7 @@ if node.roles.include?("nova-compute-kvm")
       opflex_vxlan_remote_port: neutron[:neutron][:apic][:opflex][:vxlan][:remote_port],
       # TODO(mmnelemane) : update VLAN encapsulation config when it works.
       # Currently set to VXLAN by default but can be modified from proposal.
-      ml2_type_drivers: neutron[:neutron][:ml2_type_drivers]
+      ml2_type_drivers: ml2_type_drivers
     )
   end
 

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -269,6 +269,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       mode "0640"
       variables(
         ml2_type_drivers: ml2_type_drivers,
+        ml2_mech_drivers: ml2_mech_drivers,
         tunnel_types: ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
         use_l2pop: neutron[:neutron][:use_l2pop] &&
             (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -3,7 +3,7 @@
 <% unless @tunnel_types.empty? -%>
 tunnel_types = <%= @tunnel_types.join(",") %>
 <% end -%>
-<% if @ml2_type_drivers.include?("cisco_apic_ml2") || @ml2_type_drivers.include?("apic_gbp") -%>
+<% if @ml2_mech_drivers.include?("cisco_apic_ml2") || @ml2_mech_drivers.include?("apic_gbp") -%>
 enable_tunneling = <%= @enable_tunneling %>
 <% end -%>
 <% if @use_l2pop -%>


### PR DESCRIPTION
  The checks in openvswitch_agent.ini.erb were wrongly using
  ml2_type_drivers instead of ml2_mechanism_drivers. This was corrected
  in this commit and also removed redundant assignment lines in the
  recipe