### PR TITLE
[4.0] database: UI for mysql and/or postgresql

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/database/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/database/application.js
@@ -38,15 +38,20 @@ $(document).ready(function($) {
       $(selector).hide(100).attr('disabled', 'disabled');
       $(current).show(100).removeAttr('disabled');
 
-      // update sql_engine if only one engine was selected and default to mysql if no roles are assigned
-      var activeEngine = $('#sql_engine').val();
-      if (currentEngines.length === 1) {
-        activeEngine = currentEngines[0];
-      } else if (currentEngines.length === 0) {
-        activeEngine = 'mysql';
+      // automatically select active engine only for new proposals
+      // note that this check is not perfect and will trigger autoselect also for saved but not applied
+      // proposals (even old ones).
+      if ($('#proposal_deployment').readJsonAttribute('crowbar-applied') === false) {
+        // update sql_engine if only one engine was selected and default to mysql if no roles are assigned
+        var activeEngine = $('#sql_engine').val();
+        if (currentEngines.length === 1) {
+          activeEngine = currentEngines[0];
+        } else if (currentEngines.length === 0) {
+          activeEngine = 'mysql';
+        }
+        $('#sql_engine').val(activeEngine);
+        $('#proposal_attributes').writeJsonAttribute('sql_engine', activeEngine);
       }
-      $('#sql_engine').val(activeEngine);
-      $('#proposal_attributes').writeJsonAttribute('sql_engine', activeEngine);
 
       // make sure all items have handlers attached
       setupEventHandlers();

--- a/crowbar_framework/app/assets/javascripts/barclamps/database/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/database/application.js
@@ -1,6 +1,6 @@
 /**
  * Copyright 2011-2013, Dell
- * Copyright 2013-2014, SUSE LINUX Products GmbH
+ * Copyright 2013-2018, SUSE LINUX Products GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,38 @@
  */
 
 $(document).ready(function($) {
-  $('#sql_engine').on('change', function() {
-    var value = $(this).val();
+  function updateDBEngines() {
+    // defer update of selected engines to make sure roles assignment
+    // is updated by event handlers from NodeList.
+    setTimeout(function() {
+      var nodes = {
+        postgresql: $('ul#database-server li').length,
+        mysql: $('ul#mysql-server li').length
+      };
 
-    var types = [
-      'mysql',
-      'postgresql'
-    ];
+      var selector = $.map(nodes, function(val, index) {
+        return '#{0}_container'.format(index);
+      }).join(', ');
 
-    var selector = $.map(types, function(val, index) {
-      return '#{0}_container'.format(val);
-    }).join(', ');
+      var current = $.map($.grep(Object.keys(nodes), function(val) {
+        return nodes[val] > 0;
+      }), function(val, index) {
+        return '#{0}_container'.format(val);
+      }).join(', ');
 
-    var current = '#{0}_container'.format(
-      value
-    );
+      $(selector).hide(100).attr('disabled', 'disabled');
+      $(current).show(100).removeAttr('disabled');
 
-    $(selector).hide(100).attr('disabled', 'disabled');
-    $(current).show(100).removeAttr('disabled');
-  }).trigger('change');
+      // make sure all items have handlers attached
+      setupEventHandlers();
+    }, 0);
+  }
+
+  function setupEventHandlers() {
+    $('[data-droppable=true]').off('drop', updateDBEngines).on('drop', updateDBEngines);
+    $('.dropzone .delete').off('click', updateDBEngines).on('click', updateDBEngines);
+    $('.dropzone .unassign').off('click', updateDBEngines).on('click', updateDBEngines);
+  }
+
+  updateDBEngines();
 });

--- a/crowbar_framework/app/assets/javascripts/barclamps/database/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/database/application.js
@@ -29,14 +29,24 @@ $(document).ready(function($) {
         return '#{0}_container'.format(index);
       }).join(', ');
 
-      var current = $.map($.grep(Object.keys(nodes), function(val) {
-        return nodes[val] > 0;
-      }), function(val, index) {
+      var currentEngines = $.grep(Object.keys(nodes), function(val) { return nodes[val] > 0; });
+
+      var current = $.map(currentEngines, function(val, index) {
         return '#{0}_container'.format(val);
       }).join(', ');
 
       $(selector).hide(100).attr('disabled', 'disabled');
       $(current).show(100).removeAttr('disabled');
+
+      // update sql_engine if only one engine was selected and default to mysql if no roles are assigned
+      var activeEngine = $('#sql_engine').val();
+      if (currentEngines.length === 1) {
+        activeEngine = currentEngines[0];
+      } else if (currentEngines.length === 0) {
+        activeEngine = 'mysql';
+      }
+      $('#sql_engine').val(activeEngine);
+      $('#proposal_attributes').writeJsonAttribute('sql_engine', activeEngine);
 
       // make sure all items have handlers attached
       setupEventHandlers();

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -84,6 +84,10 @@ class DatabaseService < PacemakerServiceObject
     end
   end
 
+  def already_applied?(proposal_name="default")
+    !RoleObject.find_role_by_name("#{@bc_name}-config-#{proposal_name}").nil?
+  end
+
   def validate_ha_attributes(attributes, cluster, sql_engine)
     role = available_clusters[cluster]
 
@@ -151,7 +155,7 @@ class DatabaseService < PacemakerServiceObject
 
     validation_error I18n.t(
       "barclamp.#{@bc_name}.validation.new_proposal_multi_engine"
-    ) if selected_engines.length > 1 && !proposal["deployment"]["crowbar-applied"]
+    ) if selected_engines.length > 1 && !already_applied?
 
     validation_error I18n.t(
       "barclamp.#{@bc_name}.validation.engine_roles_mismatch",

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -76,10 +76,18 @@ class DatabaseService < PacemakerServiceObject
     base
   end
 
-  def validate_ha_attributes(attributes, cluster)
+  def role_for_engine(engine)
+    if engine == "postgresql"
+      "database-server"
+    else
+      "mysql-server"
+    end
+  end
+
+  def validate_ha_attributes(attributes, cluster, sql_engine)
     role = available_clusters[cluster]
 
-    case attributes["sql_engine"]
+    case sql_engine
     when "postgresql"
       ha_attr = attributes["postgresql"]["ha"]
       storage_mode = ha_attr["storage"]["mode"]
@@ -129,26 +137,38 @@ class DatabaseService < PacemakerServiceObject
 
   def validate_proposal_after_save(proposal)
     attributes = proposal["attributes"][@bc_name]
-    sql_engine = attributes["sql_engine"]
-    db_role = if sql_engine == "postgresql"
-      "database-server"
-    else
-      "mysql-server"
-    end
-    validate_one_for_role proposal, db_role
+    active_engine = attributes["sql_engine"]
 
     validation_error I18n.t(
       "barclamp.#{@bc_name}.validation.invalid_db_engine",
-      db_engine: sql_engine
-    ) unless ["mysql", "postgresql"].include?(sql_engine)
+      db_engine: active_engine
+    ) unless ["mysql", "postgresql"].include?(active_engine)
 
-    # HA validation
-    servers = proposal["deployment"][@bc_name]["elements"][db_role]
-    unless servers.nil? || servers.first.nil? || !is_cluster?(servers.first)
-      cluster = servers.first
-      validate_ha_attributes(attributes, cluster)
+    selected_engines = ["postgresql", "mysql"].select do |engine|
+      nodes = proposal["deployment"][@bc_name]["elements"][role_for_engine engine]
+      !nodes.nil? && !nodes.first.nil?
     end
 
+    validation_error I18n.t(
+      "barclamp.#{@bc_name}.validation.engine_roles_mismatch",
+      db_engine: active_engine
+    ) unless selected_engines.include?(active_engine)
+
+    validation_error I18n.t(
+      "barclamp.#{@bc_name}.validation.secondary_psql"
+    ) if selected_engines.length > 1 && active_engine == "mysql"
+
+    selected_engines.each do |engine|
+      db_role = role_for_engine engine
+      validate_one_for_role proposal, db_role
+
+      # HA validation
+      servers = proposal["deployment"][@bc_name]["elements"][db_role]
+      unless servers.nil? || servers.first.nil? || !is_cluster?(servers.first)
+        cluster = servers.first
+        validate_ha_attributes(attributes, cluster, engine)
+      end
+    end
     super
   end
 
@@ -172,11 +192,7 @@ class DatabaseService < PacemakerServiceObject
       }
     }
     ["postgresql", "mysql"].each do |engine|
-      db_role = if engine == "postgresql"
-        "database-server"
-      else
-        "mysql-server"
-      end
+      db_role = role_for_engine engine
       database_elements, database_nodes, database_ha_enabled = role_expand_elements(role, db_role)
       db_enabled[engine]["enabled"] = true unless database_nodes.empty?
       db_enabled[engine]["ha"] = database_ha_enabled

--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -150,6 +150,10 @@ class DatabaseService < PacemakerServiceObject
     end
 
     validation_error I18n.t(
+      "barclamp.#{@bc_name}.validation.new_proposal_multi_engine"
+    ) if selected_engines.length > 1 && !proposal["deployment"]["crowbar-applied"]
+
+    validation_error I18n.t(
       "barclamp.#{@bc_name}.validation.engine_roles_mismatch",
       db_engine: active_engine
     ) unless selected_engines.include?(active_engine)

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -3,6 +3,8 @@
     = header show_raw_deployment?, true
 
   .panel-body
+    = string_field :sql_engine, disabled: true
+
     #mysql_container
       %fieldset
         %legend

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -8,49 +8,54 @@
 
     = string_field :sql_engine, disabled: true
 
-    #mysql_container
-      %fieldset
-        %legend
+    %ul.list-group#mysql_container
+      %li.list-group-item.active
+        %h3.list-group-item-heading
           = t('.mysql_attributes')
 
-        = integer_field %w(mysql max_connections)
-        = integer_field %w(mysql expire_logs_days)
-        = boolean_field %w(mysql slow_query_logging)
+      %li.list-group-item
+        %fieldset
+          = integer_field %w(mysql max_connections)
+          = integer_field %w(mysql expire_logs_days)
+          = boolean_field %w(mysql slow_query_logging)
 
-      %fieldset{ "style" => "display:none" }
-        %legend
-          = t(".mysql.ssl_header")
+        %fieldset{ "style" => "display:none" }
+          %legend
+            = t(".mysql.ssl_header")
 
-        = boolean_field %w(mysql ssl enabled),
-          "data-sslprefix" => "ssl"
+          = boolean_field %w(mysql ssl enabled),
+            "data-sslprefix" => "ssl"
 
-        #ssl_container
-          = boolean_field %w(mysql ssl generate_certs)
-          = string_field %w(mysql ssl certfile)
-          = string_field %w(mysql ssl keyfile)
-          = boolean_field %w(mysql ssl insecure)
-          = string_field %w(mysql ssl ca_certs)
+          #ssl_container
+            = boolean_field %w(mysql ssl generate_certs)
+            = string_field %w(mysql ssl certfile)
+            = string_field %w(mysql ssl keyfile)
+            = boolean_field %w(mysql ssl insecure)
+            = string_field %w(mysql ssl ca_certs)
 
-    #postgresql_container
-      %fieldset
-        %legend
+    %ul.list-group#postgresql_container
+      %li.list-group-item.active
+        %h3.list-group-item-heading
           = t('.postgresql_attributes')
 
-        = integer_field %w(postgresql config max_connections)
+      %li.list-group-item
+        %fieldset
+          = integer_field %w(postgresql config max_connections)
 
-      -# As HA is only supported for postgresql, we put this section in #postgresql_container
-      %fieldset#ha-setup{ "data-show-for-clusters-only" => "true", "data-elements-path" => "database-server" }
-        %legend
-          = t('.ha_header')
+        -# As HA is only supported for postgresql, we put this section in #postgresql_container
+        %fieldset#ha-setup{ "data-show-for-clusters-only" => "true", "data-elements-path" => "database-server" }
+          %legend
+            = t('.ha_header')
 
-        = select_field %w(postgresql ha storage mode), :collection => :ha_storage_mode_for_database, "data-showit" => ["drbd", "shared"].join(";"), "data-showit-target" => "#drbd_storage_container;#shared_storage_container", "data-showit-direct" => "true"
+          = select_field %w(postgresql ha storage mode), :collection => :ha_storage_mode_for_database, "data-showit" => ["drbd", "shared"].join(";"), "data-showit-target" => "#drbd_storage_container;#shared_storage_container", "data-showit-direct" => "true"
 
-        #drbd_storage_container
-          .alert.alert-info
-            = t('.postgresql.ha.storage.drbd_info')
-          = integer_field %w(postgresql ha storage drbd size)
+          #drbd_storage_container
+            .alert.alert-info
+              = t('.postgresql.ha.storage.drbd_info')
+            = integer_field %w(postgresql ha storage drbd size)
 
-        #shared_storage_container
-          = string_field %w(postgresql ha storage shared device)
-          = string_field %w(postgresql ha storage shared fstype)
-          = string_field %w(postgresql ha storage shared options)
+          #shared_storage_container
+            = string_field %w(postgresql ha storage shared device)
+            = string_field %w(postgresql ha storage shared fstype)
+            = string_field %w(postgresql ha storage shared options)
+

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -3,6 +3,9 @@
     = header show_raw_deployment?, true
 
   .panel-body
+    .alert.alert-warning
+      = t(".engine_upgrade")
+
     = string_field :sql_engine, disabled: true
 
     #mysql_container

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -3,8 +3,6 @@
     = header show_raw_deployment?, true
 
   .panel-body
-    = select_field :sql_engine, :collection => :engines_for_database
-
     #mysql_container
       %fieldset
         %legend

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -66,3 +66,4 @@ en:
         cluster_size_even: 'The Galera cluster needs an odd number of cluster members and at least three of them.'
         engine_roles_mismatch: 'Assigned roles do not match selected database engine: %{db_engine}.'
         secondary_psql: 'PostgreSQL can only be deployed as first SQL engine. Migration from MariaDB to PostgreSQL is not supported.'
+        new_proposal_multi_engine: 'Second SQL engine can only be added to an existing database deployment.'

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -21,7 +21,7 @@ en:
   barclamp:
     database:
       edit_attributes:
-        sql_engine: 'SQL Engine'
+        sql_engine: 'Active SQL Engine'
         mysql_attributes: 'MariaDB Options'
         mysql:
           datadir: 'Datadir'

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -21,6 +21,7 @@ en:
   barclamp:
     database:
       edit_attributes:
+        engine_upgrade: 'Deployment of multiple database engines at the same time is only supported before SUSE OpenStack Cloud 8 upgrade to allow the migration from PostgreSQL to MariaDB. Please refer to the SUSE OpenStack Cloud documentation for more information about the upgrade procedure.'
         sql_engine: 'Active SQL Engine'
         mysql_attributes: 'MariaDB Options'
         mysql:

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -64,3 +64,5 @@ en:
         invalid_size_drbd: 'Invalid size for DRBD device.'
         cluster_size_one: 'The Galera cluster needs more than one cluster member.'
         cluster_size_even: 'The Galera cluster needs an odd number of cluster members and at least three of them.'
+        engine_roles_mismatch: 'Assigned roles do not match selected database engine: %{db_engine}.'
+        secondary_psql: 'PostgreSQL can only be deployed as first SQL engine. Migration from MariaDB to PostgreSQL is not supported.'


### PR DESCRIPTION
Barclamp UI was modified to show custom view of MySQL and/or
PostgreSQL depending on assigned roles.

Extra features:
- automatic assignment of active sql engine based on roles (new proposals only)
- model validation on save
- added borders around each engine parameters section to avoid confusion