### PR TITLE
neutron: add force_metadata attribute

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -153,7 +153,8 @@ template node[:neutron][:dhcp_agent_config_file] do
     dns_domain: node[:neutron][:dns_domain],
     enable_isolated_metadata: "True",
     enable_metadata_network: "False",
-    nameservers: dns_list
+    nameservers: dns_list,
+    force_metadata: node[:neutron][:metadata][:force]
   )
 end
 

--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -4,6 +4,7 @@ resync_interval = <%= @resync_interval %>
 dhcp_driver = <%= @dhcp_driver %>
 enable_isolated_metadata = <%= @enable_isolated_metadata %>
 enable_metadata_network = <%= @enable_metadata_network %>
+force_metadata = <%= @force_metadata %>
 dns_domain = <%= @dns_domain %>
 <% if @nameservers -%>
 dnsmasq_dns_servers = <%= @nameservers %>

--- a/chef/data_bags/crowbar/migrate/neutron/210_add_force_metadata_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/210_add_force_metadata_attributes.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["metadata"] = ta["metadata"] unless a.key? "metadata"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("metadata") unless ta.key? "metadata"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -178,6 +178,9 @@
       },
       "ha_rate_limit": {
         "neutron-server": 0
+      },
+      "metadata": {
+        "force": false
       }
     }
   },
@@ -185,7 +188,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 209,
+      "schema-revision": 210,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -51,7 +51,7 @@
                       "username": { "type" : "str", "required": true },
                       "password": { "type" : "str", "required": true },
                       "optimized_metadata": { "type" : "bool", "required": true },
-                      "optimized_dhcp": { "type" : "bool", "required": true }, 
+                      "optimized_dhcp": { "type" : "bool", "required": true },
                       "vpc_pairs": { "type": "str", "required": false },
                       "ext_net": { "type" : "map", "required" : true, "mapping" : {
                           "name": { "type" : "str", "required" : true },
@@ -220,6 +220,11 @@
                     "ha_rate_limit": {
                       "type": "map", "required": true, "mapping": {
                         "neutron-server": { "type": "int", "required": true }
+                      }
+                    },
+                    "metadata": {
+                      "type": "map", "required": true, "mapping": {
+                        "force": { "type": "bool", "required": true }
                       }
                     }
               }}


### PR DESCRIPTION
This changes allows to force_metadata from the proposal. Previously, if this attribute was added directly to configuration in neutron network nodes, it was removed from the config in each chef-client execution