### PR TITLE
monasca: Set heap size for Elasticsearch

### DIFF
--- a/chef/cookbooks/monasca/recipes/elasticsearch.rb
+++ b/chef/cookbooks/monasca/recipes/elasticsearch.rb
@@ -54,7 +54,8 @@ template "/etc/systemd/system/elasticsearch.service.d/override.conf" do
   variables(
     elasticsearch_limit_nproc: node[:monasca][:elasticsearch][:tunables][:limit_nproc],
     elasticsearch_limit_nofile: node[:monasca][:elasticsearch][:tunables][:limit_nofile],
-    elasticsearch_limit_memlock: node[:monasca][:elasticsearch][:tunables][:limit_memlock]
+    elasticsearch_limit_memlock: node[:monasca][:elasticsearch][:tunables][:limit_memlock],
+    elasticsearch_heap_size: node[:monasca][:elasticsearch][:tunables][:heap_size]
   )
   notifies :run, "execute[systemctl daemon-reload]", :immediately
   notifies :restart, "service[elasticsearch]"

--- a/chef/cookbooks/monasca/templates/default/elasticsearch-systemd-override.conf.erb
+++ b/chef/cookbooks/monasca/templates/default/elasticsearch-systemd-override.conf.erb
@@ -2,3 +2,4 @@
 LimitNPROC=<%= @elasticsearch_limit_nproc %>
 LimitNOFILE=<%= @elasticsearch_limit_nofile %>
 LimitMEMLOCK=<%= @elasticsearch_limit_memlock %>
+Environment="ES_HEAP_SIZE=<%= @elasticsearch_heap_size %>"

--- a/chef/data_bags/crowbar/migrate/monasca/313_drop_elasticsearch_options.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/313_drop_elasticsearch_options.rb
@@ -1,0 +1,13 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["elasticsearch"]["tunables"].delete("max_open_files_soft_limit")
+  attrs["elasticsearch"]["tunables"].delete("memory_lock")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["elasticsearch"]["tunables"]["max_open_files_soft_limit"] =
+    template_attrs["elasticsearch"]["tunables"]["max_open_files_soft_limit"]
+  attrs["elasticsearch"]["tunables"]["memory_lock"] =
+    template_attrs["elasticsearch"]["tunables"]["memory_lock"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -75,9 +75,7 @@
           "heap_size": "4g",
           "limit_memlock": "infinity",
           "limit_nofile": 65536,
-          "max_open_files_soft_limit": 16384,
           "limit_nproc": 65536,
-          "memory_lock": true,
           "vm_max_map_count": 262144
         }
       },
@@ -155,7 +153,7 @@
     "monasca": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 312,
+      "schema-revision": 313,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
         "monasca-agent": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -116,9 +116,7 @@
                       "heap_size": { "type": "str", "required": true },
                       "limit_memlock": { "type": "str", "required": true },
                       "limit_nofile": { "type": "int", "required": true },
-                      "max_open_files_soft_limit": { "type": "int", "required": true },
                       "limit_nproc": { "type": "int", "required": true },
-                      "memory_lock": { "type": "bool", "required": true },
                       "vm_max_map_count": { "type": "int", "required": true }
                     }
                   }


### PR DESCRIPTION
The default installation of Elasticsearch is configured with a 1 GB
heap. For just about every deployment, this number is usually too small
[1]. This change allows setting `heap_size`.

elasticearch.tunables.max_open_files_soft_limit isn't used anymore. It
gets removed here, instead `limit_nofile` should be used.

elasticearch.tunables.memory_lock has is actually decoupled from
elasticsearch.bootstrap_memory_lock which it was supposed to control.
The latter has anyway a recommended default value. The setting is very
technical, so it makes sense to hide it from end user.

[1] https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html