### PR TITLE
tempest: install optional tempest plugins

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -31,7 +31,7 @@ package "euca2ools"
 
 package "openstack-tempest-test"
 
-["cinder", "designate", "ironic", "keystone", "magnum",
+["barbican", "cinder", "designate", "heat", "ironic", "keystone", "magnum",
  "manila", "neutron"].each do |service|
   package "python-#{service}-tempest-plugin"
 end


### PR DESCRIPTION
In order to increase test coverate we want to install
the available tempest plugins for services that have splitted
them into a separate package.