### PR TITLE
Fix barbican tempest tests (SCRD-7084) (bsc#1123191)

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -114,3 +114,6 @@ trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" 
 hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
 connection_string = <%= @profiler_settings[:connection_string] %>
 <% end -%>
+
+[barbican]
+auth_endpoint = <%= @keystone_settings[:internal_auth_url] %>

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -153,7 +153,7 @@ lock_path = /var/run/tempest
 
 [scenario]
 img_dir = <%= @tempest_path %>/etc/cirros/
-img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-disk.img
+img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-blank.img
 ami_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-blank.img
 ari_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-initrd
 aki_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-vmlinuz


### PR DESCRIPTION
Fix the image file that the barbican tempest plugin uses for testing signed images, and fix glance's ability to use the castellan key manager.