### PR TITLE
rabbitmq: allow setting the log level

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -37,6 +37,7 @@ default[:rabbitmq][:management_address] = nil
 default[:rabbitmq][:configfile] = nil
 default[:rabbitmq][:logdir] = nil
 default[:rabbitmq][:mnesiadir] = nil
+default[:rabbitmq][:log_level] = "info"
 
 default[:rabbitmq][:cluster] = false
 default[:rabbitmq][:clustername] = "rabbit@#{node[:hostname]}"

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -7,6 +7,13 @@
  },
  {rabbit,
   [
+   {log_levels, [
+                 {connection, <%= node[:rabbitmq][:log_level] %>},
+                 {channel, <%= node[:rabbitmq][:log_level] %>},
+                 {federation, <%= node[:rabbitmq][:log_level] %>},
+                 {mirroring, <%= node[:rabbitmq][:log_level] %>}
+                ]
+   },
    {tcp_listeners, [
                     <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:port]}}" }.join(", ") %>
                    ]},

--- a/chef/data_bags/crowbar/migrate/rabbitmq/203_add_log_level.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/203_add_log_level.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["log_level"] = ta["log_level"] unless a["log_level"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("log_level") unless ta.key?("log_level")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -8,6 +8,7 @@
       "password": "",
       "user": "nova",
       "vhost": "/nova",
+      "log_level": "info",
       "ssl": {
         "enabled": false,
         "port": 5671,
@@ -57,7 +58,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -17,6 +17,7 @@
             "password": { "type": "str", "required": true },
             "user": { "type": "str", "required": true },
             "vhost": { "type": "str", "required": true },
+            "log_level": { "type": "str", "required": true },
             "ssl": {
               "type": "map", "required": true, "mapping": {
                 "enabled": { "type": "bool", "required": true },

--- a/crowbar_framework/app/helpers/barclamp/rabbitmq_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/rabbitmq_helper.rb
@@ -26,5 +26,19 @@ module Barclamp
         selected.to_s
       )
     end
+
+    def log_levels_for_rabbitmq(selected)
+      options_for_select(
+        [
+          ["debug", "debug"],
+          ["info", "info"],
+          ["warning", "warning"],
+          ["error", "error"],
+          ["critical", "critical"],
+          ["none", "none"]
+        ],
+        selected.to_s
+      )
+    end
   end
 end

--- a/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
@@ -6,6 +6,7 @@
     = string_field :vhost
     = integer_field :port
     = string_field :user
+    = select_field :log_level, :collection => :log_levels_for_rabbitmq
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/rabbitmq/en.yml
+++ b/crowbar_framework/config/locales/rabbitmq/en.yml
@@ -22,6 +22,7 @@ en:
         vhost: 'Virtual host'
         user: 'User'
         port: 'Port'
+        log_level: 'Log level'
         ssl_header: 'SSL Support'
         ssl:
           enabled: 'Enable SSL'


### PR DESCRIPTION
We may need to be able to set the log level for rabbitmq so
this patch allows to set it via the barclamp.

There is 4 different items in which the log level can be applied
(connection, channel, mirroring and federation). While on
rabbitmq 3.4 channel logging is not used, its ignored and
can be left there in case we upgrade to 3.5/3.6 later.