### PR TITLE
mariadb: Add prefix to configs

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -44,8 +44,8 @@ unless node[:database][:galera_bootstrapped]
     # To bootstrap for the first time, start galera on one node
     # to set up the seed sst and monitoring users.
 
-    template "temporary bootstrap /etc/my.cnf.d/galera.cnf" do
-      path "/etc/my.cnf.d/galera.cnf"
+    template "temporary bootstrap /etc/my.cnf.d/75-galera.cnf" do
+      path "/etc/my.cnf.d/75-galera.cnf"
       source "galera.cnf.erb"
       owner "root"
       group "mysql"
@@ -126,7 +126,7 @@ nodes_names = cluster_nodes.map { |n| n[:hostname] }
 
 cluster_addresses = "gcomm://" + nodes_names.join(",")
 
-template "/etc/my.cnf.d/galera.cnf" do
+template "/etc/my.cnf.d/75-galera.cnf" do
   source "galera.cnf.erb"
   owner "root"
   group "mysql"
@@ -139,6 +139,11 @@ template "/etc/my.cnf.d/galera.cnf" do
     node_address: node_address,
     wsrep_slave_threads: node[:database][:mysql][:wsrep_slave_threads]
   )
+end
+
+file "/etc/my.cnf.d/galera.cnf" do
+  action :delete
+  notifies :restart, "service[mysql]"
 end
 
 # Wait for all nodes to reach this point so we know that all nodes will have

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -95,7 +95,7 @@ if node[:database][:mysql][:ssl][:enabled]
   end
 end
 
-template "/etc/my.cnf.d/openstack.cnf" do
+template "/etc/my.cnf.d/72-openstack.cnf" do
   source "my.cnf.erb"
   owner "root"
   group "mysql"
@@ -103,7 +103,12 @@ template "/etc/my.cnf.d/openstack.cnf" do
   notifies :restart, "service[mysql]", :immediately
 end
 
-template "/etc/my.cnf.d/ssl.cnf" do
+file "/etc/my.cnf.d/openstack.cnf" do
+  action :delete
+  notifies :restart, "service[mysql]"
+end
+
+template "/etc/my.cnf.d/73-ssl.cnf" do
   source "ssl.cnf.erb"
   owner "root"
   group "mysql"
@@ -111,7 +116,12 @@ template "/etc/my.cnf.d/ssl.cnf" do
   notifies :restart, "service[mysql]", :immediately
 end
 
-template "/etc/my.cnf.d/logging.cnf" do
+file "/etc/my.cnf.d/ssl.cnf" do
+  action :delete
+  notifies :restart, "service[mysql]"
+end
+
+template "/etc/my.cnf.d/71-logging.cnf" do
   source "logging.cnf.erb"
   owner "root"
   group "mysql"
@@ -122,7 +132,12 @@ template "/etc/my.cnf.d/logging.cnf" do
   notifies :restart, "service[mysql]", :immediately
 end
 
-template "/etc/my.cnf.d/tuning.cnf" do
+file "/etc/my.cnf.d/logging.cnf" do
+  action :delete
+  notifies :restart, "service[mysql]"
+end
+
+template "/etc/my.cnf.d/74-tuning.cnf" do
   source "tuning.cnf.erb"
   owner "root"
   group "mysql"
@@ -136,6 +151,11 @@ template "/etc/my.cnf.d/tuning.cnf" do
     max_heap_table_size: node[:database][:mysql][:max_heap_table_size]
   )
   notifies :restart, "service[mysql]", :immediately
+end
+
+file "/etc/my.cnf.d/tuning.cnf" do
+  action :delete
+  notifies :restart, "service[mysql]"
 end
 
 unless Chef::Config[:solo]


### PR DESCRIPTION
All default MariaDB configs have now a prefix to allow overwriting of
the options. Let's follow the same to not conflict with the defaults.