### PR TITLE
keystone: Fix missing keystone migration (bsc#1104182)

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/114_remove_updated_password.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/114_remove_updated_password.rb
@@ -2,7 +2,9 @@ def upgrade(ta, td, a, d)
   a["admin"].delete("updated_password")
   nodes = NodeObject.find("roles:keystone-server")
   nodes.each do |node|
-    node[:keystone][:admin][:old_password] = node[:keystone][:admin][:password]
+    unless node[:keystone][:admin].key?("old_password")
+      node[:keystone][:admin][:old_password] = node[:keystone][:admin][:password]
+    end
     node.save
   end
   return a, d

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -187,7 +187,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 113,
+      "schema-revision": 114,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
The removal of the update_password was landed under revision 113, so
the migration was never executed. Rename to 114 and make it idempotent