### PR TITLE
glance/cinder: Fix barbican auth endpoint

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -329,3 +329,6 @@ trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" 
 hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
 connection_string = <%= @profiler_settings[:connection_string] %>
 <% end -%>
+
+[barbican]
+auth_endpoint = <%= @keystone_settings['internal_auth_url'] %>

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -116,4 +116,4 @@ connection_string = <%= @profiler_settings[:connection_string] %>
 <% end -%>
 
 [barbican]
-auth_endpoint = <%= @keystone_settings[:internal_auth_url] %>
+auth_endpoint = <%= @keystone_settings['internal_auth_url'] %>


### PR DESCRIPTION
The keystone_settings keys use strings, not symbols, so fix the template for glance. Also add the required setting in the cinder config.