### PR TITLE
Monasca: Add Python monasca-persister

### DIFF
--- a/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/crowbar_vars.yml.erb
@@ -9,6 +9,9 @@ cassandra_mon_persister_password: <%= @master_settings['tsdb_mon_persister_passw
 cassandra_rpc_address: <%= @monasca_net_ip %>
 cassandra_admin_password: <%= @master_settings['tsdb_mon_api_password'] %>
 database_type: <%= @master_settings['tsdb'] %>
+<%- if @master_settings['mon_persister_impl'] == "python" %>
+monasca_persister_java: False
+<%- end %>
 
 database_notification_password: <%= @master_settings['database_notification_password'] %>
 database_monapi_password: <%= @master_settings['database_monapi_password'] %>
@@ -57,7 +60,7 @@ log_api_bind_host: "*"
 monasca_api_bind_host: "*"
 elasticsearch_host: <%= @monasca_net_ip %>
 nimbus_host: <%= @monasca_net_ip %>
-zookeeper_hosts: <%= @monasca_net_ip %>
+zookeeper_hosts: "<%= @monasca_net_ip %>:2181"
 mariadb_bind_address: <%= @monasca_net_ip %>
 database_host: <%= @monasca_net_ip %>
 monasca_api_url: "http://<%= @pub_net_ip %>:<%= @api_settings['bind_port'] %>/v2.0"

--- a/chef/data_bags/crowbar/migrate/monasca/301_add_mon_persister_impl.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/301_add_mon_persister_impl.rb
@@ -1,0 +1,14 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  # this migration already happened if the mon_persister_impl key exists
+  return attrs, deployment if attrs["master"].key?("mon_persister_impl")
+
+  attrs["master"]["mon_persister_impl"] = template_attrs["master"]["mon_persister_impl"]
+
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["master"].delete("mon_persister_impl")
+
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -120,7 +120,8 @@
         "smtp_from_address": "monasca@localhost",
         "tsdb": "influxdb",
         "tsdb_mon_api_password": "",
-        "tsdb_mon_persister_password": ""
+        "tsdb_mon_persister_password": "",
+        "mon_persister_impl": "java"
       },
       "db": {
         "database": "monasca",
@@ -143,7 +144,7 @@
     "monasca": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 300,
+      "schema-revision": 301,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
         "monasca-master": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -192,7 +192,8 @@
                 "smtp_from_address": { "required": true, "type": "str" },
                 "tsdb": { "required": true, "type": "str" },
                 "tsdb_mon_api_password": { "required": true, "type": "str" },
-                "tsdb_mon_persister_password": { "required": true, "type": "str" }
+                "tsdb_mon_persister_password": { "required": true, "type": "str" },
+                "mon_persister_impl": { "required": true, "type": "str", "pattern": "/^python$|^java$/" }
               }
             },
             "db": {


### PR DESCRIPTION
Optionally Python implementation of monasca-persister can be installed
by setting `mon_persister_impl = "python"`.