### PR TITLE
[4.0] tempest: remove world-readable permission from tempest.conf

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -485,7 +485,7 @@ end
 
 template "/etc/tempest/tempest.conf" do
   source "tempest.conf.erb"
-  mode 0644
+  mode 0o640
   variables(
     lazy {
       {


### PR DESCRIPTION
This is probably not a good idea, it contains passwords.

(cherry picked from commit bfbcc2d0c43dd99698d1caa664acef8e77e465e2)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1363