### PR TITLE
crowbar: change postgresql connection to avoid deadlocks

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -137,6 +137,8 @@ class CrowbarOpenStackHelper
       end
     end
 
+    db_conn_scheme = "postgresql+psycopg2" if db_conn_scheme == "postgresql"
+
     "#{db_conn_scheme}://" \
     "#{db_auth['user']}:#{db_auth['password']}@#{db_settings[:address]}/" \
     "#{db_auth['database']}" \


### PR DESCRIPTION
Change connection string scheme to postgresql+psycopg2 in case of
postgresql connections. This prevent the deadlocks in the DB particulary
using cinder and neutron.

Not mentioning a specific driver in the sql connection string configuration makes openstack use the wrapper driver instead of the native one. This causes deadlocks due to the wrapper using serialization vs the native driver using parallelism. 
