### PR TITLE
[4.0] rabbitmq: do not create the erlang cookie file on cluster deployment

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -40,7 +40,6 @@ default[:rabbitmq][:mnesiadir] = nil
 
 default[:rabbitmq][:cluster] = false
 default[:rabbitmq][:clustername] = "rabbit@#{node[:hostname]}"
-default[:rabbitmq][:erlang_cookie_path] = "/var/lib/rabbitmq/.erlang.cookie"
 
 # ha
 default[:rabbitmq][:ha][:enabled] = false

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -17,15 +17,6 @@ pid_file = "/var/run/rabbitmq/pid"
 
 agent_name = "ocf:rabbitmq:rabbitmq-server-ha"
 
-# set the shared rabbitmq cookie
-# cookie is automatically set during barclamp apply
-# on the apply_role_pre_chef_call method
-file node[:rabbitmq][:erlang_cookie_path] do
-  content node[:rabbitmq][:erlang_cookie]
-  owner node[:rabbitmq][:rabbitmq_user]
-  group node[:rabbitmq][:rabbitmq_group]
-end
-
 # create file that will be sourced by OCF resource agent on promote
 template "/etc/rabbitmq/ocf-promote" do
   source "ocf-promote.erb"


### PR DESCRIPTION
There should be no need to create the erlang cookie file for rabbit on
cluster deployments as the pacemaker resource agent already creates
it for us.

(cherry picked from commit 0a00afc7cc23d18769a0febfe52555ceb8455456)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1278