### PR TITLE
nova: saner sysctl values for compute nodes

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -186,3 +186,9 @@ default[:nova][:serial][:ssl][:enabled] = false
 # metadata/vendordata
 #
 default[:nova][:metadata][:vendordata][:json] = "{}"
+
+#
+# sysctl
+#
+default[:nova][:sysctl][:dirty_ratio] = 40
+default[:nova][:sysctl][:swappiness] = 10

--- a/chef/cookbooks/nova/templates/default/compute_sysctl.conf.erb
+++ b/chef/cookbooks/nova/templates/default/compute_sysctl.conf.erb
@@ -1,0 +1,15 @@
+# dirty_ratio
+# Contains, as a percentage of total available memory that contains free pages
+# and reclaimable pages, the number of pages at which a process which is
+# generating disk writes will itself start writing out dirty data.
+# The total available memory is not equal to total system memory.
+vm.dirty_ratio = <%= @dirty_ratio %>
+
+# swappiness
+# This control is used to define how aggressive the kernel will swap
+# memory pages.  Higher values will increase aggressiveness, lower values
+# decrease the amount of swap.  A value of 0 instructs the kernel not to
+# initiate swap until the amount of free and file-backed pages is less
+# than the high water mark in a zone.
+# The default value is 60.
+vm.swappiness = <%= @swappiness %>

--- a/chef/data_bags/crowbar/migrate/nova/304_add_sysctl.rb
+++ b/chef/data_bags/crowbar/migrate/nova/304_add_sysctl.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "sysctl"
+  attributes[key] = template_attributes[key] unless attributes.key? key
+  return attributes, deployment
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "sysctl"
+  attributes.delete(key) unless template_attributes.key? key
+  return attributes, deployment
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -177,7 +177,11 @@
           "LimitNOFILE": null
         }
       },
-      "default_log_levels": []
+      "default_log_levels": [],
+      "sysctl": {
+        "dirty_ratio": 40,
+        "swappiness": 10
+      }
     }
   },
   "deployment": {

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -280,6 +280,14 @@
               "type": "seq",
               "required": false,
               "sequence": [ { "type": "str" } ]
+            },
+            "sysctl": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "dirty_ratio": { "type": "int", "required": true },
+                "swappiness": {"type": "int", "required": true }
+              }
             }
           }
         }


### PR DESCRIPTION
Adds sysctl values for dirty_ratio and swappiness obtained from
the tuned application profiles for virtual-hosts in order to have
better performance on compute nodes