### PR TITLE
Correct configuration of DRBD resources in 3-node cluster

### DIFF
--- a/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_drbd_controller_only_location_for.rb
+++ b/chef/cookbooks/crowbar-openstack/definitions/openstack_pacemaker_drbd_controller_only_location_for.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2016, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+define :openstack_pacemaker_drbd_controller_only_location_for do
+  # ensure attributes are set
+  include_recipe "crowbar-pacemaker::attributes"
+
+  resource = params[:name]
+  location_name = "l-#{resource}-controller"
+
+  # Make sure drbd nodes are known so that drbd-controller constraint makes sense
+  location_def = if node[:pacemaker][:drbd].fetch("nodes", []).any?
+    OpenStackHAHelper.drbd_controller_only_location(location_name, resource)
+  else
+    OpenStackHAHelper.controller_only_location(location_name, resource)
+  end
+
+  pacemaker_location location_name do
+    definition location_def
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+  location_name
+end

--- a/chef/cookbooks/crowbar-openstack/libraries/ha_helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/ha_helpers.rb
@@ -40,6 +40,11 @@ module OpenStackHAHelper
       "rule 0: OpenStack-role eq controller"
   end
 
+  def self.drbd_controller_only_location(location, service)
+    "location #{location} #{service} resource-discovery=exclusive " \
+      "rule 0: OpenStack-role eq controller and drbd-controller eq true"
+  end
+
   def self.no_compute_location(location, service)
     "location #{location} #{service} resource-discovery=exclusive " \
       "rule 0: OpenStack-role ne compute"

--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -108,7 +108,7 @@ if node[:database][:postgresql][:ha][:storage][:mode] == "drbd"
   vip_location_name = openstack_pacemaker_controller_only_location_for vip_primitive
   transaction_objects << "pacemaker_location[#{vip_location_name}]"
 
-  location_name = openstack_pacemaker_controller_only_location_for service_name
+  location_name = openstack_pacemaker_drbd_controller_only_location_for service_name
   transaction_objects << "pacemaker_location[#{location_name}]"
 
 else


### PR DESCRIPTION
We have to allow user to add a new node into 2-node DRBD cluster, so that such cluster can hold (3-node) galera configuration later.

But as (our version of) DRBD needs exactly 2 nodes, there are some tweaks necessary so that the extra node does not have DRBD configured, although it is part of the pacemaker cluster.

This part handles necessary changes for DRBD-enabled services (postgresql, rabbitmq)

Requires https://github.com/crowbar/crowbar-ha/pull/327