### PR TITLE
nova: Add option to modify scheduler's enabled_filters

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -392,6 +392,7 @@ template node[:nova][:config_file] do
     oat_appraiser_host: oat_server[:hostname],
     oat_appraiser_port: "8443",
     has_itxt: has_itxt,
+    enabled_filters: node[:nova][:scheduler][:enabled_filters],
     reserved_host_memory: reserved_host_memory,
     use_baremetal_filters: use_baremetal_filters,
     track_instance_changes: track_instance_changes,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -328,10 +328,18 @@ use_baremetal_filters = true
 <% end %>
 <% if @has_itxt %>
 available_filters = nova.scheduler.filters.standard_filters
+<% if @enabled_filters.empty? %>
 enabled_filters = RetryFilter,AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,TrustedFilter
 <% else %>
+enabled_filters = <%= @enabled_filters %>
+<% end %>
+<% else %>
 available_filters = nova.scheduler.filters.all_filters
+<% if @enabled_filters.empty? %>
 enabled_filters = RetryFilter,AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,SameHostFilter,DifferentHostFilter
+<% else %>
+enabled_filters = <%= @enabled_filters %>
+<% end %>
 <% end %>
 <% unless @track_instance_changes %>
 track_instance_changes = false

--- a/chef/data_bags/crowbar/migrate/nova/208_add_scheduler_enabled_filters.rb
+++ b/chef/data_bags/crowbar/migrate/nova/208_add_scheduler_enabled_filters.rb
@@ -1,0 +1,17 @@
+def upgrade(ta, td, a, d)
+  if a["scheduler"].key? "default_filters"
+    a["scheduler"]["enabled_filters"] = a["scheduler"]["default_filters"]
+    a["scheduler"].delete("default_filters")
+  else
+    a["scheduler"]["enabled_filters"] = ta["scheduler"]["enabled_filters"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  if ta["scheduler"].key? "default_filters"
+    a["scheduler"]["default_filters"] = a["scheduler"]["enabled_filters"]
+  end
+  a["scheduler"].delete("enabled_filters")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -37,7 +37,8 @@
         "cpu_allocation_ratio": 16.0,
         "disk_allocation_ratio": 1.0,
         "reserved_host_memory_mb": 512,
-        "discover_hosts_in_cells_interval": 600
+        "discover_hosts_in_cells_interval": 600,
+        "enabled_filters": ""
       },
       "ec2-api": {
         "db": {
@@ -180,7 +181,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 207,
+      "schema-revision": 208,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -55,7 +55,8 @@
                 "cpu_allocation_ratio": { "type": "number" },
                 "disk_allocation_ratio": { "type": "number" },
                 "reserved_host_memory_mb": { "type": "number" },
-                "discover_hosts_in_cells_interval": { "type": "int", "required": true }
+                "discover_hosts_in_cells_interval": { "type": "int", "required": true },
+                "enabled_filters": { "type": "str", "required": true }
               }
             },
             "ec2-api": {


### PR DESCRIPTION
In some cases user needs to modify enabled filters, e.g. remove
DiskFilter when instances are only booted from volumes (bsc#1080997)


This is partial forward-port of https://github.com/crowbar/crowbar-openstack/pull/1568 . The change is that Newton uses `scheduler_default_filters`, while Pike has `enabled_filters`