### PR TITLE
nova: Use service keystone endpoint

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
@@ -1,10 +1,11 @@
 [placement]
+auth_type = password
+auth_uri = <%= @keystone_settings['public_auth_url'] %>
+auth_url = <%= @keystone_settings['internal_auth_url'] %>
 os_region_name = <%= @keystone_settings['endpoint_region'] %>
-auth_url = <%= @keystone_settings['admin_auth_url'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings["admin_domain"] %>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
-auth_type = password
 username = <%= @placement_service_user %>
 password = <%= @placement_service_password %>
 os_interface = internal


### PR DESCRIPTION
nova-placement should use the service endpoint because
- thats what devstack does
- that url happens to be versioned and this allows version discovery
even in the case of insecure SSL being used