### PR TITLE
horizon: fix apache logrotate

### DIFF
--- a/chef/cookbooks/horizon/templates/default/openstack-dashboard.logrotate.erb
+++ b/chef/cookbooks/horizon/templates/default/openstack-dashboard.logrotate.erb
@@ -8,7 +8,7 @@
     missingok
     create 644 root root
     postrotate
-     /etc/init.d/apache2 reload
+     systemctl reload apache2.service
     endscript
 }
 
@@ -22,6 +22,6 @@
     missingok
     create 644 root root
     postrotate
-     /etc/init.d/apache2 reload
+     systemctl reload apache2.service
     endscript
 }


### PR DESCRIPTION
/etc/init.d/apache2 does not exist anymore since SLE12