### PR TITLE
designate: add rndc_secret_key feild to proposal

### DIFF
--- a/chef/data_bags/crowbar/template-designate.json
+++ b/chef/data_bags/crowbar/template-designate.json
@@ -11,6 +11,7 @@
       "service_user": "designate",
       "service_password": "",
       "memcache_secret_key": "",
+      "rndc_secret_key": "",
       "api": {
         "protocol": "http",
         "bind_open_address": true,

--- a/chef/data_bags/crowbar/template-designate.schema
+++ b/chef/data_bags/crowbar/template-designate.schema
@@ -20,6 +20,7 @@
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
             "memcache_secret_key": { "type": "str", "required": true },
+            "rndc_secret_key": { "type": "str", "required": true },
             "api": {
               "type": "map", "required": true, "mapping": {
                 "protocol": { "type" : "str", "required" : true },

--- a/crowbar_framework/app/models/designate_service.rb
+++ b/crowbar_framework/app/models/designate_service.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+require "openssl"
+
 class DesignateService < OpenstackServiceObject
   def initialize(thelogger = nil)
     super(thelogger)
@@ -83,6 +85,7 @@ class DesignateService < OpenstackServiceObject
 
     base["attributes"][@bc_name]["service_password"] = random_password
     base["attributes"][@bc_name]["memcache_secret_key"] = random_password
+    base["attributes"][@bc_name]["rndc_secret_key"] = OpenSSL::Digest.new("md5", random_password).hexdigest
     base["attributes"][@bc_name][:db][:password] = random_password
 
     @logger.debug("Designate create_proposal: exiting")


### PR DESCRIPTION
Designate needs an rndc key to CRUD zones on the real bind9 master
server, and updates to bind9 can only be sent via a key that is
mentioned in its(bind9) config.

So the key is supposed to be shared across the nodes, (admin and
designate-worker) therefore adding it to the proposal.  one could
rsync the key between the nodes but this opens up differnt
types of race conditions/syncronization problems.

This key will be used while creating the key-file on admin and
designate-worker node.

the openssl module is part of ruby standard library. And using md5 hexdigest
as that is what rndc expects, a normal 6/8 charachter password was
deemed invalid during trial runs