### PR TITLE
fix a typo in glance-api.conf.erb

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -89,7 +89,7 @@ lock_path = /var/run/glance
 <% if @rabbit_settings[:enable_notifications] -%>
 [oslo_messaging_notifications]
 driver = messagingv2
-+<% end -%>
+<% end -%>
 
 [oslo_messaging_rabbit]
 amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>


### PR DESCRIPTION
Otherwise, oslo.config will fail to parse the file.