### PR TITLE
[5.0] Update travis config to solve bundler dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 
 rvm: 2.1.9
 
+before_install:
+  - rvm @global do gem install bundler -v '< 2.0.0'
+
 matrix:
   include:
     - env: SYNTAXCHECK


### PR DESCRIPTION
Bundler has been updated and our travis configuration is no longer
working. There's a proposed fix by limiting bunlder version to be less
than 2.0.0:

https://github.com/travis-ci/travis-ci/issues/5290

Our last working bundler version was 1.17.3

(cherry picked from commit ebc8927aada07e83cbee8ae75567df7f609618fe)