### PR TITLE
keystone: Increase WSGI request timeout to 10 minutes

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -151,6 +151,8 @@ elsif node[:keystone][:frontend] == "apache"
     if node[:keystone][:ssl][:cert_required]
       ssl_cacert node[:keystone][:ssl][:ca_certs]
     end
+    # LDAP backend can be slow..
+    timeout 600
   end
 
   apache_site "keystone-public.conf" do
@@ -174,6 +176,8 @@ elsif node[:keystone][:frontend] == "apache"
     if node[:keystone][:ssl][:cert_required]
       ssl_cacert node[:keystone][:ssl][:ca_certs]
     end
+    # LDAP backend can be slow..
+    timeout 600
   end
 
   apache_site "keystone-admin.conf" do


### PR DESCRIPTION
Some keystone requests can be incredibly timeconsuming in real world
environmentes with large, slow LDAP servers. Increase timeout
from the default of 60 seconds.