### PR TITLE
hoirzon: search for role while installing heat-plugin (SCRD-7430)

### DIFF
--- a/chef/cookbooks/horizon/libraries/helper.rb
+++ b/chef/cookbooks/horizon/libraries/helper.rb
@@ -68,3 +68,12 @@ module MonascaUiHelper
     "http://#{monasca_public_host(node)}:3000"
   end
 end
+
+module RoleHelper
+  def self.config_for_role_exists?(name)
+    shouldbe = "#{name}-config-"
+    @cached_roles = @cached_roles || Chef::Role.list.keys
+    res = @cached_roles.find { |rname| rname.start_with? shouldbe }
+    res != nil
+  end
+end

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -205,11 +205,10 @@ end
 
 # install horizon heat plugin if needed
 heat_ui_pkgname = "openstack-horizon-plugin-heat-ui"
-unless Barclamp::Config.load("openstack", "heat").empty?
-  package heat_ui_pkgname do
-    action :install
-    notifies :reload, "service[horizon]"
-  end
+package heat_ui_pkgname do
+  action :install
+  notifies :reload, "service[horizon]"
+  only_if { RoleHelper.config_for_role_exists?("heat") }
 end
 
 if node[:platform_family] == "suse"


### PR DESCRIPTION
heat proposal is still not saved while it is being applied as a
result corresponding horizon plugin will not get installed

And thus requires another chef-client run.

This additional check will get the package installed even while heat
proposal is being applied