### PR TITLE
swift: Fix switch detection (bsc#1075015)

### DIFF
--- a/chef/cookbooks/swift/libraries/rack_awareness.rb
+++ b/chef/cookbooks/swift/libraries/rack_awareness.rb
@@ -38,7 +38,10 @@ class Rack_awareness
             #get storage iface
             iface=""
             n[:crowbar_wall][:network][:interfaces].keys.each do |ifn|
-              if n[:crowbar_wall][:network][:interfaces][ifn.to_s][:addresses].include?(storage_ip)
+              ifaddrs = n[:crowbar_wall][:network][:interfaces][ifn.to_s][:addresses]
+              # strip netmasks from CIDR addresses
+              ifaddrs.map! { |addr| addr[%r{^[^/]+}] }
+              if ifaddrs.include?(storage_ip)
                 iface=ifn
                 break
               end
@@ -52,7 +55,7 @@ class Rack_awareness
                #fallback to something default
                iface=n[:crowbar_ohai][:switch_config].keys[0]
             end
-            sw_name=n[:crowbar_ohai][:switch_config][iface][:switch_name]
+            return n[:crowbar_ohai][:switch_config].fetch(iface, switch_name: -1)[:switch_name]
     end
 
     def switch_to_zone()


### PR DESCRIPTION
1. The addresses in `crowbar_wall` are full CIDR entries so netmask
needs to be removed before comparing to plain `storage_ip`.
2. Sometimes switch_config is not fully populated for all nodes (yet).
Fall back to default in such cases.

EDIT: the second problem self-healed somehow in my setup so I removed the fix for that.
EDIT2: re-enabled second fix. When deploying swift on given node the code checks for `switch_config` on all swift nodes. This can lead to race condition where chef-client didn't fill the attributes for some of the nodes yet.