### PR TITLE
openstack: don't install ruby database clients

### DIFF
--- a/chef/cookbooks/aodh/recipes/aodh.rb
+++ b/chef/cookbooks/aodh/recipes/aodh.rb
@@ -8,7 +8,6 @@ end
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 crowbar_pacemaker_sync_mark "wait-aodh_database" if ha_enabled

--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -14,7 +14,6 @@ keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 db_auth = node[:ceilometer][:db].dup

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -18,7 +18,6 @@ ha_enabled = node[:ceilometer][:ha][:server][:enabled]
   db_settings = fetch_database_settings
 
   include_recipe "database::client"
-  include_recipe "#{db_settings[:backend_name]}::client"
   include_recipe "#{db_settings[:backend_name]}::python-client"
 
   crowbar_pacemaker_sync_mark "wait-ceilometer_database" if ha_enabled

--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -56,7 +56,6 @@ nova_insecure = CrowbarOpenStackHelper.insecure(nova_config)
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 db_auth = node[:cinder][:db].dup

--- a/chef/cookbooks/cinder/recipes/sql.rb
+++ b/chef/cookbooks/cinder/recipes/sql.rb
@@ -24,7 +24,6 @@ ha_enabled = node[:cinder][:ha][:enabled]
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 crowbar_pacemaker_sync_mark "wait-cinder_database" if ha_enabled

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -26,7 +26,6 @@ ha_enabled = node[:glance][:ha][:enabled]
 
 db_settings = fetch_database_settings
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 crowbar_pacemaker_sync_mark "wait-glance_database" if ha_enabled

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -19,7 +19,6 @@ use_crowbar_pacemaker_service = ha_enabled && node[:pacemaker][:clone_stateless_
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 crowbar_pacemaker_sync_mark "wait-heat_database" if ha_enabled

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -238,14 +238,15 @@ ha_enabled = node[:horizon][:ha][:enabled]
 
 db_settings = fetch_database_settings
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 case db_settings[:backend_name]
 when "mysql"
     django_db_backend = "'django.db.backends.mysql'"
+    package "python-mysql"
 when "postgresql"
     django_db_backend = "'django.db.backends.postgresql_psycopg2'"
+    package "python-psycopg2"
 end
 
 crowbar_pacemaker_sync_mark "wait-horizon_database" if ha_enabled

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -17,7 +17,6 @@
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 # Create the Ironic Database

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -192,7 +192,6 @@ end
 
 db_settings = fetch_database_settings
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 crowbar_pacemaker_sync_mark "wait-keystone_database" if ha_enabled

--- a/chef/cookbooks/magnum/recipes/common.rb
+++ b/chef/cookbooks/magnum/recipes/common.rb
@@ -27,7 +27,6 @@ memcached_servers = MemcachedHelper.get_memcached_servers(
 memcached_instance("magnum-server")
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 # get Database data

--- a/chef/cookbooks/magnum/recipes/sql.rb
+++ b/chef/cookbooks/magnum/recipes/sql.rb
@@ -21,7 +21,6 @@ ha_enabled = node[:magnum][:ha][:enabled]
 
 db_settings = fetch_database_settings
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 crowbar_pacemaker_sync_mark "wait-magnum_database" if ha_enabled

--- a/chef/cookbooks/manila/recipes/common.rb
+++ b/chef/cookbooks/manila/recipes/common.rb
@@ -18,7 +18,6 @@ package "openstack-manila"
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 # get Database data

--- a/chef/cookbooks/manila/recipes/sql.rb
+++ b/chef/cookbooks/manila/recipes/sql.rb
@@ -4,7 +4,6 @@ ha_enabled = node[:manila][:ha][:enabled]
 
 db_settings = fetch_database_settings
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 crowbar_pacemaker_sync_mark "wait-manila_database" if ha_enabled

--- a/chef/cookbooks/mysql/recipes/python-client.rb
+++ b/chef/cookbooks/mysql/recipes/python-client.rb
@@ -19,8 +19,7 @@
 
 case node[:platform_family]
 when "suse"
-  package "python-mysql"     # C-extensions MySQL driver
-  package "python-PyMySQL"   # pure-Python MySQL driver
+  package "python-PyMySQL"
 when "rhel"
   package "MySQL-python"
 else

--- a/chef/cookbooks/neutron/recipes/database.rb
+++ b/chef/cookbooks/neutron/recipes/database.rb
@@ -19,7 +19,6 @@ ha_enabled = node[:neutron][:ha][:server][:enabled]
 
 db_settings = fetch_database_settings
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 props = [{"db_name" => node[:neutron][:db][:database],

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -57,7 +57,6 @@ if is_controller
   db_settings = fetch_database_settings
 
   include_recipe "database::client"
-  include_recipe "#{db_settings[:backend_name]}::client"
   include_recipe "#{db_settings[:backend_name]}::python-client"
 
   database_connection = fetch_database_connection_string(node[:nova][:db])

--- a/chef/cookbooks/postgresql/recipes/python-client.rb
+++ b/chef/cookbooks/postgresql/recipes/python-client.rb
@@ -17,6 +17,4 @@
 # limitations under the License.
 #
 
-package "python-psycopg2" do
-    action :install
-end
+package "python-psycopg2"

--- a/chef/cookbooks/sahara/recipes/common.rb
+++ b/chef/cookbooks/sahara/recipes/common.rb
@@ -19,7 +19,6 @@ network_settings = SaharaHelper.network_settings(node)
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 # get Database data

--- a/chef/cookbooks/sahara/recipes/sql.rb
+++ b/chef/cookbooks/sahara/recipes/sql.rb
@@ -20,7 +20,6 @@ ha_enabled = node[:sahara][:ha][:enabled]
 
 db_settings = fetch_database_settings
 include_recipe "database::client"
-include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
 crowbar_pacemaker_sync_mark "wait-sahara_database" if ha_enabled


### PR DESCRIPTION
So afaik openstack is written in python, so we only need
to install the database backend for python clients. We
can also skip installation of python-mysql as it is not
supposed to be used anymore.