### PR TITLE
nova: Increase retries for listing flavors

### DIFF
--- a/chef/cookbooks/nova/recipes/flavors.rb
+++ b/chef/cookbooks/nova/recipes/flavors.rb
@@ -108,7 +108,7 @@ ruby_block "Get current flavors" do
     raise "Flavor list not obtained, is the nova-api down?" unless cmd.exitstatus.zero?
     node.run_state["flavorlist"] = cmd.stdout.split("\n")
   end
-  retries 5
+  retries 10
 end
 
 ruby_block "Flavor creation" do


### PR DESCRIPTION
The command getting the list of flavors is executed pretty close to
starting the nova ha resource, which can take bit more time (especially
on slow clusters). So give the flavor list command a few more tries
before erroring out.

Note: this is only an issue in setups where the stateless resources are still
managed by pacemaker (clone-stateless-service=true). In the alternative
setup (managed by systemd) the service are started a bit earlier during
the chef-client run.