### PR TITLE
[4.0] copytruncate apache logs instead of creating

### DIFF
--- a/chef/cookbooks/horizon/templates/default/openstack-dashboard.logrotate.erb
+++ b/chef/cookbooks/horizon/templates/default/openstack-dashboard.logrotate.erb
@@ -1,27 +1,21 @@
 /var/log/apache2/openstack-dashboard-access_log {
     compress
+    copytruncate
     dateext
     maxage 365
     rotate 99
     size=+4096k
     notifempty
     missingok
-    create 644 root root
-    postrotate
-     /etc/init.d/apache2 reload
-    endscript
 }
 
 /var/log/apache2/openstack-dashboard-error_log {
     compress
+    copytruncate
     dateext
     maxage 365
     rotate 99
     size=+1024k
     notifempty
     missingok
-    create 644 root root
-    postrotate
-     /etc/init.d/apache2 reload
-    endscript
 }


### PR DESCRIPTION
apache2 reload causes responses 406 from keystone

bso#1083093

(cherry picked from commit cfda2347d15a16dfccbd69f0cdd08cbf0a9e31de)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1581