### PR TITLE
rabbitmq: Add list of tags comma separated for extra users

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -138,7 +138,7 @@ node[:rabbitmq][:users].each do |user|
   end
 
   # tag those users as management
-  execute "rabbitmqctl set_user_tags #{user[:username]} #{user[:tags]}" do
+  execute "rabbitmqctl set_user_tags #{user[:username]} #{user[:tags].join(",")}" do
     not_if "rabbitmqctl list_users | grep #{user[:username]} | grep -q #{user[:tags].join(",")}"
     action :run
     only_if only_if_command if ha_enabled


### PR DESCRIPTION
otherwise the tags will be added like:

`Setting user tags for user 'yarb' to ['[administrator]']`

(cherry picked from commit 3034446d7511ba23ea50060b6d68d9368d447621)