### PR TITLE
ironic: Expose pxe_append_params as attribute + migration fix

### DIFF
--- a/chef/cookbooks/ironic/attributes/default.rb
+++ b/chef/cookbooks/ironic/attributes/default.rb
@@ -78,4 +78,6 @@ default[:ironic][:config_file] = "/etc/ironic/ironic.conf.d/100-ironic.conf"
 
 default[:ironic][:tftproot] = "/var/lib/ironic/tftpboot"
 
+default[:ironic][:pxe_append_params] = "nofb nomodeset vga=normal"
+
 default[:ironic][:enabled_drivers] = []

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -188,6 +188,7 @@ template node[:ironic][:config_file] do
         ironic_ip: ironic_net_ip,
         tftp_ip: ironic_net_ip,
         tftproot: node[:ironic][:tftproot],
+        pxe_append_params: node[:ironic][:pxe_append_params],
         public_endpoint: public_endpoint,
         api_port: api_port,
         auth_version: auth_version,

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -121,6 +121,7 @@ heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 tftp_server=<%= @tftp_ip %>
 tftp_root=<%= @tftproot %>
 tftp_master_path=<%= @tftproot %>/master_images
+pxe_append_params=<%= @pxe_append_params %>
 
 [deploy]
 default_boot_option=netboot

--- a/chef/data_bags/crowbar/migrate/ironic/202_add_pxe_append_params.rb
+++ b/chef/data_bags/crowbar/migrate/ironic/202_add_pxe_append_params.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "pxe_append_params"
+    a["pxe_append_params"] = ta["pxe_append_params"]
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("pxe_append_params")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ironic.json
+++ b/chef/data_bags/crowbar/template-ironic.json
@@ -15,6 +15,7 @@
       "memcache_secret_key": "",
       "enabled_drivers": [],
       "automated_clean": true,
+      "pxe_append_params": "nofb nomodeset vga=normal",
       "api": {
         "protocol": "http",
         "port": 6385
@@ -29,7 +30,7 @@
   "deployment": {
     "ironic": {
       "crowbar-revision": 0,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "crowbar-applied": false,
       "element_states": {
         "ironic-server": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-ironic.schema
+++ b/chef/data_bags/crowbar/template-ironic.schema
@@ -24,6 +24,7 @@
             "memcache_secret_key": { "type": "str", "required": true },
             "enabled_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
             "automated_clean": { "type": "bool", "required": true },
+            "pxe_append_params": { "type": "str", "required": true },
             "api": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/models/ironic_service.rb
+++ b/crowbar_framework/app/models/ironic_service.rb
@@ -16,7 +16,7 @@
 #
 
 class IronicService < ServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "ironic"
   end


### PR DESCRIPTION
pxe_append_params option is used to add extra kernel parameters to IPA runs.
Example use:
`sshkey="<public key>"` param gives ssh access to running IPA image.
`coreos.autologin` enables console auto login (CoreOS based image)
`ipa-debug=1` enables debug logging in IPA
Great for troubleshooting.

EDIT: additional commit fixes small bug causing migrations to fail.