### PR TITLE
[4.0] mysql: Do not set a custom logfile for mysqld (bsc#1112767)

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -201,7 +201,7 @@ pacemaker_primitive service_name do
     "check_user" => "monitoring",
     "socket" => "/var/run/mysql/mysql.sock",
     "datadir" => node[:database][:mysql][:datadir],
-    "log" => "/var/log/mysql/mysql_error.log"
+    "log" => "/var/log/mysql/mysqld.log"
   })
   op primitive_op
   action :update

--- a/chef/cookbooks/mysql/templates/default/logging.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/logging.cnf.erb
@@ -1,6 +1,4 @@
 [mysqld]
-log_error=/var/log/mysql/mysql_error.log
-
 <% if @slow_query_logging_enabled -%>
 slow_query_log = 1
 slow_query_log_file = /var/log/mysql/mysql_slow.log


### PR DESCRIPTION
the mariadb package comes with a logrotate
script (/etc/logrotate.d/mariadb) that currently only rotates the
default /var/log/mysql/mysqld.log file.
So let's use that file instead of a custom path to fix log rotation.

Note: If "slow_query_logging" is enabled, this file is still not
rotated. This will hopefully be fixed in the package itself[1]

[1] https://build.opensuse.org/request/show/676156

(cherry picked from commit aabd06b7a291a2e5a3465238957f32390c8fffdd)
(cherry picked from commit a0bb13aeddef74775ab15610d4b2def6cec8ba0c)