### PR TITLE
monasca: Drop [service]max_log_size config

### DIFF
--- a/chef/cookbooks/monasca/templates/default/monasca-log-api.conf.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-log-api.conf.erb
@@ -1,6 +1,5 @@
 [service]
 region = <%= @keystone_settings['endpoint_region'] %>
-max_log_size = 5242880
 
 [log_publisher]
 topics = log


### PR DESCRIPTION
Instead of setting a custom value, drop "max_log_size" and use the
default (which is 1048576).

This fixes the following tempest tests:
- monasca_tempest_tests.tests.log_api.test_constraints.\
  TestLogApiConstraints.test_should_reject_too_big_message
- monasca_tempest_tests.tests.log_api.test_constraints.\
  TestLogApiConstraints.test_should_reject_too_big_message_multiline

Note: to fix this, it needs an change to the monasca-tempest-plugin so
the message size is configurable in tempest. Otherwise, the test will
fail if a user set a custom "max_log_size". But for now we just use
the default value.

Thanks Witek Bedyk for explaining the problem!