### PR TITLE
tempest: Install monasca tempest plugin unconditionally

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -32,19 +32,11 @@ package "euca2ools"
 package "openstack-tempest-test"
 
 ["barbican", "cinder", "designate", "heat", "ironic", "keystone", "magnum",
- "manila", "neutron"].each do |service|
+ "manila", "neutron", "monasca"].each do |service|
   package "python-#{service}-tempest-plugin"
 end
 
 ["keystone", "swift", "glance", "cinder", "neutron", "nova",
- "heat", "ceilometer", "sahara"].each do |component|
+ "heat", "ceilometer", "sahara", "monasca"].each do |component|
   package "python-#{component}client"
-end
-
-if node[:kernel][:machine] == "x86_64" &&
-    !node_search_with_cache("roles:monasca-server").empty?
-  ["api", "log-api"].each do |component|
-    package "python-monasca-#{component}"
-  end
-  package "python-monasca-tempest-plugin"
 end


### PR DESCRIPTION
Just install the plugin (as we do with the other tempest plugins) and
rely on the [service_available]monitoring parameter. If that parameter
is set to false, no monasca tempest tests will be execute.