### PR TITLE
helpers: Pass sql_engine into get_listen_address

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -107,7 +107,7 @@ class CrowbarOpenStackHelper
       if database.nil?
         Chef::Log.warn("No database server found!")
       else
-        address = CrowbarDatabaseHelper.get_listen_address(database)
+        address = CrowbarDatabaseHelper.get_listen_address(database, sql_engine)
 
         ssl_opts = {}
         if sql_engine == "mysql"


### PR DESCRIPTION
When fetch_database_settings is called by one of the database specific
cookbooks it is supposed to lookup the settings for the respective
backend instead of for the currently selected default backend.