### PR TITLE
[5.0] database: Fix backport schema migrations actualy safe for backporting

### DIFF
--- a/chef/data_bags/crowbar/migrate/database/200_add_slow_query.rb
+++ b/chef/data_bags/crowbar/migrate/database/200_add_slow_query.rb
@@ -1,9 +1,11 @@
 def upgrade(ta, td, a, d)
-  a["mysql"]["slow_query_logging"] = ta["mysql"]["slow_query_logging"]
+  unless a["mysql"].key? "slow_query_logging"
+    a["mysql"]["slow_query_logging"] = ta["mysql"]["slow_query_logging"]
+  end
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  a["mysql"].delete("slow_query_logging")
+  a["mysql"].delete("slow_query_logging") unless ta["mysql"].key? "slow_query_logging"
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/database/201_add_tuning_variables.rb
+++ b/chef/data_bags/crowbar/migrate/database/201_add_tuning_variables.rb
@@ -1,15 +1,27 @@
 def upgrade(ta, td, a, d)
-  a["mysql"]["innodb_buffer_pool_size"] = ta["mysql"]["innodb_buffer_pool_size"]
-  a["mysql"]["max_connections"] = ta["mysql"]["max_connections"]
-  a["mysql"]["tmp_table_size"] = ta["mysql"]["tmp_table_size"]
-  a["mysql"]["max_heap_table_size"] = ta["mysql"]["max_heap_table_size"]
+  unless a["mysql"].key? "innodb_buffer_pool_size"
+    a["mysql"]["innodb_buffer_pool_size"] = ta["mysql"]["innodb_buffer_pool_size"]
+  end
+
+  unless a["mysql"].key? "max_connections"
+    a["mysql"]["max_connections"] = ta["mysql"]["max_connections"]
+  end
+
+  unless a["mysql"].key? "tmp_table_size"
+    a["mysql"]["tmp_table_size"] = ta["mysql"]["tmp_table_size"]
+  end
+
+  unless a["mysql"].key? "max_heap_table_size"
+    a["mysql"]["max_heap_table_size"] = ta["mysql"]["max_heap_table_size"]
+  end
+
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  a["mysql"].delete("innodb_buffer_pool_size")
-  a["mysql"].delete("max_connections")
-  a["mysql"].delete("tmp_table_size")
-  a["mysql"].delete("max_heap_table_size")
+  a["mysql"].delete("innodb_buffer_pool_size") unless ta["mysql"].key? "innodb_buffer_pool_size"
+  a["mysql"].delete("max_connections") unless ta["mysql"].key? "max_connections"
+  a["mysql"].delete("tmp_table_size") unless ta["mysql"].key? "tmp_table_size"
+  a["mysql"].delete("max_heap_table_size") unless ta["mysql"].key? "max_heap_table_size"
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/database/202_add_ssl.rb
+++ b/chef/data_bags/crowbar/migrate/database/202_add_ssl.rb
@@ -1,9 +1,9 @@
 def upgrade(ta, td, a, d)
-  a["mysql"]["ssl"] = ta["mysql"]["ssl"]
+  a["mysql"]["ssl"] = ta["mysql"]["ssl"] unless a["mysql"].key? "ssl"
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  a["mysql"].delete("ssl")
+  a["mysql"].delete("ssl") unless ta["mysql"].key? "ssl"
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/database/203_add_expire_logs_days.rb
+++ b/chef/data_bags/crowbar/migrate/database/203_add_expire_logs_days.rb
@@ -1,9 +1,11 @@
 def upgrade(ta, td, a, d)
-  a["mysql"]["expire_logs_days"] = ta["mysql"]["expire_logs_days"]
+  unless a["mysql"].key? "expire_logs_days"
+    a["mysql"]["expire_logs_days"] = ta["mysql"]["expire_logs_days"]
+  end
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  a["mysql"].delete("expire_logs_days")
+  a["mysql"].delete("expire_logs_days") unless ta["mysql"].key? "expire_logs_days"
   return a, d
 end


### PR DESCRIPTION
Schema revision 200 to 203 have been backported to older release
branches. In order to not loose some configurations values during the
upgrade those migration needed to have additional checks in the newer
branches.

(cherry picked from commit bd39c4890ee9cc6c539ec5e961c176b4e2a00e61)

backport of #1982 