### PR TITLE
swift: Fix Monasca agent configuration (SCRD-7572)

### DIFF
--- a/chef/cookbooks/swift/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/swift/recipes/monitor_monasca.rb
@@ -20,11 +20,13 @@ return if no_monasca_server_or_master
 bind_host, bind_port = SwiftHelper.get_bind_host_port(node)
 swift_protocol = node[:swift][:ssl][:enabled] ? "https" : "http"
 
-monitor_url = "#{swift_protocol}://#{bind_host}:#{bind_port}/"
+monitor_url = "#{swift_protocol}://#{bind_host}:#{bind_port}/healthcheck"
 
 monasca_agent_plugin_http_check "http_check for swift-proxy" do
   built_by "swift-proxy"
   name "object-store-api"
   url monitor_url
   dimensions "service" => "object-store-api"
+  match_pattern "^OK$"
+  use_keystone false
 end


### PR DESCRIPTION
Status of Swift service is not checked correctly. Swift offers
healhcheck middleware for monitoring. /healthcheck resource should be
used to monitor this service [1].

[1] https://docs.openstack.org/swift/latest/middleware.html#healthcheck