### PR TITLE
Enable tempest cinder snapshot tests for NFS backend

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -409,7 +409,7 @@ cinders[0][:cinder][:volumes].each do |volume|
     break
   elsif volume[:backend_driver] == "nfs"
     storage_protocol = "nfs"
-    cinder_snapshot = false
+    cinder_snapshot = volume[:nfs][:nfs_snapshot]
     break
   elsif volume[:backend_driver] == "vmware"
     vendor_name = "VMware"


### PR DESCRIPTION
With the added support for cinder snapshot when using a NFS
backend, this change enables cinder snapshot tempest tests
when 'nfs_snapshot' is set to True.