### PR TITLE
nova: Remove deprecated attr from libvirt section(SCRD-5917)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -204,7 +204,6 @@ live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MI
 block_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE, VIR_MIGRATE_PEER2PEER, VIR_MIGRATE_NON_SHARED_INC, VIR_MIGRATE_LIVE
     <% end %>
 # Timeout migration if less than 1MB/s RAM can be copied
-live_migration_progress_timeout=0
 live_migration_completion_timeout=1000
   <% end %>
 <% end %>


### PR DESCRIPTION
nova: Remove deprecated attr from libvirt section(SCRD-5917)

Remove deprecated options:
- live_migration_progress_timeout=0

It's mentioned in Ocata release note.
https://docs.openstack.org/releasenotes/nova/ocata.html#deprecation-notes