### PR TITLE
memcached: Disable UDP by default (bsc#1083903)

### DIFF
--- a/chef/cookbooks/memcached/templates/default/memcached.sysconfig.erb
+++ b/chef/cookbooks/memcached/templates/default/memcached.sysconfig.erb
@@ -10,7 +10,7 @@
 #
 # see man 1 memcached for more
 #
-MEMCACHED_PARAMS="<%= @daemonize ? "-d" : "" %> -m <%= @memory %> -l <%= @listen %> -p <%= @port %>"
+MEMCACHED_PARAMS="<%= @daemonize ? "-d" : "" %> -U 0 -m <%= @memory %> -l <%= @listen %> -p <%= @port %>"
 
 ## Path:        Network/WWW/Memcached
 ## Description: username memcached should run as


### PR DESCRIPTION
This reduces the ability to mis-use it for cache
amplification attacks, and we don't really need it.

(cherry picked from commit 07f036903c5fbf95d2f7bb95e1c26dc61b62ec14)