### PR TITLE
nova: Remove auth_uri in placement section.

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
@@ -1,6 +1,6 @@
 [placement]
 auth_type = password
-auth_uri = <%= @keystone_settings['public_auth_url'] %>
+www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
 project_name = <%= @keystone_settings['service_tenant'] %>


### PR DESCRIPTION
'auth_uri' is migrating to 'www_authenticate_uri' and there's nothing mentioned in doc about using this option under placement section on nova.conf
https://docs.openstack.org/nova/rocky/configuration/config.html#placement