### PR TITLE
rabbitmq: fix queue_master_locator value

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -28,7 +28,7 @@
 <% end -%>
 <% if @cluster_enabled -%>
    {cluster_partition_handling, <%= @cluster_partition_handling %>},
-   {queue_master_locator, "min-masters"},
+   {queue_master_locator, <<"min-masters">>},
 <% end -%>
 <% if @hipe_compile -%>
    {hipe_compile, true},


### PR DESCRIPTION
This specific options needs to be an erlang binary string in
the config as mentioned on the docs[0]

[0] http://previous.rabbitmq.com/v3_6_x/configure.html