### PR TITLE
rabbitmq: Do not mirror queues to all nodes

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -21,6 +21,7 @@
 ha_enabled = node[:rabbitmq][:ha][:enabled]
 # we only do cluster if we do HA
 cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
+quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
 crm_resource_stop_cmd = cluster_enabled ? "force-demote" : "force-stop"
 crm_resource_start_cmd = cluster_enabled ? "force-promote" : "force-start"
 
@@ -81,7 +82,8 @@ template "/etc/rabbitmq/definitions.json" do
     json_trove_user: node[:rabbitmq][:trove][:user].to_json,
     json_trove_password: node[:rabbitmq][:trove][:password].to_json,
     json_trove_vhost: node[:rabbitmq][:trove][:vhost].to_json,
-    ha_all_policy: cluster_enabled
+    ha_all_policy: cluster_enabled,
+    quorum: quorum
   )
   # no notification to restart rabbitmq, as we still do changes with
   # rabbitmqctl in the rabbit.rb recipe (this is less disruptive)

--- a/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
@@ -15,11 +15,12 @@
 <% if @ha_all_policy -%>
     "policies": [
         {
-            "apply-to": "all",
+            "apply-to": "queues",
             "definition": {
-                "ha-mode": "all"
+                "ha-mode": "exactly",
+               "ha-params": <%= @quorum %>
             },
-            "name": "ha-all",
+            "name": "ha-queues",
             "pattern": "^(?!amq.).*",
             "priority": 0,
             "vhost": <%= @json_vhost %>


### PR DESCRIPTION
Mirroring queues is known to have an impact on performance [1] [2]. We
were looking at mirroring queues to all nodes, but what we really need
is to mirror to a quorum of nodes. This should improve things a bit as a
first step. We may choose to not mirror some queues as a later step.

[1] "To How Many Nodes to Mirror?" in https://www.rabbitmq.com/ha.html
[2] http://fuel-ccp.readthedocs.io/en/latest/design/ref_arch_1000_nodes.html#replication