### PR TITLE
[cisco_aci]neutron: Add support for L3Out External Connectivity

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_support.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_support.rb
@@ -53,7 +53,7 @@ template node[:neutron][:ml2_cisco_apic_config_file] do
     apic_switches: aciswitches,
     ml2_mechanism_drivers: node[:neutron][:ml2_mechanism_drivers],
     policy_drivers: "implicit_policy,apic",
-    default_ip_pool: "192.168.0.0/16",
+    default_ip_pool: "192.168.0.0/16"
   )
   notifies :restart, "service[#{node[:neutron][:platform][:service_name]}]"
 end

--- a/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
@@ -21,11 +21,11 @@ apic_vpc_pairs = <%= @vpc_pairs %>
 
 <% @apic_switches.keys.each do |ip| -%>
 [apic_switch:<%=ip%>]
-<%    if @apic_switches[ip].key?(:switch_ports) -%>
-<%      @apic_switches[ip][:switch_ports].each do |name, values| -%>
-<%=       name %> = <%= values[:switch_port] %>
-<%      end -%>
-<%    end -%>
+  <% if @apic_switches[ip].key?(:switch_ports) -%>
+    <% @apic_switches[ip][:switch_ports].each do |name, values| -%>
+<%= name %> = <%= values[:switch_port] %>
+    <% end -%>
+  <% end -%>
 <% end -%>
 <% if @ml2_mechanism_drivers.include?("apic_gbp") -%>
 [group_policy]
@@ -33,3 +33,11 @@ policy_drivers = <%= @policy_drivers %>
 [group_policy_implicit_policy]
 default_ip_pool = <%= @default_ip_pool %>
 <% end -%>
+
+[apic_external_network:<%=node[:neutron][:apic][:ext_net][:name]%>]
+preexisting = <%= node[:neutron][:apic][:ext_net][:preexisting] %>
+<% unless node[:neutron][:apic][:ext_net][:nat_enabled].nil? -%>
+enable_nat = <%= node[:neutron][:apic][:ext_net][:nat_enabled] %>
+<% end -%>
+external_epg = <%= node[:neutron][:apic][:ext_net][:ext_epg] %>
+host_pool_cidr = <%= node[:neutron][:apic][:ext_net][:host_pool_cidr] %>

--- a/chef/data_bags/crowbar/migrate/neutron/209_add_apic_external_network_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/209_add_apic_external_network_attributes.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["apic"]["ext_net"] = ta["apic"]["ext_net"] unless a["apic"].key? "ext_net"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["apic"].delete("ext_net") unless ta["apic"].key? "ext_net"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -47,6 +47,12 @@
         "password": "",
         "optimized_metadata": true,
         "optimized_dhcp": true,
+        "ext_net": {
+          "name": "l3out",
+          "preexisting": true,
+          "ext_epg": "l3out-epg",
+          "host_pool_cidr": ""
+        },
         "opflex": [{
           "pod": "",
           "nodes" : [],
@@ -179,7 +185,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 208,
+      "schema-revision": 209,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -53,6 +53,13 @@
                       "optimized_metadata": { "type" : "bool", "required": true },
                       "optimized_dhcp": { "type" : "bool", "required": true }, 
                       "vpc_pairs": { "type": "str", "required": false },
+                      "ext_net": { "type" : "map", "required" : true, "mapping" : {
+                          "name": { "type" : "str", "required" : true },
+                          "preexisting": { "type" : "bool", "required" : true },
+                          "nat_enabled": { "type" : "bool", "required" : false },
+                          "ext_epg": { "type" : "str", "required" : true },
+                          "host_pool_cidr": { "type" : "str", "required" : true }
+                      }},
                       "opflex": { "type": "seq", "required": true, "sequence": [ {
                         "type": "map", "required": true, "mapping": {
                           "pod": { "type" : "str", "required" : false },


### PR DESCRIPTION
This commit provides a way to configure external connectivity
to the opnenstack instances by allowing the user to provide
ml2 config file with the L3 Out network and EPG details.

The commit adds a new section [apic_external_network] in
ml2_conf_cisco_apic.ini. The name of the section and the EPG provided
in the input reflects the Bridge domain, EPG and the External
Routed Network elements created on the ACI fabric.

When the external network of the ACI fabric is mapped to ML2,
the creation of neutron subnets get mapped to the subnets on the ACI
fabric and therefore will be subject to the Contracts and Policies
defined on the tenant. 
.