### PR TITLE
heat: deferred_auth_method is deprecated and

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -1,5 +1,4 @@
 [DEFAULT]
-deferred_auth_method = trusts
 reauthentication_auth_method = trusts
 trusts_delegated_roles = <%= @trusts_delegated_roles.join(',') %>
 heat_metadata_server_url = <%= @heat_metadata_server_url %>


### PR DESCRIPTION
also is not recommmended with keyston v3

https://review.openstack.org/#/q/Ib97fa5ef62f52e305cb406f423d261b80088d8a6