### PR TITLE
Update cmurphy's code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,8 +16,12 @@
 **/*cinder*  @toabctl
 **/*manila*  @toabctl
 
-**/*keystone*  @rhafer @cmurphy
+**/*keystone*  @rhafer
 **/*monasca*  @jgrassler
 
 ha*.rb  @aspiers
 *_ha.rb  @aspiers
+
+/chef/cookbooks/keystone/ @cmurphy
+/chef/data_bags/crowbar/template-keystone.* @cmurphy
+/chef/data_bags/crowbar/migrate/keystone/ @cmurphy


### PR DESCRIPTION
Triggering on the keystone keyword is not very fine-grained because
every service uses keystone_register to create users, projects,
endpoints, and services in keystone. Switch to just managing the
keystone cookbooks and databags.