### PR TITLE
ironic: Store configdrive in Swift if possible

### DIFF
--- a/chef/cookbooks/ironic/attributes/default.rb
+++ b/chef/cookbooks/ironic/attributes/default.rb
@@ -81,3 +81,5 @@ default[:ironic][:tftproot] = "/var/lib/ironic/tftpboot"
 default[:ironic][:pxe_append_params] = "nofb nomodeset vga=normal"
 
 default[:ironic][:enabled_drivers] = []
+
+default[:ironic][:configdrive_use_object_store] = true

--- a/chef/cookbooks/ironic/libraries/helpers.rb
+++ b/chef/cookbooks/ironic/libraries/helpers.rb
@@ -62,6 +62,8 @@ module IronicHelper
         glance_container: glance[:glance][:swift][:store_container],
         glance_account: glance_account,
         protocol: swift[:swift][:ssl][:enabled] ? "https" : "http",
+        service_user: swift[:swift][:service_user],
+        service_password: swift[:swift][:service_password],
         host: swift_address,
         port: swift[:swift][:ports][:proxy]
       }

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -182,6 +182,7 @@ template node[:ironic][:config_file] do
         keystone_settings: keystone_settings,
         glance_settings: glance_settings,
         swift_settings: IronicHelper.swift_settings(node, glance),
+        configdrive_use_object_store: node[:ironic][:configdrive_use_object_store],
         neutron_settings: neutron_settings,
         database_connection: db_connection,
         ironic_net_name: ironic_net_name,

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -125,3 +125,7 @@ pxe_append_params=<%= @pxe_append_params %>
 
 [deploy]
 default_boot_option=netboot
+<% if @swift_settings -%>
+configdrive_use_object_store=<%= @configdrive_use_object_store %>
+object_store_endpoint_type=swift
+<% end -%>

--- a/chef/data_bags/crowbar/migrate/ironic/203_add_configdrive_use_object_store.rb
+++ b/chef/data_bags/crowbar/migrate/ironic/203_add_configdrive_use_object_store.rb
@@ -1,0 +1,12 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "configdrive_use_object_store"
+    a["configdrive_use_object_store"] = ta["configdrive_use_object_store"]
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("configdrive_use_object_store")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ironic.json
+++ b/chef/data_bags/crowbar/template-ironic.json
@@ -16,6 +16,7 @@
       "enabled_drivers": [],
       "automated_clean": true,
       "pxe_append_params": "nofb nomodeset vga=normal",
+      "configdrive_use_object_store": true,
       "api": {
         "protocol": "http",
         "port": 6385
@@ -30,7 +31,7 @@
   "deployment": {
     "ironic": {
       "crowbar-revision": 0,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "crowbar-applied": false,
       "element_states": {
         "ironic-server": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-ironic.schema
+++ b/chef/data_bags/crowbar/template-ironic.schema
@@ -25,6 +25,7 @@
             "enabled_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
             "automated_clean": { "type": "bool", "required": true },
             "pxe_append_params": { "type": "str", "required": true },
+            "configdrive_use_object_store": { "type": "bool", "required": true },
             "api": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
Allow storage of configdrive in Swift if it is available.
If Swift is available but user doesn't want to store the configdrive there it can be disabled using added attribute. It's value is ignored if Swift is not available.

Additional commit fixes username/password fields in swift settings.