### PR TITLE
keystone: Add retry loop to _get_token (bsc#1087466)

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -513,16 +513,27 @@ def _get_token(http, user_name, password, project = "")
   path = "/v3/auth/tokens"
   headers = _build_headers
   body = _build_auth(user_name, password, project)
-  resp = http.send_request("POST", path, JSON.generate(body), headers)
-  if resp.is_a?(Net::HTTPCreated) || resp.is_a?(Net::HTTPOK)
-    resp["X-Subject-Token"]
-  else
+
+  resp = nil
+  count = 0
+  error = true
+  while error && count < 10
+    count += 1
+    Chef::Log.debug "Trying to get keystone token for user '#{user_name}' (try #{count})"
+    resp = http.send_request("POST", path, JSON.generate(body), headers)
+    error = !(resp.is_a?(Net::HTTPCreated) || resp.is_a?(Net::HTTPOK))
+    sleep 5 if error
+  end
+
+  if error
     msg = "Failed to get token for User '#{user_name}'"
     msg += " Project '#{project}'" unless project.empty?
     Chef::Log.info msg
     Chef::Log.info "Response Code: #{resp.code}"
     Chef::Log.info "Response Message: #{resp.message}"
     nil
+  else
+    resp["X-Subject-Token"]
   end
 end
 


### PR DESCRIPTION
Sometimes _get_token fails with 502 HTTP code because Apache is being
restarted while chef-client tries to access it. Small retry loop will
give it a bit more chance to complete the operation.