### PR TITLE
horizon: copytruncate apache logs bsc#1083093

### DIFF
--- a/chef/cookbooks/horizon/templates/default/openstack-dashboard.logrotate.erb
+++ b/chef/cookbooks/horizon/templates/default/openstack-dashboard.logrotate.erb
@@ -1,27 +1,21 @@
 /var/log/apache2/openstack-dashboard-access_log {
     compress
+    copytruncate
     dateext
     maxage 365
     rotate 99
     size=+4096k
     notifempty
     missingok
-    create 644 root root
-    postrotate
-     systemctl reload apache2.service
-    endscript
 }
 
 /var/log/apache2/openstack-dashboard-error_log {
     compress
+    copytruncate
     dateext
     maxage 365
     rotate 99
     size=+1024k
     notifempty
     missingok
-    create 644 root root
-    postrotate
-     systemctl reload apache2.service
-    endscript
 }


### PR DESCRIPTION
apache2 reload causes responses 406 from keystone. This change was
verified on a customer's setup.

bsc#1083093