### PR TITLE
cinder: Remove leftover rootwrap template

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder-rootwrap.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder-rootwrap.erb
@@ -1,1 +1,0 @@
-<%= @user %> ALL=(root) NOPASSWD: /usr/local/bin/cinder-rootwrap /etc/cinder/rootwrap.conf *


### PR DESCRIPTION
This file got obsoleted by the removal of PFS in 2015.