### PR TITLE
WIP/POC Dual DB support for migrations

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -60,7 +60,13 @@ end
 
 class CrowbarOpenStackHelper
   def self.database_settings(node, barclamp)
-    instance = node[barclamp][:database_instance] || "default"
+    if barclamp == "mysql" or barclamp == "postgresql"
+      # We're called from one of the database cookbooks, which doesn't reference
+      # another database instance.
+      instance = node[:database][:config][:environment].gsub(/^database-config-/, "")
+    else
+      instance = node[barclamp][:database_instance] || "default"
+    end
 
     # Cache the result for each cookbook in an instance variable hash. This
     # cache needs to be invalidated for each chef-client run from chef-client

--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -24,6 +24,25 @@ class Chef
       CrowbarOpenStackHelper.database_settings(node, barclamp)
     end
 
+    # The following are special cases of fetch_database_settings.
+    # To allow users to migrate from postgresql to mariadb it is possible to
+    # have multiple databases deployed. Most barclamps will use the above
+    # `fetch_database_settings` to get the currently active connection details.
+    # However, for the database barclamps themselves, they may need access to
+    # one set of settings or the other regardless of which one is active.
+    # These helper functions return the appropriate settings for the database
+    # recipes.
+    # NOTE: These are probably redundant as the barclamp parameter is actually
+    # the cookbook name, not the barclamp, so we can likely use that. Leaving
+    # them for now while this patch is WIP
+    def fetch_database_mysql_settings(barclamp=@cookbook_name)
+      CrowbarOpenStackHelper.database_settings(node, barclamp, 'mysql')
+    end
+
+    def fetch_database_postgresql_settings(barclamp=@cookbook_name)
+      CrowbarOpenStackHelper.database_settings(node, barclamp, 'postgresql')
+    end
+
     def fetch_database_connection_string(db_auth, barclamp = @cookbook_name)
       db_settings = CrowbarOpenStackHelper.database_settings(node, barclamp)
       CrowbarOpenStackHelper.database_connection_string(db_settings, db_auth)
@@ -59,7 +78,7 @@ class Chef
 end
 
 class CrowbarOpenStackHelper
-  def self.database_settings(node, barclamp)
+  def self.database_settings(node, barclamp, engine=nil)
     if barclamp == "mysql" or barclamp == "postgresql"
       # We're called from one of the database cookbooks, which doesn't reference
       # another database instance.
@@ -81,17 +100,59 @@ class CrowbarOpenStackHelper
       @database_settings_cache_time = node[:ohai_time]
     end
 
-    if @database_settings && @database_settings.include?(instance)
+    if @database_settings && @database_settings.include?(instance) && false
+      # FIXME: Skip the cache for now
       Chef::Log.info("Database server found at #{@database_settings[instance][:address]} [cached]")
     else
       @database_settings ||= Hash.new
-      database = get_node(node, "database-server", "database", instance)
+      database_nodes, = Chef::Search::Query.new.search(:node, "roles:database-server")
 
-      if database.nil?
+      if database_nodes.empty?
+        # Should this be an error?
         Chef::Log.warn("No database server found!")
+        # TODO
+      elsif false
+        # Check if anything other than 1 or 2 databases were returned
+        # Raise an error if so
+        Chef::Log.warn("Somehow there are more than 2 databases deployed.")
+        # TODO
+      elsif false
+        # If we have 2 separate database nodes handle selecting one
+        # Check that there is one postgres and one mariadb. Raise an error if not
+        # Use postgres first
+        Chef::Log.info("We have 2 different database nodes")
+
+        # Inspect both the nodes and figure out which engine is deployed to which
+        # Prefer postgres over mariadb unless `engine` is given
+        # TODO
       else
-        address = CrowbarDatabaseHelper.get_listen_address(database)
-        backend_name = DatabaseLibrary::Database::Util.get_backend_name(database)
+        # We only have one database node, but we need to check if it has multiple
+        # proposals
+        database = database_nodes.first
+
+        database_roles = database["roles"].select{|roles| roles.match(/^database-config-/)}
+        if database_roles.count == 1
+          Chef::Log.info("Only one role found, so we can continue")
+          backend_name = DatabaseLibrary::Database::Util.get_backend_name(database)
+        elsif database_roles.count != 2
+          Chef::Log.warn("More than two database roles applied to node was unexpected")
+          # TODO: Raise error
+        else
+          Chef::Log.info("We have exactly 2 roles applied, figure out which one to use")
+          Chef::Log.info(database_roles)
+
+          if engine
+            backend_name = engine
+          else
+            # For now, just use postgres. After the data migration the old role
+            # should be deleted and then the logic will switch us to mariadb
+            backend_name = "postgresql"
+          end
+          Chef::Log.info("Backend_name: ")
+          Chef::Log.info(backend_name)
+        end
+
+        address = CrowbarDatabaseHelper.get_listen_address(database, backend_name)
 
         ssl_opts = {}
         if backend_name == "mysql"
@@ -102,17 +163,18 @@ class CrowbarOpenStackHelper
               database["database"]["mysql"]["ssl"]["insecure"]
           }
         end
+        db_maker_password = database["database"][backend_name][:db_maker_password] || database["database"][:db_maker_password]
         @database_settings[instance] = {
           address: address,
           url_scheme: backend_name,
           backend_name: backend_name,
-          provider: DatabaseLibrary::Database::Util.get_database_provider(database),
-          user_provider: DatabaseLibrary::Database::Util.get_user_provider(database),
-          privs: DatabaseLibrary::Database::Util.get_default_priviledges(database),
+          provider: DatabaseLibrary::Database::Util.get_database_provider(database, backend_name),
+          user_provider: DatabaseLibrary::Database::Util.get_user_provider(database, backend_name),
+          privs: DatabaseLibrary::Database::Util.get_default_priviledges(database, backend_name),
           connection: {
             host: address,
             username: "db_maker",
-            password: database["database"][:db_maker_password],
+            password: db_maker_password,
             ssl: ssl_opts
           }
         }

--- a/chef/cookbooks/database/libraries/crowbar.rb
+++ b/chef/cookbooks/database/libraries/crowbar.rb
@@ -14,9 +14,9 @@ module CrowbarDatabaseHelper
     end
   end
 
-  def self.get_listen_address(node)
+  def self.get_listen_address(node, sql_engine)
     # For SSL we prefer a cluster hostname (for certificate validation)
-    use_ssl = node[:database][:sql_engine] == "mysql" && node[:database][:mysql][:ssl][:enabled]
+    use_ssl = sql_engine == "mysql" && node[:database][:mysql][:ssl][:enabled]
     if node[:database][:ha][:enabled]
       vhostname = get_ha_vhostname(node)
       use_ssl ? "#{vhostname}.#{node[:domain]}" : CrowbarPacemakerHelper.cluster_vip(node, "admin", vhostname)

--- a/chef/cookbooks/database/libraries/database_library.rb
+++ b/chef/cookbooks/database/libraries/database_library.rb
@@ -19,7 +19,7 @@
 module DatabaseLibrary
     class Database
         class Util
-            def self.get_database_provider(node, backend)
+            def self.get_database_provider(backend)
                 db_provider = nil
                 case backend
                 when "postgresql"
@@ -32,7 +32,7 @@ module DatabaseLibrary
                 db_provider
             end
 
-            def self.get_user_provider(node, backend)
+            def self.get_user_provider(backend)
                 db_provider = nil
                 case backend
                 when "postgresql"
@@ -45,11 +45,12 @@ module DatabaseLibrary
                 db_provider
             end
 
-            def self.get_backend_name(node)
+            def self.get_backend_name_for_node(node)
+                # Note(jhesketh): This is no longer used
                 node[:database][:sql_engine]
             end
 
-            def self.get_default_priviledges(node, backend)
+            def self.get_default_priviledges(backend)
                 privs = nil
                 case backend
                 when "postgresql"

--- a/chef/cookbooks/database/libraries/database_library.rb
+++ b/chef/cookbooks/database/libraries/database_library.rb
@@ -19,8 +19,7 @@
 module DatabaseLibrary
     class Database
         class Util
-            def self.get_database_provider(node)
-                backend = node[:database][:sql_engine]
+            def self.get_database_provider(node, backend)
                 db_provider = nil
                 case backend
                 when "postgresql"
@@ -33,8 +32,7 @@ module DatabaseLibrary
                 db_provider
             end
 
-            def self.get_user_provider(node)
-                backend = node[:database][:sql_engine]
+            def self.get_user_provider(node, backend)
                 db_provider = nil
                 case backend
                 when "postgresql"
@@ -51,8 +49,7 @@ module DatabaseLibrary
                 node[:database][:sql_engine]
             end
 
-            def self.get_default_priviledges(node)
-                backend = node[:database][:sql_engine]
+            def self.get_default_priviledges(node, backend)
                 privs = nil
                 case backend
                 when "postgresql"

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -163,7 +163,7 @@ execute "assign-root-password" do
   only_if "/usr/bin/mysql -u root -e 'show databases;'"
 end
 
-db_settings = fetch_database_mysql_settings
+db_settings = fetch_database_settings
 db_connection = db_settings[:connection].dup
 db_connection[:host] = "localhost"
 db_connection[:username] = "root"

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -91,7 +91,7 @@ if node[:database][:mysql][:ssl][:enabled]
       node[:database][:mysql][:ssl][:generate_certs] ||
       node[:database][:mysql][:ssl][:insecure])
     group "mysql"
-    fqdn CrowbarDatabaseHelper.get_listen_address(node)
+    fqdn CrowbarDatabaseHelper.get_listen_address(node, "mysql")
   end
 end
 
@@ -163,7 +163,7 @@ execute "assign-root-password" do
   only_if "/usr/bin/mysql -u root -e 'show databases;'"
 end
 
-db_settings = fetch_database_settings
+db_settings = fetch_database_mysql_settings
 db_connection = db_settings[:connection].dup
 db_connection[:host] = "localhost"
 db_connection[:username] = "root"
@@ -174,7 +174,7 @@ unless node[:database][:database_bootstrapped]
   database_user "create db_maker database user" do
     connection db_connection
     username "db_maker"
-    password node[:database][:db_maker_password]
+    password node[:database][:mysql][:db_maker_password] || node[:database][:db_maker_password]
     host "%"
     provider db_settings[:user_provider]
     action :create
@@ -184,7 +184,7 @@ unless node[:database][:database_bootstrapped]
   database_user "grant db_maker access" do
     connection db_connection
     username "db_maker"
-    password node[:database][:db_maker_password]
+    password node[:database][:mysql][:db_maker_password] || node[:database][:db_maker_password]
     host "%"
     privileges db_settings[:privs] + [
       "ALTER ROUTINE",

--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -29,7 +29,7 @@ group_name = "g-#{service_name}"
 
 agent_name = "ocf:heartbeat:pgsql"
 
-ip_addr = CrowbarDatabaseHelper.get_listen_address(node)
+ip_addr = CrowbarDatabaseHelper.get_listen_address(node, "postgresql")
 
 postgres_op = {}
 postgres_op["monitor"] = {}
@@ -63,7 +63,7 @@ transaction_objects << "pacemaker_primitive[#{vip_primitive}]"
 # We run the resource agent "ocf:heartbeat:pgsql" without params, instead of
 # something like:
 #  params ({
-#    "pghost" => CrowbarDatabaseHelper.get_listen_address(node),
+#    "pghost" => CrowbarDatabaseHelper.get_listen_address(node, "postgresql"),
 #    "monitor_user" => "postgres",
 #    "monitor_password" => node['postgresql']['password']['postgres']
 #  })

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -13,11 +13,11 @@
           "required": true,
           "mapping": {
             "sql_engine": { "type": "str", "required": true },
-            "db_maker_password": { "type": "str" },
             "mysql" : {
               "type": "map",
               "required": false,
               "mapping" : {
+                "db_maker_password": { "type": "str" },
                 "server_root_password": { "type": "str" },
                 "sstuser_password": { "type": "str" },
                 "datadir": { "type": "str", "required": true },
@@ -76,6 +76,7 @@
               "type": "map",
               "required": false,
               "mapping": {
+                "db_maker_password": { "type": "str" },
                 "config": {
                   "type": "map",
                   "required": false,

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -170,7 +170,14 @@ class DatabaseService < PacemakerServiceObject
     end
 
     role.default_attributes["database"][sql_engine] = {} if role.default_attributes["database"][sql_engine].nil?
-    role.default_attributes["database"]["db_maker_password"] = (old_role && old_role.default_attributes["database"]["db_maker_password"]) || random_password
+    role.default_attributes["database"][sql_engine]["db_maker_password"] = random_password
+    if old_role
+      if old_role.default_attributes["database"][sql_engine]["db_maker_password"]
+        role.default_attributes["database"][sql_engine]["db_maker_password"] = old_role.default_attributes["database"][sql_engine]["db_maker_password"]
+      elsif old_role.default_attributes["database"]["db_maker_password"]
+        role.default_attributes["database"][sql_engine]["db_maker_password"] = old_role.default_attributes["database"]["db_maker_password"]
+      end
+    end
 
     if ( sql_engine == "mysql" )
       role.default_attributes["database"]["mysql"]["server_root_password"] = (old_role && old_role.default_attributes["database"]["mysql"]["server_root_password"]) || random_password

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -23,7 +23,7 @@ class DatabaseService < PacemakerServiceObject
 
 # turn off nulti proposal support till it really works and people ask for it.
   def self.allow_multiple_proposals?
-    false
+    true
   end
 
   class << self


### PR DESCRIPTION
This is to allow users to migrate from postgres to mariadb. It enables
multiple proposals for the database barclamp so that the deployer can
choose between migrating on the same node or over to a new node.

This assumes there are three scenarios:
 - 1 single instance of postgres is deployed (keep using in legacy)
 - 1 single instance of mariadb is deployed (migration finished)
 - 1 instance of each postgresql and mariadb is deployed. (In this case
postgres is still used by the control plane until the migration is
complete).

TODO:
 - Handle deploying to a new node
 - Handle deploying postgres+HA and mariadb+galera
 - Handle the 2 node drdb case
 - Ensure/enforce only the above 3 scenarios are possible. ie, disallow
a second postgres to be deployed.

This code is kinda hacky but only intended as a temporary measure for
the migration in cloud 7. This should not be in cloud 8.
