### PR TITLE
sahara: Add [trustee] configuration (SCRD-6088)

### DIFF
--- a/chef/cookbooks/sahara/templates/default/sahara.conf.erb
+++ b/chef/cookbooks/sahara/templates/default/sahara.conf.erb
@@ -28,6 +28,14 @@ api_insecure = <%= @heat_insecure %>
 [keystone]
 api_insecure = <%= @keystone_settings["insecure"] %>
 
+[trustee]
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
+project_name = <%= @keystone_settings['service_tenant'] %>
+project_domain_name = <%= @keystone_settings["admin_domain"]%>
+user_domain_name = <%= @keystone_settings["admin_domain"] %>
+auth_url = <%= @keystone_settings['admin_auth_url'] %>
+
 [keystone_authtoken]
 www_authenticate_uri = <%= @keystone_settings["public_auth_url"] %>
 username = <%= @keystone_settings['service_user'] %>


### PR DESCRIPTION
Use the new [trustee] section for trust configuration, as using the
credentials defined in [keystone_authtoken] is deprecated[1].

[1] https://docs.openstack.org/releasenotes/sahara/queens.html#deprecation-notes