### PR TITLE
tempest: only assign creator role if needed

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -490,6 +490,12 @@ else
   horizon_protocol = horizon[:horizon][:apache][:ssl] ? "https" : "http"
 end
 
+# Extra roles to assign to the tempest user
+tempest_roles = []
+
+barbicans = search(:node, "roles:barbican-controller") || []
+tempest_roles += ["creator"] unless barbicans.empty?
+
 template "/etc/tempest/tempest.conf" do
   source "tempest.conf.erb"
   mode 0o640
@@ -504,6 +510,7 @@ template "/etc/tempest/tempest.conf" do
         use_swift: use_swift,
         use_horizon: use_horizon,
         enabled_services: enabled_services,
+        tempest_roles: tempest_roles.join(", "),
         # boto settings
         ec2_protocol: nova[:nova][:ssl][:enabled] ? "https" : "http",
         ec2_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova][:ha][:enabled]),

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -13,7 +13,9 @@ admin_username = <%= @keystone_settings['admin_user'] %>
 admin_project_name = <%= @keystone_settings['default_tenant'] %>
 admin_password = <%= @keystone_settings['admin_password'] %>
 admin_domain_name = Default
-tempest_roles = creator
+<%- unless @tempest_roles.empty? %>
+tempest_roles = <%= @tempest_roles %>
+<%- end %>
 
 [aws]
 ec2_url = <%= @ec2_protocol %>://<%= @ec2_host %>:<%= @ec2_port %>/


### PR DESCRIPTION
Check whether the Barbican barclamp has been applied and only
assign the creator role to the tempest user if it has been.
This role is created by the Barbican barclamp and if the role
does not exist, this role assignment will fail, causing smoke
tests to fail across the board.