### PR TITLE
Add security settings (bsc#1094134)

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -166,3 +166,20 @@ execute "run ansible" do
   cwd "/opt/monasca-installer"
   action :nothing unless actual_versions != previous_versions
 end
+
+template "/opt/monasca-installer/security.yml" do
+  source "security.yml.erb"
+  owner "root"
+  group "root"
+  mode "0o644"
+end
+
+bash "Update Zookeeper security settings" do
+  cwd "/opt/monasca-installer"
+  code <<-EOH
+    ansible-playbook -i monasca-hosts \
+      -e '@/opt/monasca-installer/crowbar_vars.yml' \
+      security.yml -vvv
+    EOH
+  subscribes :run, "execute[run ansible]", :delayed
+end

--- a/chef/cookbooks/monasca/templates/default/security.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/security.yml.erb
@@ -1,0 +1,19 @@
+# Secure Zookeeper configuration.
+
+- name: Prepare/Configure hosts
+  hosts: zookeeper_group
+  become: yes
+  vars_files:
+    - credentials.yml
+  tasks:
+    - name: Insert/update security configuration for zookeeper
+      blockinfile:
+        dest: /etc/zookeeper/zoo.cfg
+        marker: "# {mark} Security settings managed by Ansible"
+        block: |
+          quorum.auth.enableSasl=true
+          quorum.auth.learnerRequireSasl=true
+          quorum.auth.serverRequireSasl=true
+          quorum.auth.learner.loginContext=QuorumLearner
+          quorum.auth.server.loginContext=QuorumServer
+          quorum.cnxn.threads.size=20


### PR DESCRIPTION
Using default settings any Zookeeper instance can join the ensemble
and inject malicious requests. This change adds settings to enable
SASL DIGEST-MD5 based authentication only allowing instances to join
that know the shared secret.