### PR TITLE
horizon: Fix configuration loading for Monasca (SCRD-8179)

### DIFF
--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -18,8 +18,7 @@ if monasca_server.nil?
   Chef::Log.warn("No monasca-server found.")
   return
 end
-monasca_cfg = Barclamp::Config.load("openstack", "monasca")
-grafana_password = monasca_cfg["db_grafana"]["password"]
+grafana_password = monasca_server[:monasca][:db_grafana][:password]
 db_settings = fetch_database_settings
 
 # Used for creating data source


### PR DESCRIPTION
Monasca plugin should only be installed when all configuration options
are already available. Otherwise if Horizon barclamp is installed first
and Monasca afterwards the installation fails with the following error
message:

  FATAL: NoMethodError: undefined method `[]' for nil:NilClass

  Relevant File Content:

  22>> grafana_password = monasca_cfg["db_grafana"]["password"]