### PR TITLE
keystone: switch to unversioned urls for keystone endpoints (bsc#1053…

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -15,17 +15,15 @@ module KeystoneHelper
   end
 
   def self.public_auth_url(node, public_host)
-    versioned_service_URL(node[:keystone][:api][:protocol],
-                          public_host,
-                          node[:keystone][:api][:service_port],
-                          node[:keystone][:api][:version])
+    service_URL(node[:keystone][:api][:protocol],
+                public_host,
+                node[:keystone][:api][:service_port])
   end
 
   def self.internal_auth_url(node, admin_host)
-    versioned_service_URL(node[:keystone][:api][:protocol],
-                          admin_host,
-                          node[:keystone][:api][:service_port],
-                          node[:keystone][:api][:version])
+    service_URL(node[:keystone][:api][:protocol],
+                admin_host,
+                node[:keystone][:api][:service_port])
   end
 
   def self.unversioned_internal_auth_url(node, admin_host)


### PR DESCRIPTION
…198)

This allows keystone middleware to discover the available api
version by itself.