### PR TITLE
travis: tests databags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ matrix:
     - env: SPEC_TESTS
       script:
       - bundle exec rake spec
+    - name: "Databag testing"
+      script: bundle exec crowbar-validate-databags chef/data_bags/crowbar

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@
 source "https://rubygems.org"
 
 group :development do
+  gem "crowbar-validate-databags", "~> 0.1"
   gem "rake", "< 12.0.0"
   gem "uglifier", "~> 2.7.2"
   gem "sass", "~> 3.2.19"


### PR DESCRIPTION
by leveraging the crowbar-validate-databags gem we can now test
the schemas, jsons and migrations for failures on each repo

This adds the appropiate trais entry so it runs the validation
on the proper dirs on each PR

crowbar-validate-databags comes from https://github.com/Itxaka/crowbar-validate-databags and its basically the extraction of `validate_data_bag.rb`[0] and `crowbar_validator.rb`[1]

As both of those utils are only available on crowbar-core, we cannot properly validate other repos that introduce new schemas and migrations. So instead of dulicating the code, it was easier to extract and make a simple gem only used for the testing part.

I also took the time to add some much needed migration duplication validation, and as you can see on the running tests for this PR it already found duplicated migrations ¬_¬

Next step would be to increase the validation into loading the migrations and executing them in order to make sure that they are at least correct, but that can come later.

[0] https://github.com/crowbar/crowbar-core/blob/master/bin/validate_data_bag.rb
[1] https://github.com/crowbar/crowbar-core/blob/master/crowbar_framework/app/models/crowbar_validator.rb