### PR TITLE
upgrade: Do not run nova online-db-migrations from chef

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -152,18 +152,6 @@ execute "nova-manage db sync" do
   end
 end
 
-execute "nova-manage db online_data_migrations" do
-  user node[:nova][:user]
-  group node[:nova][:group]
-  command "nova-manage db online_data_migrations"
-  ignore_failure true
-  action :run
-  only_if do
-    !node[:nova][:db_synced] &&
-      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node))
-  end
-end
-
 # Right after controller is upgraded to Pike, explicitely map the instances to cell1
 execute "nova-manage cell_v2 map_instances" do
   user node[:nova][:user]


### PR DESCRIPTION
Nova online data migrations should be run after the upgrade was
finished. They are not needed for regular deployments.
For the upgrade case, we can execute them directly using the upgrade
script (part of crowbar-core).

(cherry picked from commit 5cc5b312b3644fde1a500539a6bc5c77744beea4)

Port of https://github.com/crowbar/crowbar-openstack/pull/1938