### PR TITLE
monasca: pass keystone_region

### DIFF
--- a/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
@@ -25,6 +25,7 @@ authProtocol: 'https'
 keystone_insecure: <%= @keystone_settings['insecure'] %>
 <%- end %>
 api_region: <%= @keystone_settings['endpoint_region'] %>
+keystone_region: <%= @keystone_settings['endpoint_region'] %>
 database_grafana_password: <%= @master_settings['database_grafana_password'] %>
 
 notification_enable_email: <%= @master_settings['notification_enable_email'] %>


### PR DESCRIPTION
Pass keystone_region to monasca-installer: some roles use
api_region and some use keystone_region which caused us to end
up with the (wrong) default of "RegionOne" in some
configuration files.