### PR TITLE
[4.0] rabbit: fix mirroring regex

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -152,8 +152,8 @@ if cluster_enabled
     quorum = 1
   end
 
-  # don't mirror queues that are 'amqp.*' or '*_fanout_*' or `reply_*` in their names
-  queue_regex = "^(?!(amqp.)|(.*_fanout_)|(reply_)).*"
+  # don't mirror queues that are 'amq.*' or '*_fanout_*' or `reply_*` in their names
+  queue_regex = "^(?!(amq\.)|(.*_fanout_)|(reply_)).*"
   # policy doesnt need spaces between elements as they will be removed when listing them
   # making it more difficult to check for them
   policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum},\"ha-sync-mode\":\"automatic\"}"


### PR DESCRIPTION
When the regex for mirroring queues was introduced on
341f6b059b33690e607e9a3da83cf250c97323d0 a typo was introduced
which skipped some of the default queues.

Restore it to the proper regex

(cherry picked from commit 97c1e7d1814fafbcfc92a1b133d4abea4eca427a)

Backport-of: https://github.com/crowbar/crowbar-openstack/pull/2047