### PR TITLE
rabbitmq: block client port on startup

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -159,3 +159,141 @@ pacemaker_transaction "rabbitmq service" do
 end
 
 crowbar_pacemaker_sync_mark "create-rabbitmq_ha_resources"
+
+clustermon_op = { "monitor" => [{ "interval" => "10s" }] }
+clustermon_params = { "extra_options" => "-E /usr/bin/rabbitmq-alert-handler.sh --watch-fencing" }
+name = "rabbitmq-port-blocker"
+clone_name = "cl-#{name}"
+location_name = "l-#{name}-controller"
+node_upgrading = CrowbarPacemakerHelper.being_upgraded?(node)
+clone_running = "crm resource show #{clone_name}"
+primitive_running = "crm resource show #{name}"
+port = node[:rabbitmq][:port]
+ssl_port = node[:rabbitmq][:ssl][:port]
+
+crowbar_pacemaker_sync_mark "wait-rabbitmq_alert_resources"
+
+if CrowbarPacemakerHelper.cluster_nodes(node).size > 2 && !node_upgrading
+  template "/usr/bin/rabbitmq-alert-handler.sh" do
+    source "rabbitmq-alert-handler.erb"
+    owner "root"
+    group "root"
+    mode "0755"
+    variables(node: node, nodes: CrowbarPacemakerHelper.cluster_nodes(node))
+  end
+
+  template "/usr/bin/#{name}.sh" do
+    source "#{name}.erb"
+    owner "root"
+    group "root"
+    mode "0755"
+    variables(total_nodes: CrowbarPacemakerHelper.cluster_nodes(node).size,
+              port: port, ssl_port: ssl_port)
+  end
+
+  pacemaker_primitive name do
+    agent "ocf:pacemaker:ClusterMon"
+    op clustermon_op
+    params clustermon_params
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  pacemaker_clone clone_name do
+    rsc name
+    meta CrowbarPacemakerHelper.clone_meta(node)
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  pacemaker_location location_name do
+    definition OpenStackHAHelper.controller_only_location(location_name, clone_name)
+    action :update
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  pacemaker_transaction name do
+    cib_objects [
+      "pacemaker_primitive[#{name}]",
+      "pacemaker_clone[#{clone_name}]",
+      "pacemaker_location[#{location_name}]"
+    ]
+    # note that this will also automatically start the resources
+    action :commit_new
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+else
+  pacemaker_location location_name do
+    definition OpenStackHAHelper.controller_only_location(location_name, clone_name)
+    action :delete
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
+  pacemaker_clone "#{clone_name}_stop" do
+    name clone_name
+    rsc name
+    meta CrowbarPacemakerHelper.clone_meta(node)
+    action :stop
+    only_if do
+      running = system(clone_running, err: File::NULL)
+      CrowbarPacemakerHelper.is_cluster_founder?(node) && running
+    end
+  end
+
+  pacemaker_clone "#{clone_name}_delete" do
+    name clone_name
+    rsc name
+    meta CrowbarPacemakerHelper.clone_meta(node)
+    action :delete
+    only_if do
+      running = system(clone_running, err: File::NULL)
+      CrowbarPacemakerHelper.is_cluster_founder?(node) && running
+    end
+  end
+
+  pacemaker_primitive "#{name}_stop" do
+    agent "ocf:pacemaker:ClusterMon"
+    name name
+    op clustermon_op
+    params clustermon_params
+    action :stop
+    only_if do
+      running = system(primitive_running, err: File::NULL)
+      CrowbarPacemakerHelper.is_cluster_founder?(node) && running
+    end
+  end
+
+  pacemaker_primitive "#{name}_delete" do
+    agent "ocf:pacemaker:ClusterMon"
+    name name
+    op clustermon_op
+    params clustermon_params
+    action :delete
+    only_if do
+      running = system(primitive_running, err: File::NULL)
+      CrowbarPacemakerHelper.is_cluster_founder?(node) && running
+    end
+  end
+
+  file "/usr/bin/rabbitmq-alert-handler.sh" do
+    action :delete
+  end
+
+  file "/usr/bin/#{name}.sh" do
+    action :delete
+  end
+
+  # in case that the script was already deployed and the rule is already stored we need to clean it
+  # up as to not left anything around
+  bash "Remove existent rabbitmq blocking rules" do
+    code "iptables -D INPUT -p tcp --destination-port 5672 "\
+         "-m comment --comment \"rabbitmq port blocker (no quorum)\" -j DROP"
+    only_if do
+      # check for the rule
+      cmd = "iptables -L -n | grep -F \"tcp dpt:5672 /* rabbitmq port blocker (no quorum) */\""
+      system(cmd)
+    end
+  end
+end
+
+crowbar_pacemaker_sync_mark "create-rabbitmq_alert_resources"

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq-alert-handler.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq-alert-handler.erb
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# exit if isn't a rabbitmq alert or is not a monitor task
+[ "${CRM_notify_rsc}" = "rabbitmq" -a "${CRM_notify_task}" = "monitor" ] || exit 0
+
+# launch the blocker in exclusive mode
+flock /var/lock/rabbit /usr/bin/rabbitmq-port-blocker.sh

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq-port-blocker.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq-port-blocker.erb
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# calcules the blocking level applying the formula
+total_nodes=<%= @total_nodes %>
+blocking_level=$(expr $total_nodes / 2)
+comment_text="rabbitmq port blocker (no quorum)"
+port=<%= @port %>
+ssl_port=<%= @ssl_port %>
+
+# get the number of running nodes of rabbitmq in the current cluster
+function running_nodes()
+{
+  rabbitmqctl cluster_status 2>/dev/null | tr -d "\n" | sed -e 's/running_nodes,/\nrunning_nodes/g'| grep running_nodes | cut -d "[" -f2 | cut -d "]" -f1 | tr "," "\n" | wc -l
+}
+
+# check if exists the blocking rule for rabbitmq clients
+function check_rule()
+{
+  iptables -L -n | grep -F "tcp dpt:$1 /* $comment_text */" | grep DROP | wc -l
+}
+
+function create_rule(){
+  if [ $(check_rule $1) -eq 0 ]; then
+    iptables -A INPUT -p tcp --destination-port $1 -m comment --comment "$comment_text" -j DROP
+  fi
+}
+
+function delete_rule(){
+  if [[ $(check_rule $1) -gt 0 ]]; then
+    iptables -D INPUT -p tcp --destination-port $1 -m comment --comment "$comment_text" -j DROP
+  fi
+}
+
+# if the running nodes is les that the blocking level, then...
+if [ $(running_nodes) -le $blocking_level ]; then
+  # if rule not exists the rule will be added to block the clients port
+  create_rule $port
+  create_rule $ssl_port
+else
+  # finally if the rule exists it will be deleted. If there are more than one, will remove all
+  delete_rule $port
+  delete_rule $ssl_port
+fi


### PR DESCRIPTION
This script blocks the connection to the rabbitmq cluster in case the number of nodes decay below the half
of the total. In this case the remaining rabbit nodes won't accept new connections until quorum is reached.

It takes advantage of the ClusterMon agent that notifies when a rabbitmq has failed or has restored.

All nodes rabbitmq ports will be blocked if the total number of alive nodes are below to the half of
nodes of the cluster, or unblock if its over this value.

The reasoning behind this patch is to allow waiting for more than one node in the cluster to be ready,
which is useful for two reasons:

 - clients would connect to more than one node
 - master for queues would be spread more evenly

Currently most of the connections and master queues are created on the master node, as its the first
to come up when the cluster is restarted/new master promoted.

co-authored-by: Ivan Lausuch <ilausuch@suse.com>
(cherry picked from commit 0d26f8b119e1a3b0f6df75e554001956504d19c6)
Forward port from #1681