### PR TITLE
mysql: make overrides for mysql version work again

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -48,8 +48,4 @@ default[:mysql][:galera_packages] = [
   "socat",
   "galera-python-clustercheck"
 ]
-
-# newer version need an additional package on SLES
-unless node[:mysql][:mariadb][:version] == "10.1"
-  default[:mysql][:galera_packages] << "mariadb-galera"
-end
+# for versions != 10.1, mariadb-galera is added in the ha_galera.rb recipe

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -19,6 +19,14 @@
 
 resource_agent = "ocf:heartbeat:galera"
 
+# this was in attributes/server.rb where it did not work, because it
+# was evaluated too early for overrides to be useful
+#
+# newer version need an additional package on SLES
+unless node[:mysql][:mariadb][:version] == "10.1"
+  node[:mysql][:galera_packages] << "mariadb-galera"
+end
+
 node[:mysql][:galera_packages].each do |p|
   package p
 end


### PR DESCRIPTION
Apparently, attributes/server.rb is evaluated fully before overrides.rb
is considered. This breaks overriding mysql.mariadb.version, because
mariadb-galera is always added mysql.galera.packages.
Move the version check out of attributes/ into recipes/ha_galera.rb to
fix this.