### PR TITLE
[4.0] rabbitmq: active the haproxy balancing

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -68,3 +68,7 @@ end
 
 # create empty users list as it is expected by some recipes
 default[:rabbitmq][:users] = []
+
+# Ports to bind to when haproxy is used for the real ports
+default[:rabbitmq][:ha][:ports][:api] = 5630
+default[:rabbitmq][:ha][:ports][:api_ssl] = 5631

--- a/chef/cookbooks/rabbitmq/providers/vhost.rb
+++ b/chef/cookbooks/rabbitmq/providers/vhost.rb
@@ -19,6 +19,9 @@
 
 action :add do
   unless Kernel::system("rabbitmqctl list_vhosts | grep -q #{new_resource.vhost}")
+    # wait for service to have a master, and to be active
+    CrowbarPacemakerHelper.wait_until_rabbitmq_ready
+
     Chef::Log.info "Adding RabbitMQ vhost '#{new_resource.vhost}'."
     execute "rabbitmqctl add_vhost #{new_resource.vhost}"
     new_resource.updated_by_last_action(true)

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -22,6 +22,16 @@ ha_enabled = node[:rabbitmq][:ha][:enabled]
 # we only do cluster if we do HA
 cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
 quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
+crm_resource_stop_cmd = "force-stop"
+crm_resource_start_cmd = "force-start"
+
+if node[:rabbitmq][:ha][:haproxy_enabled] && cluster_enabled
+  rabbitmq_port = node[:rabbitmq][:ha][:ports][:api]
+  rabbitmq_ssl_port = node[:rabbitmq][:ha][:ports][:api_ssl]
+else
+  rabbitmq_port = node[:rabbitmq][:port]
+  rabbitmq_ssl_port = node[:rabbitmq][:ssl][:port]
+end
 
 cluster_partition_handling = if cluster_enabled
   if CrowbarPacemakerHelper.num_corosync_nodes(node) > 2
@@ -107,7 +117,9 @@ template "/etc/rabbitmq/rabbitmq.config" do
   variables(
     cluster_enabled: cluster_enabled,
     cluster_partition_handling: cluster_partition_handling,
-    hipe_compile: hipe_compile
+    hipe_compile: hipe_compile,
+    rabbitmq_port: rabbitmq_port,
+    rabbitmq_ssl_port: rabbitmq_ssl_port
   )
   notifies :restart, "service[rabbitmq-server]"
 end
@@ -157,7 +169,13 @@ bash "enabling rabbit management" do
 end
 
 service "rabbitmq-server" do
-  supports restart: true, start: true, stop: true, status: true
+  service_name "rabbitmq" if node[:rabbitmq][:ha][:haproxy_enabled]
+  supports restart: true,
+           start: true,
+           stop: true,
+           status: true,
+           crm_resource_stop_cmd: crm_resource_stop_cmd,
+           crm_resource_start_cmd: crm_resource_start_cmd
   action [:enable, :start]
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -8,11 +8,11 @@
  {rabbit,
   [
    {tcp_listeners, [
-                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:port]}}" }.join(", ") %>
+                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{@rabbitmq_port}}" }.join(", ") %>
                    ]},
 <% if node[:rabbitmq][:ssl][:enabled] -%>
    {ssl_listeners, [
-                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:ssl][:port]}}" }.join(", ") %>
+                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{@rabbitmq_ssl_port}}" }.join(", ") %>
                    ]},
    {ssl_options, [
    <% if node[:rabbitmq][:ssl][:cert_required] -%>

--- a/chef/data_bags/crowbar/migrate/rabbitmq/107_haproxy.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/107_haproxy.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ha"]["haproxy_enabled"] = ta["ha"]["haproxy_enabled"] unless a["ha"]["haproxy_enabled"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["ha"].delete("haproxy_enabled") unless ta["ha"].key?("haproxy_enabled")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -36,7 +36,8 @@
             "fstype": "",
             "options": ""
           }
-        }
+        },
+        "haproxy_enabled": false
       },
       "trove": {
         "enabled": false,
@@ -59,7 +60,7 @@
     "rabbitmq": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 106,
+      "schema-revision": 107,
       "element_states": {
         "rabbitmq-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/template-rabbitmq.schema
@@ -79,7 +79,8 @@
                       }
                     }
                   }
-                }
+                },
+                "haproxy_enabled": { "type": "bool", "required": true }
               }
             },
             "trove": {

--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -100,6 +100,17 @@ class RabbitmqService < OpenstackServiceObject
 
     role.save if save_role
 
+    # if no previous configuration of haproxy_enable, active if the proposal is not already applied
+    if old_role.nil?
+      haproxy_enabled = true
+    else
+      haproxy_enabled = old_role.default_attributes[@bc_name]["ha"]["haproxy_enabled"]
+      haproxy_enabled = false if haproxy_enabled.nil?
+    end
+
+    role.default_attributes[@bc_name]["ha"]["haproxy_enabled"] = haproxy_enabled
+    role.save
+
     rabbitmq_elements, rabbitmq_nodes, rabbitmq_ha_enabled = role_expand_elements(role, "rabbitmq-server")
     Openstack::HA.set_controller_role(rabbitmq_nodes) if rabbitmq_ha_enabled
 
@@ -134,7 +145,21 @@ class RabbitmqService < OpenstackServiceObject
         (old_role && old_role.default_attributes["rabbitmq"]["erlang_cookie"]) || random_password
     end
 
-    unless rabbitmq_ha_enabled
+    if rabbitmq_ha_enabled
+      if role.default_attributes["rabbitmq"]["cluster"] &&
+          role.default_attributes["rabbitmq"]["ha"]["haproxy_enabled"]
+        vip_networks = ["admin"]
+        vip_networks << "public" if role.default_attributes["rabbitmq"]["listen_public"]
+
+        allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(rabbitmq_elements,
+          vip_networks)
+
+        dirty = prepare_role_for_ha_with_haproxy(role, ["rabbitmq", "ha", "haproxy"],
+          rabbitmq_ha_enabled, rabbitmq_elements, vip_networks)
+
+        role.save if dirty
+      end
+    else
       # cluster mode requires HA (for now); don't do a validation check as we
       # still want to have the setting default to true in case people want to
       # turn HA on, and in this case, result in clustering by default


### PR DESCRIPTION
Enable balancing connections using haproxy in a cluster of rabbitmq

The balancer gets the default client ports specified in the proposal
and each rabbitmq node uses (5630 and 5631)

(cherry picked from commit 1cfe290e6f18cf896145bf25fb59e52eb8dba16c)
Backported from #1571