### PR TITLE
[4.0] keystone: HA founder to always rsync fernet keys

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -528,13 +528,6 @@ if node[:keystone][:signing][:token_format] == "fernet"
       action :run
       only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
     end
-
-    # We would like to propagate fernet keys to all nodes in the cluster
-    execute "propagate fernet keys to all nodes in the cluster" do
-      command rsync_command
-      action :run
-      only_if { ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node) }
-    end
   end
 
   service_transaction_objects = []
@@ -564,6 +557,13 @@ if node[:keystone][:signing][:token_format] == "fernet"
   end
 
   crowbar_pacemaker_sync_mark "create-keystone_fernet_rotate" if ha_enabled
+
+  # We would like to propagate fernet keys to all nodes in the cluster
+  execute "propagate fernet keys to all nodes in the cluster" do
+    command rsync_command
+    action :run
+    only_if { ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
 end
 
 # Wait for all nodes to reach this point so we know that all nodes will have


### PR DESCRIPTION
Currently if the founder doesn't have any fernet keys, it'll generate
them and then rsync them to the other members.
When adding a new member to an existing pacemaker cluster this rsync
wont happen. So the new member has to wait for one of the other
members fernet sync crontabs to fire and sync the keys.

However, when adding a new member to the cluster, the original members
will be put into maintenence mode. Leaving the new member to respond to
keystone requests. If this node doesn't have the fernet keys when
receiving requests, those requests will fail.

This patch, instead of only rysncing across the cluster when the
founder doesn't have any keys, it now will rsync on each run. Meaning
the keys will be there when the new member needs to respond to requests.

This was happening when adding a new cluster member and
crowbar-pacemaker wanted to regisiter servers to keystone.

Currently there is a script placed on each memeber's crontab to rsync
fernet keys. Which seems kind of redundent with this change. It would be
better if we could change the founder to only rsync keys when it
doesn't have them or a new member has been added.
Question: Is there a way to know that state? Something built in? or
do we just look for any nodes not in maintenance?

There is another PR [0] related to this issue in crowbar-ha. Where we need
to ensure the other cluster node's ssh public keys have been added to
the new member's authorized_keys, which might not happen in time.

[0] - https://github.com/crowbar/crowbar-ha/pull/319