### PR TITLE
[4.0] ceilometer: Use pacemaker to handle expirer cron link (bsc#1113107)

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -78,6 +78,7 @@ default[:ceilometer][:ha][:collector][:op][:monitor][:interval] = "10s"
 default[:ceilometer][:ha][:agent_notification][:agent] = "systemd:#{agent_notification_service_name}"
 default[:ceilometer][:ha][:agent_notification][:op][:monitor][:interval] = "10s"
 
+
 default[:ceilometer][:ha][:central][:enabled] = false
 default[:ceilometer][:ha][:central][:agent] = "systemd:#{central_service_name}"
 default[:ceilometer][:ha][:central][:op][:monitor][:interval] = "10s"
@@ -90,3 +91,7 @@ default[:ceilometer][:ha][:mongodb][:replica_set][:member] = false
 # this establishes which node is used for mongo client connections that
 # we use to initialize the replica set
 default[:ceilometer][:ha][:mongodb][:replica_set][:controller] = false
+
+# Pacemaker ceilometer expirer cronjob link
+default[:ceilometer][:ha][:expirer][:cronjob][:agent] = "ocf:heartbeat:symlink"
+default[:ceilometer][:ha][:expirer][:cronjob][:op][:monitor][:interval] = "10s"


### PR DESCRIPTION
With recent openstack-ceilometer packaging changes (Newton[1],
Pike[2]), the ceilometer-expirer cronjob is no longer installed on all
nodes where the openstack-ceilometer-collector package is
installed. Instead the cronjob is installed in
/usr/share/ceilometer//openstack-ceilometer-expirer.cron .
This is needed to avoid parallel runs of the cronjob from different
nodes which lead to database deadlocks.
Now use pacemaker to handle a symlink in /etc/cron.daily so the
cronjob is executed on a single node in the cluster.

[1] https://build.opensuse.org/request/show/676177
[2] https://build.opensuse.org/request/show/676174