### PR TITLE
[4.0] database: Make sure correct role is assigned when creating new proposal

### DIFF
--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -56,13 +56,18 @@ class DatabaseService < PacemakerServiceObject
   def create_proposal
     @logger.debug("Database create_proposal: entering")
     base = super
+    db_role = if base["attributes"]["sql_engine"] == "mysql"
+      "mysql-server"
+    else
+      "database-server"
+    end
 
     nodes = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }
     if nodes.size >= 1
       controller = nodes.find { |n| n.intended_role == "controller" } || nodes.first
       base["deployment"]["database"]["elements"] = {
-        "database-server" => [controller[:fqdn]]
+        db_role => [controller[:fqdn]]
       }
     end
 


### PR DESCRIPTION
If sql_engine is already set before creating proposal (e.g. by mkcloud)
it should be honored when auto-assigning the database role.