### PR TITLE
neutron: new configuration variables

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -54,7 +54,6 @@ default[:neutron][:api][:protocol] = "http"
 default[:neutron][:api][:service_port] = "9696"
 default[:neutron][:api][:service_host] = "0.0.0.0"
 
-default[:neutron][:sql][:min_pool_size] = 30
 default[:neutron][:sql][:max_pool_size] = 60
 default[:neutron][:sql][:max_pool_overflow] = 10
 default[:neutron][:sql][:pool_timeout] = 30

--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -86,7 +86,6 @@ template agent_config_path do
     use_l2pop: false,
     dvr_enabled: false,
     of_interface: "ovs-ofctl",
-    ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
     bridge_mappings: ""
   )
 end

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -274,8 +274,10 @@ if neutron[:neutron][:networking_plugin] == "ml2"
             (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
-        ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
-        bridge_mappings: bridge_mappings
+        bridge_mappings: bridge_mappings,
+        rate_limit: neutron[:neutron][:ovs][:rate_limit],
+        burst_limit: neutron[:neutron][:ovs][:burst_limit],
+        local_output_log_base: neutron[:neutron][:ovs][:local_output_log_base]
       )
     end
   when ml2_mech_drivers.include?("linuxbridge")

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -126,10 +126,11 @@ template neutron[:neutron][:config_file] do
     group neutron[:neutron][:platform][:group]
     variables(
       sql_connection: is_neutron_server ? neutron[:neutron][:db][:sql_connection] : nil,
-      sql_min_pool_size: neutron[:neutron][:sql][:min_pool_size],
       sql_max_pool_size: neutron[:neutron][:sql][:max_pool_size],
       sql_max_pool_overflow: neutron[:neutron][:sql][:max_pool_overflow],
       sql_pool_timeout: neutron[:neutron][:sql][:pool_timeout],
+      connection_recycle_time: neutron[:neutron][:sql][:connection_recycle_time],
+      connection_parameters: neutron[:neutron][:sql][:connection_parameters],
       debug: neutron[:neutron][:debug],
       bind_host: bind_host,
       bind_port: bind_port,
@@ -156,7 +157,9 @@ template neutron[:neutron][:config_file] do
       ipam_driver: ipam_driver,
       rpc_workers: neutron[:neutron][:rpc_workers],
       use_apic_gbp: use_apic_gbp,
-      default_log_levels: neutron[:neutron][:default_log_levels]
+      default_log_levels: neutron[:neutron][:default_log_levels],
+      report_interval: neutron[:neutron][:report_interval],
+      agent_down_time: neutron[:neutron][:agent_down_time]
     )
 end
 
@@ -186,4 +189,3 @@ if node[:platform_family] == "rhel"
     to node[:neutron][:config_file]
   end
 end
-

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -154,7 +154,12 @@ template node[:neutron][:dhcp_agent_config_file] do
     enable_isolated_metadata: "True",
     enable_metadata_network: "False",
     nameservers: dns_list,
-    force_metadata: node[:neutron][:metadata][:force]
+    force_metadata: node[:neutron][:metadata][:force],
+    dhcp_renewal_time: node[:neutron][:dhcp][:dhcp_renewal_time],
+    dhcp_rebinding_time: node[:neutron][:dhcp][:dhcp_rebinding_time],
+    ovsdb_debug: node[:neutron][:dhcp][:ovs][:ovsdb_debug],
+    ovsdb_timeout: node[:neutron][:dhcp][:ovs][:ovsdb_timeout],
+    bridge_mac_table_size: node[:neutron][:dhcp][:ovs][:bridge_mac_table_size]
   )
 end
 

--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -13,4 +13,10 @@ dnsmasq_dns_servers = <%= @nameservers %>
 dnsmasq_base_log_dir = /var/log/neutron
 <% end -%>
 debug = <%= @debug ? "True" : "False" %>
+dhcp_renewal_time = <%= @dhcp_renewal_time %>
+dhcp_rebinding_time = <%= @dhcp_rebinding_time %>
 [AGENT]
+[OVS]
+ovsdb_debug = <%= @ovsdb_debug ? "True" : "False" %>
+ovsdb_timeout = <%= @ovsdb_timeout %>
+bridge_mac_table_size = <%= @bridge_mac_table_size %>

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -28,6 +28,8 @@ wsgi_keep_alive = false
 <% unless @default_log_levels.length.zero? -%>
 default_log_levels = <%= @default_log_levels.join(", ") %>
 <% end -%>
+report_interval = <%= @report_interval %>
+agent_down_time = <%= @agent_down_time %>
 
 [agent]
 root_helper = sudo neutron-rootwrap /etc/neutron/rootwrap.conf
@@ -37,10 +39,11 @@ root_helper_daemon = sudo neutron-rootwrap-daemon /etc/neutron/rootwrap.conf
 <% unless @sql_connection.nil? || @sql_connection.empty? -%>
 connection = <%= @sql_connection %>
 <% end -%>
-min_pool_size = <%= @sql_min_pool_size %>
 max_pool_size = <%= @sql_max_pool_size %>
 max_overflow = <%= @sql_max_pool_overflow %>
 pool_timeout = <%= @sql_pool_timeout %>
+connection_recycle_time = <%= @sql_connection_recycle_time %>
+connection_parameters = <%= @sql_connection_parameters %>
 
 [keystone_authtoken]
 auth_type = password

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -20,10 +20,13 @@ tunnel_csum = True
 <% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") && !@ml2_type_drivers.include?("opflex") -%>
 tunnel_bridge = br-tunnel
 <% end -%>
-ovsdb_interface = <%= @ovsdb_interface %>
 <% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
 local_ip = <%= node.address("os_sdn").addr %>
 <% end -%>
 bridge_mappings = <%= @bridge_mappings %>
 [securitygroup]
 firewall_driver = iptables_hybrid
+[network_log]
+rate_limit = <%= @network_log_rate_limit %>
+burst_limit = <%= @network_log_burst_limit %>
+local_output_log_base = <%= @network_log_local_output_log_base %>

--- a/chef/data_bags/crowbar/migrate/neutron/303_add_neutron.ini.new.configurations.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/303_add_neutron.ini.new.configurations.rb
@@ -1,0 +1,119 @@
+def upgrade_neutron(tattr, tdep, attr, dep)
+  key = "report_interval"
+  attr[key] = tattr[key] unless attr.key? key
+
+  key = "agent_down_time"
+  attr[key] = tattr[key] unless attr.key? key
+end
+
+def downgrade_neutron(tattr, tdep, attr, dep)
+  attr.delete("report_interval") if tattr.key? "report_interval"
+  attr.delete("agent_down_time") if tattr.key? "agent_down_time"
+end
+
+def upgrade_sql(tattr, tdep, attr, dep)
+  parent_key = "sql"
+  attr[parent_key] = tattr[parent_key] unless attr.key? parent_key
+  key = "connection_recycle_time"
+  attr[parent_key][key] = tattr[parent_key][key] unless attr[parent_key].key? key
+  key = "connection_parameters"
+  attr[parent_key][key] = tattr[parent_key][key] unless attr[parent_key].key? key
+end
+
+def downgrade_sql(tattr, tdep, attr, dep)
+  parent_key = "sql"
+  key = "connection_recycle_time"
+  attr[parent_key].delete(key) if tattr[parent_key].key? key
+
+  key = "connection_parameters"
+  attr[parent_key].delete(key) if tattr[parent_key].key? key
+end
+
+def upgrade_network_log(tattr, tdep, attr, dep)
+  parent_key = "network_log"
+  attr[parent_key] = tattr[parent_key] unless attr.key? parent_key
+  key = "rate_limit"
+  attr[parent_key][key] = tattr[parent_key][key] unless attr[parent_key].key? key
+  key = "burst_limit"
+  attr[parent_key][key] = tattr[parent_key][key] unless attr[parent_key].key? key
+  key = "local_output_log_base"
+  attr[parent_key][key] = tattr[parent_key][key] unless attr[parent_key].key? key
+end
+
+def downgrade_network_log(tattr, tdep, attr, dep)
+  parent_key = "network_log"
+  attr[parent_key].delete("rate_limit") if tattr[parent_key].key? "rate_limit"
+  attr[parent_key].delete("burst_limit") if tattr[parent_key].key? "burst_limit"
+
+  key = "local_output_log_base"
+  attr[parent_key].delete(key) if tattr[parent_key].key? key
+
+  attr.delete(parent_key) if tattr.key? parent_key
+end
+
+def upgrade_dhcp(tattr, tdep, attr, dep)
+  parent_key = "dhcp"
+  attr[parent_key] = tattr[parent_key] unless attr.key? parent_key
+
+  key = "dhcp_renewal_time"
+  attr[parent_key][key] = tattr[parent_key][key] unless attr[parent_key].key? key
+  key = "dhcp_rebinding_time"
+  attr[parent_key][key] = tattr[parent_key][key] unless attr[parent_key].key? key
+
+  subparent_key = "ovs"
+  key = "ovsdb_debug"
+  attr[parent_key][subparent_key][key] = tattr[parent_key][subparent_key][key] unless
+    attr[parent_key][subparent_key].key? key
+
+  key = "ovsdb_timeout"
+  attr[parent_key][subparent_key][key] = tattr[parent_key][subparent_key][key] unless
+    attr[parent_key][subparent_key].key? key
+
+  key = "bridge_mac_table_size"
+  attr[parent_key][subparent_key][key] = tattr[parent_key][subparent_key][key] unless
+    attr[parent_key][subparent_key].key? key
+end
+
+def downgrade_dhcp(tattr, tdep, attr, dep)
+  parent_key = "dhcp"
+  attr[parent_key].delete("dhcp_renewal_time") if tattr[parent_key].key? "dhcp_renewal_time"
+  attr[parent_key].delete("dhcp_rebinding_time") if tattr[parent_key].key? "dhcp_rebinding_time"
+
+  subparent_key = "ovs"
+  key = "ovsdb_debug"
+  attr[parent_key][subparent_key].delete(key) if tattr[parent_key][subparent_key].key? key
+
+  key = "ovsdb_timeout"
+  attr[parent_key][subparent_key].delete(key) if tattr[parent_key][subparent_key].key? key
+
+  key = "bridge_mac_table_size"
+  attr[parent_key][subparent_key].delete(key) if tattr[parent_key][subparent_key].key? key
+
+  attr[parent_key].delete(subparent_key) if tattr[parent_key].key? subparent_key
+
+  attr.delete(parent_key) if tattr.key? parent_key
+end
+
+def upgrade(tattr, tdep, attr, dep)
+  upgrade_neutron(tattr, tdep, attr, dep)
+  upgrade_sql(tattr, tdep, attr, dep)
+  upgrade_network_log(tattr, tdep, attr, dep)
+  upgrade_dhcp(tattr, tdep, attr, dep)
+
+  attr["sql"].delete("min_pool_size") if attr["sql"].key? "min_pool_size"
+  attr["ovs"].delete("ovsdb_interface") if attr["ovs"].key? "ovsdb_interface"
+
+  return attr, dep
+end
+
+def downgrade(tattr, tdep, attr, dep)
+  downgrade_neutron(tattr, tdep, attr, dep)
+  downgrade_sql(tattr, tdep, attr, dep)
+  downgrade_network_log(tattr, tdep, attr, dep)
+  downgrade_dhcp(tattr, tdep, attr, dep)
+
+  attr["sql"]["min_pool_size"] = tattr["sql"]["min_pool_size"]
+  attr["ovs"]["ovsdb_interface"] = tattr["ovs"]["ovsdb_interface"]
+
+  return attr, dep
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -27,6 +27,8 @@
       "ml2_type_drivers_default_provider_network": "vxlan",
       "ml2_type_drivers_default_tenant_network": "vxlan",
       "num_vlans": 2000,
+      "agent_down_time": 75,
+      "report_interval": 30,
       "gre": {
         "tunnel_id_start": 1,
         "tunnel_id_end": 1000
@@ -36,9 +38,12 @@
         "vni_end": 99999,
         "multicast_group": "239.1.1.1"
       },
+      "network_log": {
+        "rate_limit": 100,
+        "burst_limit": 25
+      },
       "ovs": {
-        "tunnel_csum": false,
-        "ovsdb_interface": "native"
+        "tunnel_csum": false
       },
       "apic": {
         "hosts": "",
@@ -101,10 +106,11 @@
         "user": "neutron"
       },
       "sql": {
-        "min_pool_size": 1,
         "max_pool_size": 50,
         "max_pool_overflow": 50,
-        "pool_timeout": 30
+        "pool_timeout": 30,
+        "connection_recycle_time": 3600,
+        "connection_parameters": ""
       },
       "f5": {
         "ha_type": "standalone",
@@ -182,14 +188,23 @@
       "metadata": {
         "force": false
       },
-      "default_log_levels": []
+      "default_log_levels": [],
+      "dhcp": {
+        "dhcp_renewal_time": 0,
+        "dhcp_rebinding_time": 0,
+        "ovs": {
+          "ovsdb_debug": false,
+          "ovsdb_timeout": 10,
+          "bridge_mac_table_size": 50000
+        }
+      }
     }
   },
   "deployment": {
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 302,
+      "schema-revision": 303,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -32,6 +32,8 @@
                     "ml2_type_drivers_default_provider_network": { "type": "str", "required": true },
                     "ml2_type_drivers_default_tenant_network": { "type": "str", "required": true },
                     "num_vlans": { "type": "int", "required": true },
+                    "agent_down_time": {"type": "int", "required": true},
+                    "report_interval": {"type": "int", "required": true},
                     "gre": { "type": "map", "required": true, "mapping": {
                       "tunnel_id_start": { "type" : "int", "required" : true },
                       "tunnel_id_end": { "type" : "int", "required" : true }
@@ -41,9 +43,12 @@
                       "vni_end": { "type" : "int", "required" : true },
                       "multicast_group": { "type" : "str", "required": true }
                     }},
+                    "network_log": { "type": "map", "required": true, "mapping": {
+                      "rate_limit": { "type": "int", "required": true },
+                      "burst_limit": { "type": "int", "required": true }
+                    }},
                     "ovs": { "type": "map", "required": true, "mapping": {
-                      "tunnel_csum": { "type": "bool", "required": true },
-                      "ovsdb_interface": { "type": "str", "required": true }
+                      "tunnel_csum": { "type": "bool", "required": true }
                     }},
                     "apic": { "type": "map", "required": true, "mapping": {
                       "hosts": { "type" : "str", "required" : true },
@@ -126,10 +131,11 @@
                       "password": { "type" : "str" }
                     }},
                     "sql": { "type": "map", "required": true, "mapping": {
-                      "min_pool_size": { "type" : "int", "required" : true },
                       "max_pool_size": { "type" : "int", "required" : true },
                       "max_pool_overflow": { "type" : "int", "required" : true },
-                      "pool_timeout": { "type" : "int", "required" : true }
+                      "pool_timeout": { "type" : "int", "required" : true },
+                      "connection_recycle_time": { "type" : "int", "required" : true },
+                      "connection_parameters": { "type" : "str", "required" : true }
                     }},
                     "f5": { "type": "map", "required": true, "mapping": {
                       "ha_type": { "type" : "str", "required" : true },
@@ -231,6 +237,19 @@
                       "type": "seq",
                       "required": false,
                       "sequence": [ { "type": "str" } ]
+                    },
+                    "dhcp": {
+                      "type": "map", "required": true, "mapping": {
+                        "dhcp_renewal_time": { "type": "int", "required": true },
+                        "dhcp_rebinding_time": { "type": "int", "required": true },
+                        "ovs": {
+                          "type": "map", "required": true, "mapping": {
+                            "ovsdb_debug": { "type": "bool", "required": true },
+                            "ovsdb_timeout": { "type": "int", "required": true },
+                            "bridge_mac_table_size": { "type": "int", "required": true }
+                          }
+                        }
+                      }
                     }
               }}
      }},

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -403,6 +403,16 @@ class NeutronService < OpenstackServiceObject
       validate_external_networks proposal["attributes"]["neutron"]["additional_external_networks"]
     end
 
+    validation_error I18n.t("barclamp.#{@bc_name}.validation.agent_down_time_min") if
+      proposal["attributes"]["neutron"]["agent_down_time"] <
+          2 * proposal["attributes"]["neutron"]["report_interval"]
+
+    validation_error I18n.t("barclamp.#{@bc_name}.validation.network_log_rate_limit_min") if
+      proposal[:attributes][:neutron][:network_log][:rate_limit] < 100
+
+    validation_error I18n.t("barclamp.#{@bc_name}.validation.network_log_burst_limit_min") if
+      proposal[:attributes][:neutron][:network_log][:burst_limit] < 25
+
     super
   end
 

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -149,3 +149,6 @@ en:
         dvr_linuxbridge: 'DVR is not compatible with Linux Bridge ML2 driver'
         vmware_dvs_vlan: 'The "vmware_dvs" mechanism driver needs the type driver "vlan"'
         vmware_dvs_ovs_lbr: 'The "vmware_dvs" mechanism driver also needs either the "openvswitch" or the "linuxbridge" mechanism driver'
+        agent_down_time_min: 'agent_down_time should be at least twice report_interval, to be sure the agent is down for good.'
+        network_log_rate_limit_min: 'Network_log.rate_limit_min value must be higher than 100'
+        network_log_burst_limit_min: 'Network_log.burst_limit value must be higher than 25'


### PR DESCRIPTION
Removed deprecated options from the configuration

From neutron.conf
- sql/min_pool_size
Minimum number of SQL connections to keep open in a pool.

From ovs openvswitch_agent.ini
- ovs/ovsdb_interface
The interface for interacting with the OVSDB

Added additional configuration variables to neutron.conf:

- report_interval
Seconds between nodes reporting state to server; should be less
than agent_down_time, best if it is half or less than agent_down_time.

- agent_down_time
Seconds to regard the agent is down; should be at least twice
report_interval, to be sure the agent is down for good.

- sql/connection_recycle_time
Connections which have been present in the connection pool longer
than this number of seconds will be replaced with a new one the
next time they are checked out from the pool.

- sql/connection_parameters
Optional URL parameters to append onto the connection URL at connect
time; specify as param1=value1&param2=value2&…

- nova/split_loggers
Log requests to multiple loggers.

Added additional configuration variables to openvswitch_agent.conf:

- network_log/rate_limit
Maximum packets logging per second.

- burst_limit
Maximum number of packets per rate_limit.

- local_output_log_base
Output logfile path on agent side, default syslog file.

Added additional configuration variables to dhcp_agent conf:

- dhcp_renewal_time
DHCP renewal time T1 (in seconds). If set to 0, it will default to half of the lease time.

- dhcp_rebinding_time
DHCP rebinding time T2 (in seconds). If set to 0, it will default to 7/8 of the lease time.

- ovs/ovsdb_debug
Enable OVSDB debug logs

- ovs/ovsdb_timeout
Timeout in seconds for ovsdb commands. If the timeout expires, ovsdb commands will fail with ALARMCLOCK error.

- ovs/bridge_mac_table_size
The maximum number of MAC addresses to learn on a bridge managed by the
Neutron OVS agent. Values outside a reasonable range (10 to 1,000,000)
might be overridden by Open vSwitch according to the documentation.