### PR TITLE
neutron: [cisco-aci]: Add support for vpc_pairs.

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_support.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_support.rb
@@ -49,6 +49,7 @@ template node[:neutron][:ml2_cisco_apic_config_file] do
   owner "root"
   group node[:neutron][:platform][:group]
   variables(
+    vpc_pairs: node[:neutron][:apic][:vpc_pairs],
     apic_switches: aciswitches,
     ml2_mechanism_drivers: node[:neutron][:ml2_mechanism_drivers],
     policy_drivers: "implicit_policy,apic",

--- a/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
@@ -15,6 +15,10 @@ enable_optimized_metadata = <%= node[:neutron][:apic][:optimized_metadata] %>
 enable_optimized_dhcp = <%= node[:neutron][:apic][:optimized_dhcp] %>
 apic_provision_infra = True
 apic_provision_hostlinks = True
+<%  unless @vpc_pairs.nil? -%>
+apic_vpc_pairs = <%= @vpc_pairs %>
+<% end -%>
+
 <% @apic_switches.keys.each do |ip| -%>
 [apic_switch:<%=ip%>]
 <%    if @apic_switches[ip].key?(:switch_ports) -%>

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -52,6 +52,7 @@
                       "password": { "type" : "str", "required": true },
                       "optimized_metadata": { "type" : "bool", "required": true },
                       "optimized_dhcp": { "type" : "bool", "required": true }, 
+                      "vpc_pairs": { "type": "str", "required": false },
                       "opflex": { "type": "seq", "required": true, "sequence": [ {
                         "type": "map", "required": true, "mapping": {
                           "pod": { "type" : "str", "required" : false },


### PR DESCRIPTION
Cisco ACI supports connecting to the fabric either through direct port mappings that in which case, we need to specify the exact ports under [apic-switches] configuration. The pattern usually looks like "1/34" for interface Eth1 and Port 34. Associating these ports creates new policy profiles and groups for the integration. This is not feasible if the ACI is already running another production cloud and we need to integrate openstack as a supplement (which is the case with most ACI customers).
However, ACI also allows for associating pre-existing profiles using VPC_Pairs. This can be configured by specifying the apic_vpc_pairs in ml2_conf_cisco_apic.ini.
This commit provides an option to test with either modes (VPC Pairs or direct connection) as the use-case may be.

Backport: https://github.com/crowbar/crowbar-openstack/pull/1600