### PR TITLE
[4.0] rabbitmq: configure notification settings also in clustered mode

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -206,6 +206,13 @@ class CrowbarOpenStackHelper
           rabbit[:rabbitmq][:ssl][:client_ca_certs]
         end
 
+        common_rabbit_settings = {
+          use_ssl: rabbit[:rabbitmq][:ssl][:enabled],
+          client_ca_certs: client_ca_certs,
+          enable_notifications: rabbit[:rabbitmq][:client][:enable_notifications],
+          heartbeat_timeout: rabbit[:rabbitmq][:client][:heartbeat_timeout]
+        }
+
         if !rabbit[:rabbitmq][:cluster]
           @rabbitmq_settings[instance] = {
             # backwards compatible attributes, remove in cloud8?
@@ -215,8 +222,6 @@ class CrowbarOpenStackHelper
             password: rabbit[:rabbitmq][:password],
             vhost: rabbit[:rabbitmq][:vhost],
             # end backwards comatible attrs
-            use_ssl: rabbit[:rabbitmq][:ssl][:enabled],
-            client_ca_certs: client_ca_certs,
             url: "rabbit://#{rabbit[:rabbitmq][:user]}:" \
               "#{rabbit[:rabbitmq][:password]}@" \
               "#{address}:#{port}/" \
@@ -227,11 +232,9 @@ class CrowbarOpenStackHelper
               "#{rabbit[:rabbitmq][:trove][:vhost]}",
             cluster: false,
             durable_queues: false,
-            enable_notifications: rabbit[:rabbitmq][:client][:enable_notifications],
             ha_queues: false,
-            heartbeat_timeout: rabbit[:rabbitmq][:client][:heartbeat_timeout],
             pacemaker_resource: "rabbitmq"
-          }
+          }.merge(common_rabbit_settings)
 
           Chef::Log.info("RabbitMQ server found")
         else
@@ -269,16 +272,13 @@ class CrowbarOpenStackHelper
           end
 
           @rabbitmq_settings[instance] = {
-            use_ssl: rabbit[:rabbitmq][:ssl][:enabled],
-            client_ca_certs: client_ca_certs,
             url: rabbit_hosts.join(","),
             trove_url: trove_rabbit_hosts.join(","),
             cluster: true,
             durable_queues: true,
             ha_queues: true,
-            heartbeat_timeout: rabbit[:rabbitmq][:client][:heartbeat_timeout],
             pacemaker_resource: "ms-rabbitmq"
-          }
+          }.merge(common_rabbit_settings)
           Chef::Log.info("RabbitMQ cluster found")
         end
       end


### PR DESCRIPTION
Accidentally when forward porting the patch the setting was
only set for the native clustered mode because the hash is
being assembled in two locations. Break out the common part
and merge it so that we follow DRY principles.

(cherry picked from commit a06bbb3663f311ac47b85e0fea64d6973c221d12)