### PR TITLE
nova: avoid scheduling conflicts on HA CP

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -323,6 +323,9 @@ keep_alive = false
 
 [scheduler]
 discover_hosts_in_cells_interval = <%= node[:nova][:scheduler][:discover_hosts_in_cells_interval] %>
+max_attempts = 9
+# Avoid scheduler conflicts when using HA
+host_subset_size = 4
 <% if @libvirt_type.eql?('ironic') %>
 host_manager = ironic_host_manager
 <% end %>


### PR DESCRIPTION
When all schedulers are picking the "best" host, in a 3 node
HA case they will all pick the same host, which is suboptimal.
Try to scale out a bit and increase retries in case of conflicts.

Even worse, a node that had still capacity when the scheduling
started might be out of memory at the time the VM is launched,
causing failed starts of VMs.