### PR TITLE
magnum: Add domain name to keystone_auth (bsc#1080335)

### DIFF
--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -41,6 +41,8 @@ project_name = <%= @keystone_settings['service_tenant'] %>
 username = <%= @keystone_settings['service_user'] %>
 password = <%= @keystone_settings['service_password'] %>
 insecure = <%= @keystone_settings['insecure'] %>
+project_domain_name = <%= @keystone_settings["admin_domain"]%>
+user_domain_name = <%= @keystone_settings["admin_domain"] %>
 
 [keystone_authtoken]
 auth_uri = <%= @keystone_settings['public_auth_url'] %>


### PR DESCRIPTION
This adds the domain_names to the keystone_auth section as well as this is needed when magnum uses
barbican as the cert-manager.

(cherry picked from commit 0f6a08ff145e70f96ac132d87d633f16474100a8)

Backport of: https://github.com/crowbar/crowbar-openstack/pull/1559