### PR TITLE
database: allow multiple proposal for "database"

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -60,7 +60,13 @@ end
 
 class CrowbarOpenStackHelper
   def self.database_settings(node, barclamp)
-    instance = node[barclamp][:database_instance] || "default"
+    if barclamp == "mysql" or barclamp == "postgresql"
+      # We're called from one of the database cookbooks, which doesn't reference
+      # another database instance.
+      instance = node[:database][:config][:environment].gsub(/^database-config-/, "")
+    else
+      instance = node[barclamp][:database_instance] || "default"
+    end
 
     # Cache the result for each cookbook in an instance variable hash. This
     # cache needs to be invalidated for each chef-client run from chef-client

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -23,7 +23,7 @@ class DatabaseService < PacemakerServiceObject
 
 # turn off nulti proposal support till it really works and people ask for it.
   def self.allow_multiple_proposals?
-    false
+    true
   end
 
   class << self


### PR DESCRIPTION
This is some preparation work to allow multiple proposals of the
database barclamp to be deployed.

Note: This doesn't allow to deploy multiple proposals to the same
node/cluster. Which would require some more fundmental changes to
crowbar and needs more research.