### PR TITLE
keystone: Increase WSGI request timeout to 10 minutes

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -136,6 +136,8 @@ elsif node[:keystone][:frontend] == "apache"
     ssl_certfile node[:keystone][:ssl][:certfile]
     ssl_keyfile node[:keystone][:ssl][:keyfile]
     ssl_cacert node[:keystone][:ssl][:ca_certs]
+    # LDAP backend can be slow..
+    timeout 600
   end
 
   apache_site "keystone-public.conf" do
@@ -157,6 +159,8 @@ elsif node[:keystone][:frontend] == "apache"
     ssl_certfile node[:keystone][:ssl][:certfile]
     ssl_keyfile node[:keystone][:ssl][:keyfile]
     ssl_cacert node[:keystone][:ssl][:ca_certs]
+    # LDAP backend can be slow..
+    timeout 600
   end
 
   apache_site "keystone-admin.conf" do


### PR DESCRIPTION
Some keystone requests can be incredibly timeconsuming in real world
environmentes with large, slow LDAP servers. Increase timeout
from the default of 60 seconds.

(cherry picked from commit fda7393edff10e406e9e6040f5dde9eb5fcab62d)