### PR TITLE
monasca: Detect failure during monasca-installer run

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -166,7 +166,7 @@ execute "remove lock file" do
 end
 
 execute "run ansible" do
-  command "/usr/sbin/run-monasca-installer 2>&1"\
+  command "set -o pipefail; /usr/sbin/run-monasca-installer 2>&1"\
           " | awk '{ print strftime(\"[%Y-%m-%d %H:%M:%S]\"), $0 }'"\
           "   >> /var/log/monasca-installer.log"
 end


### PR DESCRIPTION
Currently, the monasca-installer run can fail but the Crowbar
deployment just continues. This might result in follow-up errors.
The reason is, that the return code of the run-monasca-installer
script is not evaluated. Instead the return code of awk is
evaluated (which is usually zero).
So set "pipefail" to also detect run-monasca-installer failures and
abort the chef-client run in that case.