### PR TITLE
rabbitmq: allow pacemaker restart

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -163,7 +163,9 @@ service "rabbitmq-server" do
            stop: true,
            status: true,
            crm_resource_stop_cmd: crm_resource_stop_cmd,
-           crm_resource_start_cmd: crm_resource_start_cmd
+           crm_resource_start_cmd: crm_resource_start_cmd,
+           restart_crm_resource: true,
+           pacemaker_resource_name: "rabbitmq"
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end


### PR DESCRIPTION
Up until now we were relaying on the restart for rabbit while on
HA to silently fail due to the resource service name called
rabbitmq-server while the pacemaker reasource is called rabbitmq.

This triggered a restart but it silently failed. Instead pass the
correct service name to allow for the services to be properly
promoted/demoted/restarted even on HA.