### PR TITLE
[4.0] rabbitmq: allow disabling queue mirroring

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -170,7 +170,8 @@ if cluster_enabled
     quorum = 1
   end
 
-  queue_regex = "^(?!amq.).*"
+  # don't mirror queues that are 'amqp.*' or '*_fanout_*' or `reply_*` in their names
+  queue_regex = "^(?!(amqp.)|(.*_fanout_)|(reply_)).*"
   # policy doesnt need spaces between elements as they will be removed when listing them
   # making it more difficult to check for them
   policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum}}"

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -174,7 +174,7 @@ if cluster_enabled
   queue_regex = "^(?!(amqp.)|(.*_fanout_)|(reply_)).*"
   # policy doesnt need spaces between elements as they will be removed when listing them
   # making it more difficult to check for them
-  policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum}}"
+  policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum},\"ha-sync-mode\":\"automatic\"}"
   vhost = node[:rabbitmq][:vhost]
   # we need to scape the regex properly so we can use it on the grep command
   queue_regex_escaped = ""

--- a/chef/data_bags/crowbar/migrate/rabbitmq/107_add_enable_queue_mirroring.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/107_add_enable_queue_mirroring.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "enable_queue_mirroring"
+  attributes[key] = template_attributes[key] unless attributes.key? key
+  return attributes, deployment
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "enable_queue_mirroring"
+  attributes.delete(key) unless template_attributes.key? key
+  return attributes, deployment
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -52,14 +52,15 @@
       "mnesia": {
         "dump_log_write_threshold": 100,
         "dump_log_time_threshold": 180000
-      }
+      },
+      "enable_queue_mirroring": true
     }
   },
   "deployment": {
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 106,
+      "schema-revision": 107,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -110,7 +110,8 @@
                 "dump_log_write_threshold": { "type": "int", "required": true},
                 "dump_log_time_threshold": { "type": "int", "required": true}
               }
-            }
+            },
+            "enable_queue_mirroring": { "type": "bool", "required": true}
           }
         }
       }


### PR DESCRIPTION
Allows to disable queue mirroring on rabbitmq as it should not be
linked to having a rabbitmq cluster

(cherry picked from commit fe7be665b25f0497d424bb87af8a201a784b35dc)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1808