### PR TITLE
database: Hide SSL options from database UI

### DIFF
--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -14,7 +14,7 @@
         = integer_field %w(mysql expire_logs_days)
         = boolean_field %w(mysql slow_query_logging)
 
-      %fieldset
+      %fieldset{ "style" => "display:none" }
         %legend
           = t(".mysql.ssl_header")
 


### PR DESCRIPTION
This is a replacement for package patch to simplify future modifications
to the sources without causing conflicts.

Original patch: https://build.suse.de/package/view_file/Devel:Cloud:7:Staging/crowbar-openstack/hide-mysql-ssl.patch?expand=1

Package revert: https://build.suse.de/request/show/171784