### PR TITLE
sahara: Fix trust delete problem (bsc#1033735) 

### DIFF
--- a/chef/cookbooks/sahara/templates/default/sahara.conf.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara.conf.erb
@@ -9,7 +9,7 @@ port = <%= @bind_port %>
 use_namespaces = true
 use_rootwrap = true
 plugins = <%= node[:sahara][:plugins] %>
-use_identity_api_v3 = true
+use_identity_api_v3 = false 
 admin_user_domain_name = <%= @keystone_settings["admin_domain"] %>
 admin_project_domain_name = <%= @keystone_settings["admin_domain"]%>
 os_region_name = <%= @keystone_settings['endpoint_region'] %>


### PR DESCRIPTION
According to https://bugzilla.suse.com/show_bug.cgi?id=1033735, a Hadoop-Cluster can not be deleted and is stuck in "deleting" state because of **'failed to delete trust'** error as described in https://bugs.launchpad.net/mos/+bug/1521184. This patch adopts the workaround proposed upstream by setting **use_identity_api_v3** to **_false_**. 