### PR TITLE
nova: use correct url from keystone helper for fence-agent (SCRD-7603)

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_ha.rb
+++ b/chef/cookbooks/nova/recipes/compute_ha.rb
@@ -36,9 +36,6 @@ include_recipe "crowbar-pacemaker::attributes"
 include_recipe "crowbar-pacemaker::remote_attributes"
 
 keystone_settings = KeystoneHelper.keystone_settings(nova, @cookbook_name)
-internal_auth_url_v2 = \
-  "#{keystone_settings["protocol"]}://" \
-  "#{keystone_settings["internal_url_host"]}:#{keystone_settings["service_port"]}/v2.0/"
 neutrons = node_search_with_cache("roles:neutron-server")
 neutron = neutrons.first || \
   raise("Neutron instance '#{nova[:nova][:neutron_instance]}' for nova not found")
@@ -172,7 +169,7 @@ nova_primitive = "nova-compute"
 pacemaker_primitive nova_primitive do
   agent "ocf:openstack:NovaCompute"
   params ({
-    "auth_url"       => internal_auth_url_v2,
+    "auth_url"       => keystone_settings["internal_auth_url"],
     # "region_name"    => keystone_settings["endpoint_region"],
     "endpoint_type"  => "internalURL",
     "username"       => keystone_settings["admin_user"],
@@ -232,7 +229,7 @@ evacuate_primitive = "nova-evacuate"
 pacemaker_primitive evacuate_primitive do
   agent "ocf:openstack:NovaEvacuate"
   params ({
-    "auth_url"       => internal_auth_url_v2,
+    "auth_url"       => keystone_settings["internal_auth_url"],
     # "region_name"    => keystone_settings["endpoint_region"],
     "endpoint_type"  => "internalURL",
     "username"       => keystone_settings["admin_user"],
@@ -274,7 +271,7 @@ pacemaker_primitive fence_primitive do
   agent "stonith:fence_compute"
   params ({
     "pcmk_host_map"  => hostmap,
-    "auth-url"       => internal_auth_url_v2,
+    "auth-url"       => keystone_settings["internal_auth_url"],
     # "region-name"    => keystone_settings["endpoint_region"],
     "endpoint-type"  => "internalURL",
     "login"          => keystone_settings["admin_user"],


### PR DESCRIPTION
**[supersedes #2017]**

Without this patch, the three OCF RAs involved in providing compute HA use v2 of the keystone API.  This is a problem because [there is no longer a v2 API available](https://docs.openstack.org/releasenotes/keystone/queens.html#other-notes).

So for example the `fence_compute` agent tries to use keystone v2 and the following failures are seen in `/var/log/nova/fence_compute.log`:

    DEBUG:
    http://cluster-services.vc1.cloud.suse.de:5000 "GET /v2.0/ HTTP/1.1" 404
    DEBUG: RESP: [404]....

and this in keystone logs:

    GET/v2.0/HTTP/1.1 404 233 - python-keystoneclient

These get flagged as `crm_mon` failures, breaking the feature and causing the CI job to fail.

This patch solves the problem by switching to the standard `internal_auth_url` used elsewhere.  This is possible because support for keystone v3 API was added to `fence_compute` in an HAE SP3 maintenance update for the benefit of Cloud 8:

- https://github.com/ClusterLabs/fence-agents/commit/549fee1c18cfb31881c9126ae46a4bd9b20b4716#diff-a9401fa3fb78f30aae7a079ece083575
- https://build.suse.de/package/view_file/SUSE:SLE-12-SP3:Update/fence-agents/0015-fencing-Add-consistency-between-command-line-and-STD.patch?expand=1
- https://bugzilla.suse.com/show_bug.cgi?id=1074000#c5
- https://bugzilla.suse.com/show_bug.cgi?id=1097260
- https://build.suse.de/request/show/169033

and so is now in HAE SP4 as used by Cloud 9:

- https://build.suse.de/package/view_file/SUSE:SLE-12-SP4:GA/fence-agents/fence-agents.changes?expand=1

and the `NovaCompute` and `NovaEvacuate` RAs only talk to keystone via `fence_compute`, e.g.:

- https://github.com/openstack/openstack-resource-agents/blob/42bb0c53e3c21550bc37bc63e0f0b1f59a2be000/ocf/NovaCompute#L182

This fixes [SCRD-7603 (nova: fence-agents still using keystone v2)](https://jira.suse.de/browse/SCRD-7603) and [SCRD-8401 (Processing failed start of fence-nova)](https://jira.suse.de/browse/SCRD-8401).

The inconsistencies between `auth-url` and `auth_url` should not matter, e.g.

- https://github.com/ClusterLabs/fence-agents/commit/de490e0590dabc8b30619092f9197ab0d4c47458#diff-94a84d829e5760b9a84e6d98bdba8fc4R556
- https://github.com/ClusterLabs/crmsh/pull/403
- https://bugzilla.suse.com/show_bug.cgi?id=1111579#c53