### PR TITLE
rabbitmq: default to openstack/openstack for new installs

### DIFF
--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -6,9 +6,9 @@
       "listen_public": false,
       "port": 5672,
       "password": "",
-      "user": "nova",
+      "user": "openstack",
       "extra_users": {},
-      "vhost": "nova",
+      "vhost": "openstack",
       "ssl": {
         "enabled": false,
         "port": 5671,


### PR DESCRIPTION
The "nova" vhost is from the dark ages before openstack was
more than just nova. Lets use a more sensible default for new
installs. Intentionall no migration for existing installations.