### PR TITLE
Bump schema revision to 300 after release

### DIFF
--- a/chef/data_bags/crowbar/migrate/aodh/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/aodh/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/barbican/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/barbican/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/ceilometer/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/cinder/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/database/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/database/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/glance/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/glance/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/heat/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/heat/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/horizon/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/ironic/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/ironic/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/keystone/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/magnum/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/magnum/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/manila/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/manila/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/monasca/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/neutron/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/nova/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/nova/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/rabbitmq/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/sahara/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/sahara/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/swift/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/swift/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/tempest/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/trove/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/trove/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-aodh.json
+++ b/chef/data_bags/crowbar/template-aodh.json
@@ -36,7 +36,7 @@
     "aodh": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 300,
       "element_states": {
         "aodh-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-barbican.json
+++ b/chef/data_bags/crowbar/template-barbican.json
@@ -41,7 +41,7 @@
     "barbican" : {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 300,
       "element_states": {
         "barbican-controller": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-ceilometer.json
+++ b/chef/data_bags/crowbar/template-ceilometer.json
@@ -44,7 +44,7 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 204,
+      "schema-revision": 300,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-central": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -182,7 +182,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 207,
+      "schema-revision": 300,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -83,7 +83,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 209,
+      "schema-revision": 300,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-glance.json
+++ b/chef/data_bags/crowbar/template-glance.json
@@ -75,7 +75,7 @@
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 300,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-heat.json
+++ b/chef/data_bags/crowbar/template-heat.json
@@ -41,7 +41,7 @@
     "heat": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 300,
       "element_states": {
         "heat-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -54,7 +54,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 203,
+      "schema-revision": 300,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-ironic.json
+++ b/chef/data_bags/crowbar/template-ironic.json
@@ -31,7 +31,7 @@
   "deployment": {
     "ironic": {
       "crowbar-revision": 0,
-      "schema-revision": 204,
+      "schema-revision": 300,
       "crowbar-applied": false,
       "element_states": {
         "ironic-server": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -178,7 +178,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 204,
+      "schema-revision": 300,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-magnum.json
+++ b/chef/data_bags/crowbar/template-magnum.json
@@ -41,7 +41,7 @@
     "magnum": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 300,
       "element_states": {
         "magnum-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-manila.json
+++ b/chef/data_bags/crowbar/template-manila.json
@@ -97,7 +97,7 @@
     "manila": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 300,
       "element_states": {
         "manila-server": [ "readying", "ready", "applying" ],
         "manila-share": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -143,7 +143,7 @@
     "monasca": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 204,
+      "schema-revision": 300,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
         "monasca-master": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -188,7 +188,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 210,
+      "schema-revision": 300,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -183,7 +183,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 209,
+      "schema-revision": 300,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -66,7 +66,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 204,
+      "schema-revision": 300,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-sahara.json
+++ b/chef/data_bags/crowbar/template-sahara.json
@@ -34,7 +34,7 @@
     "sahara": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 202,
+      "schema-revision": 300,
       "element_states": {
         "sahara-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-swift.json
+++ b/chef/data_bags/crowbar/template-swift.json
@@ -96,7 +96,7 @@
     "swift": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 300,
       "element_states": {
         "swift-dispersion": [ "ready", "applying" ],
         "swift-storage": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -41,7 +41,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 300,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-trove.json
+++ b/chef/data_bags/crowbar/template-trove.json
@@ -28,7 +28,7 @@
     "trove": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 300,
       "element_states": {
         "trove-server": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
To give some head room for future schema migrations in the
stable/5.0-pike branch we bump the schema revision for all barclamps to
300. The migration itself is a noop it's just there to ensure the
schema-revision is increased on all existing proposals and roles (mainly
needed for future upgrades from stable/5.0-pike).