### PR TITLE
[5.0] nova: Only emit unversioned notfications

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -357,3 +357,4 @@ track_instance_changes = false
 
 [notifications]
 notify_on_state_change = vm_and_task_state
+notification_format = unversioned


### PR DESCRIPTION
There is currently nothing consuming the version notifications. So
they're piling up in rabbitmq

(cherry picked from commit fd8e5947961350eb9fc26de2778f3bcff4d970b0)