### PR TITLE
database: switch to mariadb-102 packages

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -40,13 +40,13 @@ default[:mysql][:ha][:op][:monitor][:role]     = "Master"
 default[:mysql][:mariadb][:version] = "10.2"
 default[:mysql][:galera_packages] = [
   "galera-3-wsrep-provider",
-  "mariadb-tools",
+  "mariadb-102-tools",
   "xtrabackup",
   "socat",
   "galera-python-clustercheck"
 ]
 
-# newer version need an additional package on SLES
-unless node[:mysql][:mariadb][:version] == "10.1"
-  default[:mysql][:galera_packages] << "mariadb-galera"
-end
+default[:mysql][:galera_packages] << "mariadb-102-galera"
+
+default[:mysql][:mysql_client] = "mariadb-102-client"
+default[:mysql][:mysql_server] = "mariadb-102"

--- a/chef/cookbooks/mysql/recipes/client.rb
+++ b/chef/cookbooks/mysql/recipes/client.rb
@@ -17,13 +17,7 @@
 # limitations under the License.
 #
 
-package "mariadb-client" do
-  package_name value_for_platform_family(
-    ["rhel", "fedora"] => "mysql",
-    "default" => "mariadb-client"
-  )
-  action :install
-end
+package node[:mysql][:mysql_client]
 
 if platform_family?(%w{debian rhel fedora suse})
 

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -30,10 +30,7 @@ if addr != newaddr
   node.save
 end
 
-package "mysql-server" do
-  package_name "mysql" if node[:platform_family] == "suse"
-  action :install
-end
+package node[:mysql][:mysql_server]
 
 case node[:platform_family]
 when "rhel", "fedora"


### PR DESCRIPTION
For reasons that are hard to understand, the SLES team decided
to rename mariadb* packages to mariadb-102 in addition to keeping
the mariadb-* (which are old) around. Because we need the version
with galera support, pull the newer version in.