### PR TITLE
manila: Correct field name for cluster name

### DIFF
--- a/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/manila/_edit_attributes.html.haml
@@ -72,7 +72,7 @@
               = boolean_field %w(shares {{@index}} cephfs use_crowbar), "data-hideit" => "true", "data-hideit-target" => "#cephfs_conf_path_{{@index}}", "data-hideit-direct" => "true"
               %div{:id => "cephfs_conf_path_{{@index}}"}
                 = string_field %w(shares {{@index}} cephfs cephfs_conf_path)
-                = string_field %w(shares {{@index}} cephfs cephfs_clustername)
+                = string_field %w(shares {{@index}} cephfs cephfs_cluster_name)
                 = string_field %w(shares {{@index}} cephfs cephfs_auth_id)
 
           {{/if_eq}}

--- a/crowbar_framework/config/locales/manila/en.yml
+++ b/crowbar_framework/config/locales/manila/en.yml
@@ -74,7 +74,7 @@ en:
             cephfs:
               use_crowbar: 'Use Ceph deployed by Crowbar'
               cephfs_conf_path: 'Path to Ceph configuration file'
-              cephfs_clustername: 'Cluster name'
+              cephfs_cluster_name: 'Cluster name'
               cephfs_auth_id: 'Authentication ID'
             manual:
               config: 'Options'


### PR DESCRIPTION
The correct field name for the Ceph cluster name is cephfs_cluster_name,
correct it for the custom view so configurations using CephFS can be
successfully applied.