### PR TITLE
[4.0]database: Increase galera write set limits

### DIFF
--- a/chef/cookbooks/mysql/templates/default/galera.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera.cnf.erb
@@ -6,6 +6,16 @@ wsrep_cluster_address = "<%= @cluster_addresses %>"
 wsrep_provider_options = "gmcast.listen_addr=tcp://<%= @node_address %>:4567;gcs.fc_limit = <%= @wsrep_slave_threads * 5 %>;gcs.fc_factor = 0.8"
 wsrep_slave_threads = <%= @wsrep_slave_threads %>
 
+# Maximum number of rows in write set
+# "0" (unlimited) is the upstream default, but the default configuration in the
+# rpm package overwrites that
+wsrep_max_ws_rows=0
+
+# Maximum size of write set
+# "2147483647" (2GB) is the upstream default, but the default configuration in
+# the rpm package overwrites that
+wsrep_max_ws_size=2147483647
+
 # to enable debug level logging, set this to 1
 wsrep_debug = 0
 


### PR DESCRIPTION
For some reason the default configuration shipped with the
mariadb-galera package configures non-default limits for wsrep_max_ws_rows
and wsrep_max_ws_size. This commit changes the limits back to the
maximum supported values (which also happen to be the defaults used by
MariaDB if no configuration is present).
This is to reduce the likelyhood of failing DB transactions (with e.g.
"wsrep_max_ws_rows exceeded") when e.g.  ceilometer-expirer needs to
DELETE a large set of database rows.

(cherry picked from commit 8a2877cd9c3084670c6dcc4230661cd31405dffb)

backport of https://github.com/crowbar/crowbar-openstack/pull/1830