### PR TITLE
Do not share ports Apache2 and HAProxy (bsc#1105086)

### DIFF
--- a/chef/cookbooks/horizon/recipes/ha.rb
+++ b/chef/cookbooks/horizon/recipes/ha.rb
@@ -33,6 +33,15 @@ if node[:horizon][:apache][:ssl]
   end.run_action(:create)
 end
 
+# Once HAProxy is taking care of :80 and :443 we need to remove this
+# from Apache realm.  This requires update the node information from
+# Apache, and maybe the listen.conf file
+if node[:apache][:listen_ports].include?("80") || node[:apache][:listen_ports].include?("443")
+  node.set[:apache][:listen_ports] = []
+  node.save
+  include_recipe "apache2::default"
+end
+
 # Wait for all nodes to reach this point so we know that all nodes will have
 # all the required packages installed before we create the pacemaker
 # resources


### PR DESCRIPTION
If HAProxy is serving :80 or :443 (because Horizon), we do not want
that Apache2 can also be listening on those ports.

HAProxy can be configured to resuse sockets, so that means that the
tuple IP:Port can be reused for different services, produncing bugs
like bsc#1105086, where the same IPv4 and the same port (:80) is
being listening connections from Apache and for HAProxy.

This patch remove the default :listen_ports from Apache if HAProxy
is deployed for Horizon, and reapply the Apache2 recipe from Crownar
Core.

(cherry picked from commit 55ce3c5a6bff726a5148018915627028cae4f3bb)