### PR TITLE
nova: metadata to listen to all interfaces

### DIFF
--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -43,7 +43,7 @@ haproxy_loadbalancer "nova-placement-api" do
 end.run_action(:create)
 
 haproxy_loadbalancer "nova-metadata" do
-  address cluster_admin_ip
+  address "0.0.0.0"
   port node[:nova][:ports][:metadata]
   use_ssl node[:nova][:ssl][:enabled]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "metadata")


### PR DESCRIPTION
In our work to make haproxy active on all controllers we found some
services are listening on the VIP address rather than on all interfaces.
When it listens on the VIP adress and haproxy is configured in several
nodes then there's a problem binding the socket to that VIP address.

This change makes nova-metadata to use a listen-to-all interfaces
(0.0.0.0) as it is configured in all other nova services.