### PR TITLE
mysql: Set monitor to 10s for galera-python-clustercheck

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -284,8 +284,13 @@ end
 transaction_objects = []
 service_name = "galera-python-clustercheck"
 
+clustercheck_op = {}
+clustercheck_op["monitor"] = {}
+clustercheck_op["monitor"]["interval"] = "10s"
+
 pacemaker_primitive service_name do
   agent "systemd:#{service_name}"
+  op clustercheck_op
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end


### PR DESCRIPTION
This wasn't set and the default is 0, which means it wasn't monitored at
all.

(cherry picked from commit ee9b6ea7f4985d7f78655da0a89a9a113bb040fc)