### PR TITLE
[4.0] keystone: Reorganize HA/fernet code

### DIFF
--- a/chef/cookbooks/keystone/providers/fernet.rb
+++ b/chef/cookbooks/keystone/providers/fernet.rb
@@ -1,0 +1,21 @@
+action :setup do
+  execute "keystone-manage fernet_setup" do
+    command "keystone-manage fernet_setup \
+      --keystone-user #{node[:keystone][:user]} \
+      --keystone-group #{node[:keystone][:group]}"
+    action :run
+  end
+end
+
+# attribute :rsync_command, kind_of: String, default: ""
+action :rotate_script do
+  template "/var/lib/keystone/keystone-fernet-rotate" do
+    source "keystone-fernet-rotate.erb"
+    owner "root"
+    group node[:keystone][:group]
+    mode "0750"
+    variables(
+      rsync_command: new_resource.rsync_command
+    )
+  end
+end

--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -31,6 +31,143 @@ haproxy_loadbalancer "keystone-admin" do
   action :nothing
 end.run_action(:create)
 
+# Configure Keystone token fernet backend provider
+if node[:keystone][:signing][:token_format] == "fernet"
+  template "/usr/bin/keystone-fernet-keys-push.sh" do
+    source "keystone-fernet-keys-push.sh"
+    owner "root"
+    group "root"
+    mode "0755"
+  end
+
+  # To be sure that rsync package is installed
+  package "rsync"
+  crowbar_pacemaker_sync_mark "sync-keystone_install_rsync"
+
+  rsync_command = ""
+  initial_rsync_command = ""
+
+  # can't use CrowbarPacemakerHelper.cluster_nodes() here as it will sometimes not return
+  # nodes which will be added to the cluster in current chef-client run.
+  cluster_nodes = node[:pacemaker][:elements]["pacemaker-cluster-member"]
+  cluster_nodes = cluster_nodes.map { |n| Chef::Node.load(n) }
+  cluster_nodes.sort_by! { |n| n[:hostname] }
+  cluster_nodes.each do |n|
+    next if node.name == n.name
+    node_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
+    node_rsync_command = "/usr/bin/keystone-fernet-keys-push.sh #{node_address}; "
+    rsync_command += node_rsync_command
+    # initial rsync only for (new) nodes which didn't get the keys yet
+    next if n.include?(:keystone) &&
+        n[:keystone].include?(:signing) &&
+        n[:keystone][:signing][:initial_keys_sync]
+    initial_rsync_command += node_rsync_command
+  end
+  raise "No other cluster members found" if rsync_command.empty?
+
+  # Rotate primary key, which is used for new tokens
+  template "/var/lib/keystone/keystone-fernet-rotate" do
+    source "keystone-fernet-rotate.erb"
+    owner "root"
+    group node[:keystone][:group]
+    mode "0750"
+    variables(
+      rsync_command: rsync_command
+    )
+  end
+
+  crowbar_pacemaker_sync_mark "wait-keystone_fernet_rotate"
+
+  if File.exist?("/etc/keystone/fernet-keys/0")
+    # Mark node to avoid unneeded future rsyncs
+    unless node[:keystone][:signing][:initial_keys_sync]
+      node[:keystone][:signing][:initial_keys_sync] = true
+      node.save
+    end
+  else
+    # Setup a key repository for fernet tokens
+    execute "keystone-manage fernet_setup" do
+      command "keystone-manage fernet_setup \
+        --keystone-user #{node[:keystone][:user]} \
+        --keystone-group #{node[:keystone][:group]}"
+      action :run
+      only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+    end
+  end
+
+  # We would like to propagate fernet keys to all (new) nodes in the cluster
+  execute "propagate fernet keys to all nodes in the cluster" do
+    command initial_rsync_command
+    action :run
+    only_if do
+      CrowbarPacemakerHelper.is_cluster_founder?(node) &&
+        !initial_rsync_command.empty?
+    end
+  end
+
+  service_transaction_objects = []
+
+  keystone_fernet_primitive = "keystone-fernet-rotate"
+  pacemaker_primitive keystone_fernet_primitive do
+    agent node[:keystone][:ha][:fernet][:agent]
+    params(
+      "target" => "/var/lib/keystone/keystone-fernet-rotate",
+      "link" => "/etc/cron.hourly/openstack-keystone-fernet",
+      "backup_suffix" => ".orig"
+    )
+    op node[:keystone][:ha][:fernet][:op]
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+  service_transaction_objects << "pacemaker_primitive[#{keystone_fernet_primitive}]"
+
+  fernet_rotate_loc = openstack_pacemaker_controller_only_location_for keystone_fernet_primitive
+  service_transaction_objects << "pacemaker_location[#{fernet_rotate_loc}]"
+
+  pacemaker_transaction "keystone-fernet-rotate cron" do
+    cib_objects service_transaction_objects
+    # note that this will also automatically start the resources
+    action :commit_new
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  crowbar_pacemaker_sync_mark "create-keystone_fernet_rotate"
+end
+
+# note(jtomasiak): We don't need new syncmarks for the fernet-keys-sync part.
+# This is because the deployment and configuration of this feature will be done
+# once during keystone installation and it will not be used until some keystone
+# node is reinstalled. We assume that time between keystone installation and
+# possible node reinstallation is high enough to run this safely without
+# syncmarks.
+fernet_resources_action = node[:keystone][:signing][:token_format] == "fernet" ? :create : :delete
+
+template "/usr/bin/keystone-fernet-keys-sync.sh" do
+  source "keystone-fernet-keys-sync.sh"
+  owner "root"
+  group "root"
+  mode "0755"
+  action fernet_resources_action
+end
+
+# handler scripts are run by hacluster user so sudo configuration is needed
+# if the handler needs to rsync to other nodes using root's keys
+template "/etc/sudoers.d/keystone-fernet-keys-sync" do
+  source "hacluster_sudoers.erb"
+  owner "root"
+  group "root"
+  mode "0440"
+  action fernet_resources_action
+end
+
+# on founder: create/delete pacemaker alert
+pacemaker_alert "keystone-fernet-keys-sync" do
+  handler "/usr/bin/keystone-fernet-keys-sync.sh"
+  action fernet_resources_action
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+# Create/update apache resources after fernet keys setup to make sure everything is ready.
 if node[:keystone][:frontend] == "apache" && node[:pacemaker][:clone_stateless_services]
   include_recipe "crowbar-pacemaker::apache"
 
@@ -70,45 +207,4 @@ if node[:keystone][:frontend] == "apache" && node[:pacemaker][:clone_stateless_s
   end
 
   crowbar_pacemaker_sync_mark "create-keystone_ha_resources"
-end
-
-# note(jtomasiak): We don't need new syncmarks for the fernet-keys-sync part.
-# This is because the deployment and configuration of this feature will be done
-# once during keystone installation and it will not be used until some keystone
-# node is reinstalled. We assume that time between keystone installation and
-# possible node reinstallation is high enough to run this safely without
-# syncmarks.
-fernet_resources_action = node[:keystone][:signing][:token_format] == "fernet" ? :create : :delete
-
-template "/usr/bin/keystone-fernet-keys-push.sh" do
-  source "keystone-fernet-keys-push.sh"
-  owner "root"
-  group "root"
-  mode "0755"
-  action fernet_resources_action
-end
-
-template "/usr/bin/keystone-fernet-keys-sync.sh" do
-  source "keystone-fernet-keys-sync.sh"
-  owner "root"
-  group "root"
-  mode "0755"
-  action fernet_resources_action
-end
-
-# handler scripts are run by hacluster user so sudo configuration is needed
-# if the handler needs to rsync to other nodes using root's keys
-template "/etc/sudoers.d/keystone-fernet-keys-sync" do
-  source "hacluster_sudoers.erb"
-  owner "root"
-  group "root"
-  mode "0440"
-  action fernet_resources_action
-end
-
-# on founder: create/delete pacemaker alert
-pacemaker_alert "keystone-fernet-keys-sync" do
-  handler "/usr/bin/keystone-fernet-keys-sync.sh"
-  action fernet_resources_action
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -475,14 +475,8 @@ end
 # Configure Keystone token fernet backend provider (non-HA case)
 if !ha_enabled && node[:keystone][:signing][:token_format] == "fernet"
   # Rotate primary key, which is used for new tokens
-  template "/var/lib/keystone/keystone-fernet-rotate" do
-    source "keystone-fernet-rotate.erb"
-    owner "root"
-    group node[:keystone][:group]
-    mode "0750"
-    variables(
-      rsync_command: ""
-    )
+  keystone_fernet "keystone-fernet-rotate-non-ha" do
+    action :rotate_script
   end
 
   link "/etc/cron.hourly/openstack-keystone-fernet" do
@@ -491,11 +485,8 @@ if !ha_enabled && node[:keystone][:signing][:token_format] == "fernet"
 
   unless File.exist?("/etc/keystone/fernet-keys/0")
     # Setup a key repository for fernet tokens
-    execute "keystone-manage fernet_setup" do
-      command "keystone-manage fernet_setup \
-        --keystone-user #{node[:keystone][:user]} \
-        --keystone-group #{node[:keystone][:group]}"
-      action :run
+    keystone_fernet "keystone-fernet-setup-non-ha" do
+      action :setup
     end
   end
 end

--- a/chef/cookbooks/keystone/resources/fernet.rb
+++ b/chef/cookbooks/keystone/resources/fernet.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: keystone
+# Resource:: fernet
+#
+# Copyright:: 2018, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :setup, :rotate_script
+
+# :rotate_script specific attributes
+attribute :rsync_command, kind_of: String, default: ""

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -123,7 +123,7 @@ crowbar_pacemaker_sync_mark "sync-neutron-agents_before_ha"
 
 # Avoid races when creating pacemaker resources
 crowbar_pacemaker_sync_mark "wait-neutron-agents_ha_resources" do
-  timeout 90
+  timeout 150
 end
 
 if node[:pacemaker][:clone_stateless_services]

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -82,7 +82,7 @@ if node[:pacemaker][:clone_stateless_services]
 
   # Avoid races when creating pacemaker resources
   crowbar_pacemaker_sync_mark "wait-nova_ha_resources" do
-    timeout 120
+    timeout 160
   end
 
   rabbit_settings = fetch_rabbitmq_settings


### PR DESCRIPTION
Moved most of the fernet setup to ha.rb. Some redundancy was added but
it is now easier to work with the (more-complex) HA case.

The main goal was to reorder step so that fernet keys are configured and
distributed to cluster nodes before apache is (re)started. This way, there
is no time when apache would be configured to use fernet keys but no actual
keys would be present. The problem was detected in cluster extension scenario
where new node was added to an already existing cluster.