### PR TITLE
mariadb: Remove installing the xtrabackup package

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -42,7 +42,6 @@ default[:mysql][:mariadb][:version] = "10.2"
 default[:mysql][:galera_packages] = [
   "galera-3-wsrep-provider",
   "mariadb-tools",
-  "xtrabackup",
   "socat",
   "galera-python-clustercheck"
 ]


### PR DESCRIPTION
We switched some time ago to mariabackup and therefore xtrabackup is not
needed anymore