### PR TITLE
nova: Configure a rng device for guest VM entropy (bsc#985882)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -290,6 +290,7 @@ end
 
 cpu_mode = ""
 cpu_model = ""
+rng_device = nil
 
 if node.roles.include? "nova-compute-kvm"
   compute_flags = node[:nova][:compute]["kvm-#{node[:kernel][:machine]}"]
@@ -300,6 +301,14 @@ end
 if compute_flags
   cpu_model = compute_flags["cpu_model"]
   cpu_mode = compute_flags["cpu_mode"]
+end
+
+if File.exist?("/sys/devices/virtual/misc/hw_random/rng_current") &&
+    !File.read("/sys/devices/virtual/misc/hw_random/rng_current").include?("none")
+  # Unfortunately that file isn't readable by non-root so we can not set it
+  # rng_device = "/dev/hwrng"
+else
+  rng_device = "/dev/random"
 end
 
 # lock path prevents race conditions for cinder-volume and nova-compute on same
@@ -339,6 +348,7 @@ template node[:nova][:config_file] do
     cpu_mode: cpu_mode,
     cpu_model: cpu_model,
     bind_host: bind_host,
+    rng_device: rng_device,
     bind_port_api: bind_port_api,
     bind_port_api_ec2: bind_port_api_ec2,
     bind_port_metadata: bind_port_metadata,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -221,6 +221,9 @@ volume_use_multipath = true
 iser_use_multipath = true
 <% end %>
 disk_cachemodes = <%= node[:nova][:kvm][:disk_cachemodes] %>
+<% if @rng_device %>
+rng_dev_path = <%= @rng_device %>
+<% end %>
 
 [neutron]
 service_metadata_proxy = true


### PR DESCRIPTION
This allows the administrator to select flavors or images
to pass through entropy devices to the guest to give them
a chance of securely generating crypto nounces. Note
the default seems to be off, it needs to be enabled in the
nova flavor via an "hw_rng:allowed=True" extra specs