### PR TITLE
novnc: use tcp mode of haproxy only during ssl (SCRD-7127)

### DIFF
--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -55,12 +55,14 @@ if node[:nova][:use_novnc]
   haproxy_loadbalancer "nova-novncproxy" do
     address "0.0.0.0"
     port node[:nova][:ports][:novncproxy]
-    # novnc proxy does not like empty ssl packet followed by an RST
-    # http://git.haproxy.org/?p=haproxy.git;a=commit;h=fd29cc537b8511db6e256529ded625c8e7f856d0
-    # which is used for check-ssl
-    # use_ssl #node[:nova][:novnc][:ssl][:enabled]
-    mode "tcp"
-    options ["tcpka", "tcplog"]
+    if node[:nova][:novnc][:ssl][:enabled]
+      # novnc proxy does not like empty ssl packet followed by an RST
+      # http://git.haproxy.org/?p=haproxy.git;a=commit;h=fd29cc537b8511db6e256529ded625c8e7f856d0
+      # which is used for check-ssl
+      # use_ssl #node[:nova][:novnc][:ssl][:enabled]
+      mode "tcp"
+      options ["tcpka", "tcplog"]
+    end
     servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "novncproxy")
     rate_limit node[:nova][:ha_rate_limit]["nova-novncproxy"]
     action :nothing


### PR DESCRIPTION
this is a followup of bc439f8c686bb4e4533687d604508c74e538212d as mentioned in the #1993.

dropping http check when not using ssl is loss of feature which can be
avoided.

This PR add that feature back and still fixes the issue mentioned in
SCRD-7127