### PR TITLE
[4.0] ironic: Fix failing migrations

### DIFF
--- a/crowbar_framework/app/models/ironic_service.rb
+++ b/crowbar_framework/app/models/ironic_service.rb
@@ -16,7 +16,7 @@
 #
 
 class IronicService < ServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "ironic"
   end


### PR DESCRIPTION
During migration service objects are created without logger parameter.
Missing default value caused the process to fail.

(cherry picked from commit 3e6a24b82517b5c5c8777f1c69d631848318fabf)

partial backport of #1544 (fix part only)