### PR TITLE
galera: avoid replacing resources

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -203,6 +203,11 @@ pacemaker_primitive service_name do
     "datadir" => node[:database][:mysql][:datadir],
     "log" => "/var/log/mysql/mysqld.log"
   })
+  meta ({
+    "migration-threshold" => "3",
+    "failure-timeout" => "1800s",
+    "resource-stickiness" => "100"
+  })
   op primitive_op
   action :update
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }


### PR DESCRIPTION
Any restart of the database is going to cause a large downtime, so
favoring availability we tell pacemaker to do this as little as
possible. Also expire failures after a time of 30 minutes so that
the clustering can resume after transient failures.