### PR TITLE
neutron: scale up api workers on larger core envs

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -11,7 +11,7 @@ ipam_driver = <%= @ipam_driver %>
 <% end -%>
 global_physnet_mtu = <%= @mtu_value %>
 use_ssl = <%= @ssl_enabled ? "True" : "False" %>
-api_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
+api_workers = <%= [node["cpu"]["total"] / 2, 1, 16].sort[1] %>
 rpc_workers = <%= @rpc_workers %>
 dhcp_agents_per_network = <%= @network_nodes_count %>
 <% if @dvr_enabled -%>


### PR DESCRIPTION
The current max of 4 is by far too low for Cloud8, we need to raise it.
In order to stay the same at 8 cores, try to use like 1/2 of the
available cores so that the rest remains available when nova or cinder
is colocated (which are the others using a lot of CPU)