### PR TITLE
neutron: Reduce number of dhcp agents to tolerate node failures

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -13,7 +13,7 @@ global_physnet_mtu = <%= @mtu_value %>
 use_ssl = <%= @ssl_enabled ? "True" : "False" %>
 api_workers = <%= [node["cpu"]["total"] / 2, 1, 16].sort[1] %>
 rpc_workers = <%= @rpc_workers %>
-dhcp_agents_per_network = <%= @network_nodes_count %>
+dhcp_agents_per_network = <%= (@network_nodes_count + 1) / 2 %>
 <% if @dvr_enabled -%>
 router_distributed = True
 <% end -%>


### PR DESCRIPTION
If in a neutron cluster are less than configured number of
nodes online, neutron will try to start squeeze the dhcp agents
on the remaining nodes, which does not seem to actually work
and does not actually improve availability. In larger deployments
the duplicated rules seem to cause the dhcp agents to trip over
and we have rolling outages.
    
By only starting dhcp agents for the "smallest" online cluster size
we can avoid that. In a 3 node cluster we can tolerate a single
node failure, starting two agents. in a 5 node we can tolerate 2
nodes failure so 3 agents should be started and so on.

