### PR TITLE
[4.0]neutron[Cisco_ACI]: Backport from #1548

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_support.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_support.rb
@@ -21,6 +21,7 @@ if node[:neutron][:ml2_mechanism_drivers].include?("apic_gbp")
 end
 
 aciswitches = node[:neutron][:apic][:apic_switches].to_hash
+acivmms = node[:neutron][:apic][:apic_vmms].to_hash
 template "/etc/neutron/neutron-server.conf.d/100-ml2_conf_cisco_apic.ini.conf" do
   cookbook "neutron"
   source "ml2_conf_cisco_apic.ini.erb"
@@ -29,6 +30,7 @@ template "/etc/neutron/neutron-server.conf.d/100-ml2_conf_cisco_apic.ini.conf" d
   group node[:neutron][:platform][:group]
   variables(
     apic_switches: aciswitches,
+    apic_vmms: acivmms,
     ml2_mechanism_drivers: node[:neutron][:ml2_mechanism_drivers],
     policy_drivers: "implicit_policy,apic",
     default_ip_pool: "192.168.0.0/16",

--- a/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
@@ -2,7 +2,7 @@
 apic_system_id=<%= node[:neutron][:apic][:system_id] %>
 [opflex]
 networks = *
-[ml2_cisco_apic]
+[apic]
 apic_hosts=<%= node[:neutron][:apic][:hosts] %>
 apic_username=<%= node[:neutron][:apic][:username] %>
 apic_password=<%= node[:neutron][:apic][:password] %>
@@ -27,4 +27,10 @@ apic_provision_hostlinks = True
 policy_drivers = <%= @policy_drivers %>
 [group_policy_implicit_policy]
 default_ip_pool = <%= @default_ip_pool %>
+<% end -%>
+<% @apic_vmms.keys.each do |ip| -%>
+[apic_vmdom:<%=ip%>]
+<%    @apic_vmms[ip].each do |key, value|  -%>
+<%=     key %> = <%= value %>
+<%    end -%>
 <% end -%>

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -81,6 +81,19 @@
               }
             }
           }
+        },
+        "apic_vmms": {
+          "soc_kvm_domain": {
+            "apic_vmm_type": "openstack",
+            "enable_optimized_dhcp": "true",
+            "enable_optimized_metadata": "true",
+            "hosts" : ""
+          },
+          "soc_vm_domain": {
+            "apic_vmm_type": "vmware",
+            "enable_optimized_dhcp": "false",
+            "enable_optimized_metadata": "false"
+          }
         }
       },
       "allow_overlapping_ips": true,

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -73,7 +73,11 @@
                             }}
                           }}
                         }}
-                      }
+                      },
+                      "apic_vmms": { "type" : "map", "required" : true, "mapping" : {
+                        = : { "type" : "map", "required" : true, "mapping" : {
+                          = : { "type": "str", "required": true }}
+                        }}
                     }},
                     "allow_overlapping_ips": { "type": "bool", "required": true },
                     "cisco_switches": {


### PR DESCRIPTION
This PR enables the following feature for Cisco ACI:

Allows Crowbar configuration for enabling multiple VMM domain features for ACI. It was painful for the customer to change in the config file manually and avoid the chef-client from overriding the config. Both KVM and VMWare based VMM domains can be configured using this feature.

Each [apic_vmdom:<vmm_domain_name>] corresponds to a VMM configuration. In these sections, [apic] configurations can be overridden for more granular infrastructure sharing.
What is configured in the [apic] sharing will be the default used in case a more specific configuration is missing for the domain.

For example:

[apic_vmdom:soc_kvm_domain]
vlan_ranges=1000:2000

[apic_vmdom:soc_vmware_domain]
apic_vmm_type=vmware
enable_optimized_dhcp=false
enable_optimized_metadata=false

In case of a VMWare based VMM domain, the respective VMM domain MUST be created in APIC prior to configuring in neutron. For KVM, neutron will create the VMM domain if not already created.

Note: The intended target of this PR is Cloud 7 and is updated here due to the standard process being followed for all PRs (master-update followed by cloud 7 backport). The tests were only done for Cloud 7 based deployments.