### PR TITLE
[4.0] Synchronize SSL in the cluster (bsc#1081518)

### DIFF
--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -494,16 +494,47 @@ end
 
 include_recipe "horizon::ha" if ha_enabled
 
+# Type 1 synchronizarion. Only one node of the cluser will create the
+# certificates that will be transferred to the rest of the nodes
+crowbar_pacemaker_sync_mark "wait-horizon_ssl_sync" do
+  # Generate the certificate is a slow process, can timeout in the
+  # other nodes of the cluster
+  timeout 60 * 5
+end if ha_enabled
+
 if node[:horizon][:apache][:ssl] && node[:horizon][:apache][:generate_certs]
   package "apache2-utils"
 
   bash "Generate Apache certificate" do
     code <<-EOH
-      (umask 377 ; /usr/bin/gensslcert -C openstack-dashboard )
+      (umask 377 ; /usr/bin/gensslcert -C openstack-dashboard -n openstack-dashboard)
 EOH
-    not_if { File.size?(node[:horizon][:apache][:ssl_crt_file]) }
+    only_if do
+      !File.size?(node[:horizon][:apache][:ssl_crt_file]) && (
+        !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node))
+    end
+  end
+
+  if ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node)
+    cluster_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "horizon-server")
+    cluster_nodes.map do |n|
+      next if node.name == n.name
+      node_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
+      bash "Synchronize SSL cetificates" do
+        code <<-EOH
+          rsync -a /etc/apache2/ssl.key/ #{node_address}:/etc/apache2/ssl.key/
+          rsync -a /etc/apache2/ssl.crt/ #{node_address}:/etc/apache2/ssl.crt/
+          rsync -a /etc/apache2/ssl.csr/ #{node_address}:/etc/apache2/ssl.csr/
+          rsync -a /srv/www/htdocs/ #{node_address}:/srv/www/htdocs/
+          EOH
+        timeout 120
+        ignore_failure true
+      end
+    end
   end
 end
+
+crowbar_pacemaker_sync_mark "create-horizon_ssl_sync" if ha_enabled
 
 template "#{node[:apache][:dir]}/sites-available/openstack-dashboard.conf" do
   if node[:platform_family] == "suse"


### PR DESCRIPTION
When Horizon in deployed via a autogenerated self certificate, the
current code will generate a different one of each node in the
cluster.

This patch will generate a single certificate in the founder, and
share it with the rest of the cluster via `rsync`.

(cherry picked from commit b264c759f862d4b81e0a67095032e156965a17e3)