### PR TITLE
Revert "rabbitmq: allow pacemaker restart"

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -164,9 +164,7 @@ service "rabbitmq-server" do
            stop: true,
            status: true,
            crm_resource_stop_cmd: crm_resource_stop_cmd,
-           crm_resource_start_cmd: crm_resource_start_cmd,
-           restart_crm_resource: true,
-           pacemaker_resource_name: "rabbitmq"
+           crm_resource_start_cmd: crm_resource_start_cmd
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end


### PR DESCRIPTION
Reverts crowbar/crowbar-openstack#1579


Restarting rabbit seems to bring instability to the rest of the services so we better not restart.