### PR TITLE
rabbitmq: fix extra users password regeneration

### DIFF
--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -83,11 +83,11 @@ class RabbitmqService < OpenstackServiceObject
         permissions: user["permissions"]
       }
       if !old_attrs.nil? && old_attrs.include?("users") && !old_attrs["users"].each.select do |u|
-        u["username"] == user["username"]
+        u["username"] == username
       end.empty?
         # reuse the existing pass
         pass = old_attrs["users"].each.select do |u|
-          u["username"] == user["username"]
+          u["username"] == username
         end.first["password"]
 
         updated_user.update(password: pass)


### PR DESCRIPTION
Every time the rabbitmq proposal was applied the extra users
passwords was regenerated. Featured introduced in #1506

This fix mantain the paswords.