### PR TITLE
[4.0] apache: don't collect Listen ports from wsgi vhosts (bsc#1077234)

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -145,9 +145,6 @@ else
   bind_port = node[:aodh][:api][:port]
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-node.normal[:apache][:listen_ports_crowbar][:aodh] = { plain: [bind_port] }
-
 template node[:aodh][:config_file] do
   source "aodh.conf.erb"
   owner "root"

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -207,9 +207,6 @@ else
   bind_port = node[:ceilometer][:api][:port]
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-node.normal[:apache][:listen_ports_crowbar][:ceilometer] = { plain: [bind_port] }
-
 if ceilometer_protocol == "https"
   ssl_setup "setting up ssl for ceilometer" do
     generate_certs node[:ceilometer][:ssl][:generate_certs]

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -492,20 +492,7 @@ else
   bind_port_ssl = 443
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-
-if node[:horizon][:apache][:ssl]
-  node.normal[:apache][:listen_ports_crowbar][:horizon] = { plain: [bind_port], ssl: [bind_port_ssl] }
-else
-  node.normal[:apache][:listen_ports_crowbar][:horizon] = { plain: [bind_port] }
-end
-
-# we can only include the recipe after having defined the listen_ports_crowbar attribute
 include_recipe "horizon::ha" if ha_enabled
-
-# Override what the apache2 cookbook does since it enforces the ports
-resource = resources(template: "#{node[:apache][:dir]}/ports.conf")
-resource.variables({apache_listen_ports: node.normal[:apache][:listen_ports_crowbar].values.map{ |p| p.values }.flatten.uniq.sort})
 
 if node[:horizon][:apache][:ssl] && node[:horizon][:apache][:generate_certs]
   package "apache2-utils"

--- a/chef/cookbooks/horizon/templates/default/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/default/openstack-dashboard.conf.erb
@@ -6,6 +6,9 @@ RewriteEngine On
 RewriteCond %{SERVER_PORT} ^<%= @bind_port %>$
 RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 
+Listen <%= @bind_host %>:<%= @bind_port %>>
+Listen <%= @bind_host %>:<%= @bind_port_ssl %>
+
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
     SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
@@ -17,6 +20,8 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
     <% end %>
 
 <% else %>
+Listen <%= @bind_host %>:<%= @bind_port %>>
+
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
 <% end %>
     WSGIDaemonProcess horizon user=<%= @user %> group=<%= @group %> processes=3 threads=10 home=<%= @horizon_dir %>  display-name=%{GROUP}

--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -2,6 +2,8 @@
 <IfDefine SSL>
 <IfDefine !NOSSL>
 
+Listen <%= @bind_host %>:<%= @bind_port %>
+
 # Redirect non-SSL traffic to SSL
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
     RewriteEngine On
@@ -24,6 +26,8 @@
     RewriteRule / https://%1%{REQUEST_URI} [L,R]
 </VirtualHost>
 
+Listen <%= @bind_host %>:<%= @bind_port_ssl %>
+
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
     SSLCipherSuite DEFAULT_SUSE
@@ -35,6 +39,8 @@
     <% end %>
 
 <% else %>
+Listen <%= @bind_host %>:<%= @bind_port %>
+
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
 <% end %>
     WSGIScriptAlias / <%= @horizon_dir %>/openstack_dashboard/wsgi/django.wsgi

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -48,9 +48,6 @@ else
   bind_service_port = node[:keystone][:api][:service_port]
 end
 
-node.normal[:apache][:listen_ports_crowbar] ||= {}
-node.normal[:apache][:listen_ports_crowbar][:keystone] = { admin: [bind_admin_port], service: [bind_service_port] }
-
 # Ideally this would be called admin_host, but that's already being
 # misleadingly used to store a value which actually represents the
 # service bind address.


### PR DESCRIPTION
(backports #1533 to 4.0)

The listen_ports_crowbar attribute controls which ports are added
as Listen directives to the /etc/apache2/listen.conf file.

However, all wsgi vhosts aside from horizon already have an explicit
Listen directive in the vhost configuration file, so there's no need
to add these ports to the /etc/apache2/listen.conf file.

To align horizon to the other WSGI vhosts, Listen directives are
added to the horizon WSGI vhost configuration file. Since these don't
also have to be added to the /etc/apache2/listen.conf file anymore, the
usage of listen_ports_crowbar can be removed altogether.

Fixes [bsc#1077234](https://bugzilla.suse.com/show_bug.cgi?id=1077234)

