### PR TITLE
Revert "tempest: Bump up size of tempest flavor"

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -290,7 +290,7 @@ heat_flavor_ref = "8"
 
 bash "create_yet_another_tiny_flavor" do
   code <<-EOH
-  nova flavor-show tempest-stuff &> /dev/null || nova flavor-create tempest-stuff #{flavor_ref} 384 0 1 || exit 0
+  nova flavor-show tempest-stuff &> /dev/null || nova flavor-create tempest-stuff #{flavor_ref} 128 0 1 || exit 0
   nova flavor-show tempest-stuff-2 &> /dev/null || nova flavor-create tempest-stuff-2 #{alt_flavor_ref} 196 0 1 || exit 0
   nova flavor-show tempest-heat &> /dev/null || nova flavor-create tempest-heat #{heat_flavor_ref} 512 0 1 || exit 0
 EOH


### PR DESCRIPTION
This reverts commit a534ce224f6ba161000392c5844f35e9cdf81d54.

Increasing the test flavor size causes other tempest tests to fail with
a "no valid host" error since the instance size is now too big. We'll
need to find another solution to fix the problem with unmounting the
encrypted volume.