### PR TITLE
[WIP] rabbitmq: Switch back to client-local master-locator (bsc#112387)

### DIFF
--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -35,7 +35,6 @@
 <% end -%>
 <% if @cluster_enabled -%>
    {cluster_partition_handling, <%= @cluster_partition_handling %>},
-   {queue_master_locator, <<"min-masters">>},
 <% end -%>
 <% if @hipe_compile -%>
    {hipe_compile, true},


### PR DESCRIPTION
It seems "min-master" is creating issue in RabbitMQ when the target
node for the queue is not fully up yet. This is basically a workaround
for something that appears to be a bug in RabbitMQ itself
(https://bugzilla.suse.com/show_bug.cgi?id=1123872).

WIP: Do not merge yet. I just submitted it for launch a few CI runs to check whether it actually makes a difference