### PR TITLE
monasca: Set Kafka log message format version

### DIFF
--- a/chef/cookbooks/monasca/templates/default/kafka-server.properties.erb
+++ b/chef/cookbooks/monasca/templates/default/kafka-server.properties.erb
@@ -53,6 +53,13 @@ auto.create.topics.enable=<%= @kafka_auto_create_topics %>
 # for consumption, but also mean more files.
 num.partitions=<%= @kafka_num_partitions %>
 
+# Specify the message format version the broker will use to append messages to
+# the logs. Once consumers are upgraded, one can change the message format and
+# enjoy the new message format that includes new timestamp and improved
+# compression.
+# (TODO) Use new message format after updating consumers
+log.message.format.version=0.9.0.0
+
 ############################# Log Flush Policy #############################
 
 # Messages are immediately written to the filesystem but by default we only fsync() to sync


### PR DESCRIPTION
Monasca components still work with old message format version.