### PR TITLE
Adding domain credential to the neutron.conf for nova

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -81,6 +81,8 @@ insecure = <%= @nova_insecure %>
 password = <%= @keystone_settings['service_password'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 username = <%= @keystone_settings['service_user'] %>
+project_domain_name = <%= @keystone_settings['default_user_domain'] %>
+user_domain_name = <%= @keystone_settings['default_user_domain'] %>
 
 [oslo_concurrency]
 lock_path = /var/run/neutron


### PR DESCRIPTION
passing domain info for neutron to send notifications back to nova

without this patch booting vms fails with error
```
ERROR neutron.notifiers.nova Traceback (most recent call last):
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/neutron/notifiers/nova.py", line 245, in send_events
ERROR neutron.notifiers.nova     batched_events)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/novaclient/v2/server_external_events.py", line 39, in create
ERROR neutron.notifiers.nova     return_raw=True)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/novaclient/base.py", line 366, in _create
ERROR neutron.notifiers.nova     resp, body = self.api.client.post(url, body=body)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/adapter.py", line 334, in post
ERROR neutron.notifiers.nova     return self.request(url, 'POST', **kwargs)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/novaclient/client.py", line 77, in request
ERROR neutron.notifiers.nova     **kwargs)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/adapter.py", line 487, in request
ERROR neutron.notifiers.nova     resp = super(LegacyJsonAdapter, self).request(*args, **kwargs)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/adapter.py", line 213, in request
ERROR neutron.notifiers.nova     return self.session.request(url, method, **kwargs)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 684, in request
ERROR neutron.notifiers.nova     auth_headers = self.get_auth_headers(auth)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 1071, in get_auth_headers
ERROR neutron.notifiers.nova     return auth.get_headers(self, **kwargs)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/plugin.py", line 95, in get_headers
ERROR neutron.notifiers.nova     token = self.get_token(session)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/base.py", line 88, in get_token
ERROR neutron.notifiers.nova     return self.get_access(session).auth_token
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/base.py", line 134, in get_access
ERROR neutron.notifiers.nova     self.auth_ref = self.get_auth_ref(session)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/generic/base.py", line 208, in get_auth_ref
ERROR neutron.notifiers.nova     return self._plugin.get_auth_ref(session, **kwargs)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/v3/base.py", line 178, in get_auth_ref
ERROR neutron.notifiers.nova     authenticated=False, log=False, **rkwargs)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 1019, in post
ERROR neutron.notifiers.nova     return self.request(url, 'POST', **kwargs)
ERROR neutron.notifiers.nova   File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 869, in request
ERROR neutron.notifiers.nova     raise exceptions.from_response(resp, method, url)
ERROR neutron.notifiers.nova BadRequest: Expecting to find domain in project. The server could not comply with the request since it is either malformed or otherwise incorrect. The client is assumed to be in error. (HTTP 400) (Request-ID: req-a82dd8f7-45fe-42d9-9608-a45956e86c1e)
```