### PR TITLE
rabbitmq: restart epmd on config change

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -79,6 +79,7 @@ if node[:platform_family] == "suse"
   service "epmd.socket" do
     action [:enable, :start]
     only_if "grep -q Requires=epmd.service /usr/lib/systemd/system/rabbitmq-server.service"
+    subscribes :restart, "template[/etc/systemd/system/epmd.socket.d/port.conf]", :immediate
   end
 end
 


### PR DESCRIPTION
Epmd service could very well be active by the time we add the new
port.conf config so it would ignore the setting.
This just adds a subscribe event to that config file which will fire
a restart of the service if the file is changed.


This may or may not be affecting the nodes upgrade, in which after upgrading the OS and restarting, makes epmd be up and running, so the new ports config will not be applied.