### PR TITLE
[4.0] rabbitmq: tweak queue_master_locator for ha queues

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -28,6 +28,7 @@
 <% end -%>
 <% if @cluster_enabled -%>
    {cluster_partition_handling, <%= @cluster_partition_handling %>},
+   {queue_master_locator, "min-masters"},
 <% end -%>
    {disk_free_limit, 50000000}
  ]},


### PR DESCRIPTION
Instead of using the default client-local config for ha queues,
lets use min-masters which Pick the node hosting the minimum number
of masters to create master queues

(cherry picked from commit 01f18d401f06438d788414c228da3c75d9251087)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1522