### PR TITLE
nova/neutron: Fix copy'n paste error in schema migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/neutron/212_add_default_log_levels.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/212_add_default_log_levels.rb
@@ -1,11 +1,11 @@
 def upgrade(template_attributes, template_deployment, attributes, deployment)
   key = "default_log_levels"
   attributes[key] = template_attributes[key] unless attributes.key? key
-  return a, d
+  return attributes, deployment
 end
 
 def downgrade(template_attributes, template_deployment, attributes, deployment)
   key = "default_log_levels"
   attributes.delete(key) unless template_attributes.key? key
-  return a, d
+  return attributes, deploment
 end

--- a/chef/data_bags/crowbar/migrate/nova/210_add_default_log_levels.rb
+++ b/chef/data_bags/crowbar/migrate/nova/210_add_default_log_levels.rb
@@ -1,11 +1,11 @@
 def upgrade(template_attributes, template_deployment, attributes, deployment)
   key = "default_log_levels"
   attributes[key] = template_attributes[key] unless attributes.key? key
-  return a, d
+  return attributes, deploment
 end
 
 def downgrade(template_attributes, template_deployment, attributes, deployment)
   key = "default_log_levels"
   attributes.delete(key) unless template_attributes.key? key
-  return a, d
+  return attributes, deploment
 end


### PR DESCRIPTION
The "*_add_default_log_levels.rb" were currenty failing with:
"undefined local variable or method `a' for SchemaMigration:Module"