### PR TITLE
Horizon policy fix (bsc#1111421)

### DIFF
--- a/chef/cookbooks/horizon/attributes/default.rb
+++ b/chef/cookbooks/horizon/attributes/default.rb
@@ -29,7 +29,6 @@ default[:horizon][:policy_file][:identity] = "keystone_policy.json"
 default[:horizon][:policy_file][:compute] = "nova_policy.json"
 default[:horizon][:policy_file][:volume] = "cinder_policy.json"
 default[:horizon][:policy_file][:image] = "glance_policy.json"
-default[:horizon][:policy_file][:orchestration] = "heat_policy.json"
 default[:horizon][:policy_file][:network] = "neutron_policy.json"
 default[:horizon][:policy_file][:neutron_fwaas] = "neutron-fwaas-policy.json"
 

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -84,6 +84,24 @@ else
   end
 end
 
+# install horizon neutron fwaas plugin if needed
+neutron_fwaas_ui_pkgname =
+  case node[:platform_family]
+  when "suse"
+    "openstack-horizon-plugin-neutron-fwaas-ui"
+  when "rhel"
+    "openstack-neutron-fwaas-ui"
+  end
+
+unless neutron_fwaas_ui_pkgname.nil?
+  unless Barclamp::Config.load("openstack", "neutron").empty?
+    package neutron_fwaas_ui_pkgname do
+      action :install
+      notifies :reload, "service[horizon]"
+    end
+  end
+end
+
 # install horizon manila plugin if needed
 manila_ui_pkgname =
   case node[:platform_family]

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -102,7 +102,6 @@ POLICY_FILES = {
     'compute': '<%= @policy_file[:compute] %>',
     'volume': '<%= @policy_file[:volume] %>',
     'image': '<%= @policy_file[:image] %>',
-    'orchestration': '<%= @policy_file[:orchestration] %>',
     'network': '<%= @policy_file[:network] %>',
     'neutron-fwaas': '<%= @policy_file[:neutron_fwaas] %>',
 }

--- a/chef/data_bags/crowbar/migrate/horizon/302_remove_heat_policy_file.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/302_remove_heat_policy_file.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["policy_file"].delete("orchestration")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["policy_file"]["orchestration"] = template_attrs["policy_file"]["orchestration"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -27,7 +27,6 @@
         "compute": "nova_policy.json",
         "volume": "cinder_policy.json",
         "image": "glance_policy.json",
-        "orchestration": "heat_policy.json",
         "network": "neutron_policy.json",
         "neutron_fwaas": "neutron-fwaas-policy.json"
       },
@@ -53,7 +52,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 301,
+      "schema-revision": 302,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -47,7 +47,6 @@
                 "compute" : { "type": "str", "required": true },
                 "volume" : { "type": "str", "required": true },
                 "image" : { "type": "str", "required": true },
-                "orchestration" : { "type": "str", "required": true },
                 "network" : { "type": "str", "required": true },
                 "neutron_fwaas" : { "type": "str", "required": true }
               }


### PR DESCRIPTION
the policy file names are part of the settings files and the files are no longer there, so removing the config