### PR TITLE
framework: save attributes to databag during pre chef run

### DIFF
--- a/crowbar_framework/app/models/aodh_service.rb
+++ b/crowbar_framework/app/models/aodh_service.rb
@@ -118,6 +118,9 @@ class AodhService < OpenstackServiceObject
     # the VIP of the cluster to be setup
     allocate_virtual_ips_for_any_cluster_in_networks(server_elements, vip_networks)
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Aodh apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/barbican_service.rb
+++ b/crowbar_framework/app/models/barbican_service.rb
@@ -115,6 +115,9 @@ class BarbicanService < OpenstackServiceObject
       allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(server_elements, vip_networks)
     end
 
+    # save attributes into the databag
+    save_config_to_databag(_old_role, role)
+
     @logger.debug("Barbican apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -180,6 +180,9 @@ class CeilometerService < OpenstackServiceObject
                                      ["ceilometer", "ha", "central", "enabled"],\
                                      central_ha_enabled)
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Ceilometer apply_role_pre_chef_call: leaving")
   end
 

--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -257,6 +257,9 @@ class CinderService < OpenstackServiceObject
       role.save
     end
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Cinder apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-class DatabaseService < PacemakerServiceObject
+class DatabaseService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "database"
@@ -209,6 +209,9 @@ class DatabaseService < PacemakerServiceObject
     # (FIXME: is there a better way to achieve this?)
     role.default_attributes[sql_engine] = role.default_attributes["database"][sql_engine]
     role.save
+
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
 
     @logger.debug("Database apply_role_pre_chef_call: leaving")
   end

--- a/crowbar_framework/app/models/glance_service.rb
+++ b/crowbar_framework/app/models/glance_service.rb
@@ -155,6 +155,9 @@ class GlanceService < OpenstackServiceObject
     # Setup virtual IPs for the clusters
     allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(server_elements, vip_networks)
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Glance apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/heat_service.rb
+++ b/crowbar_framework/app/models/heat_service.rb
@@ -109,6 +109,9 @@ class HeatService < OpenstackServiceObject
 
     allocate_virtual_ips_for_any_cluster_in_networks(server_elements, vip_networks)
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Heat apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -173,6 +173,9 @@ class HorizonService < OpenstackServiceObject
       node.save
     end
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Horizon apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/ironic_service.rb
+++ b/crowbar_framework/app/models/ironic_service.rb
@@ -137,6 +137,9 @@ class IronicService < ServiceObject
       neutron_service.update_ovs_bridge_attributes(neutron["attributes"]["neutron"], node)
     end
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Ironic apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -163,6 +163,9 @@ class KeystoneService < OpenstackServiceObject
       end
     end
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Keystone apply_role_pre_chef_call: leaving")
   end
 

--- a/crowbar_framework/app/models/magnum_service.rb
+++ b/crowbar_framework/app/models/magnum_service.rb
@@ -130,6 +130,9 @@ class MagnumService < OpenstackServiceObject
       allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(server_elements, vip_networks)
     end
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Magnum apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -222,6 +222,9 @@ keyring = /etc/ceph/ceph.client.manila.keyring
       node.save
     end
 
+    # save attributes into the databag
+    save_config_to_databag(_old_role, role)
+
     @logger.debug("Manila apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/manila_service.rb
+++ b/crowbar_framework/app/models/manila_service.rb
@@ -163,7 +163,7 @@ class ManilaService < OpenstackServiceObject
     super
   end
 
-  def apply_role_pre_chef_call(_old_role, role, all_nodes)
+  def apply_role_pre_chef_call(old_role, role, all_nodes)
     @logger.debug("Manila apply_role_pre_chef_call: "\
                   "entering #{all_nodes.inspect}")
 
@@ -223,7 +223,7 @@ keyring = /etc/ceph/ceph.client.manila.keyring
     end
 
     # save attributes into the databag
-    save_config_to_databag(_old_role, role)
+    save_config_to_databag(old_role, role)
 
     @logger.debug("Manila apply_role_pre_chef_call: leaving")
   end

--- a/crowbar_framework/app/models/monasca_service.rb
+++ b/crowbar_framework/app/models/monasca_service.rb
@@ -195,6 +195,9 @@ class MonascaService < OpenstackServiceObject
       allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(server_elements, vip_networks)
     end
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Monasca apply_role_pre_chef_call: leaving")
   end
 

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -564,6 +564,10 @@ class NeutronService < OpenstackServiceObject
     network_nodes.each do |n|
       enable_neutron_networks(role.default_attributes["neutron"], n, net_svc)
     end
+
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Neutron apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -389,6 +389,9 @@ class NovaService < OpenstackServiceObject
       end
     end
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Nova apply_role_pre_chef_call: leaving")
   end
 

--- a/crowbar_framework/app/models/openstack_service_object.rb
+++ b/crowbar_framework/app/models/openstack_service_object.rb
@@ -22,6 +22,13 @@
 #
 
 class OpenstackServiceObject < PacemakerServiceObject
+  def apply_role_pre_chef_call(old_role, role, all_nodes)
+    Rails.logger.debug("#{@bc_name} apply_role_pre_chef_call: entering #{all_nodes.inspect}")
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+    Rails.logger.debug("#{@bc_name} apply_role_pre_chef_call: leaving")
+  end
+
   def apply_role_post_chef_call(old_role, role, all_nodes)
     Rails.logger.debug("#{@bc_name} apply_role_post_chef_call: entering")
     # do this in post, because we depend on values that are computed in the

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -143,6 +143,9 @@ class RabbitmqService < OpenstackServiceObject
 
     role.save
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Rabbitmq apply_role_pre_chef_call: leaving")
   end
 

--- a/crowbar_framework/app/models/sahara_service.rb
+++ b/crowbar_framework/app/models/sahara_service.rb
@@ -118,6 +118,9 @@ class SaharaService < OpenstackServiceObject
 
     allocate_virtual_ips_for_any_cluster_in_networks(server_elements, vip_networks)
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("sahara apply_role_pre_chef_call: leaving")
   end
 end

--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -147,6 +147,9 @@ class SwiftService < OpenstackServiceObject
 
     allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(proxy_elements, vip_networks)
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Swift apply_role_pre_chef_call: leaving")
   end
 

--- a/crowbar_framework/app/models/tempest_service.rb
+++ b/crowbar_framework/app/models/tempest_service.rb
@@ -108,6 +108,9 @@ class TempestService < ServiceObject
       net_svc.allocate_ip "default", "public", "host", n
     end
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Tempest apply_role_pre_chef_call: leaving")
   end
 

--- a/crowbar_framework/app/models/trove_service.rb
+++ b/crowbar_framework/app/models/trove_service.rb
@@ -113,6 +113,9 @@ class TroveService < OpenstackServiceObject
 
     # allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(server_elements, vip_networks)
 
+    # save attributes into the databag
+    save_config_to_databag(old_role, role)
+
     @logger.debug("Trove apply_role_pre_chef_call: leaving")
   end
 end


### PR DESCRIPTION
Instead of waiting until the post chef method to be called to save
the attributes, just do it before as some of those attributes are
used during the chef run and if they are not available they will
be defaulted to false which means that we are configuring services
with the wrong parameters, at least on the first chef run