### PR TITLE
[5.0] database: Prevent deploying mysql-server role to monasca node

### DIFF
--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -64,3 +64,4 @@ en:
         invalid_size_drbd: 'Invalid size for DRBD device.'
         cluster_size_one: 'The Galera cluster needs more than one cluster member.'
         cluster_size_even: 'The Galera cluster needs an odd number of cluster members and at least three of them.'
+        monasca_deployed: 'MariaDB cannot be deployed on a node with monasca-server role: %{node_name}.'


### PR DESCRIPTION
Monasca has its own MariaDB instance and we can't have it conflict
with the one deployed by database barclamp. See also bsc#1118759.

(cherry picked from commit f552e748361703d515bd71c7fbec079066befa92)
(cherry picked from commit fd0b95a8bb9b6f649edc95d459513771375ee0ca)