### PR TITLE
nova: delay the registration of compute node

### DIFF
--- a/chef/cookbooks/nova/recipes/compute_register_cell.rb
+++ b/chef/cookbooks/nova/recipes/compute_register_cell.rb
@@ -39,6 +39,7 @@ bash "nova-manage discover_hosts" do
     nova-manage --config-file=$tmpfile cell_v2 discover_hosts --verbose
     rm -f "$tmpfile"
     EOH
+  delayed true
 end
 
 # We want to keep a note that we've done discover_hosts, so we don't do it again.


### PR DESCRIPTION
For a compute node to be discover it should have already contacted the
scheduler once.
Currently this bash is executed immediately after first start of
nova-compute. This involves a race condition as discover_hosts will not
discover compute nodes which haven't yet contacted scheduler even once.
So this registration is like a noop, but in some cases chef is slow
enough for compute node to contact the scheduler and let it self be
known and making this bash call a success.

This patch makes this action delayed giving the compute service time to
contact the scheduler and make itself known.