### PR TITLE
[5.0] neutron: disable metadata proxy when metadata is forced

### DIFF
--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -2,8 +2,13 @@
 interface_driver = <%= @interface_driver %>
 resync_interval = <%= @resync_interval %>
 dhcp_driver = <%= @dhcp_driver %>
+<% if @force_metadata -%>
+enable_isolated_metadata = False
+enable_metadata_network = False
+<% else -%>
 enable_isolated_metadata = <%= @enable_isolated_metadata %>
 enable_metadata_network = <%= @enable_metadata_network %>
+<% end -%>
 force_metadata = <%= @force_metadata %>
 dns_domain = <%= @dns_domain %>
 <% if @nameservers -%>

--- a/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
@@ -3,6 +3,9 @@ interface_driver = <%= @interface_driver %>
 <% if @dvr_enabled -%>
 agent_mode = <%= @dvr_mode %>
 <% end -%>
+<% if node[:neutron][:metadata][:force] -%>
+enable_metadata_proxy = False
+<% end -%>
 metadata_port = <%= @metadata_port %>
 handle_internal_only_routers = <%= @handle_internal_only_routers %>
 periodic_interval = <%= @periodic_interval %>


### PR DESCRIPTION
If 'force_metadata' is configured as 'True' then disable the metadata
proxies in all nodes doe not have dhcp namespaces. They are not needed
in l3 agents.

And then 'enable_isolated_metadata' is neglected. So there is no need to
configure it, since 'force_metadata' is a superset and configured that
alone is sufficient to get the metadata from the dhcp server.

(cherry picked from commit e2b408e571e302cf2574a5b9517ca9ca0220becd)
Backport from #1826