### PR TITLE
rabbitmq: set client timout to default value

### DIFF
--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -21,7 +21,7 @@
         "client_ca_certs": "/etc/ssl/certs/rabbitca.pem"
       },
       "client": {
-        "heartbeat_timeout": 10
+        "heartbeat_timeout": 60
       },
       "cluster": true,
       "ha": {


### PR DESCRIPTION
A very low client timeout can lead to multiple disconnections of
the clients due to missing heartbeats, depending on the load on the
rabbit nodes. Instead of configuring the clients with a very low
value, lets just use the default openstack values for safety