### PR TITLE
tempest: Conditionally install nonrequired plugins

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -31,20 +31,36 @@ package "euca2ools"
 
 package "openstack-tempest-test"
 
-["barbican", "cinder", "designate", "heat", "ironic", "keystone", "magnum",
- "manila", "neutron"].each do |service|
-  package "python-#{service}-tempest-plugin"
-end
-
-["keystone", "swift", "glance", "cinder", "neutron", "nova",
- "heat", "ceilometer", "sahara"].each do |component|
+[
+  "barbican",
+  "ceilometer",
+  "cinder",
+  "designate",
+  "glance",
+  "heat",
+  "ironic",
+  "keystone",
+  "magnum",
+  "manila",
+  "neutron",
+  "nova",
+  "sahara",
+  "swift"
+].each do |component|
   package "python-#{component}client"
 end
 
-if node[:kernel][:machine] == "x86_64" &&
-    !node_search_with_cache("roles:monasca-server").empty?
-  ["api", "log-api"].each do |component|
-    package "python-monasca-#{component}"
-  end
-  package "python-monasca-tempest-plugin"
+[
+  "barbican",
+  "cinder",
+  "designate",
+  "heat",
+  "ironic",
+  "keystone",
+  "magnum",
+  "manila",
+  "monasca",
+  "neutron"
+].each do |component|
+  package "python-#{component}-tempest-plugin" if RoleHelper.config_for_role_exists?(component)
 end


### PR DESCRIPTION
If a tempest plugin is installed then by default its tests will be run
unless explicitly turned off in tempest.conf. This breaks our
tempestfull CI because we do not install magnum by default. This change
ensures only plugins for barclamps we have applied will be installed.