### PR TITLE
mariadb: Set mariadb as the default database

### DIFF
--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -3,7 +3,7 @@
   "description": "Installation for Database",
   "attributes": {
     "database": {
-      "sql_engine": "postgresql",
+      "sql_engine": "mysql",
       "mysql": {
         "datadir": "/var/lib/mysql",
         "slow_query_logging": true,


### PR DESCRIPTION
In Cloud 8 we will use maridb as the default and only supported database
for OpenStack. This change sets the database to mysql (mariadb).

(cherry picked from commit b72823f3abbb8349582188d6af62824dab6021e3)