### PR TITLE
keystone: Add basic osprofiler support

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -104,6 +104,12 @@ module KeystoneHelper
       "service_password" => current_node[cookbook_name][:service_password])
   end
 
+  def self.profiler_settings(current_node, cookbook_name)
+    instance = current_node[cookbook_name][:keystone_instance] || "default"
+    node = search_for_keystone(current_node, instance)
+    node["keystone"]["osprofiler"]
+  end
+
   private_class_method def self.search_for_keystone(node, instance)
     if @keystone_node && @keystone_node.include?(instance)
       Chef::Log.info("Keystone server found at #{@keystone_node[instance].name} [cached]")

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -247,6 +247,8 @@ register_auth_hash = { user: node[:keystone][:admin][:username],
                        password: node[:keystone][:admin][:password],
                        project: node[:keystone][:admin][:project] }
 
+profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
+
 template node[:keystone][:config_file] do
     source "keystone.conf.erb"
     owner "root"
@@ -266,7 +268,8 @@ template node[:keystone][:config_file] do
       max_active_keys: max_active_keys,
       protocol: node[:keystone][:api][:protocol],
       frontend: node[:keystone][:frontend],
-      rabbit_settings: fetch_rabbitmq_settings
+      rabbit_settings: fetch_rabbitmq_settings,
+      profiler_settings: profiler_settings
     )
     if node[:keystone][:frontend] == "apache"
       notifies :create, resources(ruby_block: "set origin for apache2 restart"), :immediately

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -107,3 +107,11 @@ driver = sql
 [token]
 expiration = <%= @token_expiration %>
 provider = <%= node[:keystone][:token_format] %>
+
+<% if @profiler_settings[:enabled] -%>
+[profiler]
+enabled = true
+trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
+hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
+connection_string = messaging://
+<% end -%>

--- a/chef/data_bags/crowbar/migrate/keystone/302_add_osprofiler.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/302_add_osprofiler.rb
@@ -1,0 +1,16 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  unless attrs.key? "osprofiler"
+    attrs["osprofiler"] = template_attrs["osprofiler"]
+    unless defined?(@@osprofiler_hmac_keys)
+      service = ServiceObject.new "fake-logger"
+      @@osprofiler_hmac_keys = service.random_password
+    end
+    attrs["osprofiler"]["hmac_keys"] << @@osprofiler_hmac_keys
+  end
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs.delete("osprofiler")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -171,6 +171,11 @@
         "apache2": {
           "LimitNOFILE": null
         }
+      },
+      "osprofiler": {
+        "enabled": false,
+        "hmac_keys": [],
+        "trace_sqlalchemy": false
       }
     }
   },
@@ -178,7 +183,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 301,
+      "schema-revision": 302,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -186,6 +186,15 @@
                           "mapping": { "LimitNOFILE": { "type": "int", "required": false }}
                         }
                       }
+                    },
+                    "osprofiler": {
+                      "type": "map",
+                      "required": true,
+                      "mapping": {
+                        "enabled": { "type" : "bool", "required" : true },
+                        "hmac_keys": { "type" : "seq", "required" : true, "sequence": [ { "type": "str" } ] },
+                        "trace_sqlalchemy": { "type" : "bool", "required" : true }
+                      }
                     }
               }}
      }},

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -66,6 +66,7 @@ class KeystoneService < OpenstackServiceObject
 
     base["attributes"][@bc_name][:service][:token] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
+    base["attributes"][@bc_name][:osprofiler][:hmac_keys] << random_password
 
     base
   end


### PR DESCRIPTION
Adding osprofiler[1] support is useful for profiling OpenStack accross
different services. This can be used to find bottlenecks or slow code
inside the different OpenStack services.
osprofiler needs to be enabled in the different services and this
commit starts with keystone.
Once osprofiler is enabled (via the Crowbar attributes), it can be
used like this:

1) Call a command with the openstack client (which supports
osprofiler). Note: You have to know (and use) the HMAC key that is in the
Crowbar attribute stored. If you don't use that HMAC key, osprofiler
won't do anything.

$ openstack --os-profile 9tcwL56PlpAx endpoint list
...
Trace ID: e860c2b0-6945-4767-bbd9-c42c08e6417c

Beside the usual output (in this case the output of "endpoint list"),
there will be a Trace ID written to the command line.
With this Trace ID, the whole trace can be shown with:

$ osprofiler trace show --html --connection-string messaging:// \
    --transport-url \
    "rabbit://openstack:DNUdYtnlMPPY@192.168.192.81:5672/openstack" \
    e860c2b0-6945-4767-bbd9-c42c08e6417c

Note: Currently we use the messaging driver so osprofiler sends it's
trace points to the rabbitmq topic "profiler" which can then be
consumed with the --transport-url.
There are other drivers which might be better (but need to setup other
storage backends) so for now, the messaging driver should be good.

[1] https://docs.openstack.org/osprofiler/latest/