### PR TITLE
[5.0] neutron/nova: allow overriding default_log_levels

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -154,7 +154,8 @@ template neutron[:neutron][:config_file] do
       infoblox: infoblox_settings,
       ipam_driver: ipam_driver,
       rpc_workers: neutron[:neutron][:rpc_workers],
-      use_apic_gbp: use_apic_gbp
+      use_apic_gbp: use_apic_gbp,
+      default_log_levels: neutron[:neutron][:default_log_levels]
     )
 end
 

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -25,6 +25,9 @@ transport_url = <%= @rabbit_settings[:url] %>
 control_exchange = neutron
 max_header_line = <%= node[:neutron][:max_header_line] %>
 wsgi_keep_alive = false
+<% unless @default_log_levels.length.zero? -%>
+default_log_levels = <%= @default_log_levels.join(", ") %>
+<% end -%>
 
 [agent]
 root_helper = sudo neutron-rootwrap /etc/neutron/rootwrap.conf

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -420,7 +420,8 @@ template node[:nova][:config_file] do
     reserved_host_memory: reserved_host_memory,
     use_baremetal_filters: use_baremetal_filters,
     track_instance_changes: track_instance_changes,
-    ironic_settings: ironic_settings
+    ironic_settings: ironic_settings,
+    default_log_levels: node[:nova][:default_log_levels]
   )
 end
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -78,6 +78,9 @@ zvm_user_profile = <%= node[:nova][:zvm][:zvm_user_profile] %>
 zvm_user_default_password = <%= node[:nova][:zvm][:zvm_user_default_password] %>
 zvm_user_default_privilege = <%= node[:nova][:zvm][:zvm_user_default_privilege] %>
 <% end %>
+<% unless @default_log_levels.length.zero? -%>
+default_log_levels = <%= @default_log_levels.join(", ") %>
+<% end -%>
 
 [api]
 auth_strategy = keystone

--- a/chef/data_bags/crowbar/migrate/neutron/212_add_default_log_levels.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/212_add_default_log_levels.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "default_log_levels"
+  attributes[key] = template_attributes[key] unless attributes.key? key
+  return a, d
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "default_log_levels"
+  attributes.delete(key) unless template_attributes.key? key
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/nova/210_add_default_log_levels.rb
+++ b/chef/data_bags/crowbar/migrate/nova/210_add_default_log_levels.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "default_log_levels"
+  attributes[key] = template_attributes[key] unless attributes.key? key
+  return a, d
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "default_log_levels"
+  attributes.delete(key) unless template_attributes.key? key
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -181,14 +181,15 @@
       },
       "metadata": {
         "force": false
-      }
+      },
+      "default_log_levels": []
     }
   },
   "deployment": {
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 211,
+      "schema-revision": 212,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -226,6 +226,11 @@
                       "type": "map", "required": true, "mapping": {
                         "force": { "type": "bool", "required": true }
                       }
+                    },
+                    "default_log_levels": {
+                      "type": "seq",
+                      "required": false,
+                      "sequence": [ { "type": "str" } ]
                     }
               }}
      }},

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -176,14 +176,15 @@
         "openstack-nova-compute": {
           "LimitNOFILE": null
         }
-      }
+      },
+      "default_log_levels": []
     }
   },
   "deployment": {
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 209,
+      "schema-revision": 210,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -275,6 +275,11 @@
                   "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
                 }
               }
+            },
+            "default_log_levels": {
+              "type": "seq",
+              "required": false,
+              "sequence": [ { "type": "str" } ]
             }
           }
         }


### PR DESCRIPTION
Allow overriding the default_log_leves from crowbar so we
can bump the log levels for several libraries like
oslo_messaging or amqp

This new setting accepts a list of "library=LEVEL" strings
as show in the docs[0][1]

[0] https://docs.openstack.org/mitaka/config-reference/compute/config-options.html#nova-logging
[1] https://docs.openstack.org/mitaka/config-reference/networking/networking_options_reference.html

(cherry picked from commit fe8cbc77e3604431a6b12551ad290463f1bc350d)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1725