### PR TITLE
magnum: Set insecure option in keystone_authtoken

### DIFF
--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -48,6 +48,7 @@ user_domain_name = <%= @keystone_settings["admin_domain"] %>
 auth_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
+insecure = <%= @keystone_settings['insecure'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 username = <%= @keystone_settings['service_user'] %>
 password = <%= @keystone_settings['service_password'] %>


### PR DESCRIPTION
This is needed when ssl is enabled. Just having it in the keystone_auth section
is not enough.