### PR TITLE
nova-compute: stop installing qemu-kvm

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -102,8 +102,6 @@ case node[:nova][:libvirt_type]
           end
 
           if node[:nova][:libvirt_type] == "kvm"
-            package "qemu-kvm" if node[:kernel][:machine] == "x86_64"
-
             # only install on architectures that support Ceph
             if node[:kernel][:machine] =~ /aarch64|x86_64/
               package "qemu-block-rbd"


### PR DESCRIPTION
This is just a wrapper package with no functionality, and
having two qemu binaries available seems to somewhat confuse
libvirt's capability caching.

(cherry picked from commit ac73ec54b215f08d79e59a021aa017183fbb1622)