### PR TITLE
galera: change listening address/port with haproxy

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -27,7 +27,7 @@ if node[:database].key? "ec2"
 end
 
 # Ports to bind to when haproxy is used
-default[:mysql][:ha][:ports][:admin_port] = 3306
+default[:mysql][:ha][:ports][:admin_port] = 5512
 
 # Default operation setting for the galera resource
 # in pacemamker

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -347,7 +347,7 @@ ha_servers = ha_servers.each do |n|
 end
 
 haproxy_loadbalancer "galera" do
-  address CrowbarPacemakerHelper.cluster_vip(node, "admin")
+  address "0.0.0.0"
   port 3306
   mode "tcp"
   # leave some room for pacemaker health checks


### PR DESCRIPTION
During our work to make haproxy active in all controller nodes, we found
out Galera is not listening to all interfaces (0.0.0.0) but the VIP
address. This scenario works when there's only one haproxy checking for
Galera but fails on multiple haproxy scenario.

By changing the address and port where Galera is listening we aim to
avoid the conflict for service listening.