### PR TITLE
nova: disable progress timeout for live migration (bsc#1091190)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -200,6 +200,9 @@ live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MI
     <% else %>
 block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_NON_SHARED_INC, VIR_MIGRATE_LIVE
     <% end %>
+# Timeout migration if less than 1MB/s RAM can be copied
+live_migration_progress_timeout=0
+live_migration_completion_timeout=1000
   <% end %>
 <% end %>
 <% if @libvirt_type.eql?('xen') %>
@@ -258,8 +261,6 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end %>
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
-# consider making configurable or even lower it
-rpc_conn_pool_size = 32
 
 [serial_console]
 enabled = <%= @serial_enabled ? "True" : "False" %>


### PR DESCRIPTION
The progress timeout is unreliable and was already disabled
by default in pike, however it is still enabled in Newton, hence
this is going to be backported. Also be a little bit more generous
to slow compute nodes and allow migration to as slow as 1MByte/s
before aborting it. this tremendeously helps live migration to
succeed on very busy compute nodes (where migrating away busy
workload is the best thing to do)

Also remove an outdated setting that is defaulting to 30 already.