### PR TITLE
Revert "neutron: disable lbaas integration for now"

### DIFF
--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -13,7 +13,7 @@
       "dns_domain": "openstack.local",
       "floating_dns_domain": "floating.openstack.local",
       "rpc_workers": 1,
-      "use_lbaas": false,
+      "use_lbaas": true,
       "lbaasv2_driver": "haproxy",
       "allow_automatic_lbaas_agent_failover": true,
       "use_l2pop": false,


### PR DESCRIPTION
We want to have the option to use lbaasv2 in Crowbar enabled given
that Octavia is not yet ready.

This reverts commit 714f8f203c95055f38e3de3444ed9282ba9fc5cc.