### PR TITLE
neutron: use entrypoints for plugin drivers

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -169,7 +169,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     # package is already installed
     neutron_agent = node[:neutron][:platform][:ovs_agent_name]
     agent_config_path = "/etc/neutron/plugins/ml2/openvswitch_agent.ini"
-    interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
+    interface_driver = "openvswitch"
     bridge_mappings = []
 
     if ml2_type_drivers.include?("vlan")
@@ -203,7 +203,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
 
     neutron_agent = node[:neutron][:platform][:lb_agent_name]
     agent_config_path = "/etc/neutron/plugins/ml2/linuxbridge_agent.ini"
-    interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
+    interface_driver = "linuxbridge"
     interface_mappings = []
 
     if ml2_type_drivers.include?("vlan")

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -161,10 +161,10 @@ template neutron[:neutron][:config_file] do
 end
 
 if neutron[:neutron][:use_lbaas]
-  interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
+  interface_driver = "openvswitch"
   if neutron[:neutron][:networking_plugin] == "ml2" &&
       neutron[:neutron][:ml2_mechanism_drivers].include?("linuxbridge")
-    interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
+    interface_driver = "linuxbridge"
   end
 
   template neutron[:neutron][:lbaas_config_file] do

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -101,12 +101,12 @@ when "ml2"
   when ml2_mech_drivers.include?("openvswitch") ||
     ml2_mech_drivers.include?("cisco_apic_ml2") ||
     ml2_mech_drivers.include?("apic_gbp")
-    interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
+    interface_driver = "openvswitch"
   when ml2_mech_drivers.include?("linuxbridge")
-    interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
+    interface_driver = "linuxbridge"
   end
 when "vmware"
-  interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
+  interface_driver = "openvswitch"
 end
 
 template "/etc/neutron/metering_agent.ini" do

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -110,7 +110,7 @@ end
 #                so the order is important
 tenant_network_types = [[node[:neutron][:ml2_type_drivers_default_tenant_network]] + node[:neutron][:ml2_type_drivers]].flatten.uniq
 
-interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
+interface_driver = "openvswitch"
 
 ironic_net = Barclamp::Inventory.get_network_definition(node, "ironic")
 
@@ -157,7 +157,7 @@ when "ml2"
 
   ml2_mech_drivers = node[:neutron][:ml2_mechanism_drivers]
   if ml2_mech_drivers.include?("linuxbridge")
-    interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
+    interface_driver = "linuxbridge"
   end
 
   # Empty the config file that is explicitly passed to neutron-server (via plugin.ini

--- a/chef/cookbooks/neutron/templates/default/linuxbridge_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/linuxbridge_agent.ini.erb
@@ -3,7 +3,7 @@
 [linux_bridge]
 physical_interface_mappings = <%= @interface_mappings %>
 [securitygroup]
-firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
+firewall_driver = iptables
 [vxlan]
 <% unless @ml2_type_drivers.include?("vxlan") -%>
 enable_vxlan = False

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -26,4 +26,4 @@ local_ip = <%= node.address("os_sdn").addr %>
 <% end -%>
 bridge_mappings = <%= @bridge_mappings %>
 [securitygroup]
-firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = iptables_hybrid


### PR DESCRIPTION
This avoids a slighly misleading warning from stevedore
that the dotted path is not really an entrypoint.