### PR TITLE
[5.0] database: Drop temporary mysql-server role, used for upgrade only

### DIFF
--- a/chef/data_bags/crowbar/migrate/database/209_merge_db_roles.rb
+++ b/chef/data_bags/crowbar/migrate/database/209_merge_db_roles.rb
@@ -1,0 +1,45 @@
+def upgrade(ta, td, a, d)
+  a["ha"] = ta["ha"] unless a.key? "ha"
+
+  # Cookbooks expect the 'enabled' flag under high level 'ha' map
+  # - only during the upgrade it was moved under 'ha/mysql'
+  if a["mysql"] && a["mysql"]["ha"]
+    a["ha"]["enabled"] = a["mysql"]["ha"]["enabled"] if a["mysql"]["ha"].key?("enabled")
+    a["mysql"]["ha"].delete("enabled")
+  end
+
+  a["postgresql"].delete("ha") if a["postgresql"] && a["postgresql"].key?("ha")
+
+  if d["elements"].key? "mysql-server"
+    d["elements"]["database-server"] = d["elements"]["mysql-server"]
+    d["elements"].delete("mysql-server")
+    if d.fetch("elements_expanded", {}).key? "mysql-server"
+      d["elements_expanded"]["database-server"] = d["elements_expanded"]["mysql-server"]
+      d["elements_expanded"].delete("mysql-server")
+    end
+
+    # Make sure mysql-server role is gone from all places
+    d["element_states"] = td["element_states"]
+    d["element_order"] = td["element_order"]
+
+    chef_order = BarclampCatalog.chef_order("database")
+    nodes = NodeObject.find("run_list_map:mysql-server")
+    nodes.each do |node|
+      node.add_to_run_list("database-server", chef_order,
+                           td["element_states"]["database-server"])
+      node.delete_from_run_list("mysql-server")
+      node.save
+    end
+  end
+
+  # Delete mysql-server role if it exists
+  role = Chef::Role.load("mysql-server") rescue nil
+  role.destroy unless role.nil?
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # No role splitting needed now; it already has suppport in SOC7 via migration 109
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -83,7 +83,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 208,
+      "schema-revision": 209,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
During upgrade there was a time where both different database engines
were deployed to the same noes and we needed extra role.
Once back on SOC8, there's again need for only one database role.

(cherry picked from commit 27f272456b684e8f74b08a8d7172cf1206782b24)

backport of https://github.com/crowbar/crowbar-openstack/pull/1712