### PR TITLE
[5.0] mysql: ha galera needs op monitor for slaves

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -31,8 +31,9 @@ default[:mysql][:ha][:ports][:admin_port] = 3306
 
 # Default operation setting for the galera resource
 # in pacemamker
-default[:mysql][:ha][:op][:monitor][:interval] = "20s"
-default[:mysql][:ha][:op][:monitor][:role]     = "Master"
+default[:mysql][:ha][:op][:monitor] = [
+  { interval: "23s" }, { interval: "20s", role: "Master" }
+]
 
 # If needed we can enhance this to set the mariadb version
 # depeding on "platform" and "platform_version". But currently


### PR DESCRIPTION
Backport from: https://github.com/crowbar/crowbar-openstack/pull/1731

In a Galera HA environment the pacemaker primitive op monitor is only
set for master mode. This is not a problem because all galera resources
are in master mode.

The problem comes when changing the pacemaker primitive and the masters
can become slaves, i.e. when shrinking the cluster. In such case the
slaves never get promoted to masters because they are not monitored.
Adding the monitor operation for slaves solves this situation.

(cherry picked from commit 67fa21f8b086c862163ac044a788226ce159edcd)