### PR TITLE
Increase sync_mark timeouts (SCRD-8179)

### DIFF
--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -58,7 +58,10 @@ template "/etc/grafana/grafana.ini" do
   mode "0640"
 end
 
-crowbar_pacemaker_sync_mark "wait-grafana_migrations" if ha_enabled
+crowbar_pacemaker_sync_mark "wait-grafana_migrations" do
+  timeout 120
+  only_if { ha_enabled }
+end
 
 # Start Grafana server on cluster founder first to ensure database migrations
 # happen there...

--- a/chef/cookbooks/manila/recipes/sql.rb
+++ b/chef/cookbooks/manila/recipes/sql.rb
@@ -7,7 +7,10 @@ include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-crowbar_pacemaker_sync_mark "wait-manila_database" if ha_enabled
+crowbar_pacemaker_sync_mark "wait-manila_database" do
+  timeout 120
+  only_if { ha_enabled }
+end
 
 # Create the Manila Database
 database "create #{node[:manila][:db][:database]} database" do


### PR DESCRIPTION
It has been observed that DB migrations for Grafana and Manila take
more time than the configured default 60 s timeout for sync_marks. This
change doubles the timeout in Horizon and Manila barclamps to 120 s.