### PR TITLE
monasca: Retry creating InfluxDB database

### DIFF
--- a/chef/cookbooks/monasca/recipes/database.rb
+++ b/chef/cookbooks/monasca/recipes/database.rb
@@ -70,6 +70,7 @@ ruby_block "Create influx database \"#{node['monasca']['db_monapi']['database']}
     InfluxDBHelper.create_database(node["monasca"]["db_monapi"]["database"],
                                    influx_host: monasca_monitoring_host)
   end
+  retries 5
 end
 
 # Set retention policy for auto-generated (called "autogen") policy


### PR DESCRIPTION
Sometimes it takes a little longer to start the InfluxDB instance and
the request to create the database fails with:

  Failed to connect to http://x.x.x.x:8086: connect: connection refused
  Please check your connection settings and ensure 'influxd' is running.

This change retries the request to give InfluxDB some more time to spin
up.