### PR TITLE
[4.0] rabbitmq: fix extra users password regeneration

### DIFF
--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -83,11 +83,11 @@ class RabbitmqService < OpenstackServiceObject
         permissions: user["permissions"]
       }
       if !old_attrs.nil? && old_attrs.include?("users") && !old_attrs["users"].each.select do |u|
-        u["username"] == user["username"]
+        u["username"] == username
       end.empty?
         # reuse the existing pass
         pass = old_attrs["users"].each.select do |u|
-          u["username"] == user["username"]
+          u["username"] == username
         end.first["password"]
 
         updated_user.update(password: pass)


### PR DESCRIPTION
Every time the rabbitmq proposal was applied the extra users
passwords was regenerated.  Featured introduced in #1511

This fix mantain the paswords.

(cherry picked from commit a2f7ac68262a5f02665c671a6b90a91b06bf0f6e)

Backported from #1723