### PR TITLE
monasca: upgrade database schema

### DIFF
--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+package "openstack-monasca-api"
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 

--- a/chef/cookbooks/monasca/templates/default/monasca-reconfigure-server.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-reconfigure-server.erb
@@ -86,3 +86,5 @@ run_setup \
      timeout=10
      name=kibana
      use_keystone=false'
+
+/usr/bin/monasca_db stamp --from-fingerprint && /usr/bin/monasca_db upgrade


### PR DESCRIPTION
Executes the upgrade of monasca dabase shema using monasca_db command

https://github.com/openstack/monasca-api/blob/master/doc/source/admin/index.rst