### PR TITLE
ironic: Add UEFI support to tftp config

### DIFF
--- a/chef/cookbooks/ironic/templates/default/grub.cfg.erb
+++ b/chef/cookbooks/ironic/templates/default/grub.cfg.erb
@@ -1,0 +1,7 @@
+set default=master
+set timeout=5
+set hidden_timeout_quiet=false
+
+menuentry "master"  {
+configfile <%= @tftproot %>/$net_default_ip.conf
+}


### PR DESCRIPTION
To manage baremetal nodes which boot using UEFI, ironic requires additional packages and configuration.