### PR TITLE
[4.0] keystone: avoid race condition during admin password change

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -27,10 +27,13 @@ action :wakeup do
   # Lets verify that the service does not exist yet
   count = 0
   error = true
-  while error and count < 50 do
+  loop do
     count = count + 1
     item_id, error = _find_id(http, headers, "fred", path, dir)
-    sleep 1 if error
+    break unless error && count < 50
+    sleep 1
+    next unless new_resource.reissue_token_on_error
+    http, headers = _build_connection(new_resource)
   end
 
   raise "Failed to validate keystone is wake" if error

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -64,3 +64,6 @@ attribute :tenant_name, kind_of: String
 # :add_ec2 specific attributes
 attribute :user_name, kind_of: String
 attribute :tenant_name, kind_of: String
+
+# :wakeup specific attributes
+attribute :reissue_token_on_error, kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
(backports #1668 to 4.0)

Workaround for: https://bugzilla.suse.com/show_bug.cgi?id=1091829

Calling the keystone_register 'wakeup' action immediately after
the admin password has been updated can sometimes result in timeout
errors on non-founder nodes, while the founder node is stuck doing
retry iterations with an expired token due to bsc#1091829.

As a workaround for bsc#1091829, a small time delay is inserted after
the admin password is changed, to give keystone time to expire all the
admin tokens already issued before creating new ones.