### PR TITLE
openstack: Switch to Rocky+ default member role name spelling

### DIFF
--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -44,7 +44,7 @@ CACHES = {
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 OPENSTACK_HOST = "<%= @keystone_settings['internal_url_host'] %>"
 OPENSTACK_KEYSTONE_URL = "<%= @keystone_settings['unversioned_internal_auth_url'] %>"
-OPENSTACK_KEYSTONE_DEFAULT_ROLE = "Member"
+OPENSTACK_KEYSTONE_DEFAULT_ROLE = "member"
 OPENSTACK_SSL_NO_VERIFY = <%= @insecure ? "True" : "False" %>
 
 OPENSTACK_ENABLE_PASSWORD_RETRIEVE = True

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -619,14 +619,15 @@ if node[:keystone][:default][:create_user]
   end
 end
 
-# Create Member role used by horizon (see OPENSTACK_KEYSTONE_DEFAULT_ROLE option)
-keystone_register "add default Member role" do
+# Create member role used by horizon (see OPENSTACK_KEYSTONE_DEFAULT_ROLE option)
+### Remove after Rocky is required (keystone-bootstrap creates it for us)
+keystone_register "add default member role" do
   protocol node[:keystone][:api][:protocol]
   insecure keystone_insecure
   host my_admin_host
   port node[:keystone][:api][:admin_port]
   auth register_auth_hash
-  role_name "Member"
+  role_name "member"
   action :add_role
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
@@ -638,7 +639,7 @@ user_roles = [
 ]
 if node[:keystone][:default][:create_user]
   user_roles << [node[:keystone][:default][:username],
-                 "Member",
+                 "member",
                  node[:keystone][:default][:project]]
 end
 user_roles.each do |args|

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -35,7 +35,7 @@ driver = <%= node[:keystone][:identity][:driver] %>
 
 <% if node[:keystone][:assignment][:driver] == 'hybrid' -%>
 [ldap_hybrid]
-default_roles = Member
+default_roles = member
 default_project = <%= node[:keystone][:default][:tenant] %>
 <% end -%>
 

--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -71,7 +71,7 @@ service_token_roles_required = true
 service_token_roles = admin
 [filter:keystoneauth]
 use = egg:swift#keystoneauth
-operator_roles = Member, admin
+operator_roles = member, admin
 reseller_prefix=<%= @reseller_prefix %>
 log_facility = LOG_LOCAL0
 log_level = <%= @debug? "DEBUG": "INFO" %>

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -89,7 +89,7 @@ openstackcli_adm = "#{adm_environment} openstack --insecure"
 enabled_services = `#{openstackcli_adm} service list -f value -c Type`.split
 
 users = [
-          {"name" => tempest_comp_user, "pass" => tempest_comp_pass, "role" => "Member"},
+          {"name" => tempest_comp_user, "pass" => tempest_comp_pass, "role" => "member"},
           {"name" => tempest_adm_user, "pass" => tempest_adm_pass, "role" => "admin" }
         ]
 

--- a/chef/data_bags/crowbar/migrate/heat/100_add_trusts_delegated_roles.rb
+++ b/chef/data_bags/crowbar/migrate/heat/100_add_trusts_delegated_roles.rb
@@ -1,9 +1,9 @@
 def upgrade(ta, td, a, d)
   # Keep heat_stack_owner as a default for existing installations: operators
   # of existing clouds may have created user accounts that do not have the
-  # "Member" role in the proposal's default, but do have the "heat_stack_owner"
+  # "member" role in the proposal's default, but do have the "heat_stack_owner"
   # role (required for Heat to work). Switching trusts_delegated_roles to
-  # "Member" would break heat for such users.
+  # "member" would break heat for such users.
   unless a.key? "trusts_delegated_roles"
     a["trusts_delegated_roles"] = ["heat_stack_owner"]
   end

--- a/chef/data_bags/crowbar/template-heat.json
+++ b/chef/data_bags/crowbar/template-heat.json
@@ -14,7 +14,7 @@
       "service_password": "",
       "auth_encryption_key": "",
       "memcache_secret_key": "",
-      "trusts_delegated_roles": [ "Member" ],
+      "trusts_delegated_roles": [ "member" ],
       "api": {
         "protocol": "http",
         "cfn_port": 8000,


### PR DESCRIPTION
Roles are case insensitive, and OpenStack Rocky generates a "member"
role by default, so it conflicts with the default role "Member" that
we create. As both are considered equal by Keystone, we can just switch
our defaults to it.