### PR TITLE
cinder: remove unused string field in the webui (bsc#1061298)

### DIFF
--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -140,8 +140,6 @@
               %span.help-block
                 = t(".volumes.nfs.nfs_shares_config_hint")
 
-              = string_field %w(volumes {{@index}} nfs)
-
           {{/if_eq}}
           {{#if_eq backend_driver 'rbd'}}
           %li.list-group-item


### PR DESCRIPTION
The file _edit_attributes.html.haml, for the NFS section, define
a single field (according to documentation) to list the NFS exports.

Somehow a ghost string field without title is presented in the UI,
and this patch remove it.

(cherry picked from commit 24c4b458c6617dbf8bbd8ea7b117fe5c57e0f784)

Backport of #1509 