### PR TITLE
ironic: Use ironic network for provisioning (bsc#1108398)

### DIFF
--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -122,6 +122,7 @@ end
 public_endpoint = "#{api_protocol}://#{my_public_host}:#{api_port}"
 admin_endpoint = "#{api_protocol}://#{my_admin_host}:#{api_port}"
 internal_endpoint = admin_endpoint
+api_url = "#{api_protocol}://#{ironic_net_ip}:#{api_port}"
 
 keystone_register "register ironic endpoint" do
   protocol keystone_settings["protocol"]
@@ -192,6 +193,7 @@ template node[:ironic][:config_file] do
         pxe_append_params: node[:ironic][:pxe_append_params],
         public_endpoint: public_endpoint,
         api_port: api_port,
+        api_url: api_url,
         auth_version: auth_version,
         memcached_servers: memcached_servers
       }

--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -11,7 +11,7 @@ port=<%= @api_port %>
 public_endpoint=<%= @public_endpoint %>
 
 [conductor]
-api_url=<%= @public_endpoint %>
+api_url=<%= @api_url %>
 automated_clean=<%= @automated_clean %>
 
 [database]


### PR DESCRIPTION
Switched to using "ironic" network IP in api_url which is passed to
ironic-python-agent running on the node during deployment and/or cleanup.
This should fix problems when IPA can't access ironic API because ironic
network is the only one attached to the node and there is no routed
access to public network via ironic network.

(cherry picked from commit b709db3a4ac87704f96e1a1c522e4bb9c42610a5)