### PR TITLE
[4.0] WIP: split database-server role into backend specific roles

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -75,7 +75,7 @@ class CrowbarOpenStackHelper
       @database_settings_cache_time = node[:ohai_time]
     end
 
-    if @database_settings && @database_settings.include?(instance)
+    if @database_settings && @database_settings.include?(instance) && false
       Chef::Log.info("Database server found at #{@database_settings[instance][:address]} [cached]")
     else
       @database_settings ||= Hash.new
@@ -85,6 +85,9 @@ class CrowbarOpenStackHelper
                         )
       db_proposal_role = db_roles.first unless db_roles.empty?
       sql_engine = db_proposal_role.default_attributes["database"]["sql_engine"]
+      if barclamp == "mysql" || barclamp == "postgresql"
+        sql_engine = barclamp
+      end
       db_role = if sql_engine == "postgresql"
                   "database-server"
                 else
@@ -97,7 +100,7 @@ class CrowbarOpenStackHelper
         Chef::Log.warn("No database server found!")
       else
         address = CrowbarDatabaseHelper.get_listen_address(database)
-        backend_name = DatabaseLibrary::Database::Util.get_backend_name(database)
+        backend_name = sql_engine
 
         ssl_opts = {}
         if backend_name == "mysql"
@@ -112,9 +115,9 @@ class CrowbarOpenStackHelper
           address: address,
           url_scheme: backend_name,
           backend_name: backend_name,
-          provider: DatabaseLibrary::Database::Util.get_database_provider(database),
-          user_provider: DatabaseLibrary::Database::Util.get_user_provider(database),
-          privs: DatabaseLibrary::Database::Util.get_default_priviledges(database),
+          provider: DatabaseLibrary::Database::Util.get_database_provider(database, backend_name),
+          user_provider: DatabaseLibrary::Database::Util.get_user_provider(database, backend_name),
+          privs: DatabaseLibrary::Database::Util.get_default_priviledges(database, backend_name),
           connection: {
             host: address,
             username: "db_maker",

--- a/chef/cookbooks/database/attributes/default.rb
+++ b/chef/cookbooks/database/attributes/default.rb
@@ -18,5 +18,7 @@
 #
 
 # ha
-default[:database][:ha][:enabled] = false
-default[:database][:ha][:storage][:mode] = nil
+default[:database][:postgresql][:ha][:enabled] = false
+default[:database][:postgresql][:ha][:storage][:mode] = nil
+
+default[:database][:mysql][:ha][:enabled] = false

--- a/chef/cookbooks/database/libraries/crowbar.rb
+++ b/chef/cookbooks/database/libraries/crowbar.rb
@@ -1,10 +1,10 @@
 module CrowbarDatabaseHelper
-  def self.get_ha_vhostname(node)
-    if node[:database][:ha][:enabled]
+  def self.get_ha_vhostname(node, sql_engine=node[:database][:sql_engine])
+    if node["database"][sql_engine]["ha"]["enabled"]
       cluster_name = CrowbarPacemakerHelper.cluster_name(node)
       # Any change in the generation of the vhostname here must be reflected in
       # apply_role_pre_chef_call of the database barclamp model
-      if node[:database][:sql_engine] == "postgresql"
+      if sql_engine == "postgresql"
         "#{node[:database][:config][:environment].gsub("-config", "")}-#{cluster_name}".tr("_", "-")
       else
         "cluster-#{cluster_name}".tr("_", "-")
@@ -14,10 +14,10 @@ module CrowbarDatabaseHelper
     end
   end
 
-  def self.get_listen_address(node)
+  def self.get_listen_address(node, sql_engine=node[:database][:sql_engine])
     # For SSL we prefer a cluster hostname (for certificate validation)
-    use_ssl = node[:database][:sql_engine] == "mysql" && node[:database][:mysql][:ssl][:enabled]
-    if node[:database][:ha][:enabled]
+    use_ssl = sql_engine == "mysql" && node[:database][:mysql][:ssl][:enabled]
+    if node["database"][sql_engine]["ha"]["enabled"]
       vhostname = get_ha_vhostname(node)
       use_ssl ? "#{vhostname}.#{node[:domain]}" : CrowbarPacemakerHelper.cluster_vip(node, "admin", vhostname)
     else

--- a/chef/cookbooks/database/libraries/database_library.rb
+++ b/chef/cookbooks/database/libraries/database_library.rb
@@ -19,8 +19,7 @@
 module DatabaseLibrary
     class Database
         class Util
-            def self.get_database_provider(node)
-                backend = node[:database][:sql_engine]
+            def self.get_database_provider(node, backend = node[:database][:sql_engine])
                 db_provider = nil
                 case backend
                 when "postgresql"
@@ -33,8 +32,7 @@ module DatabaseLibrary
                 db_provider
             end
 
-            def self.get_user_provider(node)
-                backend = node[:database][:sql_engine]
+            def self.get_user_provider(node, backend = node[:database][:sql_engine])
                 db_provider = nil
                 case backend
                 when "postgresql"
@@ -51,8 +49,7 @@ module DatabaseLibrary
                 node[:database][:sql_engine]
             end
 
-            def self.get_default_priviledges(node)
-                backend = node[:database][:sql_engine]
+            def self.get_default_priviledges(node, backend = node[:database][:sql_engine])
                 privs = nil
                 case backend
                 when "postgresql"

--- a/chef/cookbooks/database/recipes/role_database_server.rb
+++ b/chef/cookbooks/database/recipes/role_database_server.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, SUSE LINUX GmbH
+# Copyright 2018, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 if CrowbarRoleRecipe.node_state_valid_for_role?(node, "database", "database-server")
   include_recipe "database::crowbar"
-  include_recipe "database::server"
+  Chef::Log.info("Running database::server for PostgreSQL")
+  include_recipe "postgresql::server"
 end

--- a/chef/cookbooks/database/recipes/role_mysql_server.rb
+++ b/chef/cookbooks/database/recipes/role_mysql_server.rb
@@ -1,14 +1,11 @@
 #
-# Cookbook Name:: database
-# Recipe:: server
-#
-# Copyright 2012, SUSE Linux Products GmbH
+# Copyright 2018, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-backend = node[:database][:sql_engine]
-
-Chef::Log.info("Running database::server for #{backend}")
-
-include_recipe "#{backend}::server"
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "database", "mysql-server")
+  include_recipe "mysql::server"
+end

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -71,7 +71,7 @@ unless node[:database][:galera_bootstrapped]
     # unauthenticated root user is later removed in server.rb after the
     # bootstraping. Once the cluster has started other nodes will pick up on
     # the sstuser and we are able to use these credentails.
-    db_settings = fetch_database_settings
+    db_settings = fetch_database_settings(@cookbook_name)
     db_connection = db_settings[:connection].dup
     db_connection[:host] = "localhost"
     db_connection[:username] = "root"

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -325,7 +325,7 @@ end
 include_recipe "crowbar-pacemaker::haproxy"
 
 ha_servers = CrowbarPacemakerHelper.haproxy_servers_for_service(
-  node, "mysql", "database-server", "admin_port"
+  node, "mysql", "mysql-server", "admin_port"
 )
 
 # Let all nodes but one act as backup (standby) servers.

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -20,7 +20,7 @@
 include_recipe "mysql::client"
 include_recipe "database::client"
 
-ha_enabled = node[:database][:ha][:enabled]
+ha_enabled = node[:database][:mysql][:ha][:enabled]
 
 # For Crowbar, we need to set the address to bind - default to admin node.
 addr = node[:database][:mysql][:bind_address] || ""
@@ -91,7 +91,7 @@ if node[:database][:mysql][:ssl][:enabled]
       node[:database][:mysql][:ssl][:generate_certs] ||
       node[:database][:mysql][:ssl][:insecure])
     group "mysql"
-    fqdn CrowbarDatabaseHelper.get_listen_address(node)
+    fqdn CrowbarDatabaseHelper.get_listen_address(node, "mysql")
   end
 end
 

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -163,7 +163,7 @@ execute "assign-root-password" do
   only_if "/usr/bin/mysql -u root -e 'show databases;'"
 end
 
-db_settings = fetch_database_settings
+db_settings = fetch_database_settings(@cookbook_name)
 db_connection = db_settings[:connection].dup
 db_connection[:host] = "localhost"
 db_connection[:username] = "root"

--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -22,14 +22,14 @@
 #
 # This is the second step.
 
-vip_primitive = "vip-admin-#{CrowbarDatabaseHelper.get_ha_vhostname(node)}"
+vip_primitive = "vip-admin-#{CrowbarDatabaseHelper.get_ha_vhostname(node, "postgresql")}"
 service_name = "postgresql"
 fs_primitive = "fs-#{service_name}"
 group_name = "g-#{service_name}"
 
 agent_name = "ocf:heartbeat:pgsql"
 
-ip_addr = CrowbarDatabaseHelper.get_listen_address(node)
+ip_addr = CrowbarDatabaseHelper.get_listen_address(node, "postgresql")
 
 postgres_op = {}
 postgres_op["monitor"] = {}
@@ -85,7 +85,7 @@ pacemaker_primitive service_name do
 end
 transaction_objects << "pacemaker_primitive[#{service_name}]"
 
-if node[:database][:ha][:storage][:mode] == "drbd"
+if node[:database][:postgresql][:ha][:storage][:mode] == "drbd"
 
   colocation_constraint = "col-#{service_name}"
   pacemaker_colocation colocation_constraint do

--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -37,21 +37,21 @@ postgres_op["monitor"]["interval"] = "10s"
 fs_params = {}
 fs_params["directory"] = "/var/lib/pgsql"
 
-if node[:database][:ha][:storage][:mode] == "drbd"
+if node[:database][:postgresql][:ha][:storage][:mode] == "drbd"
   include_recipe "crowbar-pacemaker::drbd"
 
   crowbar_pacemaker_drbd drbd_resource do
-    size "#{node[:database][:ha][:storage][:drbd][:size]}G"
+    size "#{node[:database][:postgresql][:ha][:storage][:drbd][:size]}G"
     action :nothing
   end.run_action(:create)
 
   fs_params["device"] = node["drbd"]["rsc"][drbd_resource]["device"]
   fs_params["fstype"] = "xfs"
-elsif node[:database][:ha][:storage][:mode] == "shared"
-  fs_params["device"] = node[:database][:ha][:storage][:shared][:device]
-  fs_params["fstype"] = node[:database][:ha][:storage][:shared][:fstype]
-  unless node[:database][:ha][:storage][:shared][:options].empty?
-    fs_params["options"] = node[:database][:ha][:storage][:shared][:options]
+elsif node[:database][:postgresql][:ha][:storage][:mode] == "shared"
+  fs_params["device"] = node[:database][:postgresql][:ha][:storage][:shared][:device]
+  fs_params["fstype"] = node[:database][:postgresql][:ha][:storage][:shared][:fstype]
+  unless node[:database][:postgresql][:ha][:storage][:shared][:options].empty?
+    fs_params["options"] = node[:database][:postgresql][:ha][:storage][:shared][:options]
   end
 else
   raise "Invalid mode for HA storage!"
@@ -71,7 +71,7 @@ end
 
 transaction_objects = []
 
-if node[:database][:ha][:storage][:mode] == "drbd"
+if node[:database][:postgresql][:ha][:storage][:mode] == "drbd"
   drbd_params = {}
   drbd_params["drbd_resource"] = drbd_resource
 
@@ -120,7 +120,7 @@ transaction_objects << "pacemaker_primitive[#{fs_primitive}]"
 location_name = openstack_pacemaker_controller_only_location_for fs_primitive
 transaction_objects << "pacemaker_location[#{location_name}]"
 
-if node[:database][:ha][:storage][:mode] == "drbd"
+if node[:database][:postgresql][:ha][:storage][:mode] == "drbd"
   colocation_constraint = "col-#{fs_primitive}"
   pacemaker_colocation colocation_constraint do
     score "inf"

--- a/chef/cookbooks/postgresql/recipes/server.rb
+++ b/chef/cookbooks/postgresql/recipes/server.rb
@@ -121,7 +121,7 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   notifies change_notify, "service[postgresql]", :immediately
 end
 
-ha_enabled = node[:database][:ha][:enabled]
+ha_enabled = node[:database][:postgresql][:ha][:enabled]
 
 if ha_enabled
   log "HA support for postgresql is enabled"

--- a/chef/cookbooks/postgresql/recipes/server_debian.rb
+++ b/chef/cookbooks/postgresql/recipes/server_debian.rb
@@ -28,7 +28,7 @@ end
 # We need to include the HA recipe early, before the config files are
 # generated, but after the postgresql packages are installed since they live in
 # the directory that will be mounted for HA
-if node[:database][:ha][:enabled]
+if node[:database][:postgresql][:ha][:enabled]
   include_recipe "postgresql::ha_storage"
 end
 

--- a/chef/cookbooks/postgresql/recipes/server_redhat.rb
+++ b/chef/cookbooks/postgresql/recipes/server_redhat.rb
@@ -49,7 +49,7 @@ node["postgresql"]["server"]["packages"].each do |pg_pack|
   package pg_pack
 end
 
-ha_enabled = node[:database][:ha][:enabled]
+ha_enabled = node[:database][:postgresql][:ha][:enabled]
 
 # We need to include the HA recipe early, before the config files are
 # generated, but after the postgresql packages are installed since they live in

--- a/chef/data_bags/crowbar/migrate/database/109_separate_db_roles.rb
+++ b/chef/data_bags/crowbar/migrate/database/109_separate_db_roles.rb
@@ -1,0 +1,47 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+
+  if a["sql_engine"] == "mysql"
+    d["elements"]["mysql-server"] = d["elements"]["database-server"]
+    d["elements"]["atabase-server"] = []
+    if d.fetch("elements_expanded", {}).key? "database-server"
+      d["elements_expanded"]["mysql-server"] = d["elements_expanded"]["database-server"]
+      d["elements_expanded"].delete("database-server")
+    end
+
+    chef_order = BarclampCatalog.chef_order("database")
+    nodes = NodeObject.find("run_list_map:database-server")
+    nodes.each do |node|
+      node.add_to_run_list("mysql-server", chef_order,
+                           td["element_states"]["mysql-server"])
+      node.delete_from_run_list("database-server")
+      node.save
+    end
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+
+  if a["sql_engine"] == "mysql"
+    d["elements"]["database-server"] = d["elements"]["mysql-server"]
+    d["elements"].delete("mysql-server")
+    if d.fetch("elements_expanded", {}).key? "mysql-server"
+      d["elements_expanded"]["database-server"] = d["elements_expanded"]["mysql-server"]
+      d["elements_expanded"].delete("mysql-server")
+    end
+
+    chef_order = BarclampCatalog.chef_order("database")
+    nodes = NodeObject.find("run_list_map:mysql-server")
+    nodes.each do |node|
+      node.add_to_run_list("database-server", chef_order,
+                           td["element_states"]["database-server"])
+      node.delete_from_run_list("mysql-server")
+      node.save
+    end
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/database/109_separate_db_roles.rb
+++ b/chef/data_bags/crowbar/migrate/database/109_separate_db_roles.rb
@@ -1,4 +1,12 @@
 def upgrade(ta, td, a, d)
+  db_engine = a["sql_engine"]
+  a[db_engine]["ha"] = a["ha"]
+  a.delete("ha")
+  if db_engine == "postgresql"
+    a["mysql"]["ha"] = ta["mysql"]["ha"]
+  else
+    a["postgresql"]["ha"] = ta["postgresql"]["ha"]
+  end
   d["element_states"] = td["element_states"]
   d["element_order"] = td["element_order"]
 

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -57,18 +57,18 @@
           "log_filename": "postgresql.log-%Y%m%d%H%M",
           "log_truncate_on_rotation": false,
           "log_min_duration_statement": -1
-        }
-      },
-      "ha": {
-        "storage": {
-          "mode": "shared",
-          "drbd": {
-            "size": 50
-          },
-          "shared": {
-            "device": "",
-            "fstype": "",
-            "options": ""
+        },
+        "ha": {
+          "storage": {
+            "mode": "shared",
+            "drbd": {
+              "size": 50
+            },
+            "shared": {
+              "device": "",
+              "fstype": "",
+              "options": ""
+            }
           }
         }
       },

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -83,15 +83,17 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 108,
+      "schema-revision": 109,
       "element_states": {
-        "database-server": [ "readying", "ready", "applying" ]
+        "database-server": [ "readying", "ready", "applying" ],
+        "mysql-server": [ "readying", "ready", "applying" ]
       },
       "elements": {
-        "database-server": []
+        "database-server": [],
+        "mysql-server": []
       },
       "element_order": [
-        [ "database-server" ]
+        [ "database-server", "mysql-server" ]
       ],
       "config": {
         "environment": "database-base-config",

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -85,32 +85,32 @@
                     "log_filename": {"type": "str" },
                     "log_min_duration_statement": { "type": "int" }
                   }
-                }
-              }
-            },
-            "ha" : {
-              "type": "map",
-              "required": true,
-              "mapping" : {
-                "storage": {
+                },
+                "ha" : {
                   "type": "map",
                   "required": true,
                   "mapping" : {
-                    "mode": { "type": "str", "required": true },
-                    "drbd": {
+                    "storage": {
                       "type": "map",
                       "required": true,
                       "mapping" : {
-                        "size": { "type": "int", "required": true }
-                      }
-                    },
-                    "shared": {
-                      "type": "map",
-                      "required": true,
-                      "mapping" : {
-                        "device": { "type": "str", "required": true },
-                        "fstype": { "type": "str", "required": true },
-                        "options": { "type": "str", "required": true }
+                        "mode": { "type": "str", "required": true },
+                        "drbd": {
+                          "type": "map",
+                          "required": true,
+                          "mapping" : {
+                            "size": { "type": "int", "required": true }
+                          }
+                        },
+                        "shared": {
+                          "type": "map",
+                          "required": true,
+                          "mapping" : {
+                            "device": { "type": "str", "required": true },
+                            "fstype": { "type": "str", "required": true },
+                            "options": { "type": "str", "required": true }
+                          }
+                        }
                       }
                     }
                   }

--- a/chef/roles/database-server.rb
+++ b/chef/roles/database-server.rb
@@ -1,6 +1,5 @@
 name "database-server"
-description "Database Server Role"
+description "PostgreSQL Server Role"
 run_list("recipe[database::role_database_server]")
 default_attributes()
 override_attributes()
-

--- a/chef/roles/mysql-server.rb
+++ b/chef/roles/mysql-server.rb
@@ -1,0 +1,5 @@
+name "mysql-server"
+description "MySQL/MariaDB Server Role"
+run_list("recipe[database::role_mysql_server]")
+default_attributes()
+override_attributes()

--- a/crowbar_framework/app/helpers/barclamp/database_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/database_helper.rb
@@ -30,8 +30,8 @@ module Barclamp
     def ha_storage_mode_for_database(selected)
       options_for_select(
         [
-          [t(".ha.storage.modes.drbd"), "drbd"],
-          [t(".ha.storage.modes.shared"), "shared"]
+          [t(".postgresql.ha.storage.modes.drbd"), "drbd"],
+          [t(".postgresql.ha.storage.modes.shared"), "shared"]
         ],
         selected.to_s
       )

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -38,6 +38,16 @@ class DatabaseService < PacemakerServiceObject
             "suse" => "< 12.2",
             "windows" => "/.*/"
           }
+        },
+        "mysql-server" => {
+          "unique" => false,
+          "count" => 1,
+          "cluster" => true,
+          "admin" => false,
+          "exclude_platform" => {
+            "suse" => "< 12.2",
+            "windows" => "/.*/"
+          }
         }
       }
     end
@@ -111,17 +121,22 @@ class DatabaseService < PacemakerServiceObject
   end
 
   def validate_proposal_after_save(proposal)
-    validate_one_for_role proposal, "database-server"
-
     attributes = proposal["attributes"][@bc_name]
-    db_engine = attributes["sql_engine"]
+    sql_engine = attributes["sql_engine"]
+    db_role = if sql_engine == "postgresql"
+                "database-server"
+              else
+                "mysql-server"
+              end
+    validate_one_for_role proposal, db_role
+
     validation_error I18n.t(
       "barclamp.#{@bc_name}.validation.invalid_db_engine",
-      db_engine: db_engine
-    ) unless %w(mysql postgresql).include?(db_engine)
+      db_engine: sql_engine
+    ) unless %w(mysql postgresql).include?(sql_engine)
 
     # HA validation
-    servers = proposal["deployment"][@bc_name]["elements"]["database-server"]
+    servers = proposal["deployment"][@bc_name]["elements"][db_role]
     unless servers.nil? || servers.first.nil? || !is_cluster?(servers.first)
       cluster = servers.first
       validate_ha_attributes(attributes, cluster)
@@ -134,10 +149,18 @@ class DatabaseService < PacemakerServiceObject
     @logger.debug("Database apply_role_pre_chef_call: entering #{all_nodes.inspect}")
     return if all_nodes.empty?
 
-    database_elements, database_nodes, database_ha_enabled = role_expand_elements(role, "database-server")
+    sql_engine = role.default_attributes["database"]["sql_engine"]
+    db_role = if engine == "postgresql"
+                "database-server"
+              else
+                "mysql-server"
+              end
+
+    database_elements, database_nodes, database_ha_enabled = role_expand_elements(role, db_role)
     Openstack::HA.set_controller_role(database_nodes) if database_ha_enabled
 
     vip_networks = ["admin"]
+
     dirty = prepare_role_for_ha_with_haproxy(role, ["database", "ha", "enabled"],
       database_ha_enabled,
       database_elements,
@@ -145,8 +168,6 @@ class DatabaseService < PacemakerServiceObject
     role.save if dirty
 
     reset_sync_marks_on_clusters_founders(database_elements)
-
-    sql_engine = role.default_attributes["database"]["sql_engine"]
 
     if database_ha_enabled
       net_svc = NetworkService.new @logger

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -71,11 +71,13 @@ class DatabaseService < PacemakerServiceObject
   end
 
   def validate_ha_attributes(attributes, cluster)
-    storage_mode = attributes["ha"]["storage"]["mode"]
+    sql_engine = attributes["sql_engine"]
     role = available_clusters[cluster]
 
     case attributes["sql_engine"]
     when "postgresql"
+      ha_attr = attributes["postgresql"]["ha"]
+      storage_mode = ha_attr["storage"]["mode"]
       unless ["shared", "drbd"].include?(storage_mode)
         validation_error I18n.t(
           "barclamp.#{@bc_name}.validation.unknown_mode_ha",
@@ -83,12 +85,12 @@ class DatabaseService < PacemakerServiceObject
         )
       end
       if storage_mode == "shared"
-        if attributes["ha"]["storage"]["shared"]["device"].blank?
+        if ha_attr["storage"]["shared"]["device"].blank?
           validation_error I18n.t(
             "barclamp.#{@bc_name}.validation.no_device"
           )
         end
-        if attributes["ha"]["storage"]["shared"]["fstype"].blank?
+        if ha_attr["storage"]["shared"]["fstype"].blank?
           validation_error I18n.t(
             "barclamp.#{@bc_name}.validation.no_filesystem"
           )
@@ -100,7 +102,7 @@ class DatabaseService < PacemakerServiceObject
             cluster_name: cluster_name(cluster)
           )
         end
-        if attributes["ha"]["storage"]["drbd"]["size"] <= 0
+        if ha_attr["storage"]["drbd"]["size"] <= 0
           validation_error I18n.t(
             "barclamp.#{@bc_name}.validation.invalid_size_drbd"
           )
@@ -150,56 +152,71 @@ class DatabaseService < PacemakerServiceObject
     return if all_nodes.empty?
 
     sql_engine = role.default_attributes["database"]["sql_engine"]
-    db_role = if engine == "postgresql"
-                "database-server"
-              else
-                "mysql-server"
-              end
-
-    database_elements, database_nodes, database_ha_enabled = role_expand_elements(role, db_role)
-    Openstack::HA.set_controller_role(database_nodes) if database_ha_enabled
 
     vip_networks = ["admin"]
-
-    dirty = prepare_role_for_ha_with_haproxy(role, ["database", "ha", "enabled"],
-      database_ha_enabled,
-      database_elements,
-      vip_networks)
-    role.save if dirty
-
-    reset_sync_marks_on_clusters_founders(database_elements)
-
-    if database_ha_enabled
-      net_svc = NetworkService.new @logger
-      case sql_engine
-      when "postgresql"
-        unless database_elements.length == 1 && PacemakerServiceObject.is_cluster?(database_elements[0])
-          raise "Internal error: HA enabled, but element is not a cluster"
+    dirty = false
+    net_svc = NetworkService.new @logger
+    db_enabled = {
+      "mysql" => {
+        "enabled" => false,
+        "ha" => false
+      },
+      "postgresql" => {
+        "enabled" => false,
+        "ha" => false
+      }
+    }
+    ["postgresql", "mysql"].each do |engine|
+      db_role = if engine == "postgresql"
+                  "database-server"
+                else
+                  "mysql-server"
+                end
+      database_elements, database_nodes, database_ha_enabled = role_expand_elements(role, db_role)
+      unless database_nodes.empty?
+        db_enabled[engine]["enabled"] = true
+      end
+      db_enabled[engine]["ha"] = database_ha_enabled
+      Openstack::HA.set_controller_role(database_nodes) if database_ha_enabled
+      dirty = prepare_role_for_ha_with_haproxy(role,
+                                               ["database", engine, "ha", "enabled"],
+                                               database_ha_enabled,
+                                               database_elements,
+                                               vip_networks) || dirty
+      reset_sync_marks_on_clusters_founders(database_elements)
+      if database_ha_enabled
+        case engine
+        when "postgresql"
+          unless database_elements.length == 1 && PacemakerServiceObject.is_cluster?(database_elements[0])
+            raise "Internal error: HA enabled, but element is not a cluster"
+          end
+          cluster = database_elements[0]
+          cluster_name = PacemakerServiceObject.cluster_name(cluster)
+          # Any change in the generation of the vhostname here must be reflected in
+          # CrowbarDatabaseHelper.get_ha_vhostname
+          database_vhostname = "#{role.name.gsub("-config", "")}-#{cluster_name}.#{Crowbar::Settings.domain}".tr("_", "-")
+          net_svc.allocate_virtual_ip "default", "admin", "host", database_vhostname
+        when "mysql"
+          database_nodes.each do |n|
+            net_svc.allocate_ip "default", "admin", "host", n
+          end
+          allocate_virtual_ips_for_any_cluster_in_networks(database_elements, vip_networks)
         end
-        cluster = database_elements[0]
-        cluster_name = PacemakerServiceObject.cluster_name(cluster)
-        # Any change in the generation of the vhostname here must be reflected in
-        # CrowbarDatabaseHelper.get_ha_vhostname
-        database_vhostname = "#{role.name.gsub("-config", "")}-#{cluster_name}.#{Crowbar::Settings.domain}".tr("_", "-")
-        net_svc.allocate_virtual_ip "default", "admin", "host", database_vhostname
-      when "mysql"
-        database_nodes.each do |n|
-          net_svc.allocate_ip "default", "admin", "host", n
-        end
-        allocate_virtual_ips_for_any_cluster_in_networks(database_elements, vip_networks)
       end
     end
+    role.save if dirty
 
     role.default_attributes["database"][sql_engine] = {} if role.default_attributes["database"][sql_engine].nil?
     role.default_attributes["database"]["db_maker_password"] = (old_role && old_role.default_attributes["database"]["db_maker_password"]) || random_password
 
-    if ( sql_engine == "mysql" )
+    if db_enabled["mysql"]["enabled"]
       role.default_attributes["database"]["mysql"]["server_root_password"] = (old_role && old_role.default_attributes["database"]["mysql"]["server_root_password"]) || random_password
-      if database_ha_enabled
+      if db_enabled["mysql"]["ha"]
         role.default_attributes["database"]["mysql"]["sstuser_password"] = (old_role && old_role.default_attributes["database"]["mysql"]["sstuser_password"]) || random_password
       end
       @logger.debug("setting mysql specific attributes")
-    elsif ( sql_engine == "postgresql" )
+    end
+    if db_enabled["postgresql"]["enabled"]
       # Attribute is not living in "database" namespace, but that's because
       # it's for the postgresql cookbook. We're not using default_attributes
       # because the upstream cookbook use node.set_unless which would override

--- a/crowbar_framework/app/models/monasca_service.rb
+++ b/crowbar_framework/app/models/monasca_service.rb
@@ -93,7 +93,7 @@ class MonascaService < OpenstackServiceObject
     nodes = NodeObject.all
     non_db_nodes = nodes.reject do |n|
       # Do not deploy monasca-server to the node running database cluster (already running mariadb)
-      n.roles.include?("database-server") && n[:database][:sql_engine] == "mysql"
+      n.roles.include?("mysql-server")
     end
 
     monasca_server = select_nodes_for_role(non_db_nodes, "monasca-server", "monitoring") || []
@@ -141,7 +141,7 @@ class MonascaService < OpenstackServiceObject
     nodes = proposal["deployment"][@bc_name]["elements"]
     nodes["monasca-server"].each do |node|
       n = NodeObject.find_node_by_name(node)
-      if n.roles.include?("database-server") && n[:database][:sql_engine] == "mysql"
+      if n.roles.include?("mysql-server")
         validation_error(
           "monasca-server role cannot be deployed to the node with other MariaDB instance."
         )

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -40,14 +40,14 @@
         %legend
           = t('.ha_header')
 
-        = select_field %w(ha storage mode), :collection => :ha_storage_mode_for_database, "data-showit" => ["drbd", "shared"].join(";"), "data-showit-target" => "#drbd_storage_container;#shared_storage_container", "data-showit-direct" => "true"
+        = select_field %w(postgresql ha storage mode), :collection => :ha_storage_mode_for_database, "data-showit" => ["drbd", "shared"].join(";"), "data-showit-target" => "#drbd_storage_container;#shared_storage_container", "data-showit-direct" => "true"
 
         #drbd_storage_container
           .alert.alert-info
-            = t('.ha.storage.drbd_info')
-          = integer_field %w(ha storage drbd size)
+            = t('.postgresql.ha.storage.drbd_info')
+          = integer_field %w(postgresql ha storage drbd size)
 
         #shared_storage_container
-          = string_field %w(ha storage shared device)
-          = string_field %w(ha storage shared fstype)
-          = string_field %w(ha storage shared options)
+          = string_field %w(postgresql ha storage shared device)
+          = string_field %w(postgresql ha storage shared fstype)
+          = string_field %w(postgresql ha storage shared options)

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -40,20 +40,20 @@ en:
         postgresql:
           config:
             max_connections: 'Global Connection Limit (max_connections)'
+          ha:
+            storage:
+              mode: 'Storage Mode'
+              modes:
+                drbd: 'DRBD'
+                shared: 'Shared Storage'
+              drbd_info: 'The cluster must have been setup for DRBD.'
+              drbd:
+                size: 'Size to Allocate for DRBD Device (in Gigabytes)'
+              shared:
+                device: 'Name of Block Device or NFS Mount Specification'
+                fstype: 'Filesystem Type'
+                options: 'Mount Options'
         ha_header: 'High Availability'
-        ha:
-          storage:
-            mode: 'Storage Mode'
-            modes:
-              drbd: 'DRBD'
-              shared: 'Shared Storage'
-            drbd_info: 'The cluster must have been setup for DRBD.'
-            drbd:
-              size: 'Size to Allocate for DRBD Device (in Gigabytes)'
-            shared:
-              device: 'Name of Block Device or NFS Mount Specification'
-              fstype: 'Filesystem Type'
-              options: 'Mount Options'
       validation:
         invalid_db_engine: 'Invalid database engine: %{db_engine}.'
         unknown_mode_ha: 'Unknown mode for HA storage: %{storage_mode}.'


### PR DESCRIPTION
This is still very rough an missing a couple of things:

- [x] UI changes to allow configuring both backends in parallel: https://github.com/crowbar/crowbar-openstack/pull/1705
- [x] validation of role assignment (node assigned to the correct role for the selected backend
- [x] Likely needs some update HA
- [x] database_settings caching is disabled and needs to be fixed
- [ ] related changes on Cloud 8 (maybe just a schema migration back to the "database-server" role)
- [ ] ...

~~Note: The UI is currently broken! Only the "raw" mode is displayed for the attributes.~~

Note: The current implementation only adds the "mysql-server" role. postgresql based deployments continue to use the "database-server" role. This seems to have a couple of benefits:
* Most of the existing postgresql based ci jobs (especially the "batch" jobs) can be used without changes
* Fewer changes will be needed in "master". Basically we "just" need to rename "mysql-server" to database-server. (That would however mean the "master" will lose postgresql support)