### PR TITLE
heat: Remove cloudwatch API

### DIFF
--- a/chef/cookbooks/heat/attributes/default.rb
+++ b/chef/cookbooks/heat/attributes/default.rb
@@ -16,7 +16,6 @@
 default[:heat][:engine][:service_name] = "heat-engine"
 default[:heat][:api][:service_name] = "heat-api"
 default[:heat][:api_cfn][:service_name] = "heat-api-cfn"
-default[:heat][:api_cloudwatch][:service_name] = "heat-api-cloudwatch"
 
 case node[:platform_family]
 when "debian"
@@ -25,7 +24,6 @@ when "debian"
       "heat-engine",
       "heat-api",
       "heat-api-cfn",
-      "heat-api-cloudwatch",
       "python-heat",
       "heat-common",
       "python-heatclient"
@@ -35,7 +33,6 @@ when "debian"
       "heat-engine",
       "heat-api",
       "heat-api-cfn",
-      "heat-api-cloudwatch"
     ]
   }
 when "rhel", "suse"
@@ -44,7 +41,6 @@ when "rhel", "suse"
       "openstack-heat-engine",
       "openstack-heat-api",
       "openstack-heat-api-cfn",
-      "openstack-heat-api-cloudwatch",
       "python-heatclient"
     ],
     plugin_packages: [],
@@ -52,13 +48,11 @@ when "rhel", "suse"
       "openstack-heat-engine",
       "openstack-heat-api",
       "openstack-heat-api-cfn",
-      "openstack-heat-api-cloudwatch"
     ]
   }
   default[:heat][:engine][:service_name] = "openstack-heat-engine"
   default[:heat][:api][:service_name] = "openstack-heat-api"
   default[:heat][:api_cfn][:service_name] = "openstack-heat-api-cfn"
-  default[:heat][:api_cloudwatch][:service_name] = "openstack-heat-api-cloudwatch"
 end
 
 if node[:platform_family] == "suse"
@@ -91,7 +85,6 @@ default[:heat][:service_password] = ""
 default[:heat][:api][:protocol] = "http"
 default[:heat][:api][:cfn_port] = 8000
 default[:heat][:api][:engine_port] = 8001
-default[:heat][:api][:cloud_watch_port] = 8003
 default[:heat][:api][:port] = 8004
 
 default[:heat][:metering_secret] = "" # Set by Recipe
@@ -100,7 +93,6 @@ default[:heat][:ha][:enabled] = false
 # Ports to bind to when haproxy is used for the real ports
 default[:heat][:ha][:ports][:cfn_port] = 5570
 default[:heat][:ha][:ports][:api_port] = 5571
-default[:heat][:ha][:ports][:cloud_watch_port] = 5572
 
 # Pacemaker bits
 default[:heat][:ha][:engine][:agent] = "systemd:#{default[:heat][:engine][:service_name]}"
@@ -109,5 +101,3 @@ default[:heat][:ha][:api][:agent] = "systemd:#{default[:heat][:api][:service_nam
 default[:heat][:ha][:api][:op][:monitor][:interval] = "10s"
 default[:heat][:ha][:api_cfn][:agent] = "systemd:#{default[:heat][:api_cfn][:service_name]}"
 default[:heat][:ha][:api_cfn][:op][:monitor][:interval] = "10s"
-default[:heat][:ha][:api_cloudwatch][:agent] = "systemd:#{default[:heat][:api_cloudwatch][:service_name]}"
-default[:heat][:ha][:api_cloudwatch][:op][:monitor][:interval] = "10s"

--- a/chef/cookbooks/heat/libraries/helpers.rb
+++ b/chef/cookbooks/heat/libraries/helpers.rb
@@ -21,13 +21,11 @@ module HeatHelper
       bind_host = admin_address
       api_port = node[:heat][:ha][:ports][:api_port]
       cfn_port = node[:heat][:ha][:ports][:cfn_port]
-      cloud_watch_port = node[:heat][:ha][:ports][:cloud_watch_port]
     else
       bind_host = "0.0.0.0"
       api_port = node[:heat][:api][:port]
       cfn_port = node[:heat][:api][:cfn_port]
-      cloud_watch_port = node[:heat][:api][:cloud_watch_port]
     end
-    return bind_host, api_port, cfn_port, cloud_watch_port
+    [bind_host, api_port, cfn_port]
   end
 end

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -31,14 +31,6 @@ haproxy_loadbalancer "heat-api-cfn" do
   action :nothing
 end.run_action(:create)
 
-haproxy_loadbalancer "heat-api-cloudwatch" do
-  address "0.0.0.0"
-  port node[:heat][:api][:cloud_watch_port]
-  use_ssl (node[:heat][:api][:protocol] == "https")
-  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "heat", "heat-server", "cloud_watch_port")
-  action :nothing
-end.run_action(:create)
-
 if node[:pacemaker][:clone_stateless_services]
   # Wait for all nodes to reach this point so we know that all nodes will have
   # all the required packages installed before we create the pacemaker
@@ -49,7 +41,7 @@ if node[:pacemaker][:clone_stateless_services]
   crowbar_pacemaker_sync_mark "wait-heat_ha_resources"
 
   rabbit_settings = fetch_rabbitmq_settings
-  services = ["engine", "api", "api_cfn", "api_cloudwatch"]
+  services = ["engine", "api", "api_cfn"]
   transaction_objects = []
 
   services.each do |service|

--- a/chef/cookbooks/heat/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/heat/recipes/monitor_monasca.rb
@@ -16,7 +16,7 @@
 
 return unless node["roles"].include?("monasca-agent")
 
-bind_host, api_port, cfn_port, cloud_watch_port = HeatHelper.get_bind_host_port(node)
+bind_host, api_port, _cfn_port = HeatHelper.get_bind_host_port(node)
 
 monitor_url = "#{node[:heat][:api][:protocol]}://#{bind_host}:#{api_port}/"
 

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -4,7 +4,6 @@ reauthentication_auth_method = trusts
 trusts_delegated_roles = <%= @trusts_delegated_roles.join(',') %>
 heat_metadata_server_url = <%= @heat_metadata_server_url %>
 heat_waitcondition_server_url = <%= @heat_waitcondition_server_url %>
-heat_watch_server_url = <%= @heat_watch_server_url %>
 region_name_for_services = <%= @keystone_settings['endpoint_region'] %>
 stack_user_domain_id = <%= @stack_user_domain %>
 stack_domain_admin = <%= @stack_domain_admin %>
@@ -96,16 +95,6 @@ max_header_line = <%= node[:heat][:max_header_line] %>
 [heat_api_cfn]
 bind_host = <%= @bind_host %>
 bind_port = <%= @cfn_port %>
-<% if node[:heat][:api][:protocol] == "https" %>
-cert_file = <%= @heat_ssl[:certfile] %>
-key_file = <%= @heat_ssl[:keyfile] %>
-<% end %>
-workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
-max_header_line = <%= node[:heat][:max_header_line] %>
-
-[heat_api_cloudwatch]
-bind_host = <%= @bind_host %>
-bind_port = <%= @cloud_watch_port %>
 <% if node[:heat][:api][:protocol] == "https" %>
 cert_file = <%= @heat_ssl[:certfile] %>
 key_file = <%= @heat_ssl[:keyfile] %>

--- a/chef/cookbooks/heat/templates/suse/loadbalancer.template.erb
+++ b/chef/cookbooks/heat/templates/suse/loadbalancer.template.erb
@@ -7,19 +7,6 @@
     }
   },
   "Resources": {
-    "latency_watcher": {
-     "Type": "AWS::CloudWatch::Alarm",
-     "Properties": {
-        "MetricName": "Latency",
-        "Namespace": "AWS/ELB",
-        "Statistic": "Average",
-        "Period": "60",
-        "EvaluationPeriods": "1",
-        "Threshold": "2",
-        "AlarmActions": [],
-        "ComparisonOperator": "GreaterThanThreshold"
-      }
-    },
     "CfnLBUser" : {
       "Type" : "AWS::IAM::User"
     },
@@ -103,7 +90,7 @@
                 "\n",
                 "* * * * * /opt/aws/bin/cfn-hup -f\n",
                 "* * * * * /opt/aws/bin/cfn-push-stats ",
-                " --watch ", { "Ref" : "latency_watcher" }, " --haproxy\n"
+                " --haproxy\n"
                 ]]},
                 "mode"    : "000600",
                 "owner"   : "root",


### PR DESCRIPTION
The cloudwatch API has been removed upstream, so remove it and
its usage in the load balancer template from the barclamp as
well.