### PR TITLE
[5.0] heat: Migrate properties data from the legacy locations in the db

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -424,6 +424,17 @@ execute "heat-manage db_sync" do
   }
 end
 
+execute "heat-manage migrate_properties_data" do
+  user node[:heat][:user]
+  group node[:heat][:group]
+  command "heat-manage migrate_properties_data"
+  # We only do the migration for the first time during the deployment or after the upgrade
+  # (:db_synced flag is reset during the upgrade)
+  only_if do
+    !node[:heat][:db_synced] && (!ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node))
+  end
+end
+
 # We want to keep a note that we've done db_sync, so we don't do it again.
 # If we were doing that outside a ruby_block, we would add the note in the
 # compile phase, before the actual db_sync is done (which is wrong, since it


### PR DESCRIPTION
Although not strictly required, it seems that heat works more
efficiently after such migration.