### PR TITLE
mysql: Enable "explain" in the slow query log file

### DIFF
--- a/chef/cookbooks/mysql/templates/default/logging.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/logging.cnf.erb
@@ -2,4 +2,5 @@
 <% if @slow_query_logging_enabled -%>
 slow_query_log = 1
 slow_query_log_file = /var/log/mysql/mysql_slow.log
+log_slow_verbosity = query_plan,explain
 <% end -%>


### PR DESCRIPTION
When "slow_query_logging_enabled" is used, enable also "explain" which
adds extra information[1] to the log file.
This is useful for debugging slow queries.

[1] https://mariadb.com/kb/en/library/explain-in-the-slow-query-log/