### PR TITLE
monasca: add :start subscribes for monasca-agent

### DIFF
--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -144,6 +144,8 @@ service agent_settings[:agent_service_name] do
   # provider Chef::Provider::CrowbarPacemakerService if ha_enabled
   subscribes :restart, resources(template: "/etc/monasca/agent/agent.yaml")
   subscribes :restart, resources(template: "/etc/monasca/agent/supervisor.conf")
+  subscribes :start, resources(template: "/etc/monasca/agent/agent.yaml")
+  subscribes :start, resources(template: "/etc/monasca/agent/supervisor.conf")
 end
 utils_systemd_service_restart agent_settings[:agent_service_name] do
   # action ha_enabled ? :disable : :enable


### PR DESCRIPTION
This fixes a race condition where monasca-agent might get started before its
configuration files are ready.