### PR TITLE
[4.0] barbican: Add creator role (bsc#1081573)

### DIFF
--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -112,7 +112,7 @@ keystone_register "register barbican user" do
   action :add_user
 end
 
-keystone_register "give barbican user access" do
+keystone_register "give barbican user access as admin" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
   host keystone_settings["internal_url_host"]
@@ -121,6 +121,28 @@ keystone_register "give barbican user access" do
   user_name keystone_settings["service_user"]
   tenant_name keystone_settings["service_tenant"]
   role_name "admin"
+  action :add_access
+end
+
+keystone_register "add creator role for barbican" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  role_name "creator"
+  action :add_role
+end
+
+keystone_register "give barbican user access as creator" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  tenant_name keystone_settings["service_tenant"]
+  role_name "creator"
   action :add_access
 end
 

--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -124,6 +124,28 @@ keystone_register "give barbican user access as admin" do
   action :add_access
 end
 
+keystone_register "add key-manager:service-admin role for barbican" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  role_name "key-manager:service-admin"
+  action :add_role
+end
+
+keystone_register "give barbican user access as key-manager:service-admin" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  tenant_name keystone_settings["service_tenant"]
+  role_name "key-manager:service-admin"
+  action :add_access
+end
+
 keystone_register "add creator role for barbican" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
@@ -143,6 +165,50 @@ keystone_register "give barbican user access as creator" do
   user_name keystone_settings["service_user"]
   tenant_name keystone_settings["service_tenant"]
   role_name "creator"
+  action :add_access
+end
+
+keystone_register "add observer role for barbican" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  role_name "observer"
+  action :add_role
+end
+
+keystone_register "give barbican user access as observer" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  tenant_name keystone_settings["service_tenant"]
+  role_name "observer"
+  action :add_access
+end
+
+keystone_register "add audit role for barbican" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  role_name "audit"
+  action :add_role
+end
+
+keystone_register "give barbican user access as audit" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  tenant_name keystone_settings["service_tenant"]
+  role_name "audit"
   action :add_access
 end
 


### PR DESCRIPTION
Barbican defaults assume that a creator role exists, which allows:
creation of resources, reading all resources, deleting resources one
owns, but not deleting resources owned by others.

(cherry picked from commit a097f888e6b6d1468534d27cbf6758465e6512ed)
Backport of https://github.com/crowbar/crowbar-openstack/pull/1566