### PR TITLE
rabbitmq: allow disabling queue mirroring

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -170,7 +170,8 @@ if cluster_enabled
     quorum = 1
   end
 
-  queue_regex = "^(?!amq.).*"
+  # don't mirror queues that are 'amqp.*' or '*_fanout_*' or `reply_*` in their names
+  queue_regex = "^(?!(amqp.)|(.*_fanout_)|(reply_)).*"
   # policy doesnt need spaces between elements as they will be removed when listing them
   # making it more difficult to check for them
   policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum}}"

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -174,7 +174,7 @@ if cluster_enabled
   queue_regex = "^(?!(amqp.)|(.*_fanout_)|(reply_)).*"
   # policy doesnt need spaces between elements as they will be removed when listing them
   # making it more difficult to check for them
-  policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum}}"
+  policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum},\"ha-sync-mode\":\"automatic\"}"
   vhost = node[:rabbitmq][:vhost]
   # we need to scape the regex properly so we can use it on the grep command
   queue_regex_escaped = ""

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -60,7 +60,8 @@
         "sndbuf": null,
         "recbuf": null
       },
-      "collect_statistics_interval": 5000
+      "collect_statistics_interval": 5000,
+      "enable_queue_mirroring": true
     }
   },
   "deployment": {

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -122,7 +122,8 @@
                 "recbuf": { "type": "int", "required": false }
               }
             },
-            "collect_statistics_interval": { "type": "int", "required": true}
+            "collect_statistics_interval": { "type": "int", "required": true},
+            "enable_queue_mirroring": { "type": "bool", "required": true}
           }
         }
       }


### PR DESCRIPTION
Allows to disable queue mirroring on rabbitmq as it should not be
linked to having a rabbitmq cluster

NOTICE: before someone complains, this does *not* require a migration file because we are building cloud9 and will backport this to cloud8/7 so either this gets in on a new install of cloud9 or anyone upgrading from cloud8 will already have it migrated due to the backport, so there is no need for a migration file here