### PR TITLE
 horizon: remove option OPENSTACK_TOKEN_HASH_ENABLED (SCRD-5906) 

### DIFF
--- a/chef/cookbooks/horizon/attributes/default.rb
+++ b/chef/cookbooks/horizon/attributes/default.rb
@@ -55,6 +55,3 @@ default["horizon"]["can_set_password"] = false
 
 # Display "Domain" text field on login page
 default[:horizon][:multi_domain_support] = false
-
-# Set as false when using PKI tokens (401 errors)
-default[:horizon][:token_hash_enabled] = true

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -408,7 +408,6 @@ template local_settings do
     multi_domain_support: multi_domain_support,
     policy_file_path: node["horizon"]["policy_file_path"],
     policy_file: node["horizon"]["policy_file"],
-    token_hash_enabled: node["horizon"]["token_hash_enabled"]
   )
   action :create
   notifies :reload, "service[horizon]"

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -218,7 +218,6 @@ LOGGING = {
 }
 
 
-OPENSTACK_TOKEN_HASH_ENABLED = <%= @token_hash_enabled ? "True" : "False" %>
 HORIZON_CONFIG['help_url'] = "<%= @help_url %>"
 COMPRESS_CACHE_KEY_FUNCTION='compressor.cache.socket_cachekey'
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'

--- a/chef/data_bags/crowbar/migrate/horizon/301_remove_token_hash_enanled_attribute.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/301_remove_token_hash_enanled_attribute.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs.delete("token_hash_enabled")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["token_hash_enabled"] = template_attrs["token_hash_enabled"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -42,7 +42,6 @@
         "ssl_crt_chain_file": ""
       },
       "external_monitoring": {},
-      "token_hash_enabled": true,
       "resource_limits": {
         "apache2": {
           "LimitNOFILE": null
@@ -54,7 +53,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 300,
+      "schema-revision": 301,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -71,7 +71,6 @@
                 =: { "type": "str",  "required": false }
               }
             },
-	    "token_hash_enabled": { "type": "bool", "required": true },
             "resource_limits": {
               "type": "map",
               "required": false,


### PR DESCRIPTION
this settings was dropped in rocky

https://docs.openstack.org/releasenotes/horizon/rocky.html#upgrade-notes