### PR TITLE
Remove SSH-based drivers from ironic (bsc#1087472)

### DIFF
--- a/chef/cookbooks/ironic/attributes/default.rb
+++ b/chef/cookbooks/ironic/attributes/default.rb
@@ -29,8 +29,6 @@ when "rhel", "suse"
       "openstack-ironic-conductor"
     ],
     driver_dependencies: {
-      pxe_ssh: ["python-paramiko"],
-      agent_ssh: ["python-paramiko"]
     }
   }
   default[:ironic][:api][:service_name] = "openstack-ironic-api"
@@ -50,8 +48,6 @@ when "debian"
       "ironic-api-conductor"
     ],
     driver_dependencies: {
-      pxe_ssh: ["python-paramiko"],
-      agent_ssh: ["python-paramiko"]
     }
   }
   default[:ironic][:api][:service_name] = "ironic-api"

--- a/chef/data_bags/crowbar/migrate/ironic/204_remove_ssh_based_drivers.rb
+++ b/chef/data_bags/crowbar/migrate/ironic/204_remove_ssh_based_drivers.rb
@@ -1,0 +1,5 @@
+def upgrade(ta, td, a, d)
+  a["ironic"]["enabled_drivers"] =
+    a["ironic"]["enabled_drivers"].reject { |driver| driver.include?("ssh") }
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ironic.json
+++ b/chef/data_bags/crowbar/template-ironic.json
@@ -31,7 +31,7 @@
   "deployment": {
     "ironic": {
       "crowbar-revision": 0,
-      "schema-revision": 203,
+      "schema-revision": 204,
       "crowbar-applied": false,
       "element_states": {
         "ironic-server": [ "readying", "ready", "applying" ]

--- a/crowbar_framework/app/models/ironic_service.rb
+++ b/crowbar_framework/app/models/ironic_service.rb
@@ -94,6 +94,10 @@ class IronicService < ServiceObject
       validation_error I18n.t("barclamp.#{@bc_name}.validation.no_drivers")
     end
 
+    if proposal["attributes"][@bc_name]["enabled_drivers"].any? { |d| d.include?("ssh") }
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.wrong_drivers")
+    end
+
     # additional soft dependencies for agent_* drivers
     if proposal["attributes"][@bc_name]["enabled_drivers"].any? { |d| d.start_with?("agent_") }
       swift_svc = SwiftService.new @logger

--- a/crowbar_framework/config/locales/ironic/en.yml
+++ b/crowbar_framework/config/locales/ironic/en.yml
@@ -36,3 +36,4 @@ en:
         swift_tempurl_enabled: 'To use agent_* drivers, Swift TempURL middleware needs to be enabled.'
         glance_swift_default_store: 'To use agent_* drivers, Glance needs to have Swift set as Default Storage Store.'
         no_drivers: 'No drivers enabled. Select at least one driver.'
+        wrong_drivers: 'SSH-based power and management driver interfaces have been removed from ironic.'


### PR DESCRIPTION
Removing all SSH based drivers from config file and added validaion from ironic
proposal to not allow these drivers.