### PR TITLE
galera: Use monitoring user for observing wsrep state

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -243,7 +243,7 @@ ruby_block "wait galera bootstrap" do
   block do
     require "timeout"
     begin
-      cmd = "mysql -u '' -N -B " \
+      cmd = "mysql -u 'monitoring' -N -B " \
         "-e \"SHOW STATUS WHERE Variable_name='wsrep_local_state_comment';\" | cut -f 2"
       sync_state = ""
       Timeout.timeout(seconds) do

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -23,24 +23,30 @@ node[:mysql][:galera_packages].each do |p|
   package p
 end
 
-unless node[:database][:galera_bootstrapped]
-  directory "/var/run/mysql/" do
-    owner "mysql"
-    group "root"
-    mode "0755"
-    action :create
-  end
+directory "/var/run/mysql/" do
+  owner "mysql"
+  group "root"
+  mode "0755"
+  action :create
+end
 
-  execute "mysql_install_db" do
-    command "mysql_install_db"
-    action :run
-  end
+directory "/var/lib/mysql/" do
+  owner "mysql"
+  group "root"
+  mode "0700"
+  action :create
 end
 
 node_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
 
 unless node[:database][:galera_bootstrapped]
   if CrowbarPacemakerHelper.is_cluster_founder?(node)
+
+    execute "mysql_install_db" do
+      command "mysql_install_db"
+      action :run
+    end
+
     # To bootstrap for the first time, start galera on one node
     # to set up the seed sst and monitoring users.
 


### PR DESCRIPTION
Using the root user with empty password has the downside
that once the root user no longer has an empty password, it
can no longer observe the state. The monitoring user
is more useful for that as it is always available, even
when the cluster was already bootstrapped before. This
is important in case you want to add new nodes to an existing
cluster.