### PR TITLE
nova: Fix discover_hosts group

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_register_cell.rb
+++ b/chef/cookbooks/nova/recipes/compute_register_cell.rb
@@ -30,7 +30,9 @@ api_database_connection = fetch_database_connection_string(node[:nova][:api_db])
 # host and delete the creds
 bash "nova-manage discover_hosts" do
   user node[:nova][:user]
+  group node[:nova][:group]
   code <<-EOH
+    set -e
     tmpfile=$(mktemp /tmp/nova-discover-hosts.XXXXXX.conf)
     chmod 600 $tmpfile
     echo "[api_database]" >> $tmpfile


### PR DESCRIPTION
When the nova-manage command is run, it tries to load configuration from
the default nova config directory even if --config-file is used. The
config files are owned by the root user but readable by the nova group.
If the nova group is not specified in the chef bash resource, the
nova-manage command fails. The failure is hidden and the chef run
continues because the exit code from the bash script comes from the `rm
-f` command the not the nova-manage command. The usual result is that
when the manila server is being booted in preparation for applying the
manila barclamp in CI, it fails. This patch adds the correct group to
the bash resource so that the nova-manage command can complete, and uses
'set -e' so that if it fails for some other reason, it will exit with a
proper failure code and abort the chef run.

This is an alternative to https://github.com/crowbar/crowbar-openstack/pull/1955