### PR TITLE
glance: micro config template cleanup

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -13,7 +13,6 @@ state_path = /var/lib/cinder
 my_ip = <%= node[:cinder][:my_ip] %>
 
 glance_api_servers = <%= @glance_server_protocol %>://<%= @glance_server_host %>:<%= @glance_server_port %>
-glance_api_version = 2
 <% unless @glance_server_insecure.nil? -%>
 glance_api_insecure = <%= @glance_server_insecure %>
 <% end -%>


### PR DESCRIPTION
glance_api_version is defaulting to 2, we don't need to
explicitely set it. Found while looking for something else