### PR TITLE
keystone: Remove use of SSLCACertificate

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -55,7 +55,6 @@ default[:keystone][:ssl][:certfile] = "/etc/keystone/ssl/certs/signing_cert.pem"
 default[:keystone][:ssl][:keyfile] = "/etc/keystone/ssl/private/signing_key.pem"
 default[:keystone][:ssl][:generate_certs] = false
 default[:keystone][:ssl][:insecure] = false
-default[:keystone][:ssl][:ca_certs] = "/etc/keystone/ssl/certs/ca.pem"
 
 default[:keystone][:ldap][:url] = "ldap://localhost"
 default[:keystone][:ldap][:user] = "dc=Manager,dc=example,dc=com"

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -82,8 +82,6 @@ if node[:keystone][:api][:protocol] == "https"
     group node[:keystone][:group]
     fqdn node[:fqdn]
     alt_names ["DNS:#{my_admin_host}", "DNS:#{my_public_host}"]
-    cert_required !node[:keystone][:ssl][:insecure]
-    ca_certs node[:keystone][:ssl][:ca_certs]
   end
 end
 
@@ -154,7 +152,6 @@ elsif node[:keystone][:frontend] == "apache"
     ssl_enable node[:keystone][:api][:protocol] == "https"
     ssl_certfile node[:keystone][:ssl][:certfile]
     ssl_keyfile node[:keystone][:ssl][:keyfile]
-    ssl_cacert node[:keystone][:ssl][:ca_certs] unless node[:keystone][:ssl][:insecure]
     # LDAP backend can be slow..
     timeout 600
   end
@@ -177,7 +174,6 @@ elsif node[:keystone][:frontend] == "apache"
     ssl_enable node[:keystone][:api][:protocol] == "https"
     ssl_certfile node[:keystone][:ssl][:certfile]
     ssl_keyfile node[:keystone][:ssl][:keyfile]
-    ssl_cacert node[:keystone][:ssl][:ca_certs] unless node[:keystone][:ssl][:insecure]
     # LDAP backend can be slow..
     timeout 600
   end

--- a/chef/data_bags/crowbar/migrate/keystone/304_remove_cacert.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/304_remove_cacert.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["ssl"].delete("ca_certs")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["ssl"]["ca_certs"] = template_attrs["ssl"]["ca_certs"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -22,8 +22,7 @@
         "certfile": "/etc/keystone/ssl/certs/signing_cert.pem",
         "keyfile": "/etc/keystone/ssl/private/signing_key.pem",
         "generate_certs": false,
-        "insecure": false,
-        "ca_certs": "/etc/keystone/ssl/certs/ca.pem"
+        "insecure": false
       },
       "api": {
         "protocol": "http",
@@ -184,7 +183,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 303,
+      "schema-revision": 304,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -27,8 +27,7 @@
                       "certfile": { "type" : "str", "required" : true },
                       "keyfile": { "type" : "str", "required" : true },
                       "generate_certs": { "type" : "bool", "required" : true },
-                      "insecure": { "type" : "bool", "required" : true },
-                      "ca_certs": { "type" : "str", "required" : true }
+                      "insecure": { "type" : "bool", "required" : true }
                     }},
                     "api": { "type": "map", "required": true, "mapping": {
                       "protocol": { "type" : "str", "required" : true },

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -39,4 +39,3 @@
         = string_field %w(ssl certfile)
         = string_field %w(ssl keyfile)
         = boolean_field %w(ssl insecure)
-        = string_field %w(ssl ca_certs)

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -39,7 +39,6 @@ en:
           certfile: 'SSL Certificate File'
           keyfile: 'SSL (Private) Key File'
           insecure: 'SSL Certificate is insecure (for instance, self-signed)'
-          ca_certs: 'SSL CA Certificates File'
       validation:
         api_version: 'API version %{api_version} not recognized.'
         enable_keystone_api: 'Keystone API version 3 needs to be enabled in order to use domain specific drivers.'


### PR DESCRIPTION
The SSLCACertificate option in Apache is not about specifying the
server's certificate bundle but actually about what certificate chain to
use to validate certificates of client connections. This does not
provide significant value since none of the authentication information
is passed to keystone and the meaning of the parameter has caused
significant user and developer confusion. This change therefore removes
the cert_required and ca_certs parameters in order to clean up the code
and simplify the user interface.