### PR TITLE
keystone: Make register requests object-oriented

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -18,18 +18,16 @@
 #
 
 action :wakeup do
-  http, headers = _build_connection(new_resource)
-
-  # Lets verify that the service does not exist yet
   count = 0
   error = true
   loop do
     count = count + 1
-    _, error = _get_service_id(http, headers, "fred")
+    _, error = get_service_id("fred")
     break unless error && count < 50
     sleep 1
     next unless new_resource.reissue_token_on_error
-    http, headers = _build_connection(new_resource)
+    KeystoneHelper.reset_session
+    session
   end
 
   raise "Failed to validate keystone is wake" if error
@@ -38,17 +36,15 @@ action :wakeup do
 end
 
 action :add_service do
-  http, headers = _build_connection(new_resource)
-
   # Lets verify that the service does not exist yet
-  item_id, error = _get_service_id(http, headers, new_resource.service_name)
+  item_id, error = get_service_id(new_resource.service_name)
   unless item_id or error
     # Service does not exist yet
-    body = _build_service_object(new_resource.service_name,
-                                 new_resource.service_type,
-                                 new_resource.service_description)
+    body = build_service_object(new_resource.service_name,
+                                new_resource.service_type,
+                                new_resource.service_description)
     path = "/v3/services"
-    ret = _create_item(http, headers, path, body, new_resource.service_name)
+    ret = create_item(path, body, new_resource.service_name)
     new_resource.updated_by_last_action(ret)
   else
     raise "Failed to talk to keystone in add_service" if error
@@ -60,13 +56,12 @@ end
 # :add_project specific attributes
 # attribute :project_name, :kind_of => String
 action :add_project do
-  http, headers = _build_connection(new_resource)
-  # Lets verify that the service does not exist yet
-  item_id, error = _get_project_id(http, headers, new_resource.project_name)
+  # Lets verify that the project does not exist yet
+  item_id, error = get_project_id(new_resource.project_name)
   unless item_id or error
-    # Service does not exist yet
-    body = _build_project_object(new_resource.project_name)
-    ret = _create_item(http, headers, "/v3/projects", body, new_resource.project_name)
+    # Project does not exist yet
+    body = build_project_object(new_resource.project_name)
+    ret = create_item("/v3/projects", body, new_resource.project_name)
     new_resource.updated_by_last_action(ret)
   else
     raise "Failed to talk to keystone in add_project" if error
@@ -79,22 +74,20 @@ end
 # :add_domain specific attributes
 # attribute :domain_name, :kind_of => String
 action :add_domain do
-  http, headers = _build_connection(new_resource)
-
   # Construct the path
   path = "/v3/domains"
   dir = "domains"
 
   # Lets verify that the domain does not exist yet
-  item_id, error = _find_id(http, headers, new_resource.domain_name, path, dir)
+  item_id, error = find_id(new_resource.domain_name, path, dir)
   if item_id || error
     raise "Failed to talk to keystone in add_domain" if error
     Chef::Log.info "Domain '#{new_resource.domain_name}' already exists. Not creating." unless error
     new_resource.updated_by_last_action(false)
   else
     # Domain does not exist yet
-    body = _build_domain_object(new_resource.domain_name)
-    ret = _create_item(http, headers, path, body, new_resource.domain_name)
+    body = build_domain_object(new_resource.domain_name)
+    ret = create_item(path, body, new_resource.domain_name)
     new_resource.updated_by_last_action(ret)
   end
 end
@@ -104,14 +97,12 @@ end
 # attribute :user_name, :kind_of => String
 # attribute :role_name, :kind_of => String
 action :add_domain_role do
-  http, headers = _build_connection(new_resource)
-
-  user_id, user_error = _get_user_id(http, headers, new_resource.user_name)
-  role_id, role_error = _get_role_id(http, headers, new_resource.role_name)
+  user_id, user_error = get_user_id(new_resource.user_name)
+  role_id, role_error = get_role_id(new_resource.role_name)
   # get domain_id
   path = "/v3/domains"
   dir = "domains"
-  domain_id, derror = _find_id(http, headers, new_resource.domain_name, path, dir)
+  domain_id, derror = find_id(new_resource.domain_name, path, dir)
 
   if user_error || role_error || derror
     Chef::Log.info "Could not obtain the proper ids from keystone"
@@ -121,7 +112,7 @@ action :add_domain_role do
   # Construct the path
   path = "/v3/domains/#{domain_id}/users/#{user_id}/roles/#{role_id}"
 
-  ret = _add_item(http, headers, path, nil, new_resource.domain_name)
+  ret = add_item(path, nil, new_resource.domain_name)
   new_resource.updated_by_last_action(ret)
 end
 
@@ -130,35 +121,35 @@ end
 # attribute :user_password, :kind_of => String
 # attribute :project_name, :kind_of => String
 action :add_user do
-  http, headers = _build_connection(new_resource)
-
   # Lets verify that the item does not exist yet
   project = new_resource.project_name
-  project_id, project_error = _get_project_id(http, headers, project)
+  project_id, project_error = get_project_id(project)
 
   # Lets verify that the service does not exist yet
-  item_id, user_error = _get_user_id(http, headers, new_resource.user_name)
+  item_id, user_error = get_user_id(new_resource.user_name)
 
   raise "Failed to talk to keystone in add_user" if user_error || project_error
 
   ret = false
-  body = _build_user_object(new_resource.user_name, new_resource.user_password, project_id)
+  body = build_user_object(new_resource.user_name, new_resource.user_password, project_id)
   unless item_id
     # User does not exist yet
     path = "/v3/users"
-    ret = _create_item(http, headers, path, body, new_resource.user_name)
+    ret = create_item(path, body, new_resource.user_name)
   else
-    auth_token = _get_token(http,
-                            new_resource.user_name,
-                            new_resource.user_password)
-    if auth_token
+    user_auth = { user: new_resource.user_name, password: new_resource.user_password }
+    user_session = KeystoneHelper::KeystoneSession.new(user_auth,
+                                                       new_resource.host,
+                                                       new_resource.port,
+                                                       new_resource.protocol,
+                                                       new_resource.insecure)
+    if user_session.authenticated?
       Chef::Log.debug "User '#{new_resource.user_name}' already exists and password still works."
-      headers["X-Subject-Token"] = auth_token
-      http.delete("/v3/auth/tokens", headers)
+      user_session.revoke_token
     else
       Chef::Log.debug "User '#{new_resource.user_name}' already exists. Updating Password."
       path = "/v3/users/#{item_id}"
-      ret = _update_item(http, headers, path, body, new_resource.user_name)
+      ret = update_item(path, body, new_resource.user_name)
     end
   end
   new_resource.updated_by_last_action(ret)
@@ -167,14 +158,12 @@ end
 # :add_role specific attributes
 # attribute :role_name, :kind_of => String
 action :add_role do
-  http, headers = _build_connection(new_resource)
-
   # Lets verify that the service does not exist yet
-  item_id, error = _get_role_id(http, headers, new_resource.role_name)
+  item_id, error = get_role_id(new_resource.role_name)
   unless item_id or error
     # Service does not exist yet
-    body = _build_role_object(new_resource.role_name)
-    ret = _create_item(http, headers, "/v3/roles", body, new_resource.role_name)
+    body = build_role_object(new_resource.role_name)
+    ret = create_item("/v3/roles", body, new_resource.role_name)
     new_resource.updated_by_last_action(ret)
   else
     raise "Failed to talk to keystone in add_role" if error
@@ -188,18 +177,16 @@ end
 # attribute :user_name, :kind_of => String
 # attribute :role_name, :kind_of => String
 action :add_access do
-  http, headers = _build_connection(new_resource)
-
   # Lets verify that the item does not exist yet
   project = new_resource.project_name
   user = new_resource.user_name
   role = new_resource.role_name
-  user_id, user_error = _get_user_id(http, headers, user)
-  project_id, project_error = _get_project_id(http, headers, project)
-  role_id, role_error = _get_role_id(http, headers, role)
+  user_id, user_error = get_user_id(user)
+  project_id, project_error = get_project_id(project)
+  role_id, role_error = get_role_id(role)
 
   path = "/v3/projects/#{project_id}/users/#{user_id}/roles"
-  assigned_role_id, assignment_error = _find_id(http, headers, role, path, "roles")
+  assigned_role_id, assignment_error = find_id(role, path, "roles")
   Chef::Log.info("found role id: #{assigned_role_id}, error: #{assignment_error}")
 
   error = (assignment_error || role_error || user_error || project_error)
@@ -210,7 +197,7 @@ action :add_access do
     new_resource.updated_by_last_action(false)
   else
     # Role is not assigned yet
-    ret = _add_item(http, headers, "#{path}/#{role_id}", nil, new_resource.role_name)
+    ret = add_item("#{path}/#{role_id}", nil, new_resource.role_name)
     new_resource.updated_by_last_action(ret)
   end
 end
@@ -219,22 +206,14 @@ end
 # attribute :user_name, :kind_of => String
 # attribute :project_name, :kind_of => String
 action :add_ec2 do
-  http, headers = _build_connection(new_resource)
-
   # Lets verify that the item does not exist yet
   project = new_resource.project_name
   user = new_resource.user_name
-  user_id, user_error = _get_user_id(http, headers, user)
-  project_id, project_error = _get_project_id(http, headers, project)
+  user_id, user_error = get_user_id(user)
+  project_id, project_error = get_project_id(project)
 
   path = "/v3/users/#{user_id}/credentials/OS-EC2"
-  matching_project_id, aerror = _find_id(http,
-                                         headers,
-                                         project_id,
-                                         path,
-                                         "credentials",
-                                         "tenant_id",
-                                         "tenant_id")
+  matching_project_id, aerror = find_id(project_id, path, "credentials", "tenant_id", "tenant_id")
 
   error = (aerror || user_error || project_error)
   if project_id == matching_project_id || error
@@ -243,29 +222,27 @@ action :add_ec2 do
     new_resource.updated_by_last_action(false)
   else
     # Service does not exist yet
-    body = _build_ec2_object(project_id)
-    ret = _create_item(http, headers, path, body, project)
+    body = build_ec2_object(project_id)
+    ret = create_item(path, body, project)
     new_resource.updated_by_last_action(ret)
   end
 end
 
 action :add_endpoint do
-  http, headers = _build_connection(new_resource)
-
-  my_service_id, _error = _get_service_id(http, headers, new_resource.endpoint_service)
+  my_service_id, _error = get_service_id(new_resource.endpoint_service)
   unless my_service_id
     log_message = "Couldn't find service #{new_resource.endpoint_service} in keystone"
-    _raise_error(nil, log_message, "add_endpoint")
+    raise_error(nil, log_message, "add_endpoint")
   end
 
   # Construct the path
   path = "/v3/endpoints"
 
   # Lets verify that the endpoint does not exist yet
-  resp = http.request_get(path, headers)
+  resp = session.get(path)
   unless resp.is_a?(Net::HTTPOK)
     log_message = "Unknown response from keystone server"
-    _raise_error(resp, log_message, "add_endpoint")
+    raise_error(resp, log_message, "add_endpoint")
   end
 
   data = JSON.parse(resp.read_body)
@@ -277,15 +254,15 @@ action :add_endpoint do
   end
   endpoint_updated = false
   ["public", "internal", "admin"].each do |interface|
-    body = _build_endpoint_object(interface, my_service_id, new_resource)
+    body = build_endpoint_object(interface, my_service_id, new_resource)
     name = "#{interface} endpoint for '#{new_resource.endpoint_service}'"
     path = "/v3/endpoints"
     if !endpoints.key? interface
-      _create_item(http, headers, path, body, name)
+      create_item(path, body, name)
       endpoint_updated = true
     elsif endpoint_needs_update interface, endpoints, new_resource
       path = "#{path}/#{endpoints[interface]["id"]}"
-      endpoint_updated = _update_item(http, headers, path, body, name)
+      endpoint_updated = update_item(path, body, name)
     end
   end
   new_resource.updated_by_last_action(endpoint_updated)
@@ -297,16 +274,14 @@ action :add_endpoint do
 end
 
 action :update_endpoint do
-  http, headers = _build_connection(new_resource)
-
-  my_service_id, _error = _get_service_id(http, headers, new_resource.endpoint_service)
+  my_service_id, _error = get_service_id(new_resource.endpoint_service)
   unless my_service_id
     msg = "Couldn't find service #{new_resource.endpoint_service} in keystone"
-    _raise_error(nil, msg, "update_endpoint")
+    raise_error(nil, msg, "update_endpoint")
   end
 
   path = "/v3/endpoints"
-  resp = http.request_get(path, headers)
+  resp = session.get(path)
   if resp.is_a?(Net::HTTPOK)
     data = JSON.parse(resp.read_body)
     endpoints = {}
@@ -331,27 +306,26 @@ action :update_endpoint do
       endpoint_template["endpoint"]["service_id"] = endpoints[interface]["service_id"]
       fullpath = "#{path}/#{endpoints[interface]["id"]}"
       name = "endpoint URL #{interface} #{new_url}"
-      _update_item(http, headers, fullpath, endpoint_template, name)
+      update_item(fullpath, endpoint_template, name)
     end
   else
     log_message = "Unknown response from keystone server"
-    _raise_error(resp, log_message, "add_endpoint")
+    raise_error(resp, log_message, "add_endpoint")
   end
 end
 
 action :update_one_endpoint do
   KeystoneHelper.cache_reset
-  http, headers = _build_connection(new_resource)
 
-  my_service_id, _error = _get_service_id(http, headers, new_resource.endpoint_service)
+  my_service_id, _error = get_service_id(new_resource.endpoint_service)
   unless my_service_id
     msg = "Couldn't find service #{new_resource.endpoint_service} in keystone"
-    _raise_error(nil, msg, "update_endpoint")
+    raise_error(nil, msg, "update_endpoint")
   end
 
   path = "/v3/endpoints"
 
-  resp = http.request_get(path, headers)
+  resp = session.get(path)
   if resp.is_a?(Net::HTTPOK)
     data = JSON.parse(resp.read_body)
     endpoints = {}
@@ -369,16 +343,16 @@ action :update_one_endpoint do
     endpoint_template["endpoint"]["endpoint_id"] = endpoints[interface]["id"]
     endpoint_template["endpoint"]["service_id"] = endpoints[interface]["service_id"]
     path = "#{path}/#{endpoints[interface]["id"]}"
-    _update_item(http, headers, path, endpoint_template, "endpoint URL #{interface} #{new_url}")
+    update_item(path, endpoint_template, "endpoint URL #{interface} #{new_url}")
   else
     log_message = "Unknown response from keystone server"
-    _raise_error(resp, log_message, "add_endpoint")
+    raise_error(resp, log_message, "add_endpoint")
   end
 end
 
 # Make a POST request to create a new object
-def _create_item(http, headers, path, body, name)
-  resp = http.send_request("POST", path, JSON.generate(body), headers)
+def create_item(path, body, name)
+  resp = session.post(path, body)
   if resp.is_a?(Net::HTTPCreated)
     Chef::Log.info("Created keystone item '#{name}'")
     return true
@@ -387,18 +361,14 @@ def _create_item(http, headers, path, body, name)
     return true
   else
     log_message = "Unable to create item '#{name}'"
-    _raise_error(resp, log_message, "_create_item")
+    raise_error(resp, log_message, "create_item")
   end
 end
 
 # Make a PUT request to upload an object or create relationships between
 # objects (such as role assignments)
-def _add_item(http, headers, path, body, name)
-  unless body.nil?
-    resp = http.send_request("PUT", path, JSON.generate(body), headers)
-  else
-    resp = http.send_request("PUT", path, nil, headers)
-  end
+def add_item(path, body, name)
+  resp = session.put(path, body)
   if resp.is_a?(Net::HTTPOK)
     Chef::Log.info("Updated keystone item '#{name}'")
     return true
@@ -411,61 +381,30 @@ def _add_item(http, headers, path, body, name)
     return true
   else
     log_message = "Unable to add item '#{name}'"
-    _raise_error(resp, log_message, "_add_item")
+    raise_error(resp, log_message, "add_item")
   end
 end
 
 # Make a PATCH request to update an existing item
-def _update_item(http, headers, path, body, name)
-  resp = retry_request(http, "PATCH", path, body, headers)
+def update_item(path, body, name)
+  resp = session.patch(path, body)
   if resp.is_a?(Net::HTTPOK)
     Chef::Log.info("Updated keystone item '#{name}'")
   else
-    _raise_error(resp, "Unable to update item '#{name}'", "_update_item")
+    raise_error(resp, "Unable to update item '#{name}'", "update_item")
   end
 end
 
 private
 
-def _build_connection(new_resource)
-  # Need to require net/https so that Net::HTTP gets monkey-patched
-  # to actually support SSL:
-  require "net/https" if new_resource.protocol == "https"
-
-  # Construct the http object
-  http = Net::HTTP.new(new_resource.host, new_resource.port)
-  http.use_ssl = true if new_resource.protocol == "https"
-  http.verify_mode = OpenSSL::SSL::VERIFY_NONE if new_resource.insecure
-
-  auth_token = nil
-  if new_resource.token
-    auth_token = new_resource.token
-  elsif new_resource.auth
-    auth_token = _get_token(http,
-                            new_resource.auth[:user],
-                            new_resource.auth[:password],
-                            new_resource.auth[:project])
-    unless auth_token
-      raise "Authentication failed for user #{new_resource.auth[:user]}"
-    end
-  else
-    raise "Neither token nor auth parameter present. Failed to authenticate"
-  end
-
-  # Fill out the headers
-  headers = _build_headers(auth_token)
-
-  [http, headers]
-end
-
-def _find_id(http, headers, item_name, path, dir, key = "name", ret = "id")
+def find_id(item_name, path, dir, key = "name", ret = "id")
   # this can break your code, if you are asking for name (ret),
   # find_id will have to be modified to not search the cache.
   # the cache stores only the "ret" that it was first querried with
-  my_item_id = _find_id_in_cache(item_name, path)
+  my_item_id = find_id_in_cache(item_name, path)
   error = false
   unless my_item_id
-    resp = http.request_get(path, headers)
+    resp = session.get(path)
     if resp.is_a?(Net::HTTPOK)
       data = JSON.parse(resp.read_body)
       data = data[dir]
@@ -478,19 +417,19 @@ def _find_id(http, headers, item_name, path, dir, key = "name", ret = "id")
       KeystoneHelper.cache_update(data2hash) if my_item_id
     else
       log_message = "Find #{path}: #{item_name}: Unknown response from Keystone Server"
-      _log_error(resp, log_message)
+      log_error(resp, log_message)
       error = true
     end
   end
   [my_item_id, error]
 end
 
-def _find_id_in_cache(rsc_name, rpath)
+def find_id_in_cache(rsc_name, rpath)
   cache = KeystoneHelper.cache
   cache[[rpath, rsc_name]]
 end
 
-def _build_service_object(svc_name, svc_type, svc_desc)
+def build_service_object(svc_name, svc_type, svc_desc)
   body = {
     service: {
       name: svc_name,
@@ -501,7 +440,7 @@ def _build_service_object(svc_name, svc_type, svc_desc)
   body
 end
 
-def _build_user_object(user_name, password, project_id, domain_id = "default")
+def build_user_object(user_name, password, project_id, domain_id = "default")
   body = {
     user: {
       name: user_name,
@@ -514,62 +453,7 @@ def _build_user_object(user_name, password, project_id, domain_id = "default")
   body
 end
 
-def _build_auth(user_name,
-                password,
-                project = "",
-                user_domain = "Default",
-                project_domain = "Default")
-  body = {
-    auth: {
-      identity: {
-        methods: ["password"],
-        password: {
-          user: {
-            name: user_name,
-            password: password,
-            domain: {
-              name: user_domain
-            }
-          }
-        }
-      }
-    }
-  }
-  unless project.empty? || project.nil?
-    scope = {
-      project: {
-        name: project,
-        domain: {
-          name: project_domain
-        }
-      }
-    }
-    body[:auth][:scope] = scope
-  end
-  body
-end
-
-def _get_token(http, user_name, password, project = "")
-  path = "/v3/auth/tokens"
-  headers = _build_headers
-  body = _build_auth(user_name, password, project)
-
-  resp = retry_request(http, "POST", path, body, headers)
-  error = !resp.is_a?(Net::HTTPSuccess)
-
-  if error
-    msg = "Failed to get token for User '#{user_name}'"
-    msg += " Project '#{project}'" unless project.empty?
-    Chef::Log.info msg
-    Chef::Log.info "Response Code: #{resp.code}"
-    Chef::Log.info "Response Message: #{resp.message}"
-    nil
-  else
-    resp["X-Subject-Token"]
-  end
-end
-
-def _build_role_object(role_name)
+def build_role_object(role_name)
   body = {
     role: {
       name: role_name
@@ -578,7 +462,7 @@ def _build_role_object(role_name)
   body
 end
 
-def _build_project_object(project_name, domain_id = "default")
+def build_project_object(project_name, domain_id = "default")
   body = {
     project: {
       name: project_name,
@@ -589,7 +473,7 @@ def _build_project_object(project_name, domain_id = "default")
   body
 end
 
-def _build_domain_object(domain_name)
+def build_domain_object(domain_name)
   body = {
     domain: {
       name: domain_name,
@@ -599,23 +483,14 @@ def _build_domain_object(domain_name)
   body
 end
 
-def _build_access_object(role_id, role_name)
-  svc_obj = Hash.new
-  svc_obj.store("name", role_name)
-  svc_obj.store("id", role_id)
-  ret = Hash.new
-  ret.store("role", svc_obj)
-  return ret
-end
-
-def _build_ec2_object(project_id)
+def build_ec2_object(project_id)
   body = {
     tenant_id: project_id
   }
   body
 end
 
-def _build_endpoint_object(interface, service, new_resource)
+def build_endpoint_object(interface, service, new_resource)
   new_url = new_resource.send("endpoint_#{interface}URL".to_sym)
   body = {
     endpoint: {
@@ -629,53 +504,43 @@ def _build_endpoint_object(interface, service, new_resource)
   body
 end
 
-def _build_headers(token = nil)
-  ret = Hash.new
-  ret.store("X-Auth-Token", token) if token
-  ret.store("Content-type", "application/json")
-  return ret
-end
-
 def endpoint_needs_update(interface, endpoints, new_resource)
   !(endpoints[interface]["url"] == new_resource.send("endpoint_#{interface}URL") &&
       endpoints[interface]["region_id"] == new_resource.endpoint_region)
 end
 
-def _get_service_id(http, headers, svc_name)
-  _find_id(http, headers, svc_name, "/v3/services", "services")
+def get_service_id(svc_name)
+  find_id(svc_name, "/v3/services", "services")
 end
 
-def _get_project_id(http, headers, project_name)
-  _find_id(http, headers, project_name, "/v3/projects", "projects")
+def get_project_id(project_name)
+  find_id(project_name, "/v3/projects", "projects")
 end
 
-def _get_user_id(http, headers, user_name)
-  _find_id(http, headers, user_name, "/v3/users", "users")
+def get_user_id(user_name)
+  find_id(user_name, "/v3/users", "users")
 end
 
-def _get_role_id(http, headers, role_name)
-  _find_id(http, headers, role_name, "/v3/roles", "roles")
+def get_role_id(role_name)
+  find_id(role_name, "/v3/roles", "roles")
 end
 
-def _log_error(resp, msg)
+def log_error(resp, msg)
   Chef::Log.error(msg)
   Chef::Log.error("Response Code: #{resp.code}") if resp
   Chef::Log.error("Response Message: #{resp.message}") if resp
 end
 
-def _raise_error(resp, msg, calling_action)
-  _log_error(resp, msg)
+def raise_error(resp, msg, calling_action)
+  log_error(resp, msg)
   new_resource.updated_by_last_action(false)
   raise "#{msg} in #{calling_action}"
 end
 
-def retry_request(http, method, path, body, headers)
-  resp = nil
-  10.times do |count|
-    resp = http.send_request(method, path, JSON.generate(body), headers)
-    break unless resp.is_a?(Net::HTTPServerError)
-    Chef::Log.debug("Retrying request #{method} #{path} : #{count}")
-    sleep 5
-  end
-  resp
+def session
+  KeystoneHelper.session(new_resource.auth,
+                         new_resource.host,
+                         new_resource.port,
+                         new_resource.protocol,
+                         new_resource.insecure)
 end


### PR DESCRIPTION
The keystone_register LWRP currently does a clumsy, un-ruby-ish job of
creating an HTTP connection and performing REST operations with the
keystone server. This commit rewrites the keystone session management
interface as a class in the keystone helpers module so that the object
can be created once and used as needed in the provider, making the
interface cleaner and reducing LOC.