### PR TITLE
rabbitmq: add some performance configs

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -7,6 +7,13 @@
  },
  {rabbit,
   [
+   <% if node[:rabbitmq][:collect_statistics_interval] -%>
+   {collect_statistics_interval, <%= node[:rabbitmq][:collect_statistics_interval] %>},
+   <% end -%>
+   {tcp_listen_options, [
+                         <%= node[:rabbitmq][:tcp_listen_options].reject { |k,v| v.nil? }.map { |k,v| "{#{k}, #{v}}" }.join(",") %>
+                        ]
+   },
    {tcp_listeners, [
                     <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:port]}}" }.join(", ") %>
                    ]},

--- a/chef/data_bags/crowbar/migrate/rabbitmq/203_add_performance_config.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/203_add_performance_config.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  ["tcp_listen_options", "collect_statistics_interval"].each do |option|
+    a[option] = ta[option] unless a[option]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  ["tcp_listen_options", "collect_statistics_interval"].each do |option|
+    a.delete(option) unless ta.key?(option)
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -50,14 +50,20 @@
       "mnesia": {
         "dump_log_write_threshold": 100,
         "dump_log_time_threshold": 180000
-      }
+      },
+      "tcp_listen_options": {
+        "backlog": 128,
+        "sndbuf": null,
+        "recbuf": null
+      },
+      "collect_statistics_interval": 5000
     }
   },
   "deployment": {
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -95,7 +95,17 @@
                 "dump_log_write_threshold": { "type": "int", "required": true},
                 "dump_log_time_threshold": { "type": "int", "required": true}
               }
-            }
+            },
+            "tcp_listen_options": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "backlog": { "type": "int", "required": true },
+                "sndbuf": { "type": "int", "required": false },
+                "recbuf": { "type": "int", "required": false }
+              }
+            },
+            "collect_statistics_interval": { "type": "int", "required": true}
           }
         }
       }


### PR DESCRIPTION
Adds some performance configs to tweak rabbitmq:

- backlog: number of connections that can be initialized at the
same time. Useful for a high number of connections or for a temporal
high numbers of connections, like in a server restart. Default is 128,
recommended is 4096.

- sndbuf: increase buffer for TCP connections of consumers, on linux
this value is set automatically between 80KB and 120 KB.
The higher this value is, the higher the throughput and the RAM consumed.
Recommended values for this config depend on the number of connections
and the amount of RAM available.

- recbuf: same as sndbuf but for publishers and protocol operations.

- collect_statistics_interval: the interval in milliseconds to collect
statistics, mainly by the management plugin. Increasing it will reduce
the load on the node that has the stats collector DB. Default is 5000,
recommended is 30000 or even 60000, depending on how recent you need
the stats.