### PR TITLE
galera: enable client TCP keepalive probes on db connections

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -340,7 +340,7 @@ haproxy_loadbalancer "galera" do
   # leave some room for pacemaker health checks
   max_connections node[:database][:mysql][:max_connections] - 10
   if node[:mysql][:ha][:clustercheck]
-    options ["httpchk"]
+    options ["httpchk", "clitcpka"]
     default_server "port 5555"
   else
     options ["mysql-check user monitoring"]


### PR DESCRIPTION
when quickly restarting openstack services due to e.g. a chef
run or debugging something, the database loadbalancer quickly runs
out of available db connections because it keeps all connections
open for the default idle time of 3 hours. keepalive should
reduce that quite a bit.

(cherry picked from commit 74a58c1f9b1823211be147f1e8ce1b00c4e34ad4)

Backport of part of https://github.com/crowbar/crowbar-openstack/pull/1494