### PR TITLE
glance: registry to use same listening addr as API

### DIFF
--- a/chef/cookbooks/glance/libraries/helpers.rb
+++ b/chef/cookbooks/glance/libraries/helpers.rb
@@ -19,7 +19,7 @@ module GlanceHelper
         },
 
         registry: {
-          bind_host: @ip,
+          bind_host: !node[:glance][:ha][:enabled] && node[:glance][:api][:bind_open_address] ? "0.0.0.0" : @ip,
           bind_port: node[:glance][:ha][:enabled] ? node[:glance][:ha][:ports][:registry].to_i : node[:glance][:registry][:bind_port].to_i,
           ha_bind_host: @cluster_admin_ip,
           ha_bind_port: node[:glance][:registry][:bind_port].to_i

--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -27,7 +27,7 @@ if node[:database].key? "ec2"
 end
 
 # Ports to bind to when haproxy is used
-default[:mysql][:ha][:ports][:admin_port] = 3306
+default[:mysql][:ha][:ports][:admin_port] = 5512
 
 # Default operation setting for the galera resource
 # in pacemamker

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -347,7 +347,7 @@ ha_servers = ha_servers.each do |n|
 end
 
 haproxy_loadbalancer "galera" do
-  address CrowbarPacemakerHelper.cluster_vip(node, "admin")
+  address "0.0.0.0"
   port 3306
   mode "tcp"
   # leave some room for pacemaker health checks


### PR DESCRIPTION
In our work to make haproxy active on all controllers we found some
services are listening on the VIP address rather than on all interfaces.
When it listens on the VIP adress and haproxy is configured in several
nodes then there's a problem binding the socket to that VIP address.

This change makes glance-registry to use a listen-to-all interfaces
(0.0.0.0) by imitating the same mechanism that works perfectly for
glance-api.
