### PR TITLE
[3.0] nova: Add resource limits for api and compute (bsc#1057086)

### DIFF
--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -154,3 +154,14 @@ keystone_register "register nova_legacy endpoint" do
 end
 
 crowbar_pacemaker_sync_mark "create-nova_register"
+
+service = "openstack-nova-api"
+if node[:nova][:resource_limits] && node[:nova][:resource_limits][service]
+  limits = node[:nova][:resource_limits][service]
+  action = limits.values.any? ? :create : :delete
+  utils_systemd_override_limits "Resource limits for #{service}" do
+    service_name service
+    limits limits
+    action action
+  end
+end

--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -447,3 +447,14 @@ nova_controller_ips.each do |nova_controller_ip|
     not_if "iptables -nL VNCBLOCK | grep -q #{nova_controller_ip}"
   end
 end
+
+service = "openstack-nova-compute"
+if node[:nova][:resource_limits] && node[:nova][:resource_limits][service]
+  limits = node[:nova][:resource_limits][service]
+  action = limits.values.any? ? :create : :delete
+  utils_systemd_override_limits "Resource limits for #{service}" do
+    service_name service
+    limits limits
+    action action
+  end
+end

--- a/chef/data_bags/crowbar/migrate/nova/049_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/nova/049_add_resource_limits.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("resource_limits") unless ta.key?("resource_limits")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -94,6 +94,14 @@
       "block_device": {
         "allocate_retries": 60,
         "allocate_retries_interval": 3
+      },
+      "resource_limits": {
+        "openstack-nova-api": {
+          "LimitNOFILE": null
+        },
+        "openstack-nova-compute": {
+          "LimitNOFILE": null
+        }
       }
     }
   },
@@ -101,7 +109,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 48,
+      "schema-revision": 49,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -136,6 +136,22 @@
                 "allocate_retries": { "type": "number", "required" : true },
                 "allocate_retries_interval": { "type": "number", "required" : true }
               }
+            },
+            "resource_limits": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                "openstack-nova-api": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                },
+                "openstack-nova-compute": {
+                  "type": "map",
+                  "required": false,
+                  "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Based on exising work for allowing modification of system resource
limits, extend it to allow changing the open file limits for the
nova-api and nova-compute services.

(cherry picked from commit 650e08f80a2c51646d22128a4a85fc1e3dd70397)