### PR TITLE
mysql: create .my.cnf in root home directory for mysql cmdline

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -289,7 +289,7 @@ execute "assign-root-password-galera" do
     password \"#{node[:database][:mysql][:server_root_password]}\""
   action :run
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  only_if "/usr/bin/mysql -u root -e 'show databases;'"
+  only_if "/usr/bin/mysql --no-defaults -u root -e 'select (1);'"
 end
 
 crowbar_pacemaker_sync_mark "sync-database_root_password" do

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -177,7 +177,7 @@ execute "assign-root-password" do
   command "/usr/bin/mysqladmin -u root password \"#{server_root_password}\""
   action :run
   not_if { ha_enabled } # password already set as part of the ha bootstrap
-  only_if "/usr/bin/mysql -u root -e 'show databases;'"
+  only_if "/usr/bin/mysql --no-defaults -u root -e 'select (1);'"
 end
 
 db_settings = fetch_database_settings
@@ -275,4 +275,14 @@ directory "/var/run/mysqld/" do
   group "root"
   mode "0755"
   action :create
+end
+
+template "/root/.my.cnf" do
+  source "root-my.cnf.erb"
+  owner "root"
+  group "root"
+  mode "0600"
+  variables(
+    password: node[:database][:mysql][:server_root_password]
+  )
 end

--- a/chef/cookbooks/mysql/templates/default/root-my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/root-my.cnf.erb
@@ -1,0 +1,5 @@
+# Managed by Crowbar
+[client]
+socket = /var/run/mysql/mysql.sock
+user = root
+password = <%= @password %>


### PR DESCRIPTION
Searching for the mysql database root password can be a major
pain, so just store it in ~/.my.cnf so that mysql defaults
to it and everything just works when you're root on the controller.

As you can change the password when you're root, this shouldn't
be an additional security hassle.