### PR TITLE
keystone: Remove UUID token format (SCRD-4086)

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/301_convert_uuid_to_fernet.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/301_convert_uuid_to_fernet.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["token_format"] = "fernet" if attrs["token_format"] == "uuid"
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  # downgrade is not possible
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -178,7 +178,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 300,
+      "schema-revision": 301,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -65,7 +65,7 @@
                     "assignment" : { "type" : "map", "required" : true, "mapping": {
                       "driver": { "type": "str", "required": true }
                     }},
-                    "token_format": { "type": "str", "required": true, "pattern": "/^(fernet|uuid)$/" },
+                    "token_format": { "type": "str", "required": true, "pattern": "/^(fernet)$/" },
                     "ldap" : { "type" : "map", "mapping": {
                       "url": { "type": "str" },
                       "user": { "type": "str" },

--- a/crowbar_framework/app/helpers/barclamp/keystone_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/keystone_helper.rb
@@ -17,16 +17,6 @@
 
 module Barclamp
   module KeystoneHelper
-    def token_formats_for_keystone(selected)
-      options_for_select(
-        [
-          ["UUID", "uuid"],
-          ["Fernet", "fernet"]
-        ],
-        selected.to_s
-      )
-    end
-
     def api_protocols_for_keystone(selected)
       options_for_select(
         [

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -5,7 +5,6 @@
   .panel-body
     = instance_field :database
     = instance_field :rabbitmq
-    = select_field %w(token_format), :collection => :token_formats_for_keystone
     = string_field %w(api region)
 
     %fieldset

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -21,7 +21,6 @@ en:
       edit_attributes:
         database_instance: 'Database Instance'
         rabbitmq_instance: 'RabbitMQ'
-        token_format: 'Algorithm for Token Generation'
         default_credentials: 'Default Credentials'
         default:
           project: 'Default Project'


### PR DESCRIPTION
In Rocky the UUID token format was removed[1][2]. This patch removes
uuid as a valid token format, leaving only fernet. The dropdown menu is
also removed, however the option is still left in the schema to allow
for the possibility that new token formats may be added in the future.

[1] https://docs.openstack.org/releasenotes/keystone/rocky.html
[2] https://review.openstack.org/543060