### PR TITLE
[4.0] nova: Only emit unversioned notfications

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -8,6 +8,7 @@ instance_name_template=zvm%05x
 my_ip = <%= node[:nova][:my_ip] %>
 <% unless @ironic_settings.nil? %>scheduler_host_manager = ironic_host_manager<% end %>
 notify_on_state_change = vm_and_task_state
+notification_format = unversioned
 state_path = /var/lib/nova
 enabled_ssl_apis = <%= @ssl_enabled ? "osapi_compute,metadata" : "" %>
 osapi_compute_listen = <%= @bind_host %>


### PR DESCRIPTION
There is currently nothing consuming the version notifications. So
they're piling up in rabbitmq.

This is a backport of fd8e5947961350eb9fc26de2778f3bcff4d970b0 to
newton, where the setting still resides in the [DEFAULT] section.

Backport of: https://github.com/crowbar/crowbar-openstack/pull/1848