### PR TITLE
keystone: avoid race condition during admin password change

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -23,10 +23,13 @@ action :wakeup do
   # Lets verify that the service does not exist yet
   count = 0
   error = true
-  while error and count < 50 do
+  loop do
     count = count + 1
     _, error = _get_service_id(http, headers, "fred")
-    sleep 1 if error
+    break unless error && count < 50
+    sleep 1
+    next unless new_resource.reissue_token_on_error
+    http, headers = _build_connection(new_resource)
   end
 
   raise "Failed to validate keystone is wake" if error

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -488,6 +488,10 @@ register_auth_hash = { user: node[:keystone][:admin][:username],
 old_password = node[:keystone][:admin][:old_password]
 old_register_auth_hash = register_auth_hash.clone
 old_register_auth_hash[:password] = old_password
+update_admin_password = node[:keystone][:bootstrap] &&
+  (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
+  old_password && !old_password.empty? &&
+  old_password != node[:keystone][:admin][:password]
 
 keystone_register "update admin password" do
   protocol node[:keystone][:api][:protocol]
@@ -499,12 +503,7 @@ keystone_register "update admin password" do
   user_password node[:keystone][:admin][:password]
   project_name node[:keystone][:admin][:project]
   action :add_user
-  only_if do
-    node[:keystone][:bootstrap] &&
-      (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)) &&
-      old_password && !old_password.empty? &&
-      old_password != node[:keystone][:admin][:password]
-  end
+  only_if { update_admin_password }
 end
 
 ruby_block "backup current admin password on node attributes" do
@@ -533,7 +532,6 @@ execute "keystone-manage bootstrap" do
   end
 end
 
-
 # Silly wake-up call - this is a hack; we use retries because the server was
 # just (re)started, and might not answer on the first try
 keystone_register "wakeup keystone" do
@@ -544,6 +542,7 @@ keystone_register "wakeup keystone" do
   auth register_auth_hash
   retries 5
   retry_delay 10
+  reissue_token_on_error update_admin_password
   action :wakeup
 end
 

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -64,3 +64,6 @@ attribute :project_name, kind_of: String
 # :add_ec2 specific attributes
 attribute :user_name, kind_of: String
 attribute :project_name, kind_of: String
+
+# :wakeup specific attributes
+attribute :reissue_token_on_error, kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
Workaround for: https://bugzilla.suse.com/show_bug.cgi?id=1091829

Calling the keystone_register 'wakeup' action immediately after
the admin password has been updated can sometimes result in timeout
errors on non-founder nodes, while the founder node is stuck doing
retry iterations with an expired token due to bsc#1091829.

As a workaround for bsc#1091829, a small time delay is inserted after
the admin password is changed, to give keystone time to expire all the
admin tokens already issued before creating new ones.