### PR TITLE
[4.0] mariadb: Remove redundant config values

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -26,9 +26,6 @@ if node[:database].key? "ec2"
   default[:database][:mysql][:ebs_vol_size]            = 50
 end
 
-default[:database][:mysql][:tunable][:max_allowed_packet]       = "16M"
-default[:database][:mysql][:tunable][:thread_cache_size]        = 8
-
 # Ports to bind to when haproxy is used
 default[:mysql][:ha][:ports][:admin_port] = 3306
 

--- a/chef/cookbooks/mysql/templates/default/my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/my.cnf.erb
@@ -13,7 +13,3 @@ tmpdir                 = <%= node[:database][:mysql][:tmpdir] %>
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
 bind-address            = <%= node[:database][:mysql][:bind_address] %>
-
-[mysqldump]
-# FIXME: Remove after MariaDB 10.2.X switch (new default is 16777216)
-max_allowed_packet      = <%= node[:database][:mysql][:tunable][:max_allowed_packet] %>

--- a/chef/cookbooks/mysql/templates/default/tuning.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/tuning.cnf.erb
@@ -15,8 +15,3 @@ tmp_table_size = <%= @tmp_table_size %>M
 max_heap_table_size = <%= @max_heap_table_size %>M
 
 skip_name_resolve = 1
-
-# FIXME: Remove after MariaDB 10.2.X switch (new default is auto)
-thread_cache_size = <%= node[:database][:mysql][:tunable][:thread_cache_size] %>
-# FIXME: Remove after MariaDB 10.2.X switch (new default is 16777216)
-max_allowed_packet = <%= node[:database][:mysql][:tunable][:max_allowed_packet] %>


### PR DESCRIPTION
After the MariaDB 10.2 switch the new default makes these entrys
redundant so there are not needed anymore.

(cherry picked from commit 1aaa8c20d1e34022354ca2f0e39e4d1532910c8a)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1564