### PR TITLE
upgrade: Do not check if rabbitmq is running when it is not supposed to run

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -371,6 +371,16 @@ ruby_block "wait for #{service_name} to be started" do
           Chef::Log.debug("#{service_name} still not started")
           sleep(2)
         end
+
+        # Do not check if rabbitmq is running when it is not supposed to run.
+        # pre-upgrade attribute is set to true to indicate the case that the upgrade of the node has
+        # not been finished yet. In such case, services cannot start on the node
+        # (there's a location constraint that prevents that).
+        # See disable_pre_upgrade_attribute_for method in models/api/node.rb for more info
+        cmd = "crm_attribute --node #{node[:hostname]} --name pre-upgrade --query --quiet"
+        cmd << "| grep -q true"
+        break if ::Kernel.system(cmd)
+
         # Check that the service is available, if it's running on this node
         cmd = "crm resource show #{service_name} | grep -q \" #{node.hostname} *$\""
         if ::Kernel.system(cmd)


### PR DESCRIPTION
pre-upgrade attribute is set to true to indicate the case that the upgrade of the node has
not been finished yet. In such case, services cannot start on the node
(there's a location constraint that prevents that).
See disable_pre_upgrade_attribute_for method in models/api/node.rb for more info

See also commit 54aad4646798bf933d4ed0d9d937342a12644e0c

This should fix the cases for "shared storage" option. Referenced commit targeted only the rabbitmq clustered setup.