### PR TITLE
rabbitmq: allow tuning tcpnodelay and keepalive

### DIFF
--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -54,6 +54,8 @@
       },
       "tcp_listen_options": {
         "backlog": 128,
+        "nodelay": true,
+        "keepalive": false,
         "sndbuf": null,
         "recbuf": null
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -115,6 +115,8 @@
               "required": true,
               "mapping": {
                 "backlog": { "type": "int", "required": true },
+                "nodelay": { "type": "bool", "required": false },
+                "keepalive": { "type": "bool", "required": false },
                 "sndbuf": { "type": "int", "required": false },
                 "recbuf": { "type": "int", "required": false }
               }


### PR DESCRIPTION
nodelay is already on by default and keepalive is off by default,
but some env might want to be able to configure it.