### PR TITLE
mysql: Ensure that the galera resource has a monitor op (bsc#1059530)

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -160,6 +160,12 @@ crowbar_pacemaker_sync_mark "wait-database_ha_resources" do
   revision node[:database]["crowbar-revision"]
 end
 
+# some of the op attributes are now in the proposal, so we need to merge the
+# default attributes and the proposal attributes (that actually completely
+# override the default attributes, even the ones not defined in the proposal)
+primitive_op = node.default_attrs[:mysql][:ha][:op].to_hash
+primitive_op.merge!(node[:database][:mysql][:ha][:op].to_hash)
+
 pacemaker_primitive service_name do
   agent resource_agent
   params({
@@ -170,7 +176,7 @@ pacemaker_primitive service_name do
     "datadir" => node[:database][:mysql][:datadir],
     "log" => "/var/log/mysql/mysql_error.log"
   })
-  op node[:database][:mysql][:ha][:op]
+  op primitive_op
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end


### PR DESCRIPTION
The monitor op was dropped by accident with
2c5d20d15f8e96ad206eddb04d726433b0f2615e: when we moved the definition
of the some of the ops in the proposal, what happened is that the all
hash defining the ops in default attributes has been overridden by the
hash from the proposal, hence the monitor op getting lost.

Now we merge the two to get the desired results. This makes sure that if
mariadb is stopped, pacemaker will restart it.

https://bugzilla.suse.com/show_bug.cgi?id=1059530