### PR TITLE
[4.0] database: Fix log line

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -134,7 +134,7 @@ class CrowbarOpenStackHelper
           }
         }
 
-        Chef::Log.info("Database server found at #{@database_settings[instance][:address]}")
+        Chef::Log.info("Database server found at #{@database_settings[instance][sql_engine][:address]}")
       end
     end
 


### PR DESCRIPTION
"Database server found at" line had wrong reference to address variable.