### PR TITLE
apache: don't collect Listen ports from wsgi vhosts (bsc#1077234)

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -145,9 +145,6 @@ else
   bind_port = node[:aodh][:api][:port]
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-node.normal[:apache][:listen_ports_crowbar][:aodh] = { plain: [bind_port] }
-
 memcached_servers = MemcachedHelper.get_memcached_servers(
   ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "aodh-server") : [node]
 )

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -195,9 +195,6 @@ else
   bind_port = node[:ceilometer][:api][:port]
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-node.normal[:apache][:listen_ports_crowbar][:ceilometer] = { plain: [bind_port] }
-
 if ceilometer_protocol == "https"
   ssl_setup "setting up ssl for ceilometer" do
     generate_certs node[:ceilometer][:ssl][:generate_certs]

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -484,20 +484,7 @@ else
   bind_port_ssl = 443
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-
-if node[:horizon][:apache][:ssl]
-  node.normal[:apache][:listen_ports_crowbar][:horizon] = { plain: [bind_port], ssl: [bind_port_ssl] }
-else
-  node.normal[:apache][:listen_ports_crowbar][:horizon] = { plain: [bind_port] }
-end
-
-# we can only include the recipe after having defined the listen_ports_crowbar attribute
 include_recipe "horizon::ha" if ha_enabled
-
-# Override what the apache2 cookbook does since it enforces the ports
-resource = resources(template: "#{node[:apache][:dir]}/ports.conf")
-resource.variables({apache_listen_ports: node.normal[:apache][:listen_ports_crowbar].values.map{ |p| p.values }.flatten.uniq.sort})
 
 if node[:horizon][:apache][:ssl] && node[:horizon][:apache][:generate_certs]
   package "apache2-utils"

--- a/chef/cookbooks/horizon/templates/default/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/default/openstack-dashboard.conf.erb
@@ -6,6 +6,9 @@ RewriteEngine On
 RewriteCond %{SERVER_PORT} ^<%= @bind_port %>$
 RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 
+Listen <%= @bind_host %>:<%= @bind_port %>>
+Listen <%= @bind_host %>:<%= @bind_port_ssl %>
+
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
     SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
@@ -17,6 +20,8 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
     <% end %>
 
 <% else %>
+Listen <%= @bind_host %>:<%= @bind_port %>>
+
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
 <% end %>
     WSGIDaemonProcess horizon user=<%= @user %> group=<%= @group %> processes=3 threads=10 home=<%= @horizon_dir %>  display-name=%{GROUP}

--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -2,6 +2,8 @@
 <IfDefine SSL>
 <IfDefine !NOSSL>
 
+Listen <%= @bind_host %>:<%= @bind_port %>
+
 # Redirect non-SSL traffic to SSL
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
     RewriteEngine On
@@ -24,6 +26,8 @@
     RewriteRule / https://%1%{REQUEST_URI} [L,R]
 </VirtualHost>
 
+Listen <%= @bind_host %>:<%= @bind_port_ssl %>
+
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
     SSLCipherSuite DEFAULT_SUSE
@@ -35,6 +39,8 @@
     <% end %>
 
 <% else %>
+Listen <%= @bind_host %>:<%= @bind_port %>
+
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
 <% end %>
     WSGIScriptAlias / <%= @horizon_dir %>/openstack_dashboard/wsgi/django.wsgi

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -48,9 +48,6 @@ else
   bind_service_port = node[:keystone][:api][:service_port]
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-node.normal[:apache][:listen_ports_crowbar][:keystone] = { admin: [bind_admin_port], service: [bind_service_port] }
-
 # Ideally this would be called admin_host, but that's already being
 # misleadingly used to store a value which actually represents the
 # service bind address.

--- a/chef/cookbooks/nova/recipes/placement_api.rb
+++ b/chef/cookbooks/nova/recipes/placement_api.rb
@@ -99,9 +99,6 @@ else
   bind_port = node[:nova][:ports][:placement_api]
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-node.normal[:apache][:listen_ports_crowbar][:nova] = { plain: [bind_port] }
-
 crowbar_openstack_wsgi "WSGI entry for nova-placement-api" do
   bind_host bind_host
   bind_port bind_port


### PR DESCRIPTION
The listen_ports_crowbar attribute controls which ports are added
as Listen directives to the /etc/apache2/listen.conf file.

However, all wsgi vhosts aside from horizon already have an explicit
Listen directive in the vhost configuration file, so there's no need
to add these ports to the /etc/apache2/listen.conf file.

To align horizon to the other WSGI vhosts, Listen directives are
added to the horizon WSGI vhost configuration file. Since these don't
also have to be added to the /etc/apache2/listen.conf file anymore, the
usage of listen_ports_crowbar can be removed altogether.

Fixes [bsc#1077234](https://bugzilla.suse.com/show_bug.cgi?id=1077234)

Additional notes:
 - `listen_ports_crowbar` is still being used by the HA apache recipe [1] to determine which port to use for the status URL. If no `listen_ports_crowbar` entries are configured (which is indeed the case unless the horizon barclamp is deployed) then the default 80 port is used and the apache HA status URL is `http://127.0.0.1:80/server-status` [2]. This could be a problem (to be tested).
UPDATE: the server_status module isn't even configured in apache, so this part can be safely ignored.

[1] https://github.com/crowbar/crowbar-ha/blob/master/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb#L33
[2] https://github.com/crowbar/crowbar-ha/blob/master/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb#L46