### PR TITLE
rabbitmq: Try to trigger epmd socket bug

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -68,6 +68,12 @@ if node[:platform_family] == "suse"
     subscribes :run, "template[/etc/systemd/system/epmd.socket.d/port.conf]", :immediate
   end
 
+  # skz: TODO: remove
+  bash "wait for some epmd to come up to trigger epmd.socket bug" do
+    code "echo 'waiting for 60sec...'; sleep 60"
+    action :run
+  end
+
   # Enable epmd.socket for two reasons:
   # 1. when we don't use the rabbitmq systemd service (in HA, for instance),
   #    this will enable the use of the system-wide epmd


### PR DESCRIPTION
just for testing
wait some time before starting epmd.socket unit
during upgrade with ocf agent running this should trigger starting of some epmd process in the background... then starting epmd.socket should fail reliably