### PR TITLE
[4.0] Switch to MariaDB 10.2

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -36,6 +36,3 @@ default[:mysql][:ha][:ports][:admin_port] = 3306
 # in pacemamker
 default[:mysql][:ha][:op][:monitor][:interval] = "20s"
 default[:mysql][:ha][:op][:monitor][:role]     = "Master"
-
-# Let users override this if galera-python-clustercheck is available to them
-default[:mysql][:ha][:clustercheck] = false

--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -36,3 +36,11 @@ default[:mysql][:ha][:ports][:admin_port] = 3306
 # in pacemamker
 default[:mysql][:ha][:op][:monitor][:interval] = "20s"
 default[:mysql][:ha][:op][:monitor][:role]     = "Master"
+
+default[:mysql][:galera_packages] = [
+  "galera-3-wsrep-provider",
+  "mariadb-tools",
+  "xtrabackup",
+  "socat",
+  "galera-python-clustercheck"
+]

--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -37,6 +37,10 @@ default[:mysql][:ha][:ports][:admin_port] = 3306
 default[:mysql][:ha][:op][:monitor][:interval] = "20s"
 default[:mysql][:ha][:op][:monitor][:role]     = "Master"
 
+# If needed we can enhance this to set the mariadb version
+# depeding on "platform" and "platform_version". But currently
+# this should be enough
+default[:mysql][:mariadb][:version] = "10.1"
 default[:mysql][:galera_packages] = [
   "galera-3-wsrep-provider",
   "mariadb-tools",
@@ -44,3 +48,8 @@ default[:mysql][:galera_packages] = [
   "socat",
   "galera-python-clustercheck"
 ]
+
+# newer version need an additional package on SLES
+unless node[:mysql][:mariadb][:version] == "10.1"
+  default[:mysql][:galera_packages] << "mariadb-galera"
+end

--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -40,7 +40,7 @@ default[:mysql][:ha][:op][:monitor][:role]     = "Master"
 # If needed we can enhance this to set the mariadb version
 # depeding on "platform" and "platform_version". But currently
 # this should be enough
-default[:mysql][:mariadb][:version] = "10.1"
+default[:mysql][:mariadb][:version] = "10.2"
 default[:mysql][:galera_packages] = [
   "galera-3-wsrep-provider",
   "mariadb-tools",

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -19,10 +19,9 @@
 
 resource_agent = "ocf:heartbeat:galera"
 
-["galera-3-wsrep-provider", "mariadb-tools", "xtrabackup", "socat"].each do |p|
+["galera-3-wsrep-provider", "mariadb-tools", "xtrabackup", "socat", "galera-python-clustercheck"].each do |p|
   package p
 end
-package "galera-python-clustercheck" if node[:mysql][:ha][:clustercheck]
 
 unless node[:database][:galera_bootstrapped]
   directory "/var/run/mysql/" do
@@ -259,7 +258,6 @@ crowbar_pacemaker_sync_mark "sync-database_root_password" do
   revision node[:database]["crowbar-revision"]
 end
 
-if node[:mysql][:ha][:clustercheck]
   # Configuration files for galera-python-clustercheck
   template "/etc/galera-python-clustercheck/galera-python-clustercheck.conf" do
     source "galera-python-clustercheck.conf.erb"
@@ -281,38 +279,37 @@ if node[:mysql][:ha][:clustercheck]
     )
   end
 
-  # Start galera-clustercheck which serves the cluster state as http return codes
-  # on port 5555
-  transaction_objects = []
-  service_name = "galera-python-clustercheck"
+# Start galera-clustercheck which serves the cluster state as http return codes
+# on port 5555
+transaction_objects = []
+service_name = "galera-python-clustercheck"
 
-  pacemaker_primitive service_name do
-    agent "systemd:#{service_name}"
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
+pacemaker_primitive service_name do
+  agent "systemd:#{service_name}"
+  action :update
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
 
-  transaction_objects.push("pacemaker_primitive[#{service_name}]")
+transaction_objects.push("pacemaker_primitive[#{service_name}]")
 
-  clone_name = "cl-#{service_name}"
-  pacemaker_clone clone_name do
-    rsc service_name
-    meta CrowbarPacemakerHelper.clone_meta(node, remote: false)
-    action :update
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
+clone_name = "cl-#{service_name}"
+pacemaker_clone clone_name do
+  rsc service_name
+  meta CrowbarPacemakerHelper.clone_meta(node, remote: false)
+  action :update
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
 
-  transaction_objects.push("pacemaker_clone[#{clone_name}]")
+transaction_objects.push("pacemaker_clone[#{clone_name}]")
 
-  clone_location_name = openstack_pacemaker_controller_only_location_for clone_name
-  transaction_objects << "pacemaker_location[#{clone_location_name}]"
+clone_location_name = openstack_pacemaker_controller_only_location_for clone_name
+transaction_objects << "pacemaker_location[#{clone_location_name}]"
 
-  pacemaker_transaction "clustercheck" do
-    cib_objects transaction_objects
-    action :commit_new
-    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
-end # if node[:mysql][:ha][:clustercheck]
+pacemaker_transaction "clustercheck" do
+  cib_objects transaction_objects
+  action :commit_new
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
 
 include_recipe "crowbar-pacemaker::haproxy"
 
@@ -339,12 +336,8 @@ haproxy_loadbalancer "galera" do
   mode "tcp"
   # leave some room for pacemaker health checks
   max_connections node[:database][:mysql][:max_connections] - 10
-  if node[:mysql][:ha][:clustercheck]
-    options ["httpchk", "clitcpka"]
-    default_server "port 5555"
-  else
-    options ["mysql-check user monitoring", "clitcpka"]
-  end
+  options ["httpchk", "clitcpka"]
+  default_server "port 5555"
   stick ({ "on" => "dst" })
   servers ha_servers
   action :nothing

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -19,7 +19,7 @@
 
 resource_agent = "ocf:heartbeat:galera"
 
-["galera-3-wsrep-provider", "mariadb-tools", "xtrabackup", "socat", "galera-python-clustercheck"].each do |p|
+node[:mysql][:galera_packages].each do |p|
   package p
 end
 


### PR DESCRIPTION
Revert the temporary disable galera-clustercheck commit to make backporting easier (the package is released so this is not needed anymore) and add the missing backports to make MariaDB 10.2 work.