### PR TITLE
rabbitmq: create empty users list which is expected by some recipes

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -65,3 +65,6 @@ when "suse"
     default[:rabbitmq][:ha][:clustered_rmq_features] = true
   end
 end
+
+# create empty users list as it is expected by some recipes
+default[:rabbitmq][:users] = []


### PR DESCRIPTION
(cherry picked from commit 2787b72e40c5b6a2f48fc2af94075711b9dda507)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1652