### PR TITLE
Fixes needed for adding a node into existing cluster

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -184,6 +184,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       external_networks.concat(neutron[:neutron][:additional_external_networks])
       ext_physnet_map = NeutronHelper.get_neutron_physnets(node, external_networks)
       external_networks.each do |net|
+        next if node[:crowbar_wall][:network][:nets][net].nil?
         ext_iface = node[:crowbar_wall][:network][:nets][net].last
         # we can't do "floating:br-public, physnet1:br-public"; this also means
         # that all relevant nodes here must have a similar bridge_mappings

--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -243,14 +243,13 @@ class CinderService < OpenstackServiceObject
     # Generate secrets uuid for libvirt rbd backend
     dirty = false
     proposal = Proposal.find_by(barclamp: "cinder", name: role.inst)
-    role.default_attributes[:cinder][:volumes].each_with_index do |volume, volid|
-      next unless volume[:backend_driver] == "rbd"
-      if volume[:rbd][:secret_uuid].empty?
-        secret_uuid = `uuidgen`.strip
-        volume[:rbd][:secret_uuid] = secret_uuid
-        proposal[:attributes][:cinder][:volumes][volid][:rbd][:secret_uuid] = secret_uuid
-        dirty = true
-      end
+    role.default_attributes["cinder"]["volumes"].each_with_index do |volume, volid|
+      next unless volume["backend_driver"] == "rbd"
+      next unless volume["rbd"]["secret_uuid"].empty?
+      secret_uuid = `uuidgen`.strip
+      volume["rbd"]["secret_uuid"] = secret_uuid
+      proposal["attributes"]["cinder"]["volumes"][volid]["rbd"]["secret_uuid"] = secret_uuid
+      dirty = true
     end
     if dirty
       # This makes the proposal in the UI looked as 'applied', even if you make changes to it

--- a/crowbar_framework/lib/openstack/ha.rb
+++ b/crowbar_framework/lib/openstack/ha.rb
@@ -21,6 +21,8 @@ module Openstack
         save_it = false
         node = NodeObject.find_node_by_name nodename
 
+        node[:pacemaker] ||= {}
+
         node[:pacemaker][:attributes] ||= {}
         if node[:pacemaker][:attributes]["OpenStack-role"] != role
           node[:pacemaker][:attributes]["OpenStack-role"] = role


### PR DESCRIPTION
These are various bits found during testing the case of new node being added to existing pacemaker cluster (bsc#1083427)

- At least in the special case of adding new member to existing cluster,  Openstack::HA.set_controller_role is called and node[:pacemaker] accessed.
- cinder: Do not access role attributes with symbol keys 
- neutron: Check network presence before accessing it 