### PR TITLE
Allow write access for glance pool (bsc#1091768)

### DIFF
--- a/chef/cookbooks/cinder/recipes/ceph.rb
+++ b/chef/cookbooks/cinder/recipes/ceph.rb
@@ -122,7 +122,7 @@ unless ceph_clients.empty?
     ceph_pools.each_pair do |cinder_user, cinder_pools|
 
       allow_pools = cinder_pools.map{ |p| "allow rwx pool=#{p}" }.join(", ")
-      allow_pools += ", allow rx pool=#{glance_pool}" if glance_pool
+      allow_pools += ", allow rwx pool=#{glance_pool}" if glance_pool
       ceph_caps = { "mon" => "allow r", "osd" => "allow class-read object_prefix rbd_children, #{allow_pools}" }
 
       ceph_client cinder_user do


### PR DESCRIPTION
The allows customers to enable nova to boot images directly from Ceph.

Note for the PR:

I don't think this should be merged in the same way Ivan did in his environment to get it working, but I'm creating the PR so that reviewers can help clarifying whether this should be allowed and how to actually implement it.