### PR TITLE
monasca: add Cassandra support

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -60,6 +60,7 @@ template "/opt/monasca-installer/monasca-hosts" do
   group "root"
   mode "0644"
   variables(
+    tsdb: node[:monasca][:master][:tsdb],
     monasca_public_host: MonascaHelper.monasca_public_host(monasca_servers[0]),
     monasca_admin_host: monasca_hosts[0],
     monasca_monitoring_host: monasca_monitoring_host,

--- a/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
@@ -1,9 +1,15 @@
-influxdb_mon_api_password: <%= @master_settings['influxdb_mon_api_password'] %>
-influxdb_mon_persister_password: <%= @master_settings['influxdb_mon_persister_password'] %>
+influxdb_mon_api_password: <%= @master_settings['tsdb_mon_api_password'] %>
+influxdb_mon_persister_password: <%= @master_settings['tsdb_mon_persister_password'] %>
 influxdb_bind_address: <%= @monasca_net_ip %>
 influxdb_host: <%= @monasca_net_ip %>
 influxdb_url: "http://<%= @monasca_net_ip %>:8086"
 influxdb_retention_policy: <%= @master_settings['influxdb_retention_policy'] %>
+cassandra_mon_api_password: <%= @master_settings['tsdb_mon_api_password'] %>
+cassandra_mon_persister_password: <%= @master_settings['tsdb_mon_persister_password'] %>
+cassandra_rpc_address: <%= @monasca_net_ip %>
+cassandra_admin_password: <%= @master_settings['tsdb_mon_api_password'] %>
+database_type: <%= @master_settings['tsdb'] %>
+
 database_notification_password: <%= @master_settings['database_notification_password'] %>
 database_monapi_password: <%= @master_settings['database_monapi_password'] %>
 database_thresh_password: <%= @master_settings['database_thresh_password'] %>

--- a/chef/cookbooks/monasca/templates/default/monasca-hosts-single.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-hosts-single.erb
@@ -68,8 +68,15 @@ mariadb-node                     ansible_ssh_host=<%= @monasca_admin_host %> ans
 # Elasticsearch Curator
 elasticsearch-curator-node       ansible_ssh_host=<%= @monasca_admin_host %> ansible_ssh_user=<%= @ansible_ssh_user %>
 
+<%- if @tsdb == 'influxdb' %>
 # InfluxDB node
 influxdb-node                    ansible_ssh_host=<%= @monasca_admin_host %> ansible_ssh_user=<%= @ansible_ssh_user %>
+<%- end %>
+
+<%- if @tsdb == 'cassandra' %>
+# Cassandra node
+cassandra-node                    ansible_ssh_host=<%= @monasca_admin_host %> ansible_ssh_user=<%= @ansible_ssh_user %>
+<%- end %>
 
 ################################################################################
 # Other group definition
@@ -91,13 +98,23 @@ zookeeper-node zookeeper_listen_ip=internal-node-1
 monasca-node
 
 [monasca_api_group]
+<%- if @tsdb == 'influxdb' %>
 monasca-api-node database_node_for_api=internal-node-1 influxdb_node_for_api=internal-node-1 monasca_api_listen_ip=public-node-1
+<%- end %>
+<%- if @tsdb == 'cassandra' %>
+monasca-api-node database_node_for_api=internal-node-1 cassandra_node_for_api=internal-node-1 monasca_api_listen_ip=public-node-1
+<%- end %>
 
 [monasca_notification_group]
 monasca-notification-node database_node_for_notification=internal-node-1
 
 [monasca_persister_group]
+<%- if @tsdb == 'influxdb' %>
 monasca-persister-node influxdb_node_for_persister=internal-node-1
+<%- end %>
+<%- if @tsdb == 'cassandra' %>
+monasca-persister-node cassandra_node_for_persister=internal-node-1
+<%- end %>
 
 [monasca_log_api_group]
 monasca-log-api-node log_api_listen_ip=public-node-1
@@ -132,8 +149,14 @@ mariadb-node mariadb_listen_ip=internal-node-1
 [elasticsearch_curator_group]
 elasticsearch-curator-node
 
+<%- if @tsdb == 'influxdb' %>
 [influxdb_group]
 influxdb-node influxdb_listen_ip=internal-node-1
+<%- end %>
+<%- if @tsdb == 'cassandra' %>
+[cassandra_group]
+cassandra-node cassandra_listen_ip=internal-node-1
+<%- end %>
 
 ################################################################################
 # Group inheritance
@@ -167,4 +190,9 @@ monasca_persister_group
 storm_group
 monasca_thresh_group
 mariadb_group
+<%- if @tsdb == 'cassandra' %>
+cassandra_group
+<%- end %>
+<%- if @tsdb == 'influxdb' %>
 influxdb_group
+<%- end %>

--- a/chef/data_bags/crowbar/migrate/monasca/203_add_cassandra_support.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/203_add_cassandra_support.rb
@@ -1,0 +1,35 @@
+def upgrade(ta, td, a, d)
+  # this migration already happened if the tsdb key exists
+  return a, d if a["master"].key?("tsdb")
+
+  a["master"]["tsdb"] = ta["master"]["tsdb"]
+
+  # Use a class variable, since migrations are run twice.
+  unless defined?(@@cassandra_admin_password)
+    service = ServiceObject.new "fake-logger"
+    @@cassandra_admin_password = service.random_password
+  end
+
+  a["master"]["cassandra_admin_password"] = @@cassandra_admin_password
+
+  # Retain value of old influxdb password fields
+  a["master"]["tsdb_mon_api_password"] = a["master"]["influxdb_mon_api_password"]
+  a["master"]["tsdb_mon_persister_password"] = a["master"]["influxdb_mon_persister_password"]
+
+  a["master"].delete("influxdb_mon_api_password")
+  a["master"].delete("influxdb_mon_persister_password")
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["master"]["influxdb_mon_api_password"] = a["master"]["tsdb_mon_api_password"]
+  a["master"]["influxdb_mon_persister_password"] = a["master"]["tsdb_mon_persister_password"]
+
+  a["master"].delete("cassandra_admin_password")
+  a["master"].delete("tsdb")
+  a["master"].delete("tsdb_mon_persister_password")
+  a["master"].delete("tsdb_mon_api_password")
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -93,9 +93,8 @@
         "extra_params": ""
       },
       "master": {
-        "influxdb_mon_api_password": "",
-        "influxdb_mon_persister_password": "",
         "influxdb_retention_policy": "60d",
+        "cassandra_admin_password": "",
         "database_notification_password": "",
         "database_monapi_password": "",
         "database_thresh_password": "",
@@ -109,7 +108,10 @@
         "smtp_port": 25,
         "smtp_user": "",
         "smtp_password": "",
-        "smtp_from_address": "monasca@localhost"
+        "smtp_from_address": "monasca@localhost",
+        "tsdb": "influxdb",
+        "tsdb_mon_api_password": "",
+        "tsdb_mon_persister_password": ""
       },
       "db": {
         "database": "monasca",
@@ -132,7 +134,7 @@
     "monasca": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 203,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
         "monasca-master": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -157,13 +157,12 @@
               "required": true,
               "type": "map",
               "mapping": {
-                "influxdb_mon_api_password": { "required": true, "type": "str" },
-                "influxdb_mon_persister_password": { "required": true, "type": "str" },
                 "influxdb_retention_policy": {
                    "required": true,
                    "type": "str",
                    "pattern": "/^\d+[mhdw]|INF$/"
                  },
+                "cassandra_admin_password": { "required": true, "type": "str" },
                 "database_notification_password": { "required": true, "type": "str" },
                 "database_monapi_password": { "required": true, "type": "str" },
                 "database_thresh_password": { "required": true, "type": "str" },
@@ -177,7 +176,10 @@
                 "smtp_port": { "required": true, "type": "int" },
                 "smtp_user": { "required": true, "type": "str" },
                 "smtp_password": { "required": true, "type": "str" },
-                "smtp_from_address": { "required": true, "type": "str" }
+                "smtp_from_address": { "required": true, "type": "str" },
+                "tsdb": { "required": true, "type": "str" },
+                "tsdb_mon_api_password": { "required": true, "type": "str" },
+                "tsdb_mon_persister_password": { "required": true, "type": "str" }
               }
             },
             "db": {

--- a/crowbar_framework/app/helpers/barclamp/monasca_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/monasca_helper.rb
@@ -41,5 +41,15 @@ module Barclamp
         selected.to_s
       )
     end
+
+    def tsdbs(selected)
+      options_for_select(
+        [
+          ["InfluxDB", "influxdb"],
+          ["Cassandra", "cassandra"]
+        ],
+        selected.to_s
+      )
+    end
   end
 end

--- a/crowbar_framework/app/models/monasca_service.rb
+++ b/crowbar_framework/app/models/monasca_service.rb
@@ -120,8 +120,9 @@ class MonascaService < OpenstackServiceObject
     base["attributes"][@bc_name][:db][:password] = random_password
     base["attributes"][@bc_name][:agent][:keystone][:service_password] = random_password
     base["attributes"][@bc_name][:log_agent][:keystone][:service_password] = random_password
-    base["attributes"][@bc_name][:master][:influxdb_mon_api_password] = random_password
-    base["attributes"][@bc_name][:master][:influxdb_mon_persister_password] = random_password
+    base["attributes"][@bc_name][:master][:tsdb_mon_api_password] = random_password
+    base["attributes"][@bc_name][:master][:tsdb_mon_persister_password] = random_password
+    base["attributes"][@bc_name][:master][:cassandra_admin_password] = random_password
     base["attributes"][@bc_name][:master][:database_notification_password] = random_password
     base["attributes"][@bc_name][:master][:database_monapi_password] = random_password
     base["attributes"][@bc_name][:master][:database_thresh_password] = random_password

--- a/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
@@ -42,3 +42,4 @@
       = string_field %w(master smtp_user)
       = password_field %w(master smtp_password)
       = string_field %w(master smtp_from_address)
+      = select_field %w(master tsdb), :collection => :tsdbs

--- a/crowbar_framework/config/locales/monasca/en.yml
+++ b/crowbar_framework/config/locales/monasca/en.yml
@@ -53,6 +53,7 @@ en:
           smtp_user: 'SMTP user'
           smtp_password: 'SMTP password'
           smtp_from_address: 'SMTP sender (FROM) address'
+          tsdb: 'Time series database to use'
         db_header: 'Database settings'
         db:
           database: 'Database'


### PR DESCRIPTION
This commit adds support for Cassandra to the Monasca
barclamp. It introduces various new parameters required for
Cassandra and passes them to monasca-installer. Details:

* New parameters:
  * tsdb
  * cassandra_admin_password parameter.
* Renamed parameters:
  * influxdb_mon_api_password -> tsdb_mon_api_password
  * influxdb_mon_persister_password -> tsdb_mon_persister_password
* Parametrize monasca-installer for Cassandra setup.
* Generate cassandra_admin_password