### PR TITLE
[tempest]: Make public network name configurable.

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -359,7 +359,7 @@ end
 ruby_block "get public network id" do
   block do
     cmd = "#{openstackcli} --os-user-domain-name Default --os-project-domain-name Default"
-    cmd << " network show -f value -c id floating"
+    cmd << " network show -f value -c id #{node[:tempest][:public_network_name]}"
     public_network_id =  `#{cmd}`.strip
     raise("Cannot fetch ID of floating network") if public_network_id.empty?
     node[:tempest][:public_network_id] = public_network_id
@@ -534,6 +534,7 @@ template "/etc/tempest/tempest.conf" do
         http_image: tempest_test_image,
         # network settings
         public_network_id: node[:tempest][:public_network_id],
+        public_network_name: node[:tempest][:public_network_name],
         neutron_api_extensions: neutron_api_extensions,
         # object storage settings
         swift_cluster_name: swift_cluster_name,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -72,7 +72,7 @@ image_ref = <%= @heat_settings['image_ref'] %>
 minimal_image_ref = <%= `cat #{@machine_id_file}`.strip %>
 build_timeout = 2000
 fixed_network_name = fixed
-floating_network_name = floating
+floating_network_name = <%= @public_network_name %>
 # TODO
 skip_scenario_tests = True
 skip_functional_tests = True
@@ -107,7 +107,7 @@ api_v1 = false
 
 [magnum]
 image_id = <%= @magnum_settings['image_id'] %>
-nic_id = floating
+nic_id = <%= @public_network_name %>
 flavor_id = <%= @magnum_settings['flavor_id'] %>
 master_flavor_id = <%= @magnum_settings['master_flavor_id'] %>
 
@@ -115,7 +115,7 @@ master_flavor_id = <%= @magnum_settings['master_flavor_id'] %>
 region = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internalURL
 public_network_id = <%= @public_network_id %>
-floating_network_name = floating
+floating_network_name = <%= @public_network_name %>
 
 [network-feature-enabled]
 api_extensions = <%= @neutron_api_extensions %>
@@ -188,7 +188,7 @@ events = true
 
 [validation]
 run_validation = <%= @use_run_validation %>
-connect_method = floating
+connect_method = <% @public_network_name %>
 ip_version_for_ssh = 4
 <% if @validation_connect_timeout -%>
 connect_timeout = <%= @validation_connect_timeout %>

--- a/chef/data_bags/crowbar/migrate/tempest/201_add_public_network_name.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/201_add_public_network_name.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["public_network_name"] = ta["public_network_name"] unless a.key? "public_network_name"
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("public_network_name") unless ta.key? "public_network_name"
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -15,6 +15,7 @@
       "tempest_user_username": "tempest",
       "tempest_user_tenant": "tempest",
       "nova_instance": "none",
+      "public_network_name": "floating",
       "manila": {
         "image_with_share_tools": "manila-service-image",
         "image_username": "root",
@@ -41,7 +42,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -27,6 +27,7 @@
                 "s390x": { "type": "str", "required": true }
               }
             },
+            "public_network_name": { "type": "str", "required": true },
             "manila": {
               "type": "map",
               "mapping": {


### PR DESCRIPTION
Tempest barclamp expects the public network name to be
"floating" and is hard coded in the recipe. Some special
use-cases (for e.g: ACI) require that the public network
be named as per the configuration setup in the SDN solution.

This commit is allowing the user to define the public network
name as a variable from the Crowbar UI so that its possible
to test other SDN backends requiring such flexibility.