### PR TITLE
Nuage ml2 mechanism driver for neutron

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -32,6 +32,7 @@ default[:neutron][:l3_agent_config_file] = "/etc/neutron/neutron-l3-agent.conf.d
 default[:neutron][:metadata_agent_config_file] = "/etc/neutron/neutron-metadata-agent.conf.d/100-metadata_agent.conf"
 default[:neutron][:ml2_config_file] = "/etc/neutron/neutron.conf.d/110-ml2.conf"
 default[:neutron][:nsx_config_file] = "/etc/neutron/neutron.conf.d/110-nsx.conf"
+default[:neutron][:nuage_config_file] = "/etc/neutron/neutron.conf.d/110-nuage.conf"
 default[:neutron][:rpc_workers] = 1
 
 default[:neutron][:db][:database] = "neutron"
@@ -112,6 +113,10 @@ when "suse"
     nsx_pkgs: ["openvswitch-pki",
                    "ruby2.1-rubygem-faraday"],
     cisco_pkgs: ["python-networking-cisco"],
+    nuage_vrs_pkgs: ["nuage-openvswitch"],
+    nuage_vrs_metadata_pkgs: ["nuage-metadata-agent"],
+    nuage_vsp_pkgs: ["nuage-openstack-neutron",
+                     "nuage-openstack-neutronclient"],
     cisco_apic_pkgs: ["python-apicapi",
                       "python-neutron-ml2-driver-apic"],
     cisco_apic_gbp_pkgs: ["openstack-neutron-gbp",

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -88,6 +88,12 @@ if neutron[:neutron][:networking_plugin] == "ml2" &&
   return # skip anything else in this recipe
 end
 
+if neutron[:neutron][:networking_plugin] == "ml2" &&
+    neutron[:neutron][:ml2_mechanism_drivers].include?("nuage")
+  include_recipe "neutron::nuage_vrs"
+  return # skip anything else in this recipe
+end
+
 multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty?
 
 # openvswitch configuration specific to ML2

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -82,6 +82,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     service_plugins = ["cisco_apic_l3"]
   elsif neutron[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
     service_plugins = ["group_policy", "servicechain", "apic_gbp_l3"]
+  elsif neutron[:neutron][:ml2_mechanism_drivers].include?("nuage")
+    service_plugins = ["NuageL3", "NuageAPI", "NuagePortAttributes"]
   end
 end
 service_plugins = service_plugins.join(", ")

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -109,6 +109,12 @@ when "vmware"
   interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
 end
 
+
+if node[:neutron][:networking_plugin] == "ml2" &&
+    (node[:neutron][:ml2_mechanism_drivers].include?("nuage"))
+  return # skip anything else in this recipe
+end
+
 template "/etc/neutron/metering_agent.ini" do
   cookbook "neutron"
   source "metering_agent.ini.erb"

--- a/chef/cookbooks/neutron/recipes/nuage_vrs.rb
+++ b/chef/cookbooks/neutron/recipes/nuage_vrs.rb
@@ -1,0 +1,79 @@
+#
+# Copyright 2018 SUSE Linux GmBH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# install nuage VRS
+node[:neutron][:platform][:nuage_vrs_pkgs].each { |p| package p }
+
+# Nuage missed one dependency in their ovs package. Adding it here
+packages = ["python-setproctitle"]
+packages.each do |pkg|
+  package pkg do
+    action :install
+  end
+end
+
+if node.attribute?(:cookbook) and node[:cookbook] == "nova"
+  neutrons = node_search_with_cache("roles:neutron-server", node[:nova][:neutron_instance])
+  neutron = neutrons.first || raise("Neutron instance '#{node[:nova][:neutron_instance]}' for nova not found")
+else
+  neutron = node
+end
+
+template "/etc/default/openvswitch" do
+  source "nuage_openvswitch.erb"
+  owner "root"
+  group "root"
+  mode "0640"
+  variables(
+    nuage_config: neutron[:neutron][:nuage]
+  )
+end
+
+service "openvswitch" do
+  action [:enable, :start]
+  subscribes :restart, resources("template[/etc/default/openvswitch]")
+end
+
+if node.roles.include?("nova-compute-kvm") or 
+   node.roles.include?("nova-compute-qemu")
+  packages = ["python-novaclient"]
+  packages.each do |pkg|
+    package pkg do
+      action :install
+    end
+  end
+
+  node[:neutron][:platform][:nuage_vrs_metadata_pkgs].each { |p| package p }
+
+  keystone_settings = KeystoneHelper.keystone_settings(node, :nova)
+  admin_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+
+  template "/etc/default/nuage-metadata-agent" do
+    source "nuage_metadata_agent.erb"
+    owner "root"
+    group node[:nova][:group]
+    mode "0640"
+    variables(
+      nuage_config: neutron[:neutron][:nuage],
+      keystone_settings: keystone_settings,
+      metadata_bind_address: admin_address,
+      metadata_port: 9697,
+      nova_metadata_port: node[:nova][:ports][:metadata]
+    )
+    notifies :restart, "service[openvswitch]"
+  end
+end
+

--- a/chef/cookbooks/neutron/recipes/nuage_vsp_agents.rb
+++ b/chef/cookbooks/neutron/recipes/nuage_vsp_agents.rb
@@ -1,0 +1,69 @@
+#
+# Copyright 2017 SUSE Linux GmBH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+neutron = nil
+if node.attribute?(:cookbook) && node[:cookbook] == "nova"
+  neutrons = node_search_with_cache("roles:neutron-server", node[:nova][:neutron_instance])
+  neutron = neutrons.first || raise("Neutron instance '#{node[:nova][:neutron_instance]}' \
+                                    for nova not found")
+else
+  neutron = node
+end
+
+ml2_mech_drivers = neutron[:neutron][:ml2_mechanism_drivers]
+ml2_type_drivers = neutron[:neutron][:ml2_type_drivers]
+
+return unless ml2_mech_drivers.include?("nuage")
+
+if node.roles.include?("neutron-network")
+  # Explicitly stop and disable l2, l3 and metadata agents if Nuage is
+  # enabled on network node
+  service node[:neutron][:platform][:dhcp_agent_name] do
+    action [:stop, :disable]
+  end
+
+  service node[:neutron][:platform][:metadata_agent_name] do
+    action [:stop, :disable]
+  end
+
+  service node[:neutron][:platform][:l3_agent_name] do
+    action [:stop, :disable]
+  end
+
+  service node[:neutron][:platform][:metering_agent_name] do
+    action [:stop, :disable]
+  end
+
+  service node[:neutron][:platform][:ovs_agent_name] do
+    action [:stop, :disable]
+  end
+end
+
+if node.roles.include?("neutron-server")
+  node[:neutron][:platform][:nuage_vsp_pkgs].each { |p| package p }
+end
+
+template neutron[:neutron][:nuage_config_file] do
+  cookbook "neutron"
+  source "nuage.conf.erb"
+  mode "0640"
+  owner "root"
+  group node[:neutron][:platform][:group]
+  variables(
+    nuage_config: node[:neutron][:nuage]
+  )
+  notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]"
+end

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -163,7 +163,12 @@ when "ml2"
   os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
   mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
 
-  ml2_extension_drivers = ["dns", "port_security"]
+  if node[:neutron][:ml2_mechanism_drivers].include?("nuage")
+    ml2_extension_drivers =["nuage_subnet", "nuage_port", "port_security"]
+  else
+    ml2_extension_drivers = ["dns", "port_security"]
+  end
+
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv
@@ -260,6 +265,12 @@ if node[:neutron][:networking_plugin] == "ml2"
   elsif node[:neutron][:ml2_mechanism_drivers].include?("cisco_apic_ml2") ||
       node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
     include_recipe "neutron::cisco_apic_support"
+  end
+end
+
+if node[:neutron][:networking_plugin] == "ml2"
+  if node[:neutron][:ml2_mechanism_drivers].include?("nuage")
+    include_recipe "neutron::nuage_vsp_agents"
   end
 end
 

--- a/chef/cookbooks/neutron/templates/default/nuage.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/nuage.conf.erb
@@ -1,0 +1,19 @@
+[RESTPROXY]
+# Desired Name of VSD Organization/Enterprise to use when net-partition
+# is not specified
+default_net_partition_name = <%= @nuage_config[:vsd_default_net_partition_name] %>
+
+# Hostname or IP address and port for connection
+server = <%= @nuage_config[:vsd_server] %>
+
+# VSD Username and password for OpenStack plugin
+# User must belong to CSP Root group and CSP CMS
+serverauth = <%= @nuage_config[:vsd_user] %>:<%= @nuage_config[:vsd_password] %>
+
+cms_id=<%= @nuage_config[:vsd_cms_id] %>
+
+### Do not change the below options for standard installs
+organization = csp
+auth_resource = /me
+serverssl = True
+base_uri = /nuage/api/v5_0

--- a/chef/cookbooks/neutron/templates/default/nuage_metadata_agent.erb
+++ b/chef/cookbooks/neutron/templates/default/nuage_metadata_agent.erb
@@ -1,0 +1,78 @@
+# Copyright (C) 2017, Nuage Networks
+#
+# METADATA_PORT: This is the location to get the values from when migrating
+# from Neutron metadata agent to Nuage metadata agent and these values need
+# not be populated in neutron.conf while using Nuage Metadata agent.
+# (metadata_port in neutron.conf)
+METADATA_PORT=<%= @metadata_port %>
+
+#
+# NOVA_METADATA_IP: IP address used by Nova metadata server. This is the
+# location to get the values from when migrating from Neutron metadata
+# agent to Nuage metadata agent. These values need not be populated in
+# neutron.conf while using Nuage Metadata agent.
+# (nova_metadata_ip in neutron.conf)
+NOVA_METADATA_IP=<%= @metadata_bind_address %>
+
+#
+# NOVA_METADATA_PORT: TCP Port used by Nova metadata server
+# (metadata_listen_port in nova.conf or nova_metadata_port in neutron.conf)
+NOVA_METADATA_PORT=<%= @nova_metadata_port %>
+
+#
+# METADATA_PROXY_SHARED_SECRET: Shared secret to sign the instance-id
+# request. Must match metadata_proxy_shared_secret in nova.conf
+METADATA_PROXY_SHARED_SECRET="NuageNetworksSharedSecret"
+
+#
+# NOVA_CLIENT_VERSION:
+NOVA_CLIENT_VERSION=2
+
+#
+# NOVA_OS_USERNAME:
+NOVA_OS_USERNAME=<%= @keystone_settings['service_user'] %>
+
+#
+# NOVA_OS_PASSWORD:
+NOVA_OS_PASSWORD=<%= @keystone_settings['service_password'] %>
+
+#
+# NOVA_OS_TENANT_NAME:
+NOVA_OS_TENANT_NAME=<%= @keystone_settings['service_tenant'] %>
+
+#
+# NOVA_OS_AUTH_URL:
+OVA_OS_AUTH_URL=<%= @keystone_settings['internal_auth_url'] %>
+
+#
+# NOVA_REGION_NAME:
+NOVA_REGION_NAME=<%= @keystone_settings['endpoint_region'] %>
+
+#
+# NUAGE_METADATA_AGENT_START_WITH_OVS: if nuage-metadata-agent needs to be
+# started with nuage-openvswitch-switch
+NUAGE_METADATA_AGENT_START_WITH_OVS=true
+
+#
+# NOVA_API_ENDPOINT_TYPE: one of publicURL, internalURL, adminURL
+NOVA_API_ENDPOINT_TYPE=internalURL
+
+#
+# NOVA_PROJECT_NAME:
+NOVA_PROJECT_NAME=<%= @keystone_settings['service_tenant'] %>
+
+#
+# NOVA_USER_DOMAIN_NAME
+NOVA_USER_DOMAIN_NAME=<%= @keystone_settings['admin_domain'] %>
+
+#
+# NOVA_PROJECT_DOMAIN_NAME
+NOVA_PROJECT_DOMAIN_NAME=<%= @keystone_settings['admin_domain']%>
+
+#
+# IDENTITY_URL_VERSION
+IDENTITY_URL_VERSION=<%= @keystone_settings['api_version_for_middleware'] %>
+
+#
+# NOVA_OS_KEYSTONE_USERNAME
+NOVA_OS_KEYSTONE_USERNAME=<%= @keystone_settings['service_user'] %>

--- a/chef/cookbooks/neutron/templates/default/nuage_openvswitch.erb
+++ b/chef/cookbooks/neutron/templates/default/nuage_openvswitch.erb
@@ -1,0 +1,189 @@
+### Configuration options for openvswitch
+
+# Copyright (C) 2009, 2010, 2011 Nicira, Inc.
+
+# FORCE_COREFILES: If 'yes' then core files will be enabled.
+# FORCE_COREFILES=yes
+
+# OVSDB_SERVER_PRIORITY: "nice" priority at which to run ovsdb-server.
+#
+# OVSDB_SERVER_PRIORITY=-10
+
+# VSWITCHD_PRIORITY: "nice" priority at which to run ovs-vswitchd.
+# VSWITCHD_PRIORITY=-10
+
+# VSWITCHD_MLOCKALL: Whether to pass ovs-vswitchd the --mlockall option.
+#     This option should be set to "yes" or "no".  The default is "yes".
+#     Enabling this option can avoid networking interruptions due to
+#     system memory pressure in extraordinary situations, such as multiple
+#     concurrent VM import operations.
+# VSWITCHD_MLOCKALL=yes
+
+# OVS_CTL_OPTS: Extra options to pass to ovs-ctl.  This is, for example,
+# a suitable place to specify --ovs-vswitchd-wrapper=valgrind.
+# OVS_CTL_OPTS=
+# DELETE_BRIDGES: Delete the previously existing ones, default is "no".
+# DELETE_BRIDGES=no
+
+# PERSONALITY: vrs/vrs-g/vrs-b/nsg/nsg-br/nsg-duc/none (default: vrs)
+PERSONALITY=<%= @nuage_config[:vrs_personality] %>
+
+# UUID: uuid assigned to nsg
+UUID=
+
+# CPE_ID: 4 byte id assigned to nsg
+CPE_ID=
+
+# DATAPATH_ID: Datapath id of the nsg
+DATAPATH_ID=
+
+# UPLINK_ID: uplink id assigned to nsg
+UPLINK_ID=
+
+# NETWORK_UPLINK_INTF: uplink interface of the host
+NETWORK_UPLINK_INTF=
+# NETWORK_NAMESPACE: namespace to create pat interfaces, iptables & route rules
+NETWORK_NAMESPACE=
+
+#
+# VRSG_PEER_IP: Applies only when in GateWay mode
+# VRSG_PEER_IP=0.0.0.0
+
+# PLATFORM: kvm/xen/esx-i/lxc. Only apply when in VRS personality. 
+# lxc and kvm can exist at the same time as a , separated list like so: 
+# PLATFORM: "kvm, lxc"
+PLATFORM="kvm"
+
+# DEFAULT_BRIDGE: Nuage managed bridge
+DEFAULT_BRIDGE=alubr0
+
+# BRIDGE_MTU: Configurable bridge MTU
+#BRIDGE_MTU=
+
+# MCAST_UNDERLAY_TX_INTF: mcast tx interface
+#MCAST_UNDERLAY_TX_INTF=
+
+# GW_HB_BRIDGE: Name of the gateway heartbeat bridge
+GW_HB_BRIDGE=
+
+# GW_HB_VLAN: vlan for heart beat exchange in gateways
+GW_HB_VLAN=
+
+# GW_HB_TIMEOUT: timeout for heart beat exchange in gateways in milliseconds
+GW_HB_TIMEOUT=2000
+
+# MGMT_ETH: Comma separated names of management Ethernet interfaces
+MGMT_ETH=
+
+# UPLINK_ETH: Comma separated names of Ethernet interfaces used for uplink
+UPLINK_ETH=
+
+# GW_PEER_DATAPATH_ID: Datapath ID of peer gateway to which access resiliency
+# will be established
+GW_PEER_DATAPATH_ID=
+
+# GW_ROLE: Specify role of a gateway.
+# Set to "master" if all access link ports of the gateway should act as
+# a master in a resilient setup, "backup" if it should act as a backup.
+GW_ROLE="backup"
+
+#Sample Mcast Underlay interface and range configuration
+# MCAST_UNDERLAY_INTF_1: mcast interface
+#MCAST_UNDERLAY_INTF_1=
+
+# MCAST_UNDERLAY_INTF_RANGE_1: mcast interface range
+#MCAST_UNDERLAY_INTF_RANGE_1=
+
+# CONNID_TYPE: This could be set to type uuid or string
+# CONNID_TYPE=
+
+# CONNID_VAL: This could be a uuid value or a string
+# CONNID_VAL=
+
+# CLIENT_KEY_PATH: SSL client key file path
+# CLIENT_KEY_PATH=
+
+# CLIENT_CERT_PATH: SSL client certificate file path
+# CLIENT_CERT_PATH=
+
+# CA_CERT_PATH: CA certificate file path
+# CA_CERT_PATH=
+
+# CONN_TYPE: ssl or tcp
+CONN_TYPE=tcp
+
+# ACTIVE_CONTROLLER: Primary controller IP. Only valid IP addresses will be
+# accepted. To delete the controller comment out the ACTIVE_CONTROLLER
+# variable below
+ACTIVE_CONTROLLER=<%= @nuage_config[:vrs_active_controller] %>
+#
+# STANDBY_CONTROLLER: Secondary controller IP. Only valid IP addresses
+# will be accepted. To delete the controller comment out the STANDBY_CONTROLLER
+# variable below
+STANDBY_CONTROLLER=<%= @nuage_config[:vrs_standby_controller] %>
+#
+# NUAGE_MONITOR_PRIORITY:
+# NUAGE_MONITOR_PRIORITY= -10
+#
+# VM_MONITOR_PRIORITY:
+# VM_MONITOR_PRIORITY= -10
+#
+# MANAGEMENT_INTERFACE: Management interface (example: eth0) 
+# MANAGEMENT_INTERFACE=eth0
+
+# DHCP_RELAY_ADDRESS: IP Address of the DHCP relay server 
+# DHCP_RELAY_ADDRESS=
+
+# STATS_COLLECTOR_ADDRESS: IP or FQDN of the STATS relay server (applicable only for NSG)
+# STATS_COLLECTOR_ADDRESS=
+
+# STATS_COLLECTOR_TYPE: IP or FQDN (default: FQDN) (applicable only for NSG)
+# STATS_COLLECTOR_TYPE=
+
+# STATS_COLLECTOR_PORT: ssl port of the STATS relay server (applicable only for NSG)
+# STATS_COLLECTOR_PORT=
+#
+# DB_FILE: OVSDB file location (default: /etc/openvswitch)
+# DB_FILE=
+
+# FLOW_EVICTION_THRESHOLD: Number of flows at which eviction from
+# kernel flow table will be triggered (default : 2500) 
+#FLOW_EVICTION_THRESHOLD=
+
+# DATAPATH_SYNC_TIMEOUT: Datapath flow stats sync timeout
+# specified in milliseconds (default: 1000)
+#DATAPATH_SYNC_TIMEOUT=
+
+# DATAPATH_FLOW_IDLE_TIMEOUT : Datapath flow idle timeout
+# specified in milliseconds (default: 5000)
+#DATAPATH_FLOW_IDLE_TIMEOUT=
+
+# SKB_LRO_MOD_ENABLED: enable or disable LRO modification in skb for
+# improving performance. Allowed values: 'yes' or 'no'
+SKB_LRO_MOD_ENABLED=no
+
+# PROBE_INTERVAL : Configurable openflow echo timer
+# specified in milliseconds (default: 5000)
+#PROBE_INTERVAL=
+#
+# DEFAULT_LOG_LEVEL: default log level at openvswitch start
+# DEFAULT_LOG_LEVEL=any:file:dbg
+DEFAULT_LOG_LEVEL=
+
+# REVERTIVE_CONTROLLER: Revertive behavior of VRS (default : no)
+REVERTIVE_CONTROLLER=no
+
+# REVERTIVE_TIMER: Revert timer for the revertive behavior of VRS (default: 300 seconds)
+# Valid range : 10 - 7200 seconds
+REVERTIVE_TIMER=300
+
+# CONTROLLER_LESS_DURATION : Controller-less duration of VRS (applicable only for NSG)
+# (default is 3600 seconds. Valid Range: 3600 seconds(1 hr) - 86400 seconds(24 hr))
+# -1 indicates infinite duration 
+#CONTROLLER_LESS_DURATION=3600
+
+# Service IPV4 subnet for kubernetes
+K8S_SERVICE_IPV4_SUBNET=0.0.0.0/8
+
+# FP_PORTS: List of fast-path ports to be recognized as Network ports (applicable only for Advanced VRS) 
+#FP_PORTS=

--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -74,6 +74,10 @@ when "ml2"
     neutron_agent = ""
     neutron_agent_pkg = ""
     neutron_agent_ra = ""
+  when ml2_mech_drivers.include?("nuage")
+    neutron_agent = ""
+    neutron_agent_pkg = ""
+    neutron_agent_ra = ""
   end
 
   package neutron_agent_pkg unless neutron_agent_ra.empty?

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -145,6 +145,7 @@ if neutron_servers.length > 0
   neutron_service_user = neutron_server[:neutron][:service_user]
   neutron_service_password = neutron_server[:neutron][:service_password]
   neutron_dhcp_domain = neutron_server[:neutron][:dhcp_domain]
+  ml2_mechanism_drivers = neutron_server[:neutron][:ml2_mechanism_drivers]
   neutron_ml2_drivers = neutron_server[:neutron][:ml2_type_drivers]
   neutron_has_tunnel = neutron_ml2_drivers.include?("gre") || neutron_ml2_drivers.include?("vxlan")
 else
@@ -373,6 +374,7 @@ template node[:nova][:config_file] do
     neutron_service_password: neutron_service_password,
     neutron_dhcp_domain: neutron_dhcp_domain,
     neutron_has_tunnel: neutron_has_tunnel,
+    ml2_mechanism_drivers: ml2_mechanism_drivers,
     keystone_settings: keystone_settings,
     cinder_insecure: cinder_insecure,
     use_multipath: use_multipath,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -90,6 +90,9 @@ control_exchange = nova
 <%= "zvm_user_profile=#{node[:nova][:zvm][:zvm_user_profile]}" if @libvirt_type.eql?('zvm') %>
 <%= "zvm_user_default_password=#{node[:nova][:zvm][:zvm_user_default_password]}" if @libvirt_type.eql?('zvm') %>
 <%= "zvm_user_default_privilege=#{node[:nova][:zvm][:zvm_user_default_privilege]}" if @libvirt_type.eql?('zvm') %>
+<% if @ml2_mechanism_drivers.include?("nuage") %>
+use_forwarded_for = True
+<% end %>
 
 [api_database]
 <% if @api_database_connection -%>
@@ -200,10 +203,17 @@ block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_M
 <% if @libvirt_type.eql?('kvm') %>use_virtio_for_bridges = true<% end %>
 <%= "volume_use_multipath = true" if @use_multipath %>
 <%= "iser_use_multipath = true" if @use_multipath %>
+<% if @ml2_mechanism_drivers.include?("nuage") %>
+vif_driver = nova.virt.libvirt.vif.LibvirtGenericVIFDriver
+<% end %>
 
 [neutron]
 service_metadata_proxy = true
+<% if @ml2_mechanism_drivers.include?("nuage") %>
+metadata_proxy_shared_secret = NuageNetworksSharedSecret
+<% else %>
 metadata_proxy_shared_secret = <%= node[:nova][:neutron_metadata_proxy_shared_secret] %>
+<% end %>
 url = <%= @neutron_protocol %>://<%= @neutron_server_host %>:<%= @neutron_server_port %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
 auth_url = <%= KeystoneHelper.versioned_service_URL(@keystone_settings["protocol"],
@@ -217,6 +227,9 @@ project_name = <%= @keystone_settings['service_tenant'] %>
 tenant_name = <%= @keystone_settings['service_tenant'] %>
 timeout = <%= node[:nova][:neutron_url_timeout] %>
 username = <%= @neutron_service_user %>
+<% if @ml2_mechanism_drivers.include?("nuage") %>
+ovs_bridge = alubr0
+<% end %>
 
 [oslo_concurrency]
 <% if @need_shared_lock_path -%>

--- a/chef/data_bags/crowbar/migrate/neutron/114_add_nuage_vsp_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/114_add_nuage_vsp_attributes.rb
@@ -1,0 +1,19 @@
+def upgrade ta, td, a, d
+  a["nuage"] = {}
+  a["nuage"]["vrs_personality"] = ta["nuage"]["vrs_personality"]
+  a["nuage"]["vrs_active_controller"] = ta["nuage"]["vrs_active_controller"]
+  a["nuage"]["vrs_standby_controller"] = ta["nuage"]["vrs_standby_controller"]
+  a["nuage"]["vsd_user"] = ta["nuage"]["vsd_user"]
+  a["nuage"]["vsd_password"] = ta["nuage"]["password"]
+  a["nuage"]["vsd_server"] = ta["nuage"]["server"]
+  a["nuage"]["vsd_default_net_partition_name"] = ta["nuage"]["vsd_default_net_partition_name"]
+  a["nuage"]["vsd_cms_id"] = ta["nuage"]["vsd_cms_id"]
+
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete("nuage")
+  return a, d
+end
+

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -108,6 +108,16 @@
         "max_namespaces_per_tenant": 1,
         "route_domain_strictness": false
       },
+      "nuage": {
+        "vrs_personality": "vrs",
+        "vrs_active_controller": "0.0.0.0",
+        "vrs_standby_controller": "0.0.0.0",
+        "vsd_user": "",
+        "vsd_password": "",
+        "vsd_server": "0.0.0.0:8443",
+        "vsd_default_net_partition_name": "Openstack_default",
+        "vsd_cms_id": ""
+      },
       "vmware": {
         "user": "",
         "password": "",
@@ -175,7 +185,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 113,
+      "schema-revision": 114,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -141,6 +141,16 @@
                       "clean_on_restart": { "type" : "bool", "required" : true },
                       "precreate_networks": { "type" : "bool", "required" : true }
                     }},
+                    "nuage": { "type": "map", "required": true, "mapping": {
+                      "vrs_personality": { "type" : "str", "required" : true },
+                      "vrs_active_controller": { "type" : "str", "required" : true },
+                      "vrs_standby_controller": { "type" : "str", "required" : false },
+                      "vsd_user": { "type" : "str", "required" : true },
+                      "vsd_password": { "type" : "str", "required" : true },
+                      "vsd_server": { "type" : "str", "required" : true },
+                      "vsd_default_net_partition_name": { "type" : "str", "required" : true },
+                      "vsd_cms_id": { "type" : "str", "required" : true }
+                    }},
                     "zvm": { "type": "map", "required": true, "mapping": {
                       "zvm_xcat_server": { "type": "str", "required": true },
                       "zvm_xcat_username": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -37,7 +37,7 @@ class NeutronService < OpenstackServiceObject
   end
 
   def self.networking_ml2_mechanism_drivers_valid
-    ["linuxbridge", "openvswitch", "cisco_nexus", "vmware_dvs", "cisco_apic_ml2", "apic_gbp"]
+    ["linuxbridge", "openvswitch", "cisco_nexus", "vmware_dvs", "cisco_apic_ml2", "apic_gbp", "nuage"]
   end
 
   class << self


### PR DESCRIPTION
- Added a new ml2 mechanism driver option for nuage
- Added two recipes in neutron - nuage_vrs and nuage_vsp_agent
- nuage_vrs installs and configures nuage openvswitch on both controller
  and compute. It also installs and configures metadata agent on compute
- nuage_vsp_agent handles rest of the config necessary in neutron and nova
  for Nuage Virtual Service Platform
- All nuage related config in kept under neutron barclamp