### PR TITLE
neutron: removed deprecation settings

### DIFF
--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -86,7 +86,6 @@ template agent_config_path do
     use_l2pop: false,
     dvr_enabled: false,
     of_interface: "ovs-ofctl",
-    ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
     bridge_mappings: ""
   )
 end

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -274,7 +274,6 @@ if neutron[:neutron][:networking_plugin] == "ml2"
             (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
-        ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
         bridge_mappings: bridge_mappings
       )
     end

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -37,7 +37,6 @@ root_helper_daemon = sudo neutron-rootwrap-daemon /etc/neutron/rootwrap.conf
 <% unless @sql_connection.nil? || @sql_connection.empty? -%>
 connection = <%= @sql_connection %>
 <% end -%>
-min_pool_size = <%= @sql_min_pool_size %>
 max_pool_size = <%= @sql_max_pool_size %>
 max_overflow = <%= @sql_max_pool_overflow %>
 pool_timeout = <%= @sql_pool_timeout %>

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -20,7 +20,6 @@ tunnel_csum = True
 <% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") && !@ml2_type_drivers.include?("opflex") -%>
 tunnel_bridge = br-tunnel
 <% end -%>
-ovsdb_interface = <%= @ovsdb_interface %>
 <% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
 local_ip = <%= node.address("os_sdn").addr %>
 <% end -%>

--- a/chef/data_bags/crowbar/migrate/neutron/303_remove_rocky_deprecations.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/303_remove_rocky_deprecations.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["sql"].delete("min_pool_size")
+  attrs["ovs"].delete("ovsdb_interface")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["sql"]["min_pool_size"] = template_attrs["sql"]["min_pool_size"]
+  attrs["ovs"]["ovsdb_interface"] = template_attrs["ovs"]["ovsdb_interface"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -37,8 +37,7 @@
         "multicast_group": "239.1.1.1"
       },
       "ovs": {
-        "tunnel_csum": false,
-        "ovsdb_interface": "native"
+        "tunnel_csum": false
       },
       "apic": {
         "hosts": "",
@@ -101,7 +100,6 @@
         "user": "neutron"
       },
       "sql": {
-        "min_pool_size": 1,
         "max_pool_size": 50,
         "max_pool_overflow": 50,
         "pool_timeout": 30
@@ -189,7 +187,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 302,
+      "schema-revision": 303,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -42,8 +42,7 @@
                       "multicast_group": { "type" : "str", "required": true }
                     }},
                     "ovs": { "type": "map", "required": true, "mapping": {
-                      "tunnel_csum": { "type": "bool", "required": true },
-                      "ovsdb_interface": { "type": "str", "required": true }
+                      "tunnel_csum": { "type": "bool", "required": true }
                     }},
                     "apic": { "type": "map", "required": true, "mapping": {
                       "hosts": { "type" : "str", "required" : true },
@@ -126,7 +125,6 @@
                       "password": { "type" : "str" }
                     }},
                     "sql": { "type": "map", "required": true, "mapping": {
-                      "min_pool_size": { "type" : "int", "required" : true },
                       "max_pool_size": { "type" : "int", "required" : true },
                       "max_pool_overflow": { "type" : "int", "required" : true },
                       "pool_timeout": { "type" : "int", "required" : true }


### PR DESCRIPTION
Removed deprecated settings from the configuration

- sql/min_pool_size
Minimum number of SQL connections to keep open in a pool.
https://github.com/openstack/oslo.db/blob/ab1c2b9076dc4fef9e3b7d880a69099172a5bf27/oslo_db/options.py#L70

- ovs/ovsdb_interface
The interface for interacting with the OVSDB
https://docs.openstack.org/releasenotes/neutron/queens.html