### PR TITLE
monasca: Fix grafana config for monasca-persister

### DIFF
--- a/chef/cookbooks/horizon/files/default/grafana-monasca.json
+++ b/chef/cookbooks/horizon/files/default/grafana-monasca.json
@@ -237,7 +237,13 @@
             }
           ],
           "metricNameColor": "#000000",
-          "rangeMaps": [],
+          "rangeMaps": [
+            {
+              "from": "1",
+              "text": "UP",
+              "to": "100"
+            }
+          ],
           "rowHeight": 50,
           "showDistinctCount": false,
           "showLegend": true,
@@ -253,7 +259,7 @@
               "alias": "@hostname",
               "dimensions": [
                 {
-                  "key": "component",
+                  "key": "process_name",
                   "value": "monasca-persister"
                 },
                 {
@@ -263,7 +269,7 @@
               ],
               "error": "",
               "group": false,
-              "metric": "http_status",
+              "metric": "process.pid_count",
               "period": "300",
               "refId": "A"
             }
@@ -274,13 +280,8 @@
           "valueMaps": [
             {
               "op": "=",
-              "text": "UP",
-              "value": "0"
-            },
-            {
-              "op": "=",
               "text": "DOWN",
-              "value": "1"
+              "value": "0"
             }
           ],
           "valueTextColor": "#000000",


### PR DESCRIPTION
The monasca-persister check is done via the process plugin and
it's *not* a http_status check.
So use the same grafana config as we already use for
monasca-notification.

This fixes the Grafana UI when accessing the dashboard node under
"grafana/d/Monasca_dashboard/suse-openstack-cloud-monitoring-monasca"
. The Persister bar there was always black due to the wrong config.