### PR TITLE
horizon: django.wsgi has been deprecated, use wsgi.py (SCRD-4093)

### DIFF
--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -43,7 +43,7 @@ Listen <%= @bind_host %>:<%= @bind_port %>
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
 <% end %>
-    WSGIScriptAlias / <%= @horizon_dir %>/openstack_dashboard/wsgi/django.wsgi
+    WSGIScriptAlias / <%= @horizon_dir %>/openstack_dashboard/wsgi.py
     WSGIDaemonProcess horizon user=<%= @user %> group=<%= @group %> processes=3 threads=10 display-name=%{GROUP}
     SetEnv APACHE_RUN_USER  <%= @user %>
     SetEnv APACHE_RUN_GROUP <%= @group %>


### PR DESCRIPTION
https://bugs.launchpad.net/horizon/+bug/1763204