### PR TITLE
tempest: Bump up size of tempest flavor

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -290,7 +290,7 @@ heat_flavor_ref = "8"
 
 bash "create_yet_another_tiny_flavor" do
   code <<-EOH
-  nova flavor-show tempest-stuff &> /dev/null || nova flavor-create tempest-stuff #{flavor_ref} 128 0 1 || exit 0
+  nova flavor-show tempest-stuff &> /dev/null || nova flavor-create tempest-stuff #{flavor_ref} 384 0 1 || exit 0
   nova flavor-show tempest-stuff-2 &> /dev/null || nova flavor-create tempest-stuff-2 #{alt_flavor_ref} 196 0 1 || exit 0
   nova flavor-show tempest-heat &> /dev/null || nova flavor-create tempest-heat #{heat_flavor_ref} 512 0 1 || exit 0
 EOH


### PR DESCRIPTION
When a nova server is booted with the 'tempest-stuff' flavor and an
encrypted cinder volume is attached, it can never be detached. Instead,
it will hang in 'detaching' state for a while and then return to
'in-use' with no error messages in the logs. This causes the tempest
tempest.scenario.test_encrypted_cinder_volumes.TestEncryptedCinderVolumes
tests to fail since detaching times out. This change fixes the issue by
bumping up the size of the tempest-stuff flavor that is used for these
tempest tests.