### PR TITLE
[neutron:cisco-aci] Backport from #1699

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -57,85 +57,83 @@ if node.roles.include?("neutron-network")
 end
 
 # apply configurations to compute node
-if node.roles.include?("nova-compute-kvm")
-  node[:neutron][:platform][:cisco_opflex_pkgs].each { |p| package p }
+node[:neutron][:platform][:cisco_opflex_pkgs].each { |p| package p }
 
-  service "lldpd" do
-    action [:enable, :start]
-  end
-  utils_systemd_service_restart "lldpd"
-
-  # include neutron::common_config only now, after we've installed packages
-  include_recipe "neutron::common_config"
-
-  # Agent configurations for Cisco APIC driver
-  # The ACI setup for OpenStack releases before Pike use "of_interface" options
-  # set to "ovs-ofctl". This option has been deprecated in Pike and removed
-  # from this config file for Pike. It is still included in Newton (Cloud7)
-  agent_config_path = "/etc/neutron/plugins/ml2/openvswitch_agent.ini"
-  template agent_config_path do
-    cookbook "neutron"
-    source "openvswitch_agent.ini.erb"
-    owner "root"
-    group node[:neutron][:platform][:group]
-    mode "0640"
-    variables(
-      ml2_type_drivers: ml2_type_drivers,
-      ml2_mech_drivers: ml2_mech_drivers,
-      tunnel_types: "",
-      enable_tunneling: false,
-      use_l2pop: false,
-      dvr_enabled: false,
-      of_interface: "ovs-ofctl",
-      ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
-      bridge_mappings: ""
-    )
-  end
-
-  # Update config file from template
-  opflex_agent_conf = "/etc/opflex-agent-ovs/conf.d/10-opflex-agent-ovs.conf"
-  apic = neutron[:neutron][:apic]
-  opflex_list = apic[:opflex].select { |i| i[:nodes].include? node[:hostname] }
-  opflex_list.any? || raise("Opflex instance not found for node '#{node[:hostname]}'")
-  opflex_list.one? || raise("Multiple opflex instances found for node '#{node[:hostname]}'")
-  opflex = opflex_list.first
-  template opflex_agent_conf do
-    cookbook "neutron"
-    source "10-opflex-agent-ovs.conf.erb"
-    mode "0755"
-    owner "root"
-    group neutron[:neutron][:platform][:group]
-    variables(
-      opflex_apic_domain_name: neutron[:neutron][:apic][:system_id],
-      hostname: node[:hostname],
-      socketgroup: neutron[:neutron][:platform][:group],
-      opflex_peer_ip: opflex[:peer_ip],
-      opflex_peer_port: opflex[:peer_port],
-      opflex_vxlan_encap_iface: opflex[:vxlan][:encap_iface],
-      opflex_vxlan_uplink_iface: opflex[:vxlan][:uplink_iface],
-      opflex_vxlan_uplink_vlan: opflex[:vxlan][:uplink_vlan],
-      opflex_vxlan_remote_ip: opflex[:vxlan][:remote_ip],
-      opflex_vxlan_remote_port: opflex[:vxlan][:remote_port],
-      # TODO(mmnelemane) : update VLAN encapsulation config when it works.
-      # Currently set to VXLAN by default but can be modified from proposal.
-      ml2_type_drivers: ml2_type_drivers
-    )
-  end
-
-  neutron_metadata do
-    use_cisco_apic_ml2_driver true
-    neutron_node_object neutron
-  end
-
-  service "neutron-opflex-agent" do
-    action [:enable, :start]
-    subscribes :restart, resources("template[#{agent_config_path}]")
-  end
-  utils_systemd_service_restart "neutron-opflex-agent"
-
-  service "agent-ovs" do
-    action [:enable, :start]
-    subscribes :restart, resources("template[#{opflex_agent_conf}]")
-  end
-  utils_systemd_service_restart "agent-ovs"
+service "lldpd" do
+  action [:enable, :start]
 end
+utils_systemd_service_restart "lldpd"
+
+# include neutron::common_config only now, after we've installed packages
+include_recipe "neutron::common_config"
+
+# Agent configurations for Cisco APIC driver
+# The ACI setup for OpenStack releases before Pike use "of_interface" options
+# set to "ovs-ofctl". This option has been deprecated in Pike and removed
+# from this config file for Pike. It is still included in Newton (Cloud7)
+agent_config_path = "/etc/neutron/plugins/ml2/openvswitch_agent.ini"
+template agent_config_path do
+  cookbook "neutron"
+  source "openvswitch_agent.ini.erb"
+  owner "root"
+  group node[:neutron][:platform][:group]
+  mode "0640"
+  variables(
+    ml2_type_drivers: ml2_type_drivers,
+    ml2_mech_drivers: ml2_mech_drivers,
+    tunnel_types: "",
+    enable_tunneling: false,
+    use_l2pop: false,
+    dvr_enabled: false,
+    of_interface: "ovs-ofctl",
+    ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
+    bridge_mappings: ""
+  )
+end
+
+# Update config file from template
+opflex_agent_conf = "/etc/opflex-agent-ovs/conf.d/10-opflex-agent-ovs.conf"
+apic = neutron[:neutron][:apic]
+opflex_list = apic[:opflex].select { |i| i[:nodes].include? node[:hostname] }
+opflex_list.any? || raise("Opflex instance not found for node '#{node[:hostname]}'")
+opflex_list.one? || raise("Multiple opflex instances found for node '#{node[:hostname]}'")
+opflex = opflex_list.first
+template opflex_agent_conf do
+  cookbook "neutron"
+  source "10-opflex-agent-ovs.conf.erb"
+  mode "0755"
+  owner "root"
+  group neutron[:neutron][:platform][:group]
+  variables(
+    opflex_apic_domain_name: neutron[:neutron][:apic][:system_id],
+    hostname: node[:hostname],
+    socketgroup: neutron[:neutron][:platform][:group],
+    opflex_peer_ip: opflex[:peer_ip],
+    opflex_peer_port: opflex[:peer_port],
+    opflex_vxlan_encap_iface: opflex[:vxlan][:encap_iface],
+    opflex_vxlan_uplink_iface: opflex[:vxlan][:uplink_iface],
+    opflex_vxlan_uplink_vlan: opflex[:vxlan][:uplink_vlan],
+    opflex_vxlan_remote_ip: opflex[:vxlan][:remote_ip],
+    opflex_vxlan_remote_port: opflex[:vxlan][:remote_port],
+    # TODO(mmnelemane) : update VLAN encapsulation config when it works.
+    # Currently set to VXLAN by default but can be modified from proposal.
+    ml2_type_drivers: ml2_type_drivers
+  )
+end
+
+neutron_metadata do
+  use_cisco_apic_ml2_driver true
+  neutron_node_object neutron
+end
+
+service "neutron-opflex-agent" do
+  action [:enable, :start]
+  subscribes :restart, resources("template[#{agent_config_path}]")
+end
+utils_systemd_service_restart "neutron-opflex-agent"
+
+service "agent-ovs" do
+  action [:enable, :start]
+  subscribes :restart, resources("template[#{opflex_agent_conf}]")
+end
+utils_systemd_service_restart "agent-ovs"

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -81,12 +81,10 @@ if neutron[:neutron][:networking_plugin] == "ml2" &&
   end
 end
 
-if neutron[:neutron][:networking_plugin] == "ml2" &&
+# Skip working with regular agents if Cisco ACI is used
+return if neutron[:neutron][:networking_plugin] == "ml2" &&
     (neutron[:neutron][:ml2_mechanism_drivers].include?("cisco_apic_ml2") ||
     neutron[:neutron][:ml2_mechanism_drivers].include?("apic_gbp"))
-  include_recipe "neutron::cisco_apic_agents"
-  return # skip anything else in this recipe
-end
 
 multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty?
 

--- a/chef/cookbooks/neutron/recipes/role_neutron_sdn_cisco_aci_agents.rb
+++ b/chef/cookbooks/neutron/recipes/role_neutron_sdn_cisco_aci_agents.rb
@@ -1,0 +1,19 @@
+#
+# Copyright 2018, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "neutron", "neutron-sdn-cisco-aci-agents")
+  include_recipe "neutron::cisco_apic_agents"
+end

--- a/chef/data_bags/crowbar/migrate/neutron/119_add_cisco_aci_role.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/119_add_cisco_aci_role.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+def upgrade(ta, td, a, d)
+  unless d["element_states"].key?("neutron-sdn-cisco-aci-agents")
+    d["element_states"] = td["element_states"]
+    d["element_order"] = td["element_order"]
+    d["element_run_list_order"] = td["element_run_list_order"]
+
+    if a["networking_plugin"] == "ml2" &&
+        (a["ml2_mechanism_drivers"].include?("cisco_apic_ml2") ||
+        a["ml2_mechanism_drivers"].include?("apic_gbp"))
+      nodes = NodeObject.find("roles:nova-compute-kvm")
+      nodes.each do |node|
+        node.add_to_run_list("neutron-sdn-cisco-aci-agents",
+                             td["element_run_list_order"]["neutron-sdn-cisco-aci-agents"],
+                             td["element_states"]["neutron-sdn-cisco-aci-agents"])
+        node.save
+      end
+    end
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless td["element_states"].key?("neutron-sdn-cisco-aci-agents")
+    d["element_states"] = td["element_states"]
+    d["element_order"] = td["element_order"]
+    d["element_run_list_order"] = td["element_run_list_order"]
+    d["elements"].delete("neutron-sdn-cisco-aci-agents")
+
+    nodes = NodeObject.find("roles:neutron-sdn-cisco-aci-agents")
+    nodes.each do |node|
+      node.delete_from_run_list("neutron-sdn-cisco-aci-agents")
+      node.save
+    end
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -189,19 +189,22 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 118,
+      "schema-revision": 119,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
-        "neutron-network": [ "readying", "ready", "applying" ]
+        "neutron-network": [ "readying", "ready", "applying" ],
+        "neutron-sdn-cisco-aci-agents": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
          ["neutron-server" ],
-         ["neutron-network" ]
+         ["neutron-network" ],
+         ["neutron-sdn-cisco-aci-agents" ]
       ],
       "element_run_list_order": {
         "neutron-server": 94,
-        "neutron-network": 95
+        "neutron-network": 95,
+        "neutron-sdn-cisco-aci-agents": 96
       },
       "config": {
         "environment": "neutron-config-base",

--- a/chef/roles/neutron-sdn-cisco-aci-agents.rb
+++ b/chef/roles/neutron-sdn-cisco-aci-agents.rb
@@ -1,0 +1,4 @@
+name "neutron-sdn-cisco-aci-agents"
+description "Nodes attached to one of the Cisco ACI Leaf Ports"
+
+run_list("recipe[neutron::role_neutron_sdn_cisco_aci_agents]")

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -61,6 +61,16 @@ class NeutronService < OpenstackServiceObject
             "windows" => "/.*/"
           },
           "cluster" => true
+        },
+        "neutron-sdn-cisco-aci-agents" => {
+          "unique" => false,
+          "count" => -1,
+          "admin" => false,
+          "exclude_platform" => {
+            "suse" => "< 12.2",
+            "windows" => "/.*/"
+          },
+          "cluster" => true
         }
       }
     end
@@ -109,8 +119,9 @@ class NeutronService < OpenstackServiceObject
 
     base["deployment"]["neutron"]["elements"] = {
         "neutron-server" => [controller_node[:fqdn]],
-        "neutron-network" => network_nodes.map { |x| x[:fqdn] }
-    } unless nodes.nil? or nodes.length ==0
+        "neutron-network" => network_nodes.map { |x| x[:fqdn] },
+        "neutron-sdn-cisco-aci-agents" => nodes.map { |x| x[:fqdn] }
+    } unless nodes.nil? || nodes.length.zero?
 
     base["attributes"]["neutron"]["service_password"] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
@@ -219,39 +230,6 @@ class NeutronService < OpenstackServiceObject
       validation_error I18n.t("barclamp.#{@bc_name}.validation.vmware_dvs_vlan")
     end
  
-    # Checks for Cisco ACI ml2 driver
-    if ml2_mechanism_drivers.include?("cisco_apic_ml2") &&
-        ml2_mechanism_drivers.include?("apic_gbp")
-      validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_ml2_gbp")
-    end
-
-    if ml2_mechanism_drivers.include?("cisco_apic_ml2") ||
-        ml2_mechanism_drivers.include?("apic_gbp")
-      # openvswitch should not be used when cisco_apic_ml2 mechanism driver is used
-      if ml2_mechanism_drivers.include?("openvswitch")
-        validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_ml2")
-      end
-
-      if ml2_mechanism_drivers.include?("linuxbridge")
-        validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_linuxbridge")
-      end
-
-      # cisco_apic_ml2 mechanism driver needs opflex as the type_driver
-      unless ml2_type_drivers.include?("opflex")
-        validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_type")
-      end
-
-      # Validate if ACI configurations are provided
-      if proposal["attributes"]["neutron"]["apic"].nil? ||
-          proposal["attributes"]["neutron"]["apic"].empty?
-        validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_no_config")
-      end
-
-      # Cisco APIC already distributes neutron services not needing DVR
-      if proposal["attributes"]["neutron"]["use_dvr"]
-        validation_error I18n.t("barcalmp.#{@bc_name}.validation.cisco_apic_dvr")
-      end
-    end
 
     # for now, openvswitch and linuxbrige can't be used in parallel
     if ml2_mechanism_drivers.include?("openvswitch") &&
@@ -332,6 +310,48 @@ class NeutronService < OpenstackServiceObject
     end
   end
 
+  def validate_cisco_aci(proposal)
+    # Checks for Cisco ACI ml2 driver
+    ml2_mechanism_drivers = proposal["attributes"]["neutron"]["ml2_mechanism_drivers"]
+    ml2_type_drivers = proposal["attributes"]["neutron"]["ml2_type_drivers"]
+
+    if ml2_mechanism_drivers.include?("cisco_apic_ml2") &&
+        ml2_mechanism_drivers.include?("apic_gbp")
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_ml2_gbp")
+    end
+
+    if ml2_mechanism_drivers.include?("cisco_apic_ml2") ||
+        ml2_mechanism_drivers.include?("apic_gbp")
+
+      validate_at_least_n_for_role proposal, "neutron-sdn-cisco-aci-agents", 1
+
+      # openvswitch should not be used when cisco_apic_ml2 mechanism driver is used
+      if ml2_mechanism_drivers.include?("openvswitch")
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_ml2")
+      end
+
+      if ml2_mechanism_drivers.include?("linuxbridge")
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_linuxbridge")
+      end
+
+      # cisco_apic_ml2 mechanism driver needs opflex as the type_driver
+      unless ml2_type_drivers.include?("opflex")
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_type")
+      end
+
+      # Validate if ACI configurations are provided
+      if proposal["attributes"]["neutron"]["apic"].nil? ||
+          proposal["attributes"]["neutron"]["apic"].empty?
+        validation_error I18n.t("barclamp.#{@bc_name}.validation.cisco_apic_no_config")
+      end
+
+      # Cisco APIC already distributes neutron services not needing DVR
+      if proposal["attributes"]["neutron"]["use_dvr"]
+        validation_error I18n.t("barcalmp.#{@bc_name}.validation.cisco_apic_dvr")
+      end
+    end
+  end
+
   def validate_external_networks(external_networks)
     net_svc = NetworkService.new @logger
     network_proposal = Proposal.find_by(barclamp: net_svc.bc_name, name: "default")
@@ -374,6 +394,7 @@ class NeutronService < OpenstackServiceObject
     validate_ml2(proposal) if plugin == "ml2"
     validate_l2pop(proposal)
     validate_dvr(proposal)
+    validate_cisco_aci(proposal)
     if proposal[:attributes][:neutron][:use_infoblox]
       validate_infoblox(proposal)
     end


### PR DESCRIPTION
So far, the implementation assumed that only compute nodes
would be attached to the ACI leaf ports and the controller
nodes are independently attached to the network not connected
to the ACI fabric itself. The only form of communication from
the controller to the ACI is through the agents. However,
recent customer POCs have changed our assumption since these
setups expect all or most of the nodes attached the ACI leaf
as the ACI fabric forms the central network infrastructure
of the entire deployment. In such scenarios, we need a mechanism
where we can know which of the nodes are attached to the ACI
leaf and which nodes are not. The agents should be enabled
and run on each node attached to the ACI leaf ports.
This commit tries to achieve exactly this result, so that
future deployments can flexibly allow any node attached to
the fabric.

(cherry picked from commit d4d635eefd2dbbef5f355316ea302af04b57cf66)