### PR TITLE
trove: Remove support

### DIFF
--- a/chef/data_bags/crowbar/migrate/trove/301_remove_trove.rb
+++ b/chef/data_bags/crowbar/migrate/trove/301_remove_trove.rb
@@ -1,0 +1,26 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  deployment["element_states"] = template_deployment["element_states"]
+  deployment["element_order"] = template_deployment["element_order"]
+  deployment["element_run_list_order"] = template_deployment["element_run_list_order"]
+
+  deployment["elements"]["trove"] &&
+    deployment["elements"].delete("trove")
+  deployment.fetch("elements_expanded", {}).key?("trove") &&
+    deployment["elements_expanded"].delete("trove")
+
+  nodes = NodeObject.find("run_list_map:trove")
+  nodes.each do |node|
+    node.delete_from_run_list("trove")
+    node.save
+  end
+
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  deployment["element_states"] = template_deployment["element_states"]
+  deployment["element_order"] = template_deployment["element_order"]
+  deployment["element_run_list_order"] = template_deployment["element_run_list_order"]
+
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-trove.json
+++ b/chef/data_bags/crowbar/template-trove.json
@@ -28,13 +28,12 @@
     "trove": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
-      "schema-revision": 300,
+      "schema-revision": 301,
       "element_states": {
         "trove-server": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
-        [ "trove-server" ]
       ],
       "config": {
         "environment": "trove-base-config",

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -61,7 +61,6 @@ class RabbitmqService < OpenstackServiceObject
     }
 
     base["attributes"][@bc_name]["password"] = random_password
-    base["attributes"][@bc_name]["trove"]["password"] = random_password
 
     @logger.debug("Rabbitmq create_proposal: exiting")
     base

--- a/crowbar_framework/lib/openstack/data_bag_config.rb
+++ b/crowbar_framework/lib/openstack/data_bag_config.rb
@@ -30,7 +30,7 @@ module Openstack
           # nova
           attributes["ssl"]["enabled"]
         else
-          # magnum, sahara, trove
+          # magnum, sahara
           false
         end
 


### PR DESCRIPTION
This commit removes trove support as it was deprecated in Cloud 8.