### PR TITLE
nova: make disk_cachemodes configurable

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -220,6 +220,7 @@ volume_use_multipath = true
 <% if @use_multipath %>
 iser_use_multipath = true
 <% end %>
+disk_cachemodes = <%= node[:nova][:kvm][:disk_cachemodes] %>
 
 [neutron]
 service_metadata_proxy = true

--- a/chef/data_bags/crowbar/migrate/nova/209_add_cachemodes.rb
+++ b/chef/data_bags/crowbar/migrate/nova/209_add_cachemodes.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a["kvm"].key? "disk_cachemodes"
+    a["kvm"]["disk_cachemodes"] = ta["kvm"]["disk_cachemodes"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["kvm"].key? "disk_cachemodes"
+    a["kvm"].delete("disk_cachemodes")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -76,7 +76,8 @@
         "secret_uuid": ""
       },
       "kvm": {
-        "ksm_enabled": false
+        "ksm_enabled": false,
+        "disk_cachemodes": "network=writeback"
       },
       "vcenter": {
         "host": "",
@@ -181,7 +182,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 208,
+      "schema-revision": 209,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -134,7 +134,8 @@
             },
             "kvm": {
               "type": "map", "required": true, "mapping": {
-                "ksm_enabled": { "type": "bool", "required": true }
+                "ksm_enabled": { "type": "bool", "required": true },
+                "disk_cachemodes": { "type": "str", "required": true }
               }
             },
             "vcenter": {


### PR DESCRIPTION
Also default to writeback for network, which is improving
the performance quite a bit for ceph backed volumes and is safe
to enable (and recommended by almost every openstack install guide)