### PR TITLE
neutron: enable automatic lbaas reschedule

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -180,6 +180,7 @@ if node[:neutron][:use_lbaas] &&
       debug: node[:neutron][:debug],
       interface_driver: interface_driver,
       user_group: node[:neutron][:platform][:lbaas_haproxy_group],
+      allow_automatic_lbaas_agent_failover: node[:neutron][:allow_automatic_lbaas_agent_failover],
       device_driver: "neutron_lbaas.drivers.haproxy.namespace_driver.HaproxyNSDriver"
     )
   end

--- a/chef/cookbooks/neutron/templates/default/lbaas_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/lbaas_agent.ini.erb
@@ -2,5 +2,6 @@
 device_driver = <%= @device_driver %>
 interface_driver = <%= @interface_driver %>
 debug = <%= @debug %>
+allow_automatic_lbaas_agent_failover = <%= @allow_automatic_lbaas_agent_failover %>
 [haproxy]
 user_group = <%= @user_group %>

--- a/chef/data_bags/crowbar/migrate/neutron/208_add_allow_automatic_lbass_agent_failover.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/208_add_allow_automatic_lbass_agent_failover.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  attr = "allow_automatic_lbaas_agent_failover"
+  a[attr] = ta[attr] unless a.key? attr
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  attr = "allow_automatic_lbaas_agent_failover"
+  a.delete(attr) unless ta.key? attr
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -14,6 +14,7 @@
       "rpc_workers": 1,
       "use_lbaas": true,
       "lbaasv2_driver": "haproxy",
+      "allow_automatic_lbaas_agent_failover": true,
       "use_l2pop": false,
       "l2pop": {
         "agent_boot_time": 180
@@ -178,7 +179,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 207,
+      "schema-revision": 208,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -19,6 +19,7 @@
                     "rpc_workers": { "type": "int", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
                     "lbaasv2_driver": { "type": "str", "required": true },
+                    "allow_automatic_lbaas_agent_failover": { "type": "bool", "required": true },
                     "use_l2pop": { "type": "bool", "required": true },
                     "l2pop": { "type": "map", "required": true, "mapping": {
                       "agent_boot_time": { "type" : "int", "required" : true }


### PR DESCRIPTION
Enable the ability to automatically reschedule load balancers from LBaaS
agents the server detects to have died.
Previously, load balancers could be scheduled and realized across
multiple LBaaS agents, however if a hypervisor died, the load
balancers scheduled to that node would cease operation.
Now, these load balancers will be automatically rescheduled to a
different agent.