### PR TITLE
[4.0] Rabbitmq allow to add extra users to rabbit backport

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -132,7 +132,8 @@ template "/etc/rabbitmq/definitions.json" do
     json_trove_password: node[:rabbitmq][:trove][:password].to_json,
     json_trove_vhost: node[:rabbitmq][:trove][:vhost].to_json,
     ha_all_policy: cluster_enabled,
-    quorum: quorum
+    quorum: quorum,
+    extra_users: node[:rabbitmq][:users]
   )
   # no notification to restart rabbitmq, as we still do changes with
   # rabbitmqctl in the rabbit.rb recipe (this is less disruptive)

--- a/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
@@ -35,6 +35,13 @@
             "tags": ""
         },
 <% end -%>
+<% @extra_users.each do |user| -%>
+        {
+            "name": "<%= user[:username] %>",
+            "password": "<%= user[:password] %>",
+            "tags": "<%= user[:tags].join(',') %>"
+        },
+<% end -%>
         {
             "name": <%= @json_user %>,
             "password": <%= @json_password %>,
@@ -49,6 +56,15 @@
             "configure": ".*",
             "read": ".*",
             "write": ".*"
+        },
+<% end -%>
+<% @extra_users.each do |user| -%>
+        {
+            "user": "<%= user[:username] %>",
+            "vhost": <%= @json_vhost %>,
+            "configure": "<%= user[:permissions][0] %>",
+            "read": "<%= user[:permissions][2] %>",
+            "write": "<%= user[:permissions][1] %>"
         },
 <% end -%>
         {

--- a/chef/data_bags/crowbar/migrate/rabbitmq/105_add_extra_users.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/105_add_extra_users.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["extra_users"] = ta["extra_users"] unless a["extra_users"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("extra_users") unless ta.key?("extra_users")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -7,6 +7,7 @@
       "port": 5672,
       "password": "",
       "user": "nova",
+      "extra_users": {},
       "vhost": "/nova",
       "ssl": {
         "enabled": false,
@@ -57,7 +58,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 104,
+      "schema-revision": 105,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },
@@ -74,4 +75,3 @@
     }
   }
 }
-

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -16,6 +16,20 @@
             "port": { "type": "int", "required": true },
             "password": { "type": "str", "required": true },
             "user": { "type": "str", "required": true },
+            "extra_users": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                = : {
+                  "type": "map",
+                  "required": false,
+                  "mapping": {
+                    "permissions": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
+                    "tags": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] }
+                  }
+                }
+              }
+            },
             "vhost": { "type": "str", "required": true },
             "ssl": {
               "type": "map", "required": true, "mapping": {

--- a/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
@@ -9,6 +9,36 @@
 
     %fieldset
       %legend
+        = t(".extra_users.title")
+
+      %table.table.table-middle{ "data-dynamic" => "#extrauser-entries", "data-namespace" => "extra_users", "data-optional" => "tags",
+      "data-invalid" => t(".extra_users.error_invalid"), "data-duplicate" => t(".extra_users.error_duplicate") }
+        %thead
+          %tr
+            %th.col-sm-2
+              = t(".extra_users.username")
+            %th.col-sm-3
+              = t(".extra_users.permissions")
+            %th.col-sm-3
+              = t(".extra_users.tags")
+            %th.col-sm-1
+        %tbody
+        %tfoot
+          %tr
+            %td
+              = text_field_tag "extrauser[name]", "", :placeholder => t(".extra_users.username"),
+              :class => "form-control", "data-name" => "name", "data-type" => "string"
+            %td
+              = text_field_tag "extrauser[permissions]", "", :placeholder => t(".extra_users.permissions"),
+              :class => "form-control", "data-name" => "permissions", "data-type" => "array-string"
+            %td
+              = text_field_tag "extrauser[tags]", "", :placeholder => t(".extra_users.tags"),
+              :class => "form-control", "data-name" => "tags", "data-type" => "array-string"
+            %td
+              = link_to t(".extra_users.add"), "#", :class => "btn btn-default btn-block", "data-add" => true
+
+    %fieldset
+      %legend
         = t(".ssl_header")
 
       = boolean_field %w(ssl enabled),
@@ -48,3 +78,26 @@
           = string_field %w(ha storage shared device)
           = string_field %w(ha storage shared fstype)
           = string_field %w(ha storage shared options)
+
+
+%script#extrauser-entries{ :type => "text/x-handlebars-template" }
+  {{#each entries}}
+  %tr.edit
+    %td
+      = text_field_tag "extrauser[name]", "{{name}}", :placeholder => t(".extra_users.username"),
+      :class => "form-control", :disabled => "disabled"
+    %td
+      = text_field_tag "extrauser[permissions]", "{{permissions}}", :placeholder => t(".extra_users.permissions"),
+      :class => "form-control", "data-update" => "extra_users/{{name}}/permissions", "data-name" => "permissions",
+      "data-type" => "array-string"
+    %td
+      = text_field_tag "extrauser[tags]", "{{tags}}", :placeholder => t(".extra_users.tags"), :class => "form-control",
+      "data-update" => "extra_users/{{name}}/tags", "data-name" => "tags", "data-type" => "array-string"
+    %td
+      = link_to t(".extra_users.record_remove"), "#", :class => "btn btn-default btn-block", "data-remove" => "{{name}}"
+  {{else}}
+  %tr
+    %td{ :colspan => 4 }
+      .empty.alert.alert-info.text-center
+        = t(".extra_users.no_records")
+  {{/each}}

--- a/crowbar_framework/config/locales/rabbitmq/en.yml
+++ b/crowbar_framework/config/locales/rabbitmq/en.yml
@@ -21,6 +21,16 @@ en:
       edit_attributes:
         vhost: 'Virtual host'
         user: 'User'
+        extra_users:
+          username: 'Username'
+          permissions: 'Permissions (3 comma separated items for configure, write, read; e.g. ".*,.*,.*")'
+          tags: 'Tags (comma separated)'
+          error_invalid: 'Username and Permissions cannot be empty'
+          error_duplicate: 'There is a user with this username'
+          title: 'Extra users'
+          add: 'Add'
+          record_remove: 'Delete'
+          no_records: 'No records'
         port: 'Port'
         ssl_header: 'SSL Support'
         ssl:
@@ -54,3 +64,4 @@ en:
         no_filesystem: 'No filesystem type specified for shared storage.'
         drbd: 'DRBD is not enabled for cluster %{cluster_name}.'
         invalid_size: 'Invalid size for DRBD device.'
+        wrong_permissions: 'Wrong permissions for user %{user}. Permissions need to be 3 comma separated items (configure, write, read)'


### PR DESCRIPTION
With the introduction of the definitions file it looks like
rabbit will disregard any existing users when restarting,
using the definitions file as the blank slate to start from.

This gets in the middle of having any extra users for other
tasks like monitoring and there is no mechanism to add users.

This PR adds an method to crowbar to add a list of users
that will get written into the definitions file, allowing
us to specify extra users to be created

(cherry picked from commit 1ade84888fd3da0c606d4421986973c3e401c6b5)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1506