### PR TITLE
rabbitmq: tweak queue_master_locator for ha queues

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -28,6 +28,7 @@
 <% end -%>
 <% if @cluster_enabled -%>
    {cluster_partition_handling, <%= @cluster_partition_handling %>},
+   {queue_master_locator, "min-masters"},
 <% end -%>
    {disk_free_limit, 50000000}
  ]},


### PR DESCRIPTION
Instead of using the default client-local config for ha queues,
lets use min-masters which Pick the node hosting the minimum number
of masters to create master queues