### PR TITLE
rabbitmq: do not set the blocking mechanism if upgrade ongoing

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -121,7 +121,7 @@ ruby_block "wait for #{ms_name} to be started" do
   end # block
 end # ruby_block
 
-if CrowbarPacemakerHelper.cluster_nodes(node).size > 2
+if CrowbarPacemakerHelper.cluster_nodes(node).size > 2 && !CrowbarPacemakerHelper.being_upgraded?(node)
   # create the directory to lock rabbitmq-port-blocker
   cookbook_file "/etc/tmpfiles.d/rabbitmq.conf" do
     owner "root"


### PR DESCRIPTION
When we upgrade we can end up with only one rabbit node up on the first
chef join, so blocking rabbit until the cluster is up may not be
the most smart thing to do

Instead check if we are on upgrade status and if so, do not deploy
the blocking mechanism and instead remove it

(cherry picked from commit a32f607fb575420d9b09883ca720c08aeed187bd)