### PR TITLE
Fix monasca installer

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -26,7 +26,7 @@ raise "no nodes with monasca-server role found" if monasca_hosts.nil? || monasca
 
 package "ansible"
 package "openstack-monasca-installer" do
-  notifies :run, "execute[run ansible]", :delayed
+  notifies :run, "execute[remove lock file]", :immediately
 end
 
 cookbook_file "/etc/ansible/ansible.cfg" do
@@ -67,7 +67,7 @@ template "/opt/monasca-installer/monasca-hosts" do
     ansible_ssh_user: "root",
     keystone_host: keystone_settings["internal_url_host"]
   )
-  notifies :run, "execute[run ansible]", :delayed
+  notifies :run, "execute[remove lock file]", :immediately
 end
 
 monasca_net_ip = MonascaHelper.get_host_for_monitoring_url(monasca_node)
@@ -128,7 +128,7 @@ template "/opt/monasca-installer/crowbar_vars.yml" do
     monitor_libvirt: node[:monasca][:agent][:monitor_libvirt],
     delegate_role: node[:monasca][:delegate_role]
   )
-  notifies :run, "execute[run ansible]", :delayed
+  notifies :run, "execute[remove lock file]", :immediately
 end
 
 # This file is used to mark that ansible installer run successfully.
@@ -138,15 +138,6 @@ end
 # and monasca-installer. If they change re-execute ansible installer.
 lock_file = "/opt/monasca-installer/.installed"
 
-previous_versions = if Pathname.new(lock_file).file?
-                      File.read(lock_file).gsub(/^$\n/, "")
-                    else
-                      ""
-                    end
-
-get_versions = "rpm -qa | grep -e crowbar-openstack -e monasca-installer | sort"
-actual_versions = IO.popen(get_versions, &:read).gsub(/^$\n/, "")
-
 cookbook_file "/etc/logrotate.d/monasca-installer" do
   owner "root"
   group "root"
@@ -155,17 +146,28 @@ cookbook_file "/etc/logrotate.d/monasca-installer" do
   source "monasca-installer.logrotate"
 end
 
-ansible_cmd =
-  "rm -f #{lock_file} " \
-  "&& ansible-playbook " \
-    "-i monasca-hosts -e '@/opt/monasca-installer/crowbar_vars.yml' " \
-    "monasca.yml -vvv >> /var/log/monasca-installer.log 2>&1 " \
-  "&& echo '#{actual_versions}' > #{lock_file}"
+template "/usr/sbin/run-monasca-installer" do
+  source "run-monasca-installer.erb"
+  owner "root"
+  group "root"
+  mode "0555"
+  variables(
+    lock_file: lock_file
+  )
+  notifies :run, "execute[remove lock file]", :immediately
+end
+
+# Remove lock file. This gets notified if parameters change and ensures the
+# version check in run-monasca-installer fails.
+execute "remove lock file" do
+  command "rm -f #{lock_file}"
+  action :nothing
+end
 
 execute "run ansible" do
-  command ansible_cmd
-  cwd "/opt/monasca-installer"
-  action :nothing unless actual_versions != previous_versions
+  command "/usr/sbin/run-monasca-installer 2>&1"\
+          " | awk '{ print strftime(\"[%Y-%m-%d %H:%M:%S]\"), $0 }'"\
+          "   >> /var/log/monasca-installer.log"
 end
 
 # Record that monasca-installer has concluded successfully at least once. We

--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -25,7 +25,7 @@ monasca_hosts = MonascaHelper.monasca_hosts(monasca_servers)
 raise "no nodes with monasca-server role found" if monasca_hosts.nil? || monasca_hosts.empty?
 
 package "ansible"
-package "monasca-installer" do
+package "openstack-monasca-installer" do
   notifies :run, "execute[run ansible]", :delayed
 end
 

--- a/chef/cookbooks/monasca/templates/default/run-monasca-installer.erb
+++ b/chef/cookbooks/monasca/templates/default/run-monasca-installer.erb
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+actual_versions=$(LC_ALL=C rpm -qa crowbar-openstack openstack-monasca-installer | sort)
+previous_versions=$(cat <%= @lock_file %> 2> /dev/null || echo)
+
+# No need to run if versions match (Crowbar will ensure a mismatch by deleting
+# <%= @lock_file %> if any parameters change.
+if [ "$actual_versions" = "$previous_versions" ]; then
+  echo "No package version changes, skipping monasca-installer run"
+  exit 0
+fi
+
+cd "/opt/monasca-installer"
+rm -f <%= @lock_file %>
+  /usr/bin/ansible-playbook \
+    -i monasca-hosts \
+    -e '@/opt/monasca-installer/crowbar_vars.yml' \
+    monasca.yml -vvv
+
+# Record version information to indicate a successful run.
+LC_ALL=C rpm -qa crowbar-openstack openstack-monasca-installer | sort > <%= @lock_file %>


### PR DESCRIPTION
This pull request consists of two commits:

1) Various improvements to how monasca-installer is run.
2) A Cloud 8 specific fix for https://bugzilla.suse.com/show_bug.cgi?id=1096043

(1) can and should be backported to Cloud 7.