### PR TITLE
rabbitmq: block client port on startup

### DIFF
--- a/chef/cookbooks/rabbitmq/files/default/rabbitmq.tmpfiles
+++ b/chef/cookbooks/rabbitmq/files/default/rabbitmq.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lock/rabbit  0755  root  root  -

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -120,3 +120,71 @@ ruby_block "wait for #{ms_name} to be started" do
     end
   end # block
 end # ruby_block
+
+if CrowbarPacemakerHelper.cluster_nodes(node).size > 2
+  # create the directory to lock rabbitmq-port-blocker
+  cookbook_file "/etc/tmpfiles.d/rabbitmq.conf" do
+    owner "root"
+    group "root"
+    mode "0644"
+    action :create
+    source "rabbitmq.tmpfiles"
+  end
+
+  bash "create tmpfiles.d files for rabbitmq" do
+    code "systemd-tmpfiles --create /etc/tmpfiles.d/rabbitmq.conf"
+    action :nothing
+    subscribes :run, resources("cookbook_file[/etc/tmpfiles.d/rabbitmq.conf]"), :immediately
+  end
+
+  # create the scripts to block the client port on startup
+  template "/usr/bin/rabbitmq-alert-handler.sh" do
+    source "rabbitmq-alert-handler.erb"
+    owner "root"
+    group "root"
+    mode "0755"
+    variables(node: node, nodes: CrowbarPacemakerHelper.cluster_nodes(node))
+  end
+
+  template "/usr/bin/rabbitmq-port-blocker.sh" do
+    source "rabbitmq-port-blocker.erb"
+    owner "root"
+    group "root"
+    mode "0755"
+    variables(total_nodes: CrowbarPacemakerHelper.cluster_nodes(node).size)
+  end
+
+  template "/etc/sudoers.d/rabbitmq-port-blocker" do
+    source "hacluster_sudoers.erb"
+    owner "root"
+    group "root"
+    mode "0440"
+  end
+
+  # create the alert
+  pacemaker_alert "rabbitmq-alert-handler" do
+    handler "/usr/bin/rabbitmq-alert-handler.sh"
+    action :create
+  end
+else
+  pacemaker_alert "rabbitmq-alert-handler" do
+    handler "/usr/bin/rabbitmq-alert-handler.sh"
+    action :delete
+  end
+
+  cookbook_file "/etc/tmpfiles.d/rabbitmq.conf" do
+    action :delete
+  end
+
+  file "/usr/bin/rabbitmq-alert-handler.sh" do
+    action :delete
+  end
+
+  file "/usr/bin/rabbitmq-port-blocker.sh" do
+    action :delete
+  end
+
+  file "/etc/sudoers.d/rabbitmq-port-blocker" do
+    action :delete
+  end
+end

--- a/chef/cookbooks/rabbitmq/templates/default/hacluster_sudoers.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/hacluster_sudoers.erb
@@ -1,0 +1,4 @@
+Defaults:hacluster !requiretty
+
+hacluster ALL = (root) NOPASSWD: /usr/bin/ssh
+hacluster ALL = (root) NOPASSWD: /usr/bin/flock

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq-alert-handler.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq-alert-handler.erb
@@ -1,0 +1,19 @@
+#!/bin/sh
+if [ -z "$CRM_alert_version" ]; then
+  echo "$0 must be run by Pacemaker version 1.1.15 or later"
+  exit 0
+fi
+
+# exit if isn't a rabbitmq alert or is not a monitor task
+[ "$CRM_alert_kind" = "resource" -a "$CRM_alert_rsc" = "rabbitmq" -a "$CRM_alert_task" = "monitor" ] || exit 0
+
+# launch the blocker in exclusive mode
+nohup sudo flock /var/lock/rabbit /usr/bin/rabbitmq-port-blocker.sh &
+
+# for each node in the cluster
+<% @nodes.each do |cluster_node| -%>
+  # unless this is the current node launch remotely the blocker in exclusive mode
+  <% unless cluster_node.name==@node.name -%>
+    nohup /usr/bin/timeout 15 sudo /usr/bin/ssh -o TCPKeepAlive=no -o ServerAliveInterval=15 root@<%= cluster_node.name %> nohup flock /var/lock/rabbit /usr/bin/rabbitmq-port-blocker.sh &
+  <% end -%>
+<% end -%>

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq-port-blocker.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq-port-blocker.erb
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# calcules the blocking level applying the formula
+total_nodes=<%= @total_nodes %>
+blocking_level=$(expr $total_nodes / 2)
+comment_text="rabbitmq port blocker (no quorum)"
+
+# get the number of running nodes of rabbitmq in the current cluster
+function running_nodes()
+{
+  rabbitmqctl cluster_status 2>/dev/null | tr -d "\n" | sed -e 's/running_nodes,/\nrunning_nodes/g'| grep running_nodes | cut -d "[" -f2 | cut -d "]" -f1 | tr "," "\n" | wc -l
+}
+
+# check if exists the blocking rule for rabbitmq clients
+function check_rule()
+{
+  iptables -L -n | grep -F "tcp dpt:5672 /* $comment_text */" | grep DROP | wc -l
+}
+
+# if the running nodes is les that the blocking level, then...
+if [ $(running_nodes) -le $blocking_level ]; then
+  # if rule not exists the rule will be added to block the clients port
+  if [ $(check_rule) -eq 0 ]; then
+    iptables -A INPUT -p tcp --destination-port 5672 -m comment --comment "$comment_text" -j DROP
+  fi
+else
+  # finally if the rule exists it will be deleted. If there are more than one, will remove all
+  if [[ $(check_rule) -gt 0 ]]; then
+    iptables -D INPUT -p tcp --destination-port 5672 -m comment --comment "$comment_text" -j DROP
+  fi
+fi


### PR DESCRIPTION
This script blocks the connection to the rabbitmq cluster in case the number of nodes decay bellow the half of the total. In this case the remain rabbit nodes won't accept new connections. The problem to solve is that when a rabbit node has too much clients with low timeout, the final scenario could be a DOS when the clients try to constantly reconnect to rabbitmq and forcing more timeouts.

It takes advantage of the pacemaker notifications that notify when a rabbitmq has failed or has restored. All nodes rabbitmq ports will be blocked if the total number of alive nodes are below to the half of nodes of the cluster, or unblock if its over this value. This prevents the overload of alive nodes and the total block of service.

Only the node that have problems will receive the alert, so it is necessary to notify other nodes to block their ports if necessary. The only case when this script won't work is when the node fails completely and is not able to notify the others.

The script is divided in two parts: On one hand, the alert handler that manages the alerts discarding non interesting alerts, launches to the blocker script in this node and other cluster nodes (via SSH). And in the other hand, the blocker script than checks the condition of running nodes and blocks or unblocks the rabbitmq client port.