### PR TITLE
[5.0] Neutron force metadata disable metadata agent fix

### DIFF
--- a/chef/cookbooks/neutron/definitions/neutron_metadata.rb
+++ b/chef/cookbooks/neutron/definitions/neutron_metadata.rb
@@ -87,7 +87,7 @@ define :neutron_metadata,
     use_crowbar_pacemaker_service = \
       (neutron_network_ha && node[:pacemaker][:clone_stateless_services]) || nova_compute_ha_enabled
 
-    enable_metadata = node.roles.include?("neutron-network") || !node[:neutron][:metadata][:force]
+    enable_metadata = node.roles.include?("neutron-network") || !neutron[:neutron][:metadata][:force]
 
     # In case of Cisco ACI driver, supervisord takes care of starting up
     # the metadata agent.


### PR DESCRIPTION
In commit 8e8f8e873ab9cb94ca1042529f289ca017ceff3d is introduced
an option to disable metadata agent in computer nodes.

In some cases, the condition to check if metadata is enabled
fails because these computers don't have the information of
node[:neutron][:metadata][:force]

This commit fixes this problem

(cherry picked from commit fa92cfd)
Backported from #1825