### PR TITLE
nova: Rename deprecated placement configuration options (SCRD-5845).

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
@@ -2,13 +2,13 @@
 auth_type = password
 auth_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
-os_region_name = <%= @keystone_settings['endpoint_region'] %>
+region_name = <%= @keystone_settings['endpoint_region'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>
 project_domain_name = <%= @keystone_settings["admin_domain"] %>
 user_domain_name = <%= @keystone_settings['admin_domain'] %>
 username = <%= @placement_service_user %>
 password = <%= @placement_service_password %>
-os_interface = internal
+valid_interfaces = internal
 insecure = <%= @placement_service_insecure %>
 
 <% if @placement_database_connection -%>


### PR DESCRIPTION
https://docs.openstack.org/releasenotes/nova/queens.html#deprecation-notes
Configuration options in the [placement] section are deprecated as follows: 
	- os_region_name to region_name
	- os_interface to valid_interfaces