### PR TITLE
mysql: improve galera HA setup (bsc#1122875)

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -350,6 +350,8 @@ ha_servers = ha_servers.each do |n|
   n["fall"] = 2
   # lower the interval checking after first failure is found
   n["fastinter"] = 1000
+  # shutdown connection when backend is marked down
+  n["on_marked_down_shutdown"] = true
 end
 
 haproxy_loadbalancer "galera" do


### PR DESCRIPTION
This patch applies the option "on-marked-down shutdown-sessions"
to our haproxy galera configuration to deal with the situation that
happens keeping connections open when a backend is declared down by
the health check but the mariadb server is still alive

Depends-On: https://github.com/crowbar/crowbar-ha/pull/347

Signed-off-by: aojeagarcia <aojeagarcia@suse.com>