### PR TITLE
remove heat-api-cloudwatch

### DIFF
--- a/chef/cookbooks/heat/attributes/default.rb
+++ b/chef/cookbooks/heat/attributes/default.rb
@@ -16,7 +16,6 @@
 default[:heat][:engine][:service_name] = "heat-engine"
 default[:heat][:api][:service_name] = "heat-api"
 default[:heat][:api_cfn][:service_name] = "heat-api-cfn"
-default[:heat][:api_cloudwatch][:service_name] = "heat-api-cloudwatch"
 
 case node[:platform_family]
 when "debian"
@@ -25,7 +24,6 @@ when "debian"
       "heat-engine",
       "heat-api",
       "heat-api-cfn",
-      "heat-api-cloudwatch",
       "python-heat",
       "heat-common",
       "python-heatclient"
@@ -35,7 +33,6 @@ when "debian"
       "heat-engine",
       "heat-api",
       "heat-api-cfn",
-      "heat-api-cloudwatch"
     ]
   }
 when "rhel", "suse"
@@ -44,7 +41,6 @@ when "rhel", "suse"
       "openstack-heat-engine",
       "openstack-heat-api",
       "openstack-heat-api-cfn",
-      "openstack-heat-api-cloudwatch",
       "python-heatclient"
     ],
     plugin_packages: [],
@@ -52,13 +48,11 @@ when "rhel", "suse"
       "openstack-heat-engine",
       "openstack-heat-api",
       "openstack-heat-api-cfn",
-      "openstack-heat-api-cloudwatch"
     ]
   }
   default[:heat][:engine][:service_name] = "openstack-heat-engine"
   default[:heat][:api][:service_name] = "openstack-heat-api"
   default[:heat][:api_cfn][:service_name] = "openstack-heat-api-cfn"
-  default[:heat][:api_cloudwatch][:service_name] = "openstack-heat-api-cloudwatch"
 end
 
 if node[:platform_family] == "suse"
@@ -109,5 +103,3 @@ default[:heat][:ha][:api][:agent] = "systemd:#{default[:heat][:api][:service_nam
 default[:heat][:ha][:api][:op][:monitor][:interval] = "10s"
 default[:heat][:ha][:api_cfn][:agent] = "systemd:#{default[:heat][:api_cfn][:service_name]}"
 default[:heat][:ha][:api_cfn][:op][:monitor][:interval] = "10s"
-default[:heat][:ha][:api_cloudwatch][:agent] = "systemd:#{default[:heat][:api_cloudwatch][:service_name]}"
-default[:heat][:ha][:api_cloudwatch][:op][:monitor][:interval] = "10s"

--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -31,14 +31,6 @@ haproxy_loadbalancer "heat-api-cfn" do
   action :nothing
 end.run_action(:create)
 
-haproxy_loadbalancer "heat-api-cloudwatch" do
-  address "0.0.0.0"
-  port node[:heat][:api][:cloud_watch_port]
-  use_ssl (node[:heat][:api][:protocol] == "https")
-  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "heat", "heat-server", "cloud_watch_port")
-  action :nothing
-end.run_action(:create)
-
 if node[:pacemaker][:clone_stateless_services]
   # Wait for all nodes to reach this point so we know that all nodes will have
   # all the required packages installed before we create the pacemaker
@@ -49,7 +41,7 @@ if node[:pacemaker][:clone_stateless_services]
   crowbar_pacemaker_sync_mark "wait-heat_ha_resources"
 
   rabbit_settings = fetch_rabbitmq_settings
-  services = ["engine", "api", "api_cfn", "api_cloudwatch"]
+  services = ["engine", "api", "api_cfn"]
   transaction_objects = []
 
   services.each do |service|

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -481,17 +481,6 @@ utils_systemd_service_restart "heat-api-cfn" do
   action use_crowbar_pacemaker_service ? :disable : :enable
 end
 
-service "heat-api-cloudwatch" do
-  service_name node[:heat][:api_cloudwatch][:service_name]
-  supports status: true, restart: true
-  action [:enable, :start]
-  subscribes :restart, resources("template[/etc/heat/heat.conf.d/100-heat.conf]")
-  provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
-end
-utils_systemd_service_restart "heat-api-cloudwatch" do
-  action use_crowbar_pacemaker_service ? :disable : :enable
-end
-
 if ha_enabled
   log "HA support for heat is enabled"
   include_recipe "heat::ha"


### PR DESCRIPTION
heat-api-cloudwatch is deprecated and is no longer installable
the service was removed in https://review.openstack.org/#/c/534660/