### PR TITLE
cinder: remove use_syslog setting by deprecation

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -2,7 +2,6 @@
 tcp_keepalive_interval = 30
 debug = <%= node[:cinder][:debug] %>
 log_dir = /var/log/cinder
-use_syslog = <%= node[:cinder][:use_syslog] ? "true" : "false" %>
 use_stderr = false
 transport_url = <%= @rabbit_settings[:url] %>
 rpc_response_timeout = <%= node[:cinder][:rpc_response_timeout] %>

--- a/chef/data_bags/crowbar/migrate/cinder/301_remove_use_syslog.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/301_remove_use_syslog.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs.delete("use_syslog")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["use_syslog"] = template_attrs["use_syslog"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -5,7 +5,6 @@
     "cinder": {
       "debug": false,
       "max_header_line": 16384,
-      "use_syslog": false,
       "rabbitmq_instance": "none",
       "keystone_instance": "none",
       "glance_instance": "none",
@@ -182,7 +181,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 300,
+      "schema-revision": 301,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -14,7 +14,6 @@
           "mapping": {
             "debug": { "type": "bool", "required": true },
             "max_header_line": { "type": "int", "required": true },
-            "use_syslog": { "type": "bool", "required": true },
             "rabbitmq_instance": { "type": "str", "required": true },
             "keystone_instance": { "type": "str", "required": true },
             "database_instance": { "type": "str", "required": true },


### PR DESCRIPTION
Removed use_syslog by deprecation since Pike
https://docs.openstack.org/cinder/pike/configuration/tables/conf-changes/cinder.html

Use syslog for logging. Existing syslog format is DEPRECATED and will be
changed later to honor RFC5424. This option is ignored if log_config_append
is set. (boolean value)
https://docs.openstack.org/cinder/rocky/configuration/block-storage/samples/cinder.conf.html