### PR TITLE
[4.0] neutron: define  sql_max_pool_size for config template expansion

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -120,6 +120,7 @@ template neutron[:neutron][:config_file] do
     variables(
       sql_connection: is_neutron_server ? neutron[:neutron][:db][:sql_connection] : nil,
       sql_min_pool_size: neutron[:neutron][:sql][:min_pool_size],
+      sql_max_pool_size: neutron[:neutron][:sql][:max_pool_size],
       sql_max_pool_overflow: neutron[:neutron][:sql][:max_pool_overflow],
       sql_pool_timeout: neutron[:neutron][:sql][:pool_timeout],
       debug: neutron[:neutron][:debug],


### PR DESCRIPTION
Without that change, the previous patch that tried to make this
parameter configurable and is expanded to the (raised) default of 50
did not work as it was never set.

(cherry picked from commit 3951bae99b7293ed50b42aad2dc358a6a5e6c6ca)