### PR TITLE
Neutron: Remove deprecated sql/min_pool_size

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -54,7 +54,6 @@ default[:neutron][:api][:protocol] = "http"
 default[:neutron][:api][:service_port] = "9696"
 default[:neutron][:api][:service_host] = "0.0.0.0"
 
-default[:neutron][:sql][:min_pool_size] = 30
 default[:neutron][:sql][:max_pool_size] = 60
 default[:neutron][:sql][:max_pool_overflow] = 10
 default[:neutron][:sql][:pool_timeout] = 30

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -126,7 +126,6 @@ template neutron[:neutron][:config_file] do
     group neutron[:neutron][:platform][:group]
     variables(
       sql_connection: is_neutron_server ? neutron[:neutron][:db][:sql_connection] : nil,
-      sql_min_pool_size: neutron[:neutron][:sql][:min_pool_size],
       sql_max_pool_size: neutron[:neutron][:sql][:max_pool_size],
       sql_max_pool_overflow: neutron[:neutron][:sql][:max_pool_overflow],
       sql_pool_timeout: neutron[:neutron][:sql][:pool_timeout],
@@ -186,4 +185,3 @@ if node[:platform_family] == "rhel"
     to node[:neutron][:config_file]
   end
 end
-

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -37,7 +37,6 @@ root_helper_daemon = sudo neutron-rootwrap-daemon /etc/neutron/rootwrap.conf
 <% unless @sql_connection.nil? || @sql_connection.empty? -%>
 connection = <%= @sql_connection %>
 <% end -%>
-min_pool_size = <%= @sql_min_pool_size %>
 max_pool_size = <%= @sql_max_pool_size %>
 max_overflow = <%= @sql_max_pool_overflow %>
 pool_timeout = <%= @sql_pool_timeout %>

--- a/chef/data_bags/crowbar/migrate/neutron/303_remove_sql_min_pool_size.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/303_remove_sql_min_pool_size.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["neutron"]["sql"].delete("min_pool_size")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["neutron"]["sql"]["min_pool_size"] = template_attrs["neutron"]["sql"]["min_pool_size"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -38,7 +38,6 @@
       },
       "ovs": {
         "tunnel_csum": false,
-        "ovsdb_interface": "native"
       },
       "apic": {
         "hosts": "",
@@ -101,7 +100,6 @@
         "user": "neutron"
       },
       "sql": {
-        "min_pool_size": 1,
         "max_pool_size": 50,
         "max_pool_overflow": 50,
         "pool_timeout": 30
@@ -189,7 +187,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 302,
+      "schema-revision": 303,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -126,7 +126,6 @@
                       "password": { "type" : "str" }
                     }},
                     "sql": { "type": "map", "required": true, "mapping": {
-                      "min_pool_size": { "type" : "int", "required" : true },
                       "max_pool_size": { "type" : "int", "required" : true },
                       "max_pool_overflow": { "type" : "int", "required" : true },
                       "pool_timeout": { "type" : "int", "required" : true }


### PR DESCRIPTION
In rocky min_pool_size has been declared deprecated. This remove it
from the barclamp