### PR TITLE
kick off an experiment with CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,23 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners would be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+#*       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+#*.js    @js-owner
+
+**/*cinder*  @toabctl
+**/*manila*  @toabctl
+
+**/*keystone*  @rhafer @cmurphy
+**/*monasca*  @jgrassler
+
+ha*.rb  @aspiers
+*_ha.rb  @aspiers


### PR DESCRIPTION
This is an experiment which could supersede the mentionbot which was just removed in #1781.  It will cause the mentioned users to be automatically notified when pull requests are proposed which modify files matching the specified patterns, as described in

- https://help.github.com/articles/about-codeowners/

In our context, it does not mean anything about real ownership (yet), only notification.

Users and file patterns have been picked without any serious thought, and can of course easily be improved later.