### PR TITLE
ssl: Fix ACL setup in ssl_setup provider

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/provider_ssl_setup.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/provider_ssl_setup.rb
@@ -108,19 +108,19 @@ subjectAltName       = #{@current_resource.alt_names.join ', '}
 
       def _fix_acl(certificate, group)
         partial = "/"
-        directory.split(File::SEPARATOR).each do |entry|
+        certificate.split(::File::SEPARATOR).each do |entry|
           next if entry.empty?
 
-          partial = File.join(partial, entry)
+          partial = ::File.join(partial, entry)
           # If the file is readable by all users, and the directory is
           # readable and executable (we can list the contents) we can
           # avoid an ACL modification
-          if File.world_readable?(partial)
-            next if File.file?(partial)
-            next if _world_executable?(partial) && File.directory?(partial)
+          if ::File.world_readable?(partial)
+            next if ::File.file?(partial)
+            next if _world_executable?(partial) && ::File.directory?(partial)
           end
 
-          mask = if File.directory?(partial)
+          mask = if ::File.directory?(partial)
             "group:#{group}:r-x"
           else
             "group:#{group}:r--"
@@ -129,8 +129,8 @@ subjectAltName       = #{@current_resource.alt_names.join ', '}
         end
       end
 
-      def _world_executable(path)
-        File.stat(path).mode & 1 == 1
+      def _world_executable?(path)
+        ::File.stat(path).mode & 1 == 1
       end
     end
   end


### PR DESCRIPTION
In 75fe195a a method was introduced to ensure certificates that are
installed by the operator were readable to OpenStack service users. This
method is never tested in CI because we only ever use self-signed,
crowbar-generated certs in CI. If an operator does generate their own
certs instead of having crowbar generate them, crowbar fails with this
message:

  ArgumentError: ssl_setup[setting up ssl for keystone] (keystone::server line
  78) had an error: ArgumentError: You must supply a name when declaring a
  directory resource

This is because the method calls an operation on an object called
'directory' without defining it first, but 'directory' is already reserved
as the name of a Chef resource. Moreover, we can't directly call the
ruby File module from inside this module as ruby will assume it is a
relative module, not a global module. This change fixes the reference to
'directory' to use the cert path passed into the method, which must have
been the intended usage, and also adds the global namespace to the File
module references. Finally, it fixes the misnamed reference to the
locally defined world_executable method.