### PR TITLE
rabbit: Change failover strategy to shuffle

### DIFF
--- a/chef/cookbooks/aodh/templates/default/aodh.conf.erb
+++ b/chef/cookbooks/aodh/templates/default/aodh.conf.erb
@@ -50,4 +50,5 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/cookbooks/barbican/templates/default/barbican.conf.erb
+++ b/chef/cookbooks/barbican/templates/default/barbican.conf.erb
@@ -12,6 +12,7 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 ssl_ca_file = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [queue]

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -83,6 +83,7 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 <% if @is_compute_agent -%>

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -320,6 +320,7 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [ssl]

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -52,6 +52,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [keystone_authtoken]

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -50,6 +50,7 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 ssl_ca_file = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [paste_deploy]

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -144,4 +144,5 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 ssl_ca_file = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -115,6 +115,7 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [pxe]

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -96,6 +96,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [oslo_policy]

--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -90,6 +90,7 @@ rabbit_use_ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [oslo_policy]

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -93,6 +93,7 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 #############################################################################

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -102,6 +102,7 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] -%>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end -%>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [ssl]

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -273,6 +273,7 @@ ssl = <%= @rabbit_settings[:use_ssl] %>
 <% if @rabbit_settings[:client_ca_certs] %>
 kombu_ssl_ca_certs = <%= @rabbit_settings[:client_ca_certs] %>
 <% end %>
+kombu_failover_strategy = shuffle
 heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [serial_console]


### PR DESCRIPTION
The default, round-robin, leads to a predictable reconnect order
as we're listing the services always in the same order in the config
file. This causes queues to be be less balanced, e.g. the first
node is always servicing more load than the other nodes in the rabbitmq
cluster. with a shuffle strategy this should become more balanced over
time.