### PR TITLE
nova: Remove deprecated vnc keymap configuration (SCRD-5787)

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -83,6 +83,7 @@ default[:nova][:vcenter][:password] = ""
 default[:nova][:vcenter][:clusters] = []
 default[:nova][:vcenter][:interface] = ""
 default[:nova][:vcenter][:dvs_name] = "dvSwitch0"
+default[:nova][:vcenter][:vnc_keymap] = "en-us"
 
 #
 # Scheduler Settings
@@ -106,7 +107,6 @@ default[:nova][:user] = "nova"
 default[:nova][:group] = "nova"
 default[:nova][:home_dir] = "/var/lib/nova"
 default[:nova][:instances_path] = "/var/lib/nova/instances"
-default[:nova][:vnc_keymap] = "en-us"
 
 default[:nova][:neutron_metadata_proxy_shared_secret] = ""
 default[:nova][:neutron_url_timeout] = 30

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -311,11 +311,11 @@ cluster_name = "<%= cluster %>"
   <% end %>
 datastore_regex = <%= node[:nova][:vcenter][:datastore] %>
 vlan_interface = <%= node[:nova][:vcenter][:interface] %>
+vnc_keymap = <%= node[:nova][:vcenter][:vnc_keymap] %>
 <% end %>
 
 [vnc]
 enabled = <%= @vnc_enabled ? "True" : "False" %>
-keymap = <%= node[:nova][:vnc_keymap] %>
 server_listen = "0.0.0.0"
 server_proxyclient_address = <%= node[:nova][:my_ip] %>
 novncproxy_host = <%= @bind_host %>

--- a/chef/data_bags/crowbar/migrate/nova/303_update_vnc_keymap.rb
+++ b/chef/data_bags/crowbar/migrate/nova/303_update_vnc_keymap.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["vcenter"]["vnc_keymap"] = attrs["vnc_keymap"]
+  attrs.delete("vnc_keymap")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["vcenter"].delete("vnc_keymap")
+  attrs["vnc_keymap"] = template_attrs["vnc_keymap"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -31,7 +31,6 @@
       "use_syslog": false,
       "neutron_url_timeout": 30,
       "force_config_drive": false,
-      "vnc_keymap": "en-us",
       "scheduler": {
         "ram_allocation_ratio": 1.0,
         "cpu_allocation_ratio": 16.0,
@@ -91,7 +90,8 @@
         "ca_file": "",
         "insecure": false,
         "dvs_name": "dvSwitch0",
-        "dvs_security_groups": false
+        "dvs_security_groups": false,
+        "vnc_keymap": "en-us"
       },
       "zvm": {
         "zvm_xcat_server": "",
@@ -184,7 +184,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 302,
+      "schema-revision": 303,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -47,7 +47,6 @@
             "neutron_metadata_proxy_shared_secret": { "type": "str" },
             "neutron_url_timeout": {"type": "int"},
             "force_config_drive": { "type": "bool", "required": true },
-            "vnc_keymap": { "type": "str" , "required": true },
             "scheduler": {
               "type": "map",
               "mapping": {
@@ -151,7 +150,8 @@
                 "ca_file": { "type": "str", "required": true },
                 "insecure": { "type": "bool", "required": true },
                 "dvs_name": { "type": "str", "required": true },
-                "dvs_security_groups": { "type": "bool", "required": true }
+                "dvs_security_groups": { "type": "bool", "required": true },
+                "vnc_keymap": { "type": "str" , "required": true }
               }
             },
             "zvm": {

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -52,6 +52,7 @@
       = string_field %w(vcenter interface)
       = string_field %w(vcenter ca_file)
       = boolean_field %w(vcenter insecure)
+      = string_field %w(vcenter vnc_keymap)
 
     %fieldset
       %legend
@@ -106,7 +107,6 @@
       %legend
         = t(".vnc_header")
 
-      = string_field :vnc_keymap
 
       = boolean_field %w(novnc ssl enabled), :collection => :ssl_protocols_for_nova, "data-sslprefix" => "novnc_ssl", "data-sslcert" => "", "data-sslkey" => ""
 

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -28,7 +28,6 @@ en:
         itxt_instance: 'Intel TXT'
         trusted_flavors: 'Create Trusted Flavors'
         scheduler_header: 'Scheduler Options'
-        vnc_keymap: 'Keymap'
         scheduler:
           ram_allocation_ratio: 'Virtual RAM to Physical RAM allocation ratio'
           cpu_allocation_ratio: 'Virtual CPU to Physical CPU allocation ratio'
@@ -51,6 +50,7 @@ en:
           interface: 'VLAN Interface'
           ca_file: 'CA file for verifying the vCenter certificate'
           insecure: 'vCenter SSL Certificate is insecure (for instance, self-signed)'
+          vnc_keymap: 'Keymap'
         vmware_cluster_hint: 'A comma-separated list of cluster names'
         zvm_header: 'z/VM Configuration'
         zvm:


### PR DESCRIPTION
 - get rid of keymap in [vnc]