### PR TITLE
[4.0] rabbitmq: allow pacemaker service restart

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -22,6 +22,8 @@ ha_enabled = node[:rabbitmq][:ha][:enabled]
 # we only do cluster if we do HA
 cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
 quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
+crm_resource_stop_cmd = cluster_enabled ? "force-demote" : "force-stop"
+crm_resource_start_cmd = cluster_enabled ? "force-promote" : "force-start"
 
 cluster_partition_handling = if cluster_enabled
   if CrowbarPacemakerHelper.num_corosync_nodes(node) > 2
@@ -157,7 +159,14 @@ bash "enabling rabbit management" do
 end
 
 service "rabbitmq-server" do
-  supports restart: true, start: true, stop: true, status: true
+  supports restart: true,
+           start: true,
+           stop: true,
+           status: true,
+           crm_resource_stop_cmd: crm_resource_stop_cmd,
+           crm_resource_start_cmd: crm_resource_start_cmd,
+           restart_crm_resource: true,
+           pacemaker_resource_name: "rabbitmq"
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end


### PR DESCRIPTION
Up until now we were relaying on the restart for rabbit while on
HA to silently fail due to the resource service name called
rabbitmq-server while the pacemaker reasource is called rabbitmq.

This triggered a restart but it silently failed. Instead pass the
correct service name to allow for the services to be properly
promoted/demoted/restarted even on HA.

(cherry picked from commit 00c9abd8c4f0067090a8a25faf268edcaa0b71b4)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1579