### PR TITLE
mysql: saner sysctl values for galera nodes

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -51,3 +51,5 @@ default[:mysql][:galera_packages] << "mariadb-galera"
 
 default[:mysql][:mysql_client] = "mariadb-client"
 default[:mysql][:mysql_server] = "mariadb"
+
+default[:mysql][:sysctl][:swappiness] = 10

--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -364,3 +364,22 @@ haproxy_loadbalancer "galera" do
   servers ha_servers
   action :nothing
 end.run_action(:create)
+
+directory "create /etc/sysctl.d for galera values" do
+  path "/etc/sysctl.d"
+  mode "755"
+end
+
+template "galera_sysctl.conf" do
+  path "/etc/sysctl.d/90-galera_sysctl.conf"
+  mode "0644"
+  variables(
+    swappiness: node[:mysql][:sysctl][:swappiness]
+  )
+end
+
+bash "reload galera_sysctl.conf" do
+  code "/sbin/sysctl -e -q -p /etc/sysctl.d/90-galera_sysctl.conf"
+  action :nothing
+  subscribes :run, resources(template: "galera_sysctl.conf"), :delayed
+end

--- a/chef/cookbooks/mysql/templates/default/galera_sysctl.conf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera_sysctl.conf.erb
@@ -1,0 +1,8 @@
+# swappiness
+# This control is used to define how aggressive the kernel will swap
+# memory pages.  Higher values will increase aggressiveness, lower values
+# decrease the amount of swap.  A value of 0 instructs the kernel not to
+# initiate swap until the amount of free and file-backed pages is less
+# than the high water mark in a zone.
+# The default value is 60.
+vm.swappiness = <%= @swappiness %>

--- a/chef/data_bags/crowbar/migrate/database/301_add_galera_sysctl.rb
+++ b/chef/data_bags/crowbar/migrate/database/301_add_galera_sysctl.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "sysctl"
+  attributes[key] = template_attributes[key] unless attributes.key? key
+  return attributes, deployment
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "sysctl"
+  attributes.delete(key) unless template_attributes.key? key
+  return attributes, deployment
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -76,6 +76,9 @@
         "postgresql": {
           "LimitNOFILE": null
         }
+      },
+      "sysctl": {
+        "swappiness": 10
       }
     }
   },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -127,6 +127,13 @@
                   "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
                 }
               }
+            },
+            "sysctl": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "swappiness": {"type": "int", "required": true }
+              }
             }
           }
         }


### PR DESCRIPTION
Adds sysctl values for swappiness obtained from the tuned application
profiles for virtual-hosts in order to have less aggresive swap
in galera nodes