### PR TITLE
rabbitmq: Fix address handling in rabbitmq (aka "glance timeout")

### DIFF
--- a/chef/cookbooks/crowbar-openstack/metadata.rb
+++ b/chef/cookbooks/crowbar-openstack/metadata.rb
@@ -8,3 +8,4 @@ version "0.1"
 
 depends "crowbar-pacemaker"
 depends "database"
+depends "rabbitmq"

--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -29,8 +29,6 @@ default[:rabbitmq][:rabbitmq_group] = "rabbitmq"
 default[:rabbitmq][:nodename]  = "rabbit@#{node[:hostname]}"
 # This is the address for internal usage
 default[:rabbitmq][:address] = nil
-# These are all the addresses, possibly including public one
-default[:rabbitmq][:addresses] = []
 default[:rabbitmq][:port]  = 5672
 default[:rabbitmq][:management_port] = 15672
 default[:rabbitmq][:management_address] = nil

--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -31,7 +31,6 @@ default[:rabbitmq][:nodename]  = "rabbit@#{node[:hostname]}"
 default[:rabbitmq][:address] = nil
 default[:rabbitmq][:port]  = 5672
 default[:rabbitmq][:management_port] = 15672
-default[:rabbitmq][:management_address] = nil
 default[:rabbitmq][:configfile] = nil
 default[:rabbitmq][:logdir] = nil
 default[:rabbitmq][:mnesiadir] = nil

--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -27,8 +27,6 @@ default[:rabbitmq][:rabbitmq_user] = "rabbitmq"
 default[:rabbitmq][:rabbitmq_group] = "rabbitmq"
 
 default[:rabbitmq][:nodename]  = "rabbit@#{node[:hostname]}"
-# This is the address for internal usage
-default[:rabbitmq][:address] = nil
 default[:rabbitmq][:port]  = 5672
 default[:rabbitmq][:management_port] = 15672
 default[:rabbitmq][:configfile] = nil

--- a/chef/cookbooks/rabbitmq/libraries/crowbar.rb
+++ b/chef/cookbooks/rabbitmq/libraries/crowbar.rb
@@ -24,4 +24,8 @@ module CrowbarRabbitmqHelper
       Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
     end
   end
+
+  def self.get_management_address(node)
+    get_listen_address(node)
+  end
 end

--- a/chef/cookbooks/rabbitmq/metadata.rb
+++ b/chef/cookbooks/rabbitmq/metadata.rb
@@ -25,10 +25,6 @@ attribute "rabbitmq/nodename",
           description: "The Erlang node name for this server.",
           default: "node[:hostname]"
 
-attribute "rabbitmq/address",
-          display_name: "RabbitMQ server IP address",
-          description: "IP address to bind."
-
 attribute "rabbitmq/port",
           display_name: "RabbitMQ server port",
           description: "TCP port to bind."

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -116,6 +116,7 @@ template "/etc/rabbitmq/rabbitmq.config" do
     cluster_enabled: cluster_enabled,
     cluster_partition_handling: cluster_partition_handling,
     addresses: addresses,
+    management_address: CrowbarRabbitmqHelper.get_management_address(node),
     hipe_compile: hipe_compile
   )
   notifies :restart, "service[rabbitmq-server]"

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -18,7 +18,8 @@
 # limitations under the License.
 #
 
-addresses = [CrowbarRabbitmqHelper.get_listen_address(node)]
+listen_address = CrowbarRabbitmqHelper.get_listen_address(node)
+addresses = [listen_address]
 if node[:rabbitmq][:listen_public]
   addresses << CrowbarRabbitmqHelper.get_public_listen_address(node)
 end
@@ -62,7 +63,7 @@ if node[:platform_family] == "suse"
     group "root"
     mode 0o644
     variables(
-      listen_address: node[:rabbitmq][:address]
+      listen_address: listen_address
     )
     only_if "systemctl list-dependencies --plain rabbitmq-server.service | grep -q epmd.service"
   end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -18,6 +18,11 @@
 # limitations under the License.
 #
 
+addresses = [CrowbarRabbitmqHelper.get_listen_address(node)]
+if node[:rabbitmq][:listen_public]
+  addresses << CrowbarRabbitmqHelper.get_public_listen_address(node)
+end
+
 ha_enabled = node[:rabbitmq][:ha][:enabled]
 # we only do cluster if we do HA
 cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
@@ -110,6 +115,7 @@ template "/etc/rabbitmq/rabbitmq.config" do
   variables(
     cluster_enabled: cluster_enabled,
     cluster_partition_handling: cluster_partition_handling,
+    addresses: addresses,
     hipe_compile: hipe_compile
   )
   notifies :restart, "service[rabbitmq-server]"

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -34,15 +34,6 @@ if node[:rabbitmq][:management_address] != listen_address
   dirty = true
 end
 
-addresses = [node[:rabbitmq][:address]]
-if node[:rabbitmq][:listen_public]
-  addresses << CrowbarRabbitmqHelper.get_public_listen_address(node)
-end
-if node[:rabbitmq][:addresses] != addresses
-  node.set[:rabbitmq][:addresses] = addresses
-  dirty = true
-end
-
 nodename = "rabbit@#{CrowbarRabbitmqHelper.get_ha_vhostname(node)}"
 
 if cluster_enabled

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -24,13 +24,11 @@ cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
 
 dirty = false
 
+management_address = CrowbarRabbitmqHelper.get_management_address(node)
+
 listen_address = CrowbarRabbitmqHelper.get_listen_address(node)
 if node[:rabbitmq][:address] != listen_address
   node.set[:rabbitmq][:address] = listen_address
-  dirty = true
-end
-if node[:rabbitmq][:management_address] != listen_address
-  node.set[:rabbitmq][:management_address] = listen_address
   dirty = true
 end
 
@@ -103,7 +101,7 @@ end
 rabbitmq_user "adding user #{node[:rabbitmq][:user]}" do
   user node[:rabbitmq][:user]
   password node[:rabbitmq][:password]
-  address node[:rabbitmq][:management_address]
+  address management_address
   port node[:rabbitmq][:management_port]
   action :add
   only_if only_if_command if ha_enabled
@@ -130,7 +128,7 @@ node[:rabbitmq][:users].each do |user|
   rabbitmq_user "adding user #{user[:username]}" do
     user user[:username]
     password user[:password]
-    address node[:rabbitmq][:management_address]
+    address management_address
     port node[:rabbitmq][:management_port]
     action :add
     only_if only_if_command if ha_enabled
@@ -186,7 +184,7 @@ if node[:rabbitmq][:trove][:enabled]
   rabbitmq_user "adding user #{node[:rabbitmq][:trove][:user]}" do
     user node[:rabbitmq][:trove][:user]
     password node[:rabbitmq][:trove][:password]
-    address node[:rabbitmq][:management_address]
+    address management_address
     port node[:rabbitmq][:management_port]
     action :add
     only_if only_if_command if ha_enabled
@@ -204,7 +202,7 @@ if node[:rabbitmq][:trove][:enabled]
 else
   rabbitmq_user "deleting user #{node[:rabbitmq][:trove][:user]}" do
     user node[:rabbitmq][:trove][:user]
-    address node[:rabbitmq][:management_address]
+    address management_address
     port node[:rabbitmq][:management_port]
     action :delete
     only_if only_if_command if ha_enabled

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -25,13 +25,6 @@ cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
 dirty = false
 
 management_address = CrowbarRabbitmqHelper.get_management_address(node)
-
-listen_address = CrowbarRabbitmqHelper.get_listen_address(node)
-if node[:rabbitmq][:address] != listen_address
-  node.set[:rabbitmq][:address] = listen_address
-  dirty = true
-end
-
 nodename = "rabbit@#{CrowbarRabbitmqHelper.get_ha_vhostname(node)}"
 
 if cluster_enabled

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -15,11 +15,11 @@
                         ]
    },
    {tcp_listeners, [
-                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:port]}}" }.join(", ") %>
+                    <%= @addresses.map { |address| "{\"#{address}\", #{node[:rabbitmq][:port]}}" }.join(", ") %>
                    ]},
 <% if node[:rabbitmq][:ssl][:enabled] -%>
    {ssl_listeners, [
-                    <%= node[:rabbitmq][:addresses].map { |address| "{\"#{address}\", #{node[:rabbitmq][:ssl][:port]}}" }.join(", ") %>
+                    <%= @addresses.map { |address| "{\"#{address}\", #{node[:rabbitmq][:ssl][:port]}}" }.join(", ") %>
                    ]},
    {ssl_options, [
    <% if node[:rabbitmq][:ssl][:cert_required] -%>

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -44,7 +44,7 @@
  ]},
  {rabbitmq_management,
   [
-   {listener, [{ip, "<%= node[:rabbitmq][:management_address] %>"}, {port, <%= node[:rabbitmq][:management_port] %>}]},
+   {listener, [{ip, "<%= @management_address %>"}, {port, <%= node[:rabbitmq][:management_port] %>}]},
    {load_definitions, "/etc/rabbitmq/definitions.json"}
   ]
  }


### PR DESCRIPTION
PR #1833 removed some attributes from rabbitmq nodes and replaced them with direct value lookups. This was a fix for race condition leading to empty addresses in rabbitmq connection strings. The change needs to be forward ported to later branches because otherwise the attributes (and the original problem) would be re-added in new systems and during the upgrade.

forward port of #1833 