### PR TITLE
change  deprecated options from rocky

### DIFF
--- a/chef/cookbooks/aodh/templates/default/aodh.conf.erb
+++ b/chef/cookbooks/aodh/templates/default/aodh.conf.erb
@@ -12,7 +12,7 @@ alarm_history_time_to_live = <%= @alarm_history_ttl %>
 connection = <%= @database_connection %>
 
 [keystone_authtoken]
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 <% if @keystone_settings['insecure'] -%>

--- a/chef/cookbooks/barbican/templates/default/barbican.conf.erb
+++ b/chef/cookbooks/barbican/templates/default/barbican.conf.erb
@@ -30,7 +30,7 @@ kek = <%= @kek %>
 [keystone_authtoken]
 auth_type = password
 auth_url = <%= @keystone_settings["internal_auth_url"] %>
-auth_uri = <%= @keystone_settings["public_auth_url"] %>
+www_authenticate_uri = <%= @keystone_settings["public_auth_url"] %>
 auth_version = <%= @keystone_settings["api_version_for_middleware"] %>
 username = <%= @keystone_settings["service_user"] %>
 password = <%= @keystone_settings["service_password"] %>

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -19,7 +19,7 @@ event_time_to_live = <%= @event_time_to_live %>
 connection = <%= @database_connection %>
 
 [keystone_authtoken]
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['admin_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 <% if @keystone_settings['insecure'] -%>

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -272,7 +272,7 @@ max_over_subscription_ratio = <%= volume[volume['backend_driver']]['max_over_sub
 
 [key_manager]
 <% unless node[:cinder][:keymgr_fixed_key].empty? -%>
-api_class = cinder.keymgr.conf_key_mgr.ConfKeyManager
+backend = cinder.keymgr.conf_key_mgr.ConfKeyManager
 fixed_key = <%= node[:cinder][:keymgr_fixed_key].each_byte.map { |b| b.to_s(16) }.join %>
 <% end -%>
 
@@ -284,7 +284,7 @@ pool_timeout = <%= node[:cinder][:pool_timeout] %>
 
 [keystone_authtoken]
 auth_type = password
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version= <%= @keystone_settings['api_version_for_middleware'] %>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
+++ b/chef/cookbooks/ec2-api/templates/default/ec2api.conf.erb
@@ -56,7 +56,7 @@ heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
 
 [keystone_authtoken]
 auth_type = password
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version= <%= @keystone_settings['api_version_for_middleware'] %>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -27,7 +27,7 @@ enable_v2_registry = true
 
 [database]
 connection = <%= node[:glance][:sql_connection] %>
-idle_timeout = <%= node[:glance][:sql_idle_timeout] %>
+connection_recycle_time = <%= node[:glance][:sql_idle_timeout] %>
 
 [glance_store]
 stores = <%= @glance_stores %>
@@ -63,7 +63,7 @@ allowed_origin = <%= node[:glance][:crossdomain][:cross_domain_hosts].join(",") 
 <% end -%>
 
 [keystone_authtoken]
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 <% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -12,13 +12,13 @@ control_exchange = glance
 
 [database]
 connection = <%= node[:glance][:sql_connection] %>
-idle_timeout = <%= node[:glance][:sql_idle_timeout] %>
+connection_recycle_time = <%= node[:glance][:sql_idle_timeout] %>
 
 [glance_store]
 cinder_catalog_info = volumev2:cinderv2:internalURL
 
 [keystone_authtoken]
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 <% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
@@ -19,7 +19,7 @@ use_stderr = false
 [database]
 
 connection = <%= node[:glance][:sql_connection] %>
-idle_timeout = <%= node[:glance][:sql_idle_timeout] %>
+connection_recycle_time = <%= node[:glance][:sql_idle_timeout] %>
 
 [oslo_concurrency]
 

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -46,7 +46,7 @@ insecure = <%= @keystone_settings['insecure'] %>
 [clients_keystone]
 endpoint_type = internalURL
 insecure = <%= @keystone_settings['insecure'] %>
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 
 [clients_magnum]
 endpoint_type = publicURL
@@ -104,7 +104,7 @@ max_header_line = <%= node[:heat][:max_header_line] %>
 
 [keystone_authtoken]
 auth_type = password
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -53,7 +53,7 @@ region_name=<%= @keystone_settings['endpoint_region'] %>
 
 [keystone_authtoken]
 auth_type=password
-auth_uri=<%= @keystone_settings['protocol'] %>://<%= @keystone_settings['public_url_host'] %>:<%= @keystone_settings['service_port'] %>/<%= @auth_version %>/
+www_authenticate_uri=<%= @keystone_settings['protocol'] %>://<%= @keystone_settings['public_url_host'] %>:<%= @keystone_settings['service_port'] %>/<%= @auth_version %>/
 auth_url=<%= @keystone_settings['admin_auth_url'] %>
 auth_version=<%= @auth_version %>
 region_name=<%= @keystone_settings['endpoint_region'] %>

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -16,7 +16,7 @@ memcache_socket_timeout = 1
 
 [database]
 connection = <%= @sql_connection %>
-idle_timeout = <%= @sql_idle_timeout %>
+connection_recycle_time = <%= @sql_idle_timeout %>
 
 [fernet_tokens]
 max_active_keys = <%= @max_active_keys %>

--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -45,7 +45,7 @@ project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 
 [keystone_authtoken]
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/manila/templates/default/manila.conf.erb
+++ b/chef/cookbooks/manila/templates/default/manila.conf.erb
@@ -41,7 +41,7 @@ username=<%= @cinder_admin_username %>
 connection=<%= @sql_connection %>
 
 [keystone_authtoken]
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version= <%= @keystone_settings['api_version_for_middleware'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -44,7 +44,7 @@ pool_timeout = <%= @sql_pool_timeout %>
 
 [keystone_authtoken]
 auth_type = password
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -162,13 +162,13 @@ user_domain_name = <%= @keystone_settings['admin_domain'] %>
 
 [key_manager]
 <% unless @keymgr_fixed_key.empty? %>
-api_class = nova.keymgr.conf_key_mgr.ConfKeyManager
+backend = nova.keymgr.conf_key_mgr.ConfKeyManager
 fixed_key = <%= @keymgr_fixed_key.each_byte.map { |b| b.to_s(16) }.join %>
 <% end %>
 
 [keystone_authtoken]
 auth_type = password
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 auth_version= <%= @keystone_settings['api_version_for_middleware'] %>
 insecure = <%= @keystone_settings['insecure'] %>
@@ -317,8 +317,8 @@ vlan_interface = <%= node[:nova][:vcenter][:interface] %>
 [vnc]
 enabled = <%= @vnc_enabled ? "True" : "False" %>
 keymap = <%= node[:nova][:vnc_keymap] %>
-vncserver_listen = "0.0.0.0"
-vncserver_proxyclient_address = <%= node[:nova][:my_ip] %>
+server_listen = "0.0.0.0"
+server_proxyclient_address = <%= node[:nova][:my_ip] %>
 novncproxy_host = <%= @bind_host %>
 novncproxy_port = <%= @bind_port_novncproxy %>
 novncproxy_base_url = <%= @vncproxy_ssl_enabled ? "https" : "http" %>://<%= @vncproxy_public_host %>:<%= node[:nova][:ports][:novncproxy] %>/vnc_auto.html

--- a/chef/cookbooks/sahara/templates/default/sahara.conf.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara.conf.erb
@@ -29,7 +29,7 @@ api_insecure = <%= @heat_insecure %>
 api_insecure = <%= @keystone_settings["insecure"] %>
 
 [keystone_authtoken]
-auth_uri = <%= @keystone_settings["public_auth_url"] %>
+www_authenticate_uri = <%= @keystone_settings["public_auth_url"] %>
 username = <%= @keystone_settings['service_user'] %>
 password = <%= @keystone_settings['service_password'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>

--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -54,7 +54,7 @@ user_test_tester3 = testing3
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 auth_type = password
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 project_domain_name = <%= @keystone_settings["admin_domain"]%>
 user_domain_name = <%= @keystone_settings["admin_domain"] %>
 project_name = <%= @keystone_settings['service_tenant'] %>


### PR DESCRIPTION
```
           option                     from                    option                   to
idle_timeout                  database              connection_recycle_time    databas
auth_uri                      keystone_authtoken    www_authenticate_uri       keystone_authtoken
api_class                     key_manager           backend                    key_manager
vncserver_listen              vnc                   server_listen              vnc
vncserver_proxyclient_address vnc                   server_proxyclient_address vnc
rabbit_use_ssl                oslo_messaging_rabbit ssl                        oslo_messaging_rabbit
```

picked up from various log files