### PR TITLE
barbican: Add missing roles used in policy.json (bsc#1081573)

### DIFF
--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -124,6 +124,28 @@ keystone_register "give barbican user access as admin" do
   action :add_access
 end
 
+keystone_register "add key-manager:service-admin role for barbican" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  role_name "key-manager:service-admin"
+  action :add_role
+end
+
+keystone_register "give barbican user access as key-manager:service-admin" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  project_name keystone_settings["service_tenant"]
+  role_name "key-manager:service-admin"
+  action :add_access
+end
+
 keystone_register "add creator role for barbican" do
   protocol keystone_settings["protocol"]
   insecure keystone_settings["insecure"]
@@ -143,6 +165,50 @@ keystone_register "give barbican user access as creator" do
   user_name keystone_settings["service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "creator"
+  action :add_access
+end
+
+keystone_register "add observer role for barbican" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  role_name "observer"
+  action :add_role
+end
+
+keystone_register "give barbican user access as observer" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  project_name keystone_settings["service_tenant"]
+  role_name "observer"
+  action :add_access
+end
+
+keystone_register "add audit role for barbican" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  role_name "audit"
+  action :add_role
+end
+
+keystone_register "give barbican user access as audit" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  project_name keystone_settings["service_tenant"]
+  role_name "audit"
   action :add_access
 end
 


### PR DESCRIPTION
Add the key-manager:service-admin, observer and audit roles. These roles
are used in the policy.json file for the barbican API.