### PR TITLE
Disallow postgresql and unclustered HA for rabbitmq for new deployments

### DIFF
--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -167,6 +167,15 @@ class RabbitmqService < OpenstackServiceObject
 
     # Shared storage validation for HA
     if ha_enabled && !attributes["cluster"]
+      # disallow non-cluster HA for new deployments
+      proposal_id = proposal["id"].gsub("#{@bc_name}-", "")
+      proposal_object = Proposal.where(barclamp: @bc_name, name: proposal_id).first
+      if proposal_object.nil? || !proposal_object.active_status?
+        validation_error I18n.t(
+          "barclamp.#{@bc_name}.validation.no_new_unclustered"
+        )
+      end
+
       storage_mode = attributes["ha"]["storage"]["mode"]
       validation_error I18n.t(
         "barclamp.#{@bc_name}.validation.unknown_mode", storage_mode: storage_mode

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -56,6 +56,7 @@ en:
               options: 'Mount Options'
       validation:
         invalid_db_engine: 'Invalid database engine: %{db_engine}.'
+        no_new_postgresql: 'PostgreSQL is not allowed for new deployments.'
         unknown_mode_ha: 'Unknown mode for HA storage: %{storage_mode}.'
         no_device: 'No device specified for shared storage.'
         no_filesystem: 'No filesystem type specified for shared storage.'

--- a/crowbar_framework/config/locales/rabbitmq/en.yml
+++ b/crowbar_framework/config/locales/rabbitmq/en.yml
@@ -43,21 +43,6 @@ en:
           cert_required: 'Require Client Certificate'
           ca_certs: 'SSL CA Certificates File'
           client_ca_certs: 'SSL client CA file (used to validate rabbitmq server certificate)'
-        ha_header: 'High Availability'
-        cluster: 'Use RabbitMQ Clustering'
-        ha:
-          storage:
-            mode: 'Storage Mode'
-            modes:
-              drbd: 'DRBD'
-              shared: 'Shared Storage'
-            drbd_info: 'The cluster must have been setup for DRBD.'
-            drbd:
-              size: 'Size to Allocate for DRBD Device (in Gigabytes)'
-            shared:
-              device: 'Name of Block Device or NFS Mount Specification'
-              fstype: 'Filesystem Type'
-              options: 'Mount Options'
       validation:
         no_new_unclustered: 'HA without RabbitMQ clustering is not allowed for new deployments.'
         unknown_mode: 'Unknown mode for HA storage: %{storage_mode}.'

--- a/crowbar_framework/config/locales/rabbitmq/en.yml
+++ b/crowbar_framework/config/locales/rabbitmq/en.yml
@@ -59,6 +59,7 @@ en:
               fstype: 'Filesystem Type'
               options: 'Mount Options'
       validation:
+        no_new_unclustered: 'HA without RabbitMQ clustering is not allowed for new deployments.'
         unknown_mode: 'Unknown mode for HA storage: %{storage_mode}.'
         no_device: 'No device specified for shared storage.'
         no_filesystem: 'No filesystem type specified for shared storage.'


### PR DESCRIPTION
We don't want new deployments to use these old ways of deploying the database and rabbitmq.

Old deployments will still work fine, as the check is only done when the barclamp is not applied yet.