### PR TITLE
[5.0] neutron: Don't assign the aci role to any node by default

### DIFF
--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -119,8 +119,7 @@ class NeutronService < OpenstackServiceObject
 
     base["deployment"]["neutron"]["elements"] = {
         "neutron-server" => [controller_node[:fqdn]],
-        "neutron-network" => network_nodes.map { |x| x[:fqdn] },
-        "neutron-sdn-cisco-aci-agents" => nodes.map { |x| x[:fqdn] }
+        "neutron-network" => network_nodes.map { |x| x[:fqdn] }
     } unless nodes.nil? || nodes.length.zero?
 
     base["attributes"]["neutron"]["service_password"] = random_password


### PR DESCRIPTION
This needs be assigned manually when the ACI/opflex drivers are enabled

(cherry picked from commit 2581217e072c0f415be410e80a266ba028637e1c)