### PR TITLE
monasca: add elasticsearch tunables (bsc#1090343)

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -124,6 +124,7 @@ template "/opt/monasca-installer/crowbar_vars.yml" do
     curator_cron_config: [curator_cron_config].to_yaml.split("\n")[1..-1],
     curator_excluded_index: curator_excluded_index.to_yaml.split("\n")[1..-1],
     elasticsearch_repo_dir: node[:monasca][:elasticsearch][:repo_dir].to_yaml.split("\n")[1..-1],
+    elasticsearch_tunables: node[:monasca][:elasticsearch][:tunables],
     monitor_libvirt: node[:monasca][:agent][:monitor_libvirt],
     delegate_role: node[:monasca][:delegate_role]
   )

--- a/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
@@ -58,6 +58,9 @@ monasca_log_api_url: "http://<%= @pub_net_ip %>:<%= @log_api_settings['bind_port
 memcached_nodes: ["<%= @monasca_net_ip %>:11211"]
 elasticsearch_nodes: ["<%= @monasca_net_ip %>"]
 elasticsearch_hosts: <%= @monasca_net_ip %>
+<%- @elasticsearch_tunables.each_key do |t| %>
+elasticsearch_<%= t %>: <%= @elasticsearch_tunables[t] %>
+<%- end %>
 monasca_api_log_level: <%= @api_settings['log_level'] %>
 log_api_log_level: <%= @log_api_settings['log_level'] %>
 

--- a/chef/data_bags/crowbar/migrate/monasca/104_add_elasticsearch_tunables.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/104_add_elasticsearch_tunables.rb
@@ -1,0 +1,14 @@
+def upgrade(ta, td, a, d)
+  # this migration already happened if the tsdb key exists
+  return a, d if a["elasticsearch"].key?("tunables")
+
+  a["elasticsearch"]["tunables"] = ta["elasticsearch"]["tunables"]
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["elasticsearch"].delete("tunables")
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -69,7 +69,16 @@
         "log_level": "INFO"
       },
       "elasticsearch": {
-        "repo_dir": []
+        "repo_dir": [],
+        "tunables": {
+          "heap_size": "4g",
+          "max_locked_memory": "infinity",
+          "max_open_files_hard_limit": 65536,
+          "max_open_files_soft_limit": 16384,
+          "max_procs": 65536,
+          "memory_lock": true,
+          "vm_max_map_count": 262144
+        }
       },
       "elasticsearch_curator": {
         "delete_exclude_index": [ ".kibana" ],
@@ -132,7 +141,7 @@
     "monasca": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 103,
+      "schema-revision": 104,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
         "monasca-master": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -107,6 +107,19 @@
                   "required": true,
                   "type": "seq",
                   "sequence": [ { "type": "str" } ]
+                  },
+                  "tunables": {
+                    "required": true,
+                    "type": "map",
+                    "mapping": {
+                      "heap_size": { "type": "str", "required": true },
+                      "max_locked_memory": { "type": "str", "required": true },
+                      "max_open_files_hard_limit": { "type": "int", "required": true },
+                      "max_open_files_soft_limit": { "type": "int", "required": true },
+                      "max_procs": { "type": "int", "required": true },
+                      "memory_lock": { "type": "bool", "required": true },
+                      "vm_max_map_count": { "type": "int", "required": true }
+                    }
                   }
                 }
             },


### PR DESCRIPTION
This commit adds various new elasticsearch tunables and passes them to
monasca-installer.

(cherry picked from commit a91f9c5d0fde868540b85ea14c7cf864a564f53a)