### PR TITLE
[4.0] cinder: Set os_privileged_* values

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -12,6 +12,12 @@ wsgi_keep_alive = false
 state_path = /var/lib/cinder
 my_ip = <%= node[:cinder][:my_ip] %>
 
+# os_privileged_* values are required for migrations of attached volumes
+# See bsc#1079763
+os_privileged_user_name = <%= @keystone_settings['service_user'] %>
+os_privileged_user_password = <%= @keystone_settings['service_password'] %>
+os_privileged_user_tenant = <%= @keystone_settings['service_tenant'] %>
+
 glance_api_servers = <%= @glance_server_protocol %>://<%= @glance_server_host %>:<%= @glance_server_port %>
 glance_api_version = 2
 <% unless @glance_server_insecure.nil? -%>


### PR DESCRIPTION
When the privileged user is not set, cinder does not provide
correct credentials to nova client and migration of attached
volumes fails.

See https://bugs.launchpad.net/cinder/+bug/1614344 for upstream bug.
The relevant code was rewritten for Pike so providing those options
won't be necessary in newer releases. But as the work was not
backported, we have to provide os_privileged values in Newton codebase
if we want to make the migration work (bsc#1079763).