### PR TITLE
[4.0] Add rate limiting for glance api (bsc#1005886)

### DIFF
--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -29,6 +29,7 @@ haproxy_loadbalancer "glance-api" do
   port network_settings[:api][:ha_bind_port]
   use_ssl (node[:glance][:api][:protocol] == "https")
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "glance", "glance-server", "api")
+  rate_limit node[:glance][:ha_rate_limit]["glance-api"]
   action :nothing
 end.run_action(:create)
 

--- a/chef/data_bags/crowbar/migrate/glance/105_add_rate_limit.rb
+++ b/chef/data_bags/crowbar/migrate/glance/105_add_rate_limit.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ha_rate_limit"] = ta["ha_rate_limit"] unless a.key? "ha_rate_limit"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ha_rate_limit") unless ta.key? "ha_rate_limit"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -65,14 +65,17 @@
       "keystone_instance": "none",
       "service_user": "glance",
       "database_instance": "none",
-      "rabbitmq_instance": "none"
+      "rabbitmq_instance": "none",
+      "ha_rate_limit": {
+        "glance-api": 0
+      }
     }
   },
   "deployment": {
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 104,
+      "schema-revision": 105,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-glance.schema
+++ b/chef/data_bags/crowbar/template-glance.schema
@@ -96,7 +96,12 @@
             "keystone_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str" },
-            "database_instance": { "type": "str", "required": true }
+            "database_instance": { "type": "str", "required": true },
+            "ha_rate_limit": {
+              "type": "map", "required": true, "mapping": {
+                "glance-api": { "type": "int", "required": true }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Disabled by default default. It can be set to avoid filling up image
related tables.

Though the tables are only filled by POST requests this limit is for all
request types.

See https://wiki.openstack.org/wiki/OSSN/OSSN-0076 for details.

(cherry picked from commit c4c1b8e0f27489dbeaa7503b920051b67a4523d1)
Backport of https://github.com/crowbar/crowbar-openstack/pull/1677