### PR TITLE
monasca: fix bsc#1076594

### DIFF
--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -21,6 +21,12 @@ agent_keystone = agent_settings[:keystone]
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
+monasca_master = node_search_with_cache("roles:monasca-master").first
+if monasca_master.nil?
+  Chef::Log.warn("No monasca-master found. Skip monasca-agent setup.")
+  return
+end
+
 monasca_server = node_search_with_cache("roles:monasca-server").first
 if monasca_server.nil?
   Chef::Log.warn("No monasca-server found. Skip monasca-agent setup.")
@@ -35,6 +41,11 @@ kibana_url = "http://" + MonascaHelper.monasca_public_host(monasca_server) + ":5
 monasca_net_ip = MonascaHelper.get_host_for_monitoring_url(monasca_server)
 
 if node["roles"].include?("monasca-server")
+  unless monasca_master[:monasca] && monasca_master[:monasca][:installed]
+    Chef::Log.warn("monasca-installer has not finished successfully, yet. Skipping" \
+                   " monasca-agent setup.")
+    return
+  end
   # Special monasca-reconfigure script for monasca-server: on this machine
   # monasca-reconfigure will configure the agent.
   template "/usr/sbin/monasca-reconfigure" do


### PR DESCRIPTION
This commit fixes a race condition where monasca-reconfigure
would otherwise run too early (before monasca-installer
concludes) on the monasca-server node, thus causing it to
fail. To prevent this situation, it introduces a node
attribute that denotes at least one successful
monasca-installer run has occured in the past.