### PR TITLE
rabbitmq: do not set the blocking mechanism if upgrade ongoing

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -131,7 +131,7 @@ ruby_block "wait for #{ms_name} to be started" do
   end # block
 end # ruby_block
 
-if CrowbarPacemakerHelper.cluster_nodes(node).size > 2
+if CrowbarPacemakerHelper.cluster_nodes(node).size > 2 && !CrowbarPacemakerHelper.being_upgraded?(node)
   # create the directory to lock rabbitmq-port-blocker
   cookbook_file "/etc/tmpfiles.d/rabbitmq.conf" do
     owner "root"
@@ -196,5 +196,17 @@ else
 
   file "/etc/sudoers.d/rabbitmq-port-blocker" do
     action :delete
+  end
+
+  # in case that the script was already deployed and the rule is already stored we need to clean it
+  # up as to not left anything around
+  bash "Remove existent rabbitmq blocking rules" do
+    code "iptables -D INPUT -p tcp --destination-port 5672 "\
+         "-m comment --comment \"rabbitmq port blocker (no quorum)\" -j DROP"
+    only_if do
+      # check for the rule
+      cmd = "iptables -L -n | grep -F \"tcp dpt:5672 /* rabbitmq port blocker (no quorum) */\""
+      system(cmd)
+    end
   end
 end


### PR DESCRIPTION
When we upgrade we can end up with only one rabbit node up on the first
chef join, so blocking rabbit until the cluster is up may not be
the most smart thing to do

Instead check if we are on upgrade status and if so, do not deploy
the blocking mechanism and instead remove it