### PR TITLE
nova: disable progress timeout for live migration

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -203,6 +203,9 @@ live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MI
     <% else -%>
 block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_NON_SHARED_INC, VIR_MIGRATE_LIVE
     <% end -%>
+# Timeout migration if less than 1MB/s RAM can be copied
+live_migration_progress_timeout=0
+live_migration_completion_timeout=1000
   <% end -%>
 <% end -%>
 <%= "disk_prefix = xvd" if @libvirt_type.eql?('xen') %>


### PR DESCRIPTION
The progress timeout is unreliable and was already disabled
by default in pike, however it is still enabled in Newton, hence
this is going to be backported. Also be a little bit more generous
to slow compute nodes and allow migration to as slow as 1MByte/s
before aborting it. this tremendeously helps live migration to
succeed on very busy compute nodes (where migrating away busy
workload is the best thing to do)

Also remove an outdated setting that is defaulting to 30 already.

(cherry picked from commit 4e1feb7cea89092f17e838f8df3b7993ed6bc539)