### PR TITLE
[4.0] rabbitmq: Various changes to enable the use of rabbitmq 3.6.x

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -57,10 +57,12 @@ default[:rabbitmq][:ha][:clustered_op][:monitor] = [
   { interval: "30s" }, { interval: "27s", role: "Master" }
 ]
 
+default[:rabbitmq][:hipe_compile] = false
 default[:rabbitmq][:ha][:clustered_rmq_features] = false
 case node[:platform_family]
 when "suse"
   if node[:platform] != "suse" || node[:platform_version].to_f > 12.2
+    default[:rabbitmq][:hipe_compile] = true
     default[:rabbitmq][:ha][:clustered_rmq_features] = true
   end
 end

--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -56,3 +56,11 @@ default[:rabbitmq][:ha][:clustered_op][:notify][:timeout] = "180s"
 default[:rabbitmq][:ha][:clustered_op][:monitor] = [
   { interval: "30s" }, { interval: "27s", role: "Master" }
 ]
+
+default[:rabbitmq][:ha][:clustered_rmq_features] = false
+case node[:platform_family]
+when "suse"
+  if node[:platform] != "suse" || node[:platform_version].to_f > 12.2
+    default[:rabbitmq][:ha][:clustered_rmq_features] = true
+  end
+end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -37,6 +37,45 @@ end
 package "rabbitmq-server"
 package "rabbitmq-server-plugins" if node[:platform_family] == "suse"
 
+if node[:platform_family] == "suse"
+  # With new erlang packages, we move to a system-wide epmd service, with a
+  # epmd.socket unit. This is enabled by default but only listens on 127.0.0.1,
+  # while we need it to listen on the admin network too.
+
+  directory "/etc/systemd/system/epmd.socket.d" do
+    owner "root"
+    group "root"
+    mode 0o755
+    action :create
+    only_if "grep -q Requires=epmd.service /usr/lib/systemd/system/rabbitmq-server.service"
+  end
+
+  template "/etc/systemd/system/epmd.socket.d/port.conf" do
+    source "epmd.socket-port.conf.erb"
+    owner "root"
+    group "root"
+    mode 0o644
+    variables(
+      listen_address: node[:rabbitmq][:address]
+    )
+    only_if "grep -q Requires=epmd.service /usr/lib/systemd/system/rabbitmq-server.service"
+  end
+
+  bash "reload systemd for epmd.socket extension" do
+    code "systemctl daemon-reload"
+    action :nothing
+    subscribes :run, "template[/etc/systemd/system/epmd.socket.d/port.conf]", :immediate
+  end
+
+  # Enable epmd.socket so that even when we don't use the rabbitmq systemd
+  # service (in HA, for instance), we use the system-wide epmd.
+  # (not a typo, we want the socket, not the service here)
+  service "epmd.socket" do
+    action :enable
+    only_if "grep -q Requires=epmd.service /usr/lib/systemd/system/rabbitmq-server.service"
+  end
+end
+
 directory "/etc/rabbitmq/" do
   owner "root"
   group "root"

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -67,11 +67,16 @@ if node[:platform_family] == "suse"
     subscribes :run, "template[/etc/systemd/system/epmd.socket.d/port.conf]", :immediate
   end
 
-  # Enable epmd.socket so that even when we don't use the rabbitmq systemd
-  # service (in HA, for instance), we use the system-wide epmd.
+  # Enable epmd.socket for two reasons:
+  # 1. when we don't use the rabbitmq systemd service (in HA, for instance),
+  #    this will enable the use of the system-wide epmd
+  # 2. the call to rabbitmq-plugins before we start the rabbitmq-server service
+  #    will cause epmd to be started, but not by systemd; this will make the
+  #    rabbitmq-server service fail to start due to dependencies. By
+  #    proactively starting epmd.socket, we avoid this.
   # (not a typo, we want the socket, not the service here)
   service "epmd.socket" do
-    action :enable
+    action [:enable, :start]
     only_if "grep -q Requires=epmd.service /usr/lib/systemd/system/rabbitmq-server.service"
   end
 end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -98,7 +98,8 @@ template "/etc/rabbitmq/rabbitmq.config" do
   mode 0644
   variables(
     cluster_enabled: cluster_enabled,
-    cluster_partition_handling: cluster_partition_handling
+    cluster_partition_handling: cluster_partition_handling,
+    hipe_compile: node[:rabbitmq][:hipe_compile]
   )
   notifies service_action, "service[rabbitmq-server]"
 end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -96,6 +96,16 @@ template "/etc/rabbitmq/rabbitmq-env.conf" do
   notifies service_action, "service[rabbitmq-server]"
 end
 
+virtualized = [
+  "KVM", "QEMU", "Bochs",
+  "VMWare Virtual Platform", "VMware Virtual Platform",
+  "VirtualBox"
+]
+hipe_compile = node[:rabbitmq][:hipe_compile] &&
+  node[:dmi][:system] &&
+  !virtualized.include?(node[:dmi][:system][:product_name]) &&
+  !virtualized.include?(node[:dmi][:system][:manufacturer])
+
 template "/etc/rabbitmq/rabbitmq.config" do
   source "rabbitmq.config.erb"
   owner "root"
@@ -104,7 +114,7 @@ template "/etc/rabbitmq/rabbitmq.config" do
   variables(
     cluster_enabled: cluster_enabled,
     cluster_partition_handling: cluster_partition_handling,
-    hipe_compile: node[:rabbitmq][:hipe_compile]
+    hipe_compile: hipe_compile
   )
   notifies service_action, "service[rabbitmq-server]"
 end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -96,15 +96,9 @@ template "/etc/rabbitmq/rabbitmq-env.conf" do
   notifies service_action, "service[rabbitmq-server]"
 end
 
-virtualized = [
-  "KVM", "QEMU", "Bochs",
-  "VMWare Virtual Platform", "VMware Virtual Platform",
-  "VirtualBox"
-]
-hipe_compile = node[:rabbitmq][:hipe_compile] &&
-  node[:dmi][:system] &&
-  !virtualized.include?(node[:dmi][:system][:product_name]) &&
-  !virtualized.include?(node[:dmi][:system][:manufacturer])
+`systemd-detect-virt -v -q`
+virtualized = $?.exitstatus.zero?
+hipe_compile = node[:rabbitmq][:hipe_compile] && !virtualized
 
 template "/etc/rabbitmq/rabbitmq.config" do
   source "rabbitmq.config.erb"

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -54,8 +54,8 @@ pacemaker_primitive service_name do
     "erlang_cookie" => node[:rabbitmq][:erlang_cookie],
     "pid_file" => pid_file,
     "policy_file" => "/etc/rabbitmq/ocf-promote",
-    "rmq_feature_health_check" => false,
-    "rmq_feature_local_list_queues" => false,
+    "rmq_feature_health_check" => node[:rabbitmq][:ha][:clustered_rmq_features],
+    "rmq_feature_local_list_queues" => node[:rabbitmq][:ha][:clustered_rmq_features],
     "default_vhost" => node[:rabbitmq][:vhost]
   })
   op node[:rabbitmq][:ha][:clustered_op]

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -29,6 +29,9 @@
 <% if @cluster_enabled -%>
    {cluster_partition_handling, <%= @cluster_partition_handling %>},
 <% end -%>
+<% if @hipe_compile -%>
+   {hipe_compile, true},
+<% end -%>
    {disk_free_limit, 50000000}
  ]},
  {rabbitmq_management,

--- a/chef/cookbooks/rabbitmq/templates/suse/epmd.socket-port.conf.erb
+++ b/chef/cookbooks/rabbitmq/templates/suse/epmd.socket-port.conf.erb
@@ -1,0 +1,3 @@
+[Socket]
+ListenStream=<%= @listen_address %>:4369
+FreeBind=true


### PR DESCRIPTION
This is still compatible with current behavior (as in "no change") for old rabbitmq, but enables people to play with rabbitmq 3.6.x on that branch.

Backport of https://github.com/crowbar/crowbar-openstack/pull/1519, https://github.com/crowbar/crowbar-openstack/pull/1525, https://github.com/crowbar/crowbar-openstack/pull/1527.