### PR TITLE
db: Raise default connection limit to 1400

### DIFF
--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -9,7 +9,7 @@
         "slow_query_logging": true,
         "innodb_flush_log_at_trx_commit": 1,
         "innodb_buffer_pool_instances": 1,
-        "max_connections": 800,
+        "max_connections": 1400,
         "tmp_table_size": 64,
         "max_heap_table_size": 64,
         "expire_logs_days": 10,


### PR DESCRIPTION
if you deploy the minimal of 10 services (each with the minimum
of 15 database threads) with the default 4 workers on a 3 node cluster,
you're at 1800 connections max already, so going with 1400 seems
to a reasonable default.