### PR TITLE
Revert "database: Hide SSL options from database UI"

### DIFF
--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -14,7 +14,7 @@
         = integer_field %w(mysql expire_logs_days)
         = boolean_field %w(mysql slow_query_logging)
 
-      %fieldset{ "style" => "display:none" }
+      %fieldset
         %legend
           = t(".mysql.ssl_header")
 


### PR DESCRIPTION
Reverts crowbar/crowbar-openstack#1984

as discussed in https://github.com/crowbar/crowbar-openstack/pull/1985 we were somehow confused about what Rick wanted so this should not have landed.