### PR TITLE
rabbitmq: Use systemd-detect-virt instead of custom code

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -97,15 +97,9 @@ template "/etc/rabbitmq/rabbitmq-env.conf" do
   notifies :restart, "service[rabbitmq-server]"
 end
 
-virtualized = [
-  "KVM", "QEMU", "Bochs",
-  "VMWare Virtual Platform", "VMware Virtual Platform",
-  "VirtualBox"
-]
-hipe_compile = node[:rabbitmq][:hipe_compile] &&
-  node[:dmi][:system] &&
-  !virtualized.include?(node[:dmi][:system][:product_name]) &&
-  !virtualized.include?(node[:dmi][:system][:manufacturer])
+`systemd-detect-virt -v -q`
+virtualized = $?.exitstatus.zero?
+hipe_compile = node[:rabbitmq][:hipe_compile] && !virtualized
 
 template "/etc/rabbitmq/rabbitmq.config" do
   source "rabbitmq.config.erb"


### PR DESCRIPTION
This was suggested by Dirk Mueller, and is indeed a much safer way to
detect virtualized environment.