### PR TITLE
[4.0] nova: Add option to modify scheduler_default_filters

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -388,6 +388,7 @@ template node[:nova][:config_file] do
     oat_appraiser_host: oat_server[:hostname],
     oat_appraiser_port: "8443",
     has_itxt: has_itxt,
+    default_filters: node[:nova][:scheduler][:default_filters],
     reserved_host_memory: reserved_host_memory,
     use_baremetal_filters: use_baremetal_filters,
     track_instance_changes: track_instance_changes,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -34,9 +34,20 @@ reserved_host_memory_mb = <%= @reserved_host_memory %>
 cpu_allocation_ratio = <%= node[:nova][:scheduler][:cpu_allocation_ratio] %>
 ram_allocation_ratio = <%= node[:nova][:scheduler][:ram_allocation_ratio] %>
 disk_allocation_ratio = <%= node[:nova][:scheduler][:disk_allocation_ratio] %>
-<% if @use_baremetal_filters %>scheduler_use_baremetal_filters = true<% end -%>
-<% if @has_itxt -%>scheduler_available_filters = nova.scheduler.filters.standard_filters<% end %>
-<% if @has_itxt %>scheduler_default_filters = RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,TrustedFilter<% end %>
+<% if @use_baremetal_filters %>
+scheduler_use_baremetal_filters = true
+<% end -%>
+<% if @has_itxt %>
+scheduler_available_filters = nova.scheduler.filters.standard_filters
+<% if @default_filters.empty? %>
+scheduler_default_filters = RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,TrustedFilter
+<% else %>
+scheduler_default_filters = <%= @default_filters %>
+<% end %>
+<% elsif !@default_filters.empty? %>
+scheduler_available_filters = nova.scheduler.filters.all_filters
+scheduler_default_filters = <%= @default_filters %>
+<% end %>
 <% unless @track_instance_changes %>scheduler_tracks_instance_changes = false<% end %>
 <% if @libvirt_type.eql?('vmware') -%>
 compute_driver = vmwareapi.VMwareVCDriver

--- a/chef/data_bags/crowbar/migrate/nova/122_add_scheduler_default_filters.rb
+++ b/chef/data_bags/crowbar/migrate/nova/122_add_scheduler_default_filters.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["scheduler"]["default_filters"] = ta["scheduler"]["default_filters"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["scheduler"].delete("default_filters")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -36,7 +36,8 @@
         "ram_allocation_ratio": 1.0,
         "cpu_allocation_ratio": 16.0,
         "disk_allocation_ratio": 1.0,
-        "reserved_host_memory_mb": 512
+        "reserved_host_memory_mb": 512,
+        "default_filters": ""
       },
       "ec2-api": {
         "db": {
@@ -174,7 +175,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 121,
+      "schema-revision": 122,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -53,7 +53,8 @@
                 "ram_allocation_ratio": { "type": "number" },
                 "cpu_allocation_ratio": { "type": "number" },
                 "disk_allocation_ratio": { "type": "number" },
-                "reserved_host_memory_mb": { "type": "number" }
+                "reserved_host_memory_mb": { "type": "number" },
+                "default_filters": { "type": "str", "required": true }
               }
             },
             "ec2-api": {


### PR DESCRIPTION
In some cases user needs to modify default filters, e.g. remove
DiskFilter when instances are only booted from volumes (bsc#1080997)

See https://github.com/crowbar/crowbar-openstack/pull/1578 for master version