### PR TITLE
[4.0] keystone: Fix retry behavior on password update

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -558,8 +558,9 @@ def _get_token(http, user_name, password, tenant = "")
     count += 1
     Chef::Log.debug "Trying to get keystone token for user '#{user_name}' (try #{count})"
     resp = http.send_request("POST", path, JSON.generate(body), headers)
-    error = !(resp.is_a?(Net::HTTPCreated) || resp.is_a?(Net::HTTPOK))
-    sleep 5 if error
+    error = !resp.is_a?(Net::HTTPSuccess)
+    # retry on any 5XX (server error) error code but not on 4XX (client error)
+    sleep 5 if resp.is_a?(Net::HTTPServerError)
   end
 
   if error


### PR DESCRIPTION
With commit 9ee935f86f we added a retry loop to _get_token() to avoid
issues with service restarts during chef-client runs. The retrys
currently happen on any non-success response code including the 4XX
ones. However the code for updating the password relies on the get_token
to return 401. The current retry behavior will trigger unnecessary
retrys. Which will often cause the HA syncmark on the admin password
update code in keystone/recipe/server.rb to run into a timeout.

This change update the retry loop to only retry on 5XX errors, which
caused the original problem that the retry loop was trying to address.
Everything else will be handled as a success (2XX) or hard
(non-retryable) error.

(cherry picked from commit 5a6a79eb27d3fe752ddea2b1360f1cd331e50c4a)