### PR TITLE
ceilometer: add validation that notifications are enabled client side

### DIFF
--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -139,6 +139,19 @@ class CeilometerService < OpenstackServiceObject
         end
       end
     end
+
+    rabbitmq_proposal = Proposal.find_by(
+      barclamp: "rabbitmq",
+      name: proposal["attributes"][@bc_name]["rabbitmq_instance"]
+    )
+
+    unless rabbitmq_proposal &&
+        rabbitmq_proposal["attributes"]["rabbitmq"]["client"]["enable_notifications"]
+      validation_error I18n.t(
+        "barclamp.#{@bc_name}.validation.notifications_enabled"
+      )
+    end
+
     super
   end
 

--- a/crowbar_framework/config/locales/ceilometer/en.yml
+++ b/crowbar_framework/config/locales/ceilometer/en.yml
@@ -45,6 +45,7 @@ en:
           cert_required: 'Require Client Certificate'
           ca_certs: 'SSL CA Certificates File'
       validation:
+        notifications_enabled: 'Sending notifications has to be enabled in the RabbitMQ proposal first.'
         hyper_v_support: 'Hyper-V support is not available.'
         swift_proxy: 'Nodes with the ceilometer-swift-proxy-middleware role must also have the swift-proxy role.'
         nodes_count: 'The cluster assigned to the ceilometer-server role should have at least 3 nodes, but it only has %{nodes_count}.'


### PR DESCRIPTION
Telemetry collection is based on clients configured to send
notifications. With the change to make the client notification sending
optional, we now should warn the user that the notifications have to
be enabled for Ceilometer/Telemetry to work.