### PR TITLE
Fix "enable_metadata_proxy" setting for DVR setups

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -334,6 +334,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
         interface_driver: interface_driver,
         handle_internal_only_routers: "True",
         metadata_port: 9697,
+        force_metadata: neutron[:neutron][:metadata][:force],
         periodic_interval: 40,
         periodic_fuzzy_delay: 5,
         dvr_enabled: neutron[:neutron][:use_dvr],

--- a/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
@@ -3,7 +3,7 @@ interface_driver = <%= @interface_driver %>
 <% if @dvr_enabled -%>
 agent_mode = <%= @dvr_mode %>
 <% end -%>
-<% if node[:neutron][:metadata][:force] -%>
+<% if @force_metadata -%>
 enable_metadata_proxy = False
 <% end -%>
 metadata_port = <%= @metadata_port %>


### PR DESCRIPTION
With DVR the l3-agent needs to be configured on the compute nodes as
well. As the computes don't have the neutron proposal assigned we need
to read the [:metadata][:force] attribute from a neutron-node.