### PR TITLE
[5.0] rabbitmq: Remove redundant code

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -198,7 +198,6 @@ class CrowbarOpenStackHelper
             "#{rabbit[:rabbitmq][:address]}:#{port}/" \
             "#{rabbit[:rabbitmq][:trove][:vhost]}",
           durable_queues: false,
-          enable_notifications: rabbit[:rabbitmq][:client][:enable_notifications],
           ha_queues: false,
           pacemaker_resource: "rabbitmq"
         }.merge(common_rabbit_settings)


### PR DESCRIPTION
Remove enable_notifications line left in single_rabbit_settings by
previous commit.