### PR TITLE
Gemfile: Drop crowbar-validate-databags gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@
 source "https://rubygems.org"
 
 group :development do
-  gem "crowbar-validate-databags", "~> 0.1"
+  gem "crowbar-validate-databags"
   gem "rake", "< 12.0.0"
   gem "uglifier", "~> 2.7.2"
   gem "sass", "~> 3.2.19"


### PR DESCRIPTION
We dont need an specific version and we control the gem release
versioning so we can manage it ourselves properly