### PR TITLE
[tempest]: Backport from #1614. Add public_network_name.

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -362,7 +362,7 @@ ruby_block "get public network id" do
     cmd << " --os-username #{tempest_comp_user} --os-password #{tempest_comp_pass}"
     cmd << " --os-tenant-name #{tempest_comp_tenant}"
     cmd << " --os-auth-url #{keystone_settings["internal_auth_url"]}"
-    cmd << " net-list -f value -c id --name floating"
+    cmd << " net-list -f value -c id --name #{node[:tempest][:public_network_name]}"
     public_network_id =  `#{cmd}`.strip
     raise("Cannot fetch ID of floating network") if public_network_id.empty?
     node[:tempest][:public_network_id] = public_network_id
@@ -537,6 +537,7 @@ template "/etc/tempest/tempest.conf" do
         http_image: tempest_test_image,
         # network settings
         public_network_id: node[:tempest][:public_network_id],
+        public_network_name: node[:tempest][:public_network_name],
         neutron_api_extensions: neutron_api_extensions,
         # object storage settings
         swift_cluster_name: swift_cluster_name,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -71,7 +71,7 @@ image_ref = <%= @heat_settings['image_ref'] %>
 minimal_image_ref = <%= `cat #{@machine_id_file}`.strip %>
 build_timeout = 2000
 fixed_network_name = fixed
-floating_network_name = floating
+floating_network_name = <%= @public_network_name %>
 # TODO
 skip_scenario_tests = True
 skip_functional_tests = True
@@ -112,7 +112,7 @@ ssh_user_regex = [["^.*[Cc]irros.*$", "cirros"]]
 
 [magnum]
 image_id = <%= @magnum_settings['image_id'] %>
-nic_id = floating
+nic_id = <%= @public_network_name %>
 flavor_id = <%= @magnum_settings['flavor_id'] %>
 master_flavor_id = <%= @magnum_settings['master_flavor_id'] %>
 
@@ -120,7 +120,7 @@ master_flavor_id = <%= @magnum_settings['master_flavor_id'] %>
 region = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internalURL
 public_network_id = <%= @public_network_id %>
-floating_network_name = floating
+floating_network_name = <%= @public_network_name %>
 
 [network-feature-enabled]
 api_extensions = <%= @neutron_api_extensions %>
@@ -193,7 +193,7 @@ events = true
 
 [validation]
 run_validation = <%= @use_run_validation %>
-connect_method = floating
+connect_method = <% @public_network_name %>
 ip_version_for_ssh = 4
 <% if @validation_connect_timeout -%>
 connect_timeout = <%= @validation_connect_timeout %>

--- a/chef/data_bags/crowbar/migrate/tempest/106_add_public_network_name.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/106_add_public_network_name.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["public_network_name"] = ta["public_network_name"] unless a.key? "public_network_name"
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("public_network_name") unless ta.key? "public_network_name"
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -15,6 +15,7 @@
       "tempest_user_username": "tempest",
       "tempest_user_tenant": "tempest",
       "nova_instance": "none",
+      "public_network_name": "floating",
       "manila": {
         "image_with_share_tools": "manila-service-image",
         "image_username": "root",
@@ -41,7 +42,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 105,
+      "schema-revision": 106,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -27,6 +27,7 @@
                 "s390x": { "type": "str", "required": true }
               }
             },
+            "public_network_name": { "type": "str", "required": true },
             "manila": {
               "type": "map",
               "mapping": {


### PR DESCRIPTION
Tempest barclamp expects the public network name to be
"floating" and is hard coded in the recipe. Some special
use-cases (for e.g: ACI) require that the public network
be named as per the configuration setup in the SDN solution.

This commit is allowing the user to define the public network
name as a variable from the Crowbar UI so that its possible
to test other SDN backends requiring such flexibility.

(cherry picked from commit c5ccc84310ba8398c3d51fc11f6f56de773dd7ca)