### PR TITLE
neutron[cisco_aci]: backport of #1502

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -70,15 +70,24 @@ default[:neutron][:apic][:hosts] = ""
 default[:neutron][:apic][:username] = "admin"
 default[:neutron][:apic][:password] = ""
 
-default[:neutron][:apic][:opflex][:peer_ip] = ""
-default[:neutron][:apic][:opflex][:peer_port] = 8009
-default[:neutron][:apic][:opflex][:encap] = "vxlan"
-default[:neutron][:apic][:opflex][:vxlan][:uplink_iface] = "vlan.4093"
-default[:neutron][:apic][:opflex][:vxlan][:uplink_vlan] = 4093
-default[:neutron][:apic][:opflex][:vxlan][:encap_iface] = "br-int_vxlan0"
-default[:neutron][:apic][:opflex][:vxlan][:remote_ip] = ""
-default[:neutron][:apic][:opflex][:vxlan][:remote_port] = 8472
-default[:neutron][:apic][:opflex][:vlan][:encap_iface] = ""
+default[:neutron][:apic][:opflex] = [{
+  pod: "",
+  nodes: [],
+  peer_ip: "",
+  peer_port: "",
+  encap: "vxlan",
+  vxlan: {
+    uplink_iface: "vlan.4093",
+    uplink_vlan: 4093,
+    encap_iface: "br-int_vxlan0",
+    remote_ip: "",
+    remote_port: 8472
+  },
+  vlan: {
+    encap_iface: ""
+  }
+}]
+
 
 case node[:platform_family]
 when "suse"

--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -93,6 +93,11 @@ if node.roles.include?("nova-compute-kvm")
 
   # Update config file from template
   opflex_agent_conf = "/etc/opflex-agent-ovs/conf.d/10-opflex-agent-ovs.conf"
+  apic = neutron[:neutron][:apic]
+  opflex_list = apic[:opflex].select { |i| i[:nodes].include? node[:hostname] }
+  opflex_list.any? || raise("Opflex instance not found for node '#{node[:hostname]}'")
+  opflex_list.one? || raise("Multiple opflex instances found for node '#{node[:hostname]}'")
+  opflex = opflex_list.first
   template opflex_agent_conf do
     cookbook "neutron"
     source "10-opflex-agent-ovs.conf.erb"
@@ -103,13 +108,13 @@ if node.roles.include?("nova-compute-kvm")
       opflex_apic_domain_name: neutron[:neutron][:apic][:system_id],
       hostname: node[:hostname],
       socketgroup: neutron[:neutron][:platform][:group],
-      opflex_peer_ip: neutron[:neutron][:apic][:opflex][:peer_ip],
-      opflex_peer_port: neutron[:neutron][:apic][:opflex][:peer_port],
-      opflex_vxlan_encap_iface: neutron[:neutron][:apic][:opflex][:vxlan][:encap_iface],
-      opflex_vxlan_uplink_iface: neutron[:neutron][:apic][:opflex][:vxlan][:uplink_iface],
-      opflex_vxlan_uplink_vlan: neutron[:neutron][:apic][:opflex][:vxlan][:uplink_vlan],
-      opflex_vxlan_remote_ip: neutron[:neutron][:apic][:opflex][:vxlan][:remote_ip],
-      opflex_vxlan_remote_port: neutron[:neutron][:apic][:opflex][:vxlan][:remote_port],
+      opflex_peer_ip: opflex[:peer_ip],
+      opflex_peer_port: opflex[:peer_port],
+      opflex_vxlan_encap_iface: opflex[:vxlan][:encap_iface],
+      opflex_vxlan_uplink_iface: opflex[:vxlan][:uplink_iface],
+      opflex_vxlan_uplink_vlan: opflex[:vxlan][:uplink_vlan],
+      opflex_vxlan_remote_ip: opflex[:vxlan][:remote_ip],
+      opflex_vxlan_remote_port: opflex[:vxlan][:remote_port],
       # TODO(mmnelemane) : update VLAN encapsulation config when it works.
       # Currently set to VXLAN by default but can be modified from proposal.
       ml2_type_drivers: neutron[:neutron][:ml2_type_drivers]

--- a/chef/data_bags/crowbar/migrate/neutron/114_add_cisco_apic_multipod.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/114_add_cisco_apic_multipod.rb
@@ -1,0 +1,21 @@
+def upgrade(ta, td, a, d)
+  if a.key?("apic") && a["apic"]["opflex"].is_a?(Hash)
+    nodes = a["apic"]["apic_switches"]
+            .map { |_, value| value["switch_ports"].keys }
+            .flatten
+            .uniq
+    a["apic"]["opflex"]["nodes"] = nodes
+    opflex = [ta["apic"]["opflex"].first.merge(a["apic"]["opflex"])]
+    a["apic"]["opflex"] = opflex
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if a.key?("apic") && ta["apic"]["opflex"].is_a?(Array)
+    a["apic"]["opflex"] = a["apic"]["opflex"].first
+    a["apic"]["opflex"].delete("pod")
+    a["apic"]["opflex"].delete("nodes")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -45,7 +45,9 @@
         "system_id": "soc",
         "username": "admin",
         "password": "",
-        "opflex": {
+        "opflex": [{
+          "pod": "",
+          "nodes" : [],
           "peer_ip": "",
           "peer_port": 8009,
           "encap": "vxlan",
@@ -59,7 +61,7 @@
           "vlan": {
               "encap_iface": ""
           }
-        },
+        }],
         "apic_switches": {
           "101": {
             "switch_ports": {
@@ -175,7 +177,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 113,
+      "schema-revision": 114,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -50,21 +50,25 @@
                       "system_id": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required": true },
                       "password": { "type" : "str", "required": true },
-                      "opflex": { "type": "map", "required": true, "mapping": {
-                        "peer_ip": { "type": "str", "required" : true },
-                        "peer_port": { "type": "int", "required" : true },
-                        "encap": { "type": "str", "required": true },
-                        "vxlan": { "type": "map", "required": true, "mapping" : {
-                          "encap_iface": {"type": "str", "required": true },
-                          "uplink_iface": { "type": "str", "required": true },
-                          "uplink_vlan": { "type": "int", "required": true },
-                          "remote_ip": { "type": "str", "required": true },
-                          "remote_port": { "type": "int", "required": true }
-                        }},
-                        "vlan": { "type": "map", "required": true, "mapping": {
-                          "encap_iface": { "type": "str", "required": true }
-                        }}
-                      }},
+                      "opflex": { "type": "seq", "required": true, "sequence": [ {
+                        "type": "map", "required": true, "mapping": {
+                          "pod": { "type" : "str", "required" : false },
+                          "nodes": { "type" : "seq", "required" : true, "sequence": [ { "type": "str" } ] },
+                          "peer_ip": { "type": "str", "required" : true },
+                          "peer_port": { "type": "int", "required" : true },
+                          "encap": { "type": "str", "required": true },
+                          "vxlan": { "type": "map", "required": true, "mapping" : {
+                            "encap_iface": {"type": "str", "required": true },
+                            "uplink_iface": { "type": "str", "required": true },
+                            "uplink_vlan": { "type": "int", "required": true },
+                            "remote_ip": { "type": "str", "required": true },
+                            "remote_port": { "type": "int", "required": true }
+                          }},
+                          "vlan": { "type": "map", "required": true, "mapping": {
+                            "encap_iface": { "type": "str", "required": true }
+                          }}
+                        }
+                      } ] },
                       "apic_switches": { "type" : "map", "required" : true, "mapping" : {
                         = : { "type" : "map", "required" : true, "mapping" : {
                           "switch_ports": { "type" : "map", "required" : true, "mapping" : {


### PR DESCRIPTION
This PR adds multi-pod support to cisco_aci. More information on [bug 1066920](https://bugzilla.novell.com/show_bug.cgi?id=1066920).

Note: The intended target of this PR is Cloud 7 and is updated here due to the standard process being followed for all PRs (master-update followed by cloud 7 backport). The tests were only done for Cloud 7 based deployments.
  