### PR TITLE
[5.0] mariadb: Set wsrep_sst_method to mariabackup (bsc#1116686)

### DIFF
--- a/chef/cookbooks/mysql/templates/default/galera.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera.cnf.erb
@@ -32,5 +32,5 @@ query_cache_type = 0
 expire_logs_days = <%= @expire_logs_days %>
 
 # SST method
-wsrep_sst_method = xtrabackup-v2
+wsrep_sst_method = mariabackup
 wsrep_sst_auth = <%= @sstuser %>:<%= @sstuser_password %>


### PR DESCRIPTION
MariaDB 10.2.16 added a new option innodb_safe_truncate which requies a
the switch to mariabackup which can handle crash-safe rename operations.

(cherry picked from commit cf6018758eca6af67f3f3c2c44c895608a0ae516)