### PR TITLE
swift: Replace deprecated option.

### DIFF
--- a/chef/cookbooks/swift/templates/default/object-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/object-server.conf.erb
@@ -16,7 +16,7 @@ use = egg:swift#healthcheck
 [filter:recon]
 use = egg:swift#recon
 [object-replicator]
-run_pause = <%= node[:swift][:replication_interval] %>
+interval = <%= node[:swift][:replication_interval] %>
 [object-updater]
 [object-auditor]
 [filter:xprofile]


### PR DESCRIPTION
Getting this from the object-server.log:
swift-o: Option object-replicator/run_pause is deprecated and will be removed
in a future version. Update your configuration to use option object-replica
tor/interval.