### PR TITLE
horizon: Fix mem.used_mb in Grafana

### DIFF
--- a/chef/cookbooks/horizon/files/default/grafana-monasca.json
+++ b/chef/cookbooks/horizon/files/default/grafana-monasca.json
@@ -1597,10 +1597,10 @@
               ],
               "error": "",
               "function": "none",
-              "metric": "mem.used_mb",
+              "metric": "mem.used_real_mb",
               "period": "300",
               "refId": "B",
-              "series": "mem.used_mb",
+              "series": "mem.used_real_mb",
               "target": ""
             },
             {

--- a/chef/cookbooks/horizon/files/default/grafana-openstack.json
+++ b/chef/cookbooks/horizon/files/default/grafana-openstack.json
@@ -1184,7 +1184,7 @@
               ],
               "error": "",
               "function": "none",
-              "metric": "mem.used_mb",
+              "metric": "mem.used_real_mb",
               "period": "300",
               "refId": "A",
               "series": "cpu.percent"
@@ -1195,7 +1195,7 @@
               "dimensions": [],
               "error": "",
               "group": false,
-              "metric": "mem.used_mb",
+              "metric": "mem.used_real_mb",
               "period": "300",
               "refId": "B"
             }


### PR DESCRIPTION
monasca-agent creates the metric "mem.used_real_mb" now(see [1]). So
use that metric to list the used memory for the Monasca node and all
the OpenStack nodes.

[1] https://review.openstack.org/#/c/437159/