### PR TITLE
[5.0] Heat: Make non-founder HA nodes do less work

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -130,6 +130,7 @@ keystone_register "heat wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register heat user" do
@@ -142,6 +143,7 @@ keystone_register "register heat user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give heat user access" do
@@ -154,6 +156,7 @@ keystone_register "give heat user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "add heat stack user role" do
@@ -164,6 +167,7 @@ keystone_register "add heat stack user role" do
   auth register_auth_hash
   role_name "heat_stack_user"
   action :add_role
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 node[:heat][:trusts_delegated_roles].each do |role|
@@ -175,6 +179,7 @@ node[:heat][:trusts_delegated_roles].each do |role|
     auth register_auth_hash
     role_name role
     action :add_role
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
   keystone_register "give admin access to stack owner role #{role}" do
@@ -187,6 +192,7 @@ node[:heat][:trusts_delegated_roles].each do |role|
     project_name keystone_settings["default_tenant"]
     role_name role
     action :add_access
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end
 
@@ -287,6 +293,7 @@ bash "register heat domain" do
     "OS_REGION_NAME" => keystone_settings["endpoint_region"],
     "OS_IDENTITY_API_VERSION" => "3"
   })
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # Create Heat CloudFormation service
@@ -300,6 +307,7 @@ keystone_register "register Heat CloudFormation Service" do
   service_type "cloudformation"
   service_description "Heat CloudFormation Service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register heat Cfn endpoint" do
@@ -314,6 +322,7 @@ keystone_register "register heat Cfn endpoint" do
   endpoint_adminURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:cfn_port]}/v1"
   endpoint_internalURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:cfn_port]}/v1"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # Create Heat service
@@ -327,6 +336,7 @@ keystone_register "register Heat Service" do
   service_type "orchestration"
   service_description "Heat Service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register heat endpoint" do
@@ -347,6 +357,7 @@ keystone_register "register heat endpoint" do
                        "#{my_admin_host}:"\
                        "#{node[:heat][:api][:port]}/v1/$(project_id)s"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-heat_register" if ha_enabled


### PR DESCRIPTION
There is an intermittent update and HA ci failure that is originates
from the heat::server recipe. It has been observed in manual upgrade
tests and in ci.

The problem goes something like this. The founder set's a wait pacemaker
sync mark:

  crowbar_pacemaker_sync_mark "wait-heat_register" if ha_enabled

And then goes off and registers heat with keystone. The non-founders
happily sit and wait for the founder to finish and set the create mark.
When the non-founders finally start, none of the register jobs that the
founder has just completed has "only_if's" attached so the non-founders
happily go and re-run them.
The problem is, these register jobs can take time. In the failures I've
seen the `register heat domain` block take up to 40-50 seconds. This places
the non-founders well behind the founder.

The intermittent failure happens when we get later in the chef run, where any
more delays on one of the non-founders can cause later sync marks to
timeout. Which usually fails in the ceilometer recipe where the founder
times out after waiting a minute for the other nodes to catch up,
resulting in:

  FATAL: RuntimeError: crowbar-pacemaker_sync_mark[sync-ceilometer_central_before_ha] (ceilometer::central_ha line 19) had an error: \
  RuntimeError: Some cluster nodes didn't set ceilometer_central_before_ha!

This patch goes as adds an:

  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }

to each keystone register block between the wait and create so once the
non-founders start again they don't go re-do that the founder just
completed.

(cherry picked from commit a980679aebbb61471cfcba41a79a4417b878a996)

Backport of https://github.com/crowbar/crowbar-openstack/pull/1736