### PR TITLE
[5.0] upgrade: reduce keystone downtime

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -129,6 +129,7 @@ if node[:keystone][:frontend] == "uwsgi"
   end
 
 elsif node[:keystone][:frontend] == "apache"
+  keystone_enabled = !node[:keystone][:disable_vhost]
 
   service "keystone" do
     service_name node[:keystone][:service_name]
@@ -160,7 +161,7 @@ elsif node[:keystone][:frontend] == "apache"
   end
 
   apache_site "keystone-public.conf" do
-    enable true
+    enable keystone_enabled
   end
 
   crowbar_openstack_wsgi "WSGI entry for keystone-admin" do
@@ -185,7 +186,7 @@ elsif node[:keystone][:frontend] == "apache"
   end
 
   apache_site "keystone-admin.conf" do
-    enable true
+    enable keystone_enabled
   end
 end
 

--- a/crowbar_framework/lib/openstack/upgrade.rb
+++ b/crowbar_framework/lib/openstack/upgrade.rb
@@ -33,7 +33,7 @@ module Openstack
       # this point the nodes maybe don't have roles assigned anymore
       components = [
         :ceilometer, :cinder, :glance, :heat,
-        :keystone, :manila, :neutron, :nova
+        :manila, :neutron, :nova
       ]
       NodeObject.all.each do |node|
         save_it = false


### PR DESCRIPTION
This introduces the needed changes in the keystone cookbook for reducing its downtime during the upgrade. More details in: https://github.com/crowbar/crowbar-core/pull/1715

ToDo items:

- [x] Skip clearing the db_sync flag for keystone only when really needed. Currenty this PR breaks upgrades of the "normal" setups 
