### PR TITLE
tempest: Install monasca-tempest plugin if needed

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -46,4 +46,5 @@ if node[:kernel][:machine] == "x86_64" &&
   ["api", "log-api"].each do |component|
     package "python-monasca-#{component}"
   end
+  package "python-monasca-tempest-plugin"
 end

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -116,6 +116,10 @@ nic_id = floating
 flavor_id = <%= @magnum_settings['flavor_id'] %>
 master_flavor_id = <%= @magnum_settings['master_flavor_id'] %>
 
+[monitoring]
+region = <%= @keystone_settings['endpoint_region'] %>
+endpoint_type = internalURL
+
 [network]
 region = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internalURL
@@ -170,6 +174,9 @@ magnum = <%= @enabled_services.include? "container-infra" %>
 ironic = <%= @enabled_services.include? "baremetal" %>
 ironic_inspector = <%= @enabled_services.include? "baremetal" %>
 designate = <%= @enabled_services.include? "dns" %>
+logs = <%= @enabled_services.include? "logs_v2" %>
+logs-search = <%= @enabled_services.include? "logs-search" %>
+monasca = <%= @enabled_services.include? "monitoring" %>
 
 [share]
 region = <%= @keystone_settings['endpoint_region'] %>


### PR DESCRIPTION
When monasca-server is deployed, install the tempest plugin for
monasca. Otherwise there are no tests executed for monasca.