### PR TITLE
nova: use correct url from keystone helper for fence-agent (SCRD-7603)

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -36,9 +36,6 @@ include_recipe "crowbar-pacemaker::attributes"
 include_recipe "crowbar-pacemaker::remote_attributes"
 
 keystone_settings = KeystoneHelper.keystone_settings(nova, @cookbook_name)
-internal_auth_url_v2 = \
-  "#{keystone_settings["protocol"]}://" \
-  "#{keystone_settings["internal_url_host"]}:#{keystone_settings["service_port"]}/v2.0/"
 neutrons = node_search_with_cache("roles:neutron-server")
 neutron = neutrons.first || \
   raise("Neutron instance '#{nova[:nova][:neutron_instance]}' for nova not found")
@@ -172,7 +169,7 @@ nova_primitive = "nova-compute"
 pacemaker_primitive nova_primitive do
   agent "ocf:openstack:NovaCompute"
   params ({
-    "auth_url"       => internal_auth_url_v2,
+    "auth_url"       => keystone_settings["internal_auth_url"],
     # "region_name"    => keystone_settings["endpoint_region"],
     "endpoint_type"  => "internalURL",
     "username"       => keystone_settings["admin_user"],
@@ -232,7 +229,7 @@ evacuate_primitive = "nova-evacuate"
 pacemaker_primitive evacuate_primitive do
   agent "ocf:openstack:NovaEvacuate"
   params ({
-    "auth_url"       => internal_auth_url_v2,
+    "auth_url"       => keystone_settings["internal_auth_url"],
     # "region_name"    => keystone_settings["endpoint_region"],
     "endpoint_type"  => "internalURL",
     "username"       => keystone_settings["admin_user"],
@@ -274,7 +271,7 @@ pacemaker_primitive fence_primitive do
   agent "stonith:fence_compute"
   params ({
     "pcmk_host_map"  => hostmap,
-    "auth-url"       => internal_auth_url_v2,
+    "auth_url"       => keystone_settings["internal_auth_url"],
     # "region-name"    => keystone_settings["endpoint_region"],
     "endpoint-type"  => "internalURL",
     "login"          => keystone_settings["admin_user"],


### PR DESCRIPTION
Using v2 version returns are 404 therefore switching to
whichever is available

the fence-agents using keystone v2 fail with

/var/log/nova/fence_compute.log

2019-02-11 23:41:43,662 DEBUG: http://cluster-services.vc1.cloud.suse.de:5000 "GET /v2.0/ HTTP/1.1" 404 233 │
│2019-02-11 23:41:43,663 DEBUG: RESP: [404] Date: Mon, 11 Feb 2019 23:41:43 GMT Server: Apache Content-Length: 233 Vary: X-Auth-Token x-openstack-request-id: req-87f8d6a8-db2d-47f1-bce6-587aaa747a39 Content-Type: text/html; charset=utf-│
│RESP BODY: Omitted, Content-Type is set to text/html; charset=utf-8. Only application/json responses have their bodies logged.

and see this in keystone logs

[11/Feb/2019:23:41:43 +0000] GET/v2.0/HTTP/1.1 404 233 - python-keystoneclient

these get flagged as crm_mon failures: causing the job to fail
