### PR TITLE
[5.0] neutron: Increase wait_neutron-agents_ha_resources timeout

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -122,7 +122,9 @@ end
 crowbar_pacemaker_sync_mark "sync-neutron-agents_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-neutron-agents_ha_resources"
+crowbar_pacemaker_sync_mark "wait-neutron-agents_ha_resources" do
+  timeout 90
+end
 
 if node[:pacemaker][:clone_stateless_services]
   transaction_objects = []


### PR DESCRIPTION
The cloud-mkcloud8-job-upgrade-nondisruptive-ha-mariadb-x86_64 job has
failed on multiple occasions due to the default timeout of 60 seconds
timing out for the `wait-neutron-agents_ha_resources` pacemaker sync
mark.

Runs 188 and 185 are 2 such examples.

Looking at the chef-agent logs on the crowbar node we see the following:

node1 - founder

[2018-08-28T06:29:53+00:00] INFO: Processing crowbar-pacemaker_sync_mark[wait-neutron-agents_ha_resources] action guess (neutron::network_agents_ha line 125)
....
[2018-08-28T06:31:02+00:00] INFO: Processing crowbar-pacemaker_sync_mark[create-neutron-agents_ha_resources] action guess (neutron::network_agents_ha line 302)

node 2

[2018-08-28T06:29:57+00:00] INFO: Processing crowbar-pacemaker_sync_mark[wait-neutron-agents_ha_resources] action guess (neutron::network_agents_ha line 125)
[2018-08-28T06:29:57+00:00] INFO: Checking if cluster founder has set neutron-agents_ha_resources...
[2018-08-28T06:30:57+00:00] FATAL: Cluster founder didn't set neutron-agents_ha_resources!

NOTE: The founder sets the mark 5 seconds later.

node 3

[2018-08-28T06:29:53+00:00] INFO: Processing crowbar-pacemaker_sync_mark[wait-neutron-agents_ha_resources] action guess (neutron::network_agents_ha line 125)
[2018-08-28T06:29:53+00:00] INFO: Checking if cluster founder has set neutron-agents_ha_resources...
[2018-08-28T06:30:54+00:00] FATAL: Cluster founder didn't set neutron-agents_ha_resources!

NOTE: The founder sets the mark 8 seconds later.

When looking at the what's happening on the founder there is no obvious
time hole. There are simply many [0]:

INFO: Processing pacemaker_.*[.*] action update ...

Messages each taking around 2 - 3 seconds which seems to sometime push
the founder past the 60 second mark.

This patch increases the timeout to 90 seconds to give the updates more
time.

This timeout also occurs sometimes when adding a brand new node to a
pacemaker cluster. As we've discovered in the upgrade squad, this commit
was pulled from a chain that Jacek is currently working on to fix the
increase cluster size issues we've found over here [1]. Pushing this up
as a seperate change to get the CI job green while we still work on the
cluster increase case.

I have only seen this happen in SOC7 before an upgrade to SOC8,
so this will need to be backported. However, I haven't looked closely at
other CI jobs to know if other versions are affected.

[0] - http://pastebin.nue.suse.com/18759/src
[1] - https://github.com/crowbar/crowbar-openstack/pull/1741

(cherry picked from commit 06a9cdd631849dde760dfe4f177c5e55256d3af2)