### PR TITLE
do not install/configure ceilometer-api

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -60,17 +60,14 @@ ha_enabled = node[:ceilometer][:ha][:server][:enabled]
 case node[:platform_family]
 when "suse"
   package "openstack-ceilometer-agent-notification"
-  package "openstack-ceilometer-api"
 when "rhel"
   package "openstack-ceilometer-common"
   package "openstack-ceilometer-agent-notification"
-  package "openstack-ceilometer-api"
   package "python-ceilometerclient"
 else
   package "python-ceilometerclient"
   package "ceilometer-common"
   package "ceilometer-agent-notification"
-  package "ceilometer-api"
 end
 
 include_recipe "#{@cookbook_name}::common"
@@ -81,13 +78,6 @@ directory "/var/cache/ceilometer" do
   mode 00755
   action :create
 end unless node[:platform_family] == "suse"
-
-keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
-ceilometer_protocol = node[:ceilometer][:api][:protocol]
-my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
-my_public_host = CrowbarHelper.get_host_for_public_url(node,
-                                                       ceilometer_protocol == "https",
-                                                       ha_enabled)
 
 crowbar_pacemaker_sync_mark "wait-ceilometer_upgrade" if ha_enabled
 
@@ -133,141 +123,6 @@ utils_systemd_service_restart "ceilometer-agent-notification" do
   action use_crowbar_pacemaker_service ? :disable : :enable
 end
 
-service "ceilometer-api" do
-  service_name node[:ceilometer][:api][:service_name]
-  supports status: true, restart: true, start: true, stop: true
-  action [:disable, :stop]
-  ignore_failure true
-end
-
-if node[:ceilometer][:ha][:server][:enabled]
-  admin_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  bind_host = admin_address
-  bind_port = node[:ceilometer][:ha][:ports][:api]
-else
-  bind_host = node[:ceilometer][:api][:host]
-  bind_port = node[:ceilometer][:api][:port]
-end
-
-if ceilometer_protocol == "https"
-  ssl_setup "setting up ssl for ceilometer" do
-    generate_certs node[:ceilometer][:ssl][:generate_certs]
-    certfile node[:ceilometer][:ssl][:certfile]
-    keyfile node[:ceilometer][:ssl][:keyfile]
-    group node[:ceilometer][:group]
-    fqdn node[:fqdn]
-    cert_required node[:ceilometer][:ssl][:cert_required]
-    ca_certs node[:ceilometer][:ssl][:ca_certs]
-  end
-end
-
-crowbar_openstack_wsgi "WSGI entry for ceilometer-api" do
-  bind_host bind_host
-  bind_port bind_port
-  daemon_process "ceilometer-api"
-  user node[:ceilometer][:user]
-  group node[:ceilometer][:group]
-  ssl_enable node[:ceilometer][:api][:protocol] == "https"
-  ssl_certfile node[:ceilometer][:ssl][:certfile]
-  ssl_keyfile node[:ceilometer][:ssl][:keyfile]
-  if node[:ceilometer][:ssl][:cert_required]
-    ssl_cacert node[:ceilometer][:ssl][:ca_certs]
-  end
-  timeout node[:ceilometer][:api][:timeout]
-end
-
-apache_site "ceilometer-api.conf" do
-  enable true
-end
-
-if ha_enabled
-  log "HA support for ceilometer is enabled"
-  include_recipe "ceilometer::server_ha"
-else
-  log "HA support for ceilometer is disabled"
-end
-
-crowbar_pacemaker_sync_mark "wait-ceilometer_register" if ha_enabled
-
-register_auth_hash = { user: keystone_settings["admin_user"],
-                       password: keystone_settings["admin_password"],
-                       project: keystone_settings["admin_project"] }
-
-keystone_register "ceilometer wakeup keystone" do
-  protocol keystone_settings["protocol"]
-  insecure keystone_settings["insecure"]
-  host keystone_settings["internal_url_host"]
-  port keystone_settings["admin_port"]
-  auth register_auth_hash
-  action :wakeup
-end
-
-keystone_register "register ceilometer user" do
-  protocol keystone_settings["protocol"]
-  insecure keystone_settings["insecure"]
-  host keystone_settings["internal_url_host"]
-  port keystone_settings["admin_port"]
-  auth register_auth_hash
-  user_name keystone_settings["service_user"]
-  user_password keystone_settings["service_password"]
-  project_name keystone_settings["service_tenant"]
-  action :add_user
-end
-
-keystone_register "give ceilometer user access" do
-  protocol keystone_settings["protocol"]
-  insecure keystone_settings["insecure"]
-  host keystone_settings["internal_url_host"]
-  port keystone_settings["admin_port"]
-  auth register_auth_hash
-  user_name keystone_settings["service_user"]
-  project_name keystone_settings["service_tenant"]
-  role_name "admin"
-  action :add_access
-end
-
-swift_middlewares = node[:ceilometer][:elements]["ceilometer-swift-proxy-middleware"] || []
-unless swift_middlewares.empty?
-  keystone_register "give ceilometer user ResellerAdmin role" do
-    protocol keystone_settings["protocol"]
-    insecure keystone_settings["insecure"]
-    host keystone_settings["internal_url_host"]
-    port keystone_settings["admin_port"]
-    auth register_auth_hash
-    user_name keystone_settings["service_user"]
-    project_name keystone_settings["service_tenant"]
-    role_name "ResellerAdmin"
-    action :add_access
-  end
-end
-
-# Create ceilometer service
-keystone_register "register ceilometer service" do
-  protocol keystone_settings["protocol"]
-  insecure keystone_settings["insecure"]
-  host keystone_settings["internal_url_host"]
-  port keystone_settings["admin_port"]
-  auth register_auth_hash
-  service_name "ceilometer"
-  service_type "metering"
-  service_description "Openstack Telemetry Service"
-  action :add_service
-end
-
-keystone_register "register ceilometer endpoint" do
-  protocol keystone_settings["protocol"]
-  insecure keystone_settings["insecure"]
-  host keystone_settings["internal_url_host"]
-  port keystone_settings["admin_port"]
-  auth register_auth_hash
-  endpoint_service "ceilometer"
-  endpoint_region keystone_settings["endpoint_region"]
-  endpoint_publicURL "#{ceilometer_protocol}://#{my_public_host}:#{node[:ceilometer][:api][:port]}"
-  endpoint_adminURL "#{ceilometer_protocol}://#{my_admin_host}:#{node[:ceilometer][:api][:port]}"
-  endpoint_internalURL "#{ceilometer_protocol}://#{my_admin_host}:#{node[:ceilometer][:api][:port]}"
-  action :add_endpoint
-end
-
 # In stoney/icehouse we have the cronjob crowbar-ceilometer-expirer in
 # /etc/cron.daily/.  In tex/juno this cronjob is moved into the
 # package, and is renamed as openstack-ceilometer-expirer.  We remove
@@ -279,5 +134,3 @@ end
 file "/etc/cron.weekly/crowbar-repairdatabase-mongodb" do
   action :delete
 end
-
-crowbar_pacemaker_sync_mark "create-ceilometer_register" if ha_enabled


### PR DESCRIPTION

monasca-ceilometer was removed from rpm-packaging as it was not building
against master. As a result openstack-ceilometer-api is no longer
available.

This patch is here to help get ahead of that blocker until
monasca-ceilometer is available again.