### PR TITLE
aodh: Add config for alarm_history_ttl (bsc#1073703)

### DIFF
--- a/chef/cookbooks/aodh/attributes/default.rb
+++ b/chef/cookbooks/aodh/attributes/default.rb
@@ -55,6 +55,7 @@ default[:aodh][:evaluator][:service_name] = evaluator_service_name
 default[:aodh][:notifier][:service_name]  = notifier_service_name
 default[:aodh][:listener][:service_name]  = listener_service_name
 default[:aodh][:evaluation_interval] = 600
+default[:aodh][:alarm_history_ttl] = -1
 
 default[:aodh][:debug] = false
 

--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -166,7 +166,8 @@ template node[:aodh][:config_file] do
     database_connection: db_connection,
     node_hostname: node["hostname"],
     aodh_ssl: node[:aodh][:ssl],
-    evaluation_interval: node[:aodh][:evaluation_interval]
+    evaluation_interval: node[:aodh][:evaluation_interval],
+    alarm_history_ttl: node[:aodh][:alarm_history_ttl]
   )
   notifies :reload, resources(service: "apache2")
 end

--- a/chef/cookbooks/aodh/templates/default/aodh.conf.erb
+++ b/chef/cookbooks/aodh/templates/default/aodh.conf.erb
@@ -8,6 +8,7 @@ transport_url = <%= @rabbit_settings[:url] %>
 workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 
 [database]
+alarm_history_time_to_live = <%= @alarm_history_ttl %>
 connection = <%= @database_connection %>
 
 [keystone_authtoken]

--- a/chef/data_bags/crowbar/migrate/aodh/202_add_alarm_history_ttl.rb
+++ b/chef/data_bags/crowbar/migrate/aodh/202_add_alarm_history_ttl.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "alarm_history_ttl"
+    a["alarm_history_ttl"] = ta["alarm_history_ttl"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "alarm_history_ttl"
+    a.delete("alarm_history_ttl")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-aodh.json
+++ b/chef/data_bags/crowbar/template-aodh.json
@@ -5,6 +5,7 @@
     "aodh": {
       "debug": false,
       "evaluation_interval": 600,
+      "alarm_history_ttl": -1,
       "rabbitmq_instance": "none",
       "database_instance": "none",
       "keystone_instance": "none",
@@ -35,7 +36,7 @@
     "aodh": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "element_states": {
         "aodh-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-aodh.schema
+++ b/chef/data_bags/crowbar/template-aodh.schema
@@ -14,6 +14,7 @@
           "mapping": {
             "debug": { "type": "bool", "required": true },
             "evaluation_interval": { "type": "int", "required": true },
+            "alarm_history_ttl": { "type": "int", "required": true },
             "database_instance": { "type": "str", "required": true },
             "rabbitmq_instance": { "type": "str", "required": true },
             "keystone_instance": { "type": "str", "required": true },

--- a/crowbar_framework/app/views/barclamp/aodh/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/aodh/_edit_attributes.html.haml
@@ -9,7 +9,7 @@
     = instance_field :ceilometer
 
     = integer_field :evaluation_interval
-
+    = integer_field :alarm_history_ttl
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/aodh/en.yml
+++ b/crowbar_framework/config/locales/aodh/en.yml
@@ -25,6 +25,8 @@ en:
         rabbitmq_instance: 'RabbitMQ'
         ceilometer_instance: 'Ceilometer'
         evaluation_interval: 'Evaluation interval for threshold alarms (in seconds).'
+        alarm_history_ttl: 'Number of seconds that alarm histories are kept in the database for (<= 0 means forever).'
+
         api:
           protocol: 'Protocol'
         ssl_header: 'SSL Support'


### PR DESCRIPTION
The alarm_history_ttl config option for aodh was
not previously configurable.