### PR TITLE
nova: Ignore errors for discover_hosts

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_register_cell.rb
+++ b/chef/cookbooks/nova/recipes/compute_register_cell.rb
@@ -32,7 +32,6 @@ bash "nova-manage discover_hosts" do
   user node[:nova][:user]
   group node[:nova][:group]
   code <<-EOH
-    set -e
     tmpfile=$(mktemp /tmp/nova-discover-hosts.XXXXXX.conf)
     chmod 600 $tmpfile
     echo "[api_database]" >> $tmpfile


### PR DESCRIPTION
In some cases there can be a race condition where a compute node is
being discovered by the controller at the same instant that the node is
trying to register itself with `nova-manage cell_v2 discover_hosts`,
which results in an error like this:

 DBDuplicateEntry: (pymysql.err.IntegrityError) (1062, u"Duplicate entry 'd00-25-90-e5-0b-aa' for key 'uniq_host_mappings0host'")

In a case like this, it is safe to ignore because the host is already
discovered. This patch removes the `set -e` part of the script in order
to be more forgiving for errors like this, since we can't use crowbar
sync marks to orchestrate node discovery like this.