### PR TITLE
monasca: Fix alarm_state_history repo module

### DIFF
--- a/chef/cookbooks/monasca/templates/default/monasca-persister.conf.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-persister.conf.erb
@@ -415,6 +415,7 @@ uri=<%= @kafka_host %>:<%= node[:monasca][:kafka][:port] %>
 
 # The repository driver to use for alarm state history (string value)
 #alarm_state_history_driver = monasca_persister.repositories.influxdb.metrics_repository:MetricInfluxdbRepository
+alarm_state_history_driver = monasca_persister.repositories.influxdb.alarm_state_history_repository:AlarmStateHistInfluxdbRepository
 
 # The repository driver to use for events (string value)
 #events_driver = monasca_persister.repositories.elasticsearch.events_repository:ElasticSearchEventsRepository


### PR DESCRIPTION
Upstream default value for `alarm_state_history_driver` in _monasca-persister_ configuration is wrong. It prevents storing alarms history and causes tempest tests failures.
This change sets the correct value.