### PR TITLE
[4.0] rabbitmq: fix queue_master_locator value

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -28,7 +28,7 @@
 <% end -%>
 <% if @cluster_enabled -%>
    {cluster_partition_handling, <%= @cluster_partition_handling %>},
-   {queue_master_locator, "min-masters"},
+   {queue_master_locator, <<"min-masters">>},
 <% end -%>
 <% if @hipe_compile -%>
    {hipe_compile, true},


### PR DESCRIPTION
It needs to be an erlang binary

(cherry picked from commit 5f266b46e9f1e36cd605a6b4046accd3a0b3c20e)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1536