### PR TITLE
Update travis config to solve bundler dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 
 rvm: 2.1.9
 
+before_install:
+  - rvm @global do gem install bundler -v '< 2.0.0'
+
 matrix:
   include:
     - env: SYNTAXCHECK


### PR DESCRIPTION
Bundler has been updated and our travis configuration is no longer
working. There's a proposed fix at:

https://travis-ci.community/t/bundle-is-not-installed-for-ruby-2-3/1641