### PR TITLE
[4.0] rabbitmq: active the haproxy balancing

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -68,3 +68,7 @@ end
 
 # create empty users list as it is expected by some recipes
 default[:rabbitmq][:users] = []
+
+# Ports to bind to when haproxy is used for the real ports
+default[:rabbitmq][:ha][:ports][:api] = 5630
+default[:rabbitmq][:ha][:ports][:api_ssl] = 5631

--- a/chef/cookbooks/rabbitmq/providers/vhost.rb
+++ b/chef/cookbooks/rabbitmq/providers/vhost.rb
@@ -19,6 +19,9 @@
 
 action :add do
   unless Kernel::system("rabbitmqctl list_vhosts | grep -q #{new_resource.vhost}")
+    # wait for service to have a master, and to be active
+    CrowbarPacemakerHelper.wait_until_rabbitmq_ready
+
     Chef::Log.info "Adding RabbitMQ vhost '#{new_resource.vhost}'."
     execute "rabbitmqctl add_vhost #{new_resource.vhost}"
     new_resource.updated_by_last_action(true)

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -22,8 +22,16 @@ ha_enabled = node[:rabbitmq][:ha][:enabled]
 # we only do cluster if we do HA
 cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
 quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
-crm_resource_stop_cmd = cluster_enabled ? "force-demote" : "force-stop"
-crm_resource_start_cmd = cluster_enabled ? "force-promote" : "force-start"
+crm_resource_stop_cmd = "force-stop"
+crm_resource_start_cmd = "force-start"
+
+if node[:rabbitmq][:ha][:haproxy_enabled] && cluster_enabled
+  rabbitmq_port = node[:rabbitmq][:ha][:ports][:api]
+  rabbitmq_ssl_port = node[:rabbitmq][:ha][:ports][:api_ssl]
+else
+  rabbitmq_port = node[:rabbitmq][:port]
+  rabbitmq_ssl_port = node[:rabbitmq][:ssl][:port]
+end
 
 cluster_partition_handling = if cluster_enabled
   if CrowbarPacemakerHelper.num_corosync_nodes(node) > 2
@@ -110,7 +118,9 @@ template "/etc/rabbitmq/rabbitmq.config" do
   variables(
     cluster_enabled: cluster_enabled,
     cluster_partition_handling: cluster_partition_handling,
-    hipe_compile: hipe_compile
+    hipe_compile: hipe_compile,
+    rabbitmq_port: rabbitmq_port,
+    rabbitmq_ssl_port: rabbitmq_ssl_port
   )
   notifies :restart, "service[rabbitmq-server]"
 end

--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -108,6 +108,13 @@ end
 
 transaction_objects = []
 
+rabbitmq_port = if node[:rabbitmq][:ha][:haproxy_enabled]
+  node[:rabbitmq][:ha][:ports][:api]
+else
+  node[:rabbitmq][:port]
+end
+
+service_name = "rabbitmq"
 pacemaker_primitive service_name do
   agent agent_name
   # nodename is empty so that we explicitly depend on the config files
@@ -117,7 +124,8 @@ pacemaker_primitive service_name do
     "policy_file" => "/etc/rabbitmq/ocf-promote",
     "rmq_feature_health_check" => node[:rabbitmq][:ha][:clustered_rmq_features],
     "rmq_feature_local_list_queues" => node[:rabbitmq][:ha][:clustered_rmq_features],
-    "default_vhost" => node[:rabbitmq][:vhost]
+    "default_vhost" => node[:rabbitmq][:vhost],
+    "node_port" => rabbitmq_port
   })
   op node[:rabbitmq][:ha][:clustered_op]
   meta ({
@@ -127,6 +135,7 @@ pacemaker_primitive service_name do
   })
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  notifies :restart, "service[rabbitmq-server]", :immediately
 end
 transaction_objects.push("pacemaker_primitive[#{service_name}]")
 
@@ -159,3 +168,57 @@ pacemaker_transaction "rabbitmq service" do
 end
 
 crowbar_pacemaker_sync_mark "create-rabbitmq_ha_resources"
+
+# wait for all nodes the first time haproxy is enabled to be sure to have the ports in the ha
+# information of the node used by CrowbarPacemakerHelper.haproxy_servers_for_service
+crowbar_pacemaker_sync_mark "sync-rabbitmq_haproxy_enabled"
+
+if node[:rabbitmq][:ha][:haproxy_enabled]
+  include_recipe "crowbar-pacemaker::haproxy"
+
+  cluster_admin_ip = CrowbarPacemakerHelper.cluster_vip(node, "admin")
+
+  haproxy_loadbalancer "rabbitmq" do
+    address node[:rabbitmq][:listen_public] ? "0.0.0.0" : cluster_admin_ip
+    port node[:rabbitmq][:port]
+    mode "tcp"
+    servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "rabbitmq",
+      "rabbitmq-server", "api")
+    action :nothing
+  end.run_action(:create)
+
+  if node[:rabbitmq][:ssl][:enabled]
+    haproxy_loadbalancer "rabbitmq-ssl" do
+      address node[:rabbitmq][:listen_public] ? "0.0.0.0" : cluster_admin_ip
+      port node[:rabbitmq][:ssl][:port]
+      use_ssl true
+      mode "tcp"
+      servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "rabbitmq",
+        "rabbitmq-server", "api_ssl")
+      action :nothing
+    end.run_action(:create)
+  end
+
+  unless node[:rabbitmq][:listen_public]
+    haproxy_loadbalancer "rabbitmq-local" do
+      address node[:rabbitmq][:address]
+      port node[:rabbitmq][:port]
+      mode "tcp"
+      servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "rabbitmq",
+        "rabbitmq-server", "api")
+      action :nothing
+    end.run_action(:create)
+
+    if node[:rabbitmq][:ssl][:enabled]
+      haproxy_loadbalancer "rabbitmq-local-ssl" do
+        address node[:rabbitmq][:address]
+        port node[:rabbitmq][:ssl][:port]
+        use_ssl true
+        mode "tcp"
+        servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "rabbitmq",
+          "rabbitmq-server", "api_ssl")
+        action :nothing
+      end.run_action(:create)
+    end
+  end
+end

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -15,11 +15,11 @@
                         ]
    },
    {tcp_listeners, [
-                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:port]}}" }.join(", ") %>
+                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{@rabbitmq_port}}" }.join(", ") %>
                    ]},
 <% if node[:rabbitmq][:ssl][:enabled] -%>
    {ssl_listeners, [
-                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:ssl][:port]}}" }.join(", ") %>
+                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{@rabbitmq_ssl_port}}" }.join(", ") %>
                    ]},
    {ssl_options, [
    <% if node[:rabbitmq][:ssl][:cert_required] -%>

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -100,6 +100,17 @@ class RabbitmqService < OpenstackServiceObject
 
     role.save if save_role
 
+    # if no previous configuration of haproxy_enable, active if the proposal is not already applied
+    if old_role.nil?
+      haproxy_enabled = true
+    else
+      haproxy_enabled = old_role.default_attributes[@bc_name]["ha"]["haproxy_enabled"]
+      haproxy_enabled = false if haproxy_enabled.nil?
+    end
+
+    role.default_attributes[@bc_name]["ha"]["haproxy_enabled"] = haproxy_enabled
+    role.save
+
     rabbitmq_elements, rabbitmq_nodes, rabbitmq_ha_enabled = role_expand_elements(role, "rabbitmq-server")
     Openstack::HA.set_controller_role(rabbitmq_nodes) if rabbitmq_ha_enabled
 
@@ -134,7 +145,21 @@ class RabbitmqService < OpenstackServiceObject
         (old_role && old_role.default_attributes["rabbitmq"]["erlang_cookie"]) || random_password
     end
 
-    unless rabbitmq_ha_enabled
+    if rabbitmq_ha_enabled
+      if role.default_attributes["rabbitmq"]["cluster"] &&
+          role.default_attributes["rabbitmq"]["ha"]["haproxy_enabled"]
+        vip_networks = ["admin"]
+        vip_networks << "public" if role.default_attributes["rabbitmq"]["listen_public"]
+
+        allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(rabbitmq_elements,
+          vip_networks)
+
+        dirty = prepare_role_for_ha_with_haproxy(role, ["rabbitmq", "ha", "haproxy"],
+          rabbitmq_ha_enabled, rabbitmq_elements, vip_networks)
+
+        role.save if dirty
+      end
+    else
       # cluster mode requires HA (for now); don't do a validation check as we
       # still want to have the setting default to true in case people want to
       # turn HA on, and in this case, result in clustering by default


### PR DESCRIPTION
Enable balancing connections using haproxy in a cluster of rabbitmq

(cherry picked from commit a4ebcfe603bc03c1c9c1fa32857987e4b40c7666)