### PR TITLE
Add osprofiler support for more services

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -116,6 +116,8 @@ memcached_servers = MemcachedHelper.get_memcached_servers(
 
 memcached_instance("cinder") if node["roles"].include?("cinder-controller")
 
+profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
+
 template node[:cinder][:config_file] do
   source "cinder.conf.erb"
   owner "root"
@@ -139,6 +141,7 @@ template node[:cinder][:config_file] do
     strict_ssh_host_key_policy: node[:cinder][:strict_ssh_host_key_policy],
     default_availability_zone: node[:cinder][:default_availability_zone],
     default_volume_type: node[:cinder][:default_volume_type],
-    memcached_servers: memcached_servers
+    memcached_servers: memcached_servers,
+    profiler_settings: profiler_settings
     )
 end

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -321,3 +321,11 @@ key_file = <%= node[:cinder][:ssl][:keyfile] if node[:cinder][:api][:protocol] =
 
 [volumes]
 backups_enabled = false
+
+<% if @profiler_settings[:enabled] -%>
+[profiler]
+enabled = true
+trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
+hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
+connection_string = <%= @profiler_settings[:connection_string] %>
+<% end -%>

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -25,6 +25,7 @@ when "rhel", "fedora"
 end
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
 
 if node[:glance][:api][:protocol] == "https"
   ssl_setup "setting up ssl for glance" do
@@ -76,7 +77,8 @@ template node[:glance][:api][:config_file] do
       swift_api_insecure: swift_insecure,
       cinder_api_insecure: cinder_insecure,
       enable_v1: node[:glance][:enable_v1],
-      glance_stores: glance_stores.join(",")
+      glance_stores: glance_stores.join(","),
+      profiler_settings: profiler_settings
   )
   notifies :restart, "service[#{node[:glance][:api][:service_name]}]"
 end

--- a/chef/cookbooks/glance/recipes/cache.rb
+++ b/chef/cookbooks/glance/recipes/cache.rb
@@ -29,6 +29,7 @@ end
 network_settings = GlanceHelper.network_settings(node)
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
 
 template node[:glance][:cache][:config_file] do
   source "glance-cache.conf.erb"
@@ -36,7 +37,8 @@ template node[:glance][:cache][:config_file] do
   group node[:glance][:group]
   mode 0640
   variables(
-    keystone_settings: keystone_settings
+    keystone_settings: keystone_settings,
+    profiler_settings: profiler_settings
   )
 end
 

--- a/chef/cookbooks/glance/recipes/scrubber.rb
+++ b/chef/cookbooks/glance/recipes/scrubber.rb
@@ -21,6 +21,7 @@
 network_settings = GlanceHelper.network_settings(node)
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
 
 template node[:glance][:scrubber][:config_file] do
   source "glance-scrubber.conf.erb"
@@ -28,7 +29,8 @@ template node[:glance][:scrubber][:config_file] do
   group node[:glance][:group]
   mode 0640
   variables(
-    keystone_settings: keystone_settings
+    keystone_settings: keystone_settings,
+    profiler_settings: profiler_settings
   )
 end
 

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -106,3 +106,11 @@ flavor = keystone
 
 [task]
 work_dir = /var/lib/glance/taskflow
+
+<% if @profiler_settings[:enabled] -%>
+[profiler]
+enabled = true
+trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
+hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
+connection_string = <%= @profiler_settings[:connection_string] %>
+<% end -%>

--- a/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
@@ -7,3 +7,11 @@ debug = <%= node[:glance][:debug] ? 'True' : 'False' %>
 log_file = <%= node[:glance][:cache][:log_file] %>
 use_syslog = <%= node[:glance][:use_syslog] ? 'True' : 'False' %>
 use_stderr = false
+
+<% if @profiler_settings[:enabled] -%>
+[profiler]
+enabled = true
+trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
+hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
+connection_string = <%= @profiler_settings[:connection_string] %>
+<% end -%>

--- a/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
@@ -21,3 +21,11 @@ connection_recycle_time = <%= node[:glance][:sql_idle_timeout] %>
 [oslo_concurrency]
 
 lock_path = /var/run/glance
+
+<% if @profiler_settings[:enabled] -%>
+[profiler]
+enabled = true
+trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
+hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
+connection_string = <%= @profiler_settings[:connection_string] %>
+<% end -%>

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -113,5 +113,5 @@ provider = <%= node[:keystone][:token_format] %>
 enabled = true
 trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
 hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
-connection_string = messaging://
+connection_string = <%= @profiler_settings[:connection_string] %>
 <% end -%>

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -67,6 +67,7 @@ if node[:platform_family] == "rhel"
 end
 
 keystone_settings = KeystoneHelper.keystone_settings(neutron, @cookbook_name)
+profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
 
 ha_enabled = node[:neutron][:ha][:server][:enabled]
 memcached_servers = MemcachedHelper.get_memcached_servers(
@@ -138,6 +139,7 @@ template neutron[:neutron][:config_file] do
       # query on the "neutron" node, not on "node"
       rabbit_settings: CrowbarOpenStackHelper.rabbitmq_settings(neutron, "neutron"),
       keystone_settings: keystone_settings,
+      profiler_settings: profiler_settings,
       memcached_servers: memcached_servers,
       ssl_enabled: neutron[:neutron][:api][:protocol] == "https",
       ssl_cert_file: neutron[:neutron][:ssl][:certfile],

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -130,3 +130,11 @@ http_pool_maxsize = <%= @infoblox[:grids][grid][:http_pool_maxsize] %>
 http_request_timeout = <%= @infoblox[:grids][grid][:http_request_timeout] %>
 <% end -%>
 <% end -%>
+
+<% if @profiler_settings[:enabled] -%>
+[profiler]
+enabled = true
+trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
+hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
+connection_string = <%= @profiler_settings[:connection_string] %>
+<% end -%>

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 keystone_settings = KeystoneHelper.keystone_settings(node, :nova)
+profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
 is_controller = node["roles"].include?("nova-controller")
 
 my_ip_net = "admin"
@@ -344,6 +345,7 @@ template node[:nova][:placement_config_file] do
   mode 0640
   variables(
     keystone_settings: keystone_settings,
+    profiler_settings: profiler_settings,
     placement_database_connection: placement_database_connection,
     placement_service_user: node["nova"]["placement_service_user"],
     placement_service_password: node["nova"]["placement_service_password"],
@@ -402,6 +404,7 @@ template node[:nova][:config_file] do
     neutron_service_password: neutron_service_password,
     neutron_has_tunnel: neutron_has_tunnel,
     keystone_settings: keystone_settings,
+    profiler_settings: profiler_settings,
     cinder_insecure: cinder_insecure,
     use_multipath: use_multipath,
     keymgr_fixed_key: keymgr_fixed_key,

--- a/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova-placement.conf.erb
@@ -15,3 +15,11 @@ insecure = <%= @placement_service_insecure %>
 [placement_database]
 connection = <%= @placement_database_connection %>
 <% end -%>
+
+<% if @profiler_settings[:enabled] -%>
+[profiler]
+enabled = true
+trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
+hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
+connection_string = <%= @profiler_settings[:connection_string] %>
+<% end -%>

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -368,3 +368,10 @@ enabled_filters = <%= @enabled_filters %>
 track_instance_changes = false
 <% end %>
 
+<% if @profiler_settings[:enabled] -%>
+[profiler]
+enabled = true
+trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" %>
+hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
+connection_string = <%= @profiler_settings[:connection_string] %>
+<% end -%>

--- a/chef/data_bags/crowbar/migrate/keystone/303_add_osprofiler_connection_string.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/303_add_osprofiler_connection_string.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["osprofiler"]["connection_string"] = template_attrs["osprofiler"]["connection_string"]
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["osprofiler"].delete("connection_string")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -175,7 +175,8 @@
       "osprofiler": {
         "enabled": false,
         "hmac_keys": [],
-        "trace_sqlalchemy": false
+        "trace_sqlalchemy": false,
+        "connection_string": "messaging://"
       }
     }
   },
@@ -183,7 +184,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 302,
+      "schema-revision": 303,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -193,7 +193,8 @@
                       "mapping": {
                         "enabled": { "type" : "bool", "required" : true },
                         "hmac_keys": { "type" : "seq", "required" : true, "sequence": [ { "type": "str" } ] },
-                        "trace_sqlalchemy": { "type" : "bool", "required" : true }
+                        "trace_sqlalchemy": { "type" : "bool", "required" : true },
+                        "connection_string": { "type" : "str", "required" : true }
                       }
                     }
               }}


### PR DESCRIPTION
Adding osprofiler[1] support is useful for profiling OpenStack accross
different services. This can be used to find bottlenecks or slow code
inside the different OpenStack services.
See also commit 5ba4f0e1af92 for more information.

[1] https://docs.openstack.org/osprofiler/latest/