### PR TITLE
[4.0] keystone: Always try to rsync keys to new nodes

### DIFF
--- a/chef/cookbooks/horizon/recipes/ha.rb
+++ b/chef/cookbooks/horizon/recipes/ha.rb
@@ -36,7 +36,9 @@ end
 # Wait for all nodes to reach this point so we know that all nodes will have
 # all the required packages installed before we create the pacemaker
 # resources
-crowbar_pacemaker_sync_mark "sync-horizon_before_ha"
+crowbar_pacemaker_sync_mark "sync-horizon_before_ha" do
+  timeout 150
+end
 
 # no wait/create sync mark as it's done in crowbar-pacemaker itself
 

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -81,7 +81,9 @@ if node[:pacemaker][:clone_stateless_services]
   crowbar_pacemaker_sync_mark "sync-nova_before_ha"
 
   # Avoid races when creating pacemaker resources
-  crowbar_pacemaker_sync_mark "wait-nova_ha_resources"
+  crowbar_pacemaker_sync_mark "wait-nova_ha_resources" do
+    timeout 120
+  end
 
   rabbit_settings = fetch_rabbitmq_settings
   transaction_objects = []


### PR DESCRIPTION
When adding new node to existing cluster, fernet keys need to be pushed from
the founder to keep all keystone nodes in sync. Before this change the keys
were pushed to all nodes when cluster was initially set up and then rotated
periodically.

This commit introduces internal node attribute which indicates that the keys
are already in place. Founder pushes the fernet keys to all nodes which don't
have this attribute set. The same code covers initial cluster setup as well
as adding new node to existing cluster.

In addition the lookup of cluster member nodes was changed. Helper function
from crowbar-pacemaker cookbook which was based on Chef search was replaced
with direct lookup of `elements` attribute (based on deployment part of
proposal). This way, new soon-to-be-cluster-member node will be included in
the list even before Chef search index is updated and/or chef-client is run
on that node. This guarantees that fernet keys are pushed to the new node as
soon as possible.

Additional commits increase required timeouts to match specifics of cluster
extension scenario.