### PR TITLE
[4.0] neutron: disable metering agent if no ceilometer

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -199,12 +199,14 @@ if node[:pacemaker][:clone_stateless_services]
     end
   end
 
-  metering_agent_primitive = "neutron-metering-agent"
-  objects = openstack_pacemaker_controller_clone_for_transaction metering_agent_primitive do
-    agent node[:neutron][:ha][:network][:metering_ra]
-    op node[:neutron][:ha][:network][:op]
+  if node.roles.include? "ceilometer-agent"
+    metering_agent_primitive = "neutron-metering-agent"
+    objects = openstack_pacemaker_controller_clone_for_transaction metering_agent_primitive do
+      agent node[:neutron][:ha][:network][:metering_ra]
+      op node[:neutron][:ha][:network][:op]
+    end
+    transaction_objects.push(objects)
   end
-  transaction_objects.push(objects)
 
   if use_lbaas_agent &&
       [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])


### PR DESCRIPTION
Currently we are enabling and running the metering agent at all
times in the network nodes for no reason.

Instead this patch makes it so its only deployed in the case of having
the ceilometer-agent role, which indicates that we are gathering
metrics and we want to run it. Otherwise its just wasted resources

(cherry picked from commit 17206688fe668ac5cba0517d4135155c9f5afd3b)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/1867