### PR TITLE
neutron-ha-tool: Add insecure flag (bsc#1075394)

### DIFF
--- a/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
+++ b/chef/cookbooks/neutron/files/default/neutron-l3-ha-service.rb
@@ -334,7 +334,7 @@ class HATool
   end
 
   def status_command
-    [@options.program, "--l3-agent-check", "--quiet"]
+    [@options.program, "--l3-agent-check", "--quiet"] + insecure_flag
   end
 
   def migration_command


### PR DESCRIPTION
The insecure flag was missing from the status command which was causing the neutron-l3-ha-service to
fail.