### PR TITLE
tempest: update neutron extension list

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -325,8 +325,11 @@ neutron_api_extensions = [
   "address-scope",
   "agent",
   "allowed-address-pairs",
+  "availability_zone",
+  "availability_zone_filter",
   "auto-allocated-topology",
   "binding",
+  "binding-extended",
   "default-subnetpools",
   "dhcp_agent_scheduler",
   "external-net",
@@ -339,16 +342,21 @@ neutron_api_extensions = [
   "hm_max_retries_down",
   "l3_agent_scheduler",
   "l3-flavors",
+  "l7",
   "metering",
   "multi-provider",
   "net-mtu",
+  "net-mtu-writable",
   "network_availability_zone",
   "network-ip-availability",
   "pagination",
   "port-security",
   "project-id",
   "provider",
+  "quota_details",
   "quotas",
+  "rbac-policies",
+  "revision-if-match",
   "router",
   "router_availability_zone",
   "security-group",
@@ -357,16 +365,25 @@ neutron_api_extensions = [
   "sorting",
   "standard-attr-description",
   "standard-attr-revisions",
-  "subnet_allocation",
+  "standard-attr-tag",
+  "standard-attr-timestamp",
   "subnet-service-types",
-  "tag",
-].join(",")
+  "subnet_allocation",
+  "trunk",
+  "trunk-details"
+].join(", ")
 
 unless neutrons[0].nil?
-  if neutrons[0][:neutron][:use_lbaas] then
-    neutron_api_extensions += ",lbaasv2,lbaas_agent_schedulerv2,lb-graph,lb_network_vip"
+  neutron_attr = neutrons[0][:neutron]
+  if neutron_attr[:use_lbaas]
+    neutron_api_extensions += ", lbaasv2, lbaas_agent_schedulerv2"
+    neutron_api_extensions += ", lb-graph, lb_network_vip"
   end
+  neutron_api_extensions += ", dvr" if neutron_attr[:use_dvr]
+  neutron_api_extensions += ", l3-ha" if neutron_attr[:l3_ha][:use_l3_ha]
 end
+
+neutron_api_extensions += ", dns-integration" if enabled_services.include?("dns")
 
 ruby_block "get public network id" do
   block do

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -417,7 +417,8 @@ cinders = search(:node, "roles:cinder-controller") || []
 storage_protocol = "iSCSI"
 vendor_name = "Open Source"
 cinder_snapshot = true
-use_attach_encrypted_volume = true
+# Currently broken in general, even with LVM
+use_attach_encrypted_volume = false
 cinders[0][:cinder][:volumes].each do |volume|
   if volume[:backend_driver] == "rbd"
     storage_protocol = "ceph"
@@ -460,42 +461,22 @@ if backend_names.length > 1
 end
 
 kvm_compute_nodes = search(:node, "roles:nova-compute-kvm") || []
-xen_compute_nodes = search(:node, "roles:nova-compute-xen") || []
 
 use_resize = kvm_compute_nodes.length > 1
 use_livemigration = nova[:nova][:use_migration] && kvm_compute_nodes.length > 1
-
-# create a flag to disable some test for xen (lp#1443898)
-xen_only = !xen_compute_nodes.empty? && kvm_compute_nodes.empty?
-file "#{node[:tempest][:tempest_path]}/flag-xen_only" do
-  action xen_only ? :create : :delete
-end
 
 # tempest timeouts for ssh and connection can be different for XEN, a
 # `nil` value will use the tempest default value
 validation_connect_timeout = nil
 validation_ssh_timeout = nil
-if xen_only
-  # Default: 60
-  validation_connect_timeout = 90
-  # Default: 300
-  validation_ssh_timeout = 450
-  use_interface_attach = false
-  use_rescue = false
-  use_suspend = false
-  use_vnc = node[:kernel][:machine] != "aarch64"
-  use_run_validation = false
-  use_config_drive = false
-end
+use_rescue = false
+use_suspend = false
+use_vnc = false
 
 unless kvm_compute_nodes.empty?
-  use_interface_attach = true
   use_rescue = true
   use_suspend = true
   use_vnc = node[:kernel][:machine] != "aarch64"
-  use_run_validation = true
-  use_config_drive = true
-  image_regex = "^cirros-#{cirros_version}-#{cirros_arch}-tempest-machine$"
 end
 
 # FIXME: should avoid search with no environment in query
@@ -546,14 +527,11 @@ template "/etc/tempest/tempest.conf" do
         flavor_ref: flavor_ref,
         alt_flavor_ref: alt_flavor_ref,
         nova_api_v3: nova[:nova][:enable_v3_api],
-        use_interface_attach: use_interface_attach,
         use_rescue: use_rescue,
         use_resize: use_resize,
         use_suspend: use_suspend,
         use_vnc: use_vnc,
         use_livemigration: use_livemigration,
-        # compute-feature-enabled settings
-        use_config_drive: use_config_drive,
         use_attach_encrypted_volume: use_attach_encrypted_volume,
         # dashboard settings
         horizon_host: horizon_host,
@@ -586,9 +564,7 @@ template "/etc/tempest/tempest.conf" do
         # scenario settings
         cirros_arch: cirros_arch,
         cirros_version: cirros_version,
-        image_regex: image_regex,
-        # validation settings
-        use_run_validation: use_run_validation,
+        image_regex: "^cirros-#{cirros_version}-#{cirros_arch}-tempest-machine$",
         validation_connect_timeout: validation_connect_timeout,
         validation_ssh_timeout: validation_ssh_timeout,
         # volume settings

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -45,11 +45,11 @@ live_migration = <%= @use_livemigration %>
 block_migration_for_live_migration = true
 vnc_console = <%= @use_vnc %>
 rescue = <%= @use_rescue %>
-interface_attach = <%= @use_interface_attach %>
 personality = True
-volume_multiattach = True
+# only supported by LVM driver
+# see https://docs.openstack.org/cinder/rocky/reference/support-matrix.html#operation_multi_attach
+volume_multiattach = False
 swap_volume = True
-config_drive = <%= @use_config_drive %>
 attach_encrypted_volume = <%= @use_attach_encrypted_volume %>
 api_extensions = all
 
@@ -212,7 +212,6 @@ too_slow_to_test = false
 events = true
 
 [validation]
-run_validation = <%= @use_run_validation %>
 connect_method = floating
 ip_version_for_ssh = 4
 <% if @validation_connect_timeout -%>

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -46,9 +46,12 @@ block_migration_for_live_migration = true
 vnc_console = <%= @use_vnc %>
 rescue = <%= @use_rescue %>
 interface_attach = <%= @use_interface_attach %>
-personality = false
+personality = True
+volume_multiattach = True
+swap_volume = True
 config_drive = <%= @use_config_drive %>
 attach_encrypted_volume = <%= @use_attach_encrypted_volume %>
+api_extensions = all
 
 [dashboard]
 dashboard_url = <%= @horizon_protocol %>://<%= @horizon_host %>/
@@ -101,6 +104,12 @@ alt_domain_name = Default
 
 [identity-feature-enabled]
 domain_specific_drivers = <%= node[:keystone][:domain_specific_drivers] ? "True" : "False" %>
+# Not enabled in keystone
+security_compliance = False
+application_credentials = True
+project_tags = True
+api_v2_admin = False
+api_v2 = False
 
 [image]
 region = <%= @keystone_settings['endpoint_region'] %>
@@ -128,6 +137,7 @@ floating_network_name = floating
 
 [network-feature-enabled]
 api_extensions = <%= @neutron_api_extensions %>
+port_security = True
 
 [object-storage]
 region = <%= @keystone_settings['endpoint_region'] %>
@@ -138,6 +148,7 @@ cluster_name = <%= @swift_cluster_name %>
 
 [object-storage-feature-enabled]
 object_versioning = <%= @object_versioning ? 'true' : 'false' %>
+discoverable_apis = all
 
 [orchestration]
 region = <%= @keystone_settings['endpoint_region'] %>
@@ -149,7 +160,7 @@ build_timeout = 2000
 instance_type = <%= @heat_flavor_ref %>
 
 [oslo_concurrency]
-lock_path = /var/run/tempest
+lock_path = /run/tempest
 
 [scenario]
 img_dir = <%= @tempest_path %>/etc/cirros/
@@ -185,8 +196,8 @@ capability_storage_protocol = <%= @manila_settings['capability_storage_protocol'
 enable_ip_rules_for_protocols = <%= @manila_settings['enable_ip_rules_for_protocols'] %>
 enable_cert_rules_for_protocols = <%= @manila_settings['enable_cert_rules_for_protocols'] %>
 suppress_errors_in_cleanup = true
-run_snapshot_tests =<%= @manila_settings['run_snapshot_tests'] %>
-run_share_group_tests =<%= @manila_settings['run_share_group_tests'] %>
+run_snapshot_tests = <%= @manila_settings['run_snapshot_tests'] %>
+run_share_group_tests = <%= @manila_settings['run_share_group_tests'] %>
 image_with_share_tools = <%= @manila_settings['image_with_share_tools'] %>
 image_username = <%= @manila_settings['image_username'] %>
 image_password = <%= @manila_settings['image_password'] %>
@@ -230,5 +241,9 @@ max_microversion = latest
 [volume-feature-enabled]
 multi_backend = <%= @cinder_multi_backend ? 'true' : 'false' %>
 backup = false
+extend_attached_volume = True
+manage_volume = True
+manage_snapshot = True
 api_v3 = True
 snapshot = <%= @cinder_snapshot %>
+api_extensions = all

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -97,10 +97,6 @@ username = <%= @comp_user %>
 tenant_name = <%= @comp_tenant %>
 password = <%= @comp_pass %>
 domain_name = Default
-alt_username = <%= @alt_comp_user %>
-alt_tenant_name = <%= @alt_comp_tenant %>
-alt_password = <%= @alt_comp_pass %>
-alt_domain_name = Default
 
 [identity-feature-enabled]
 domain_specific_drivers = <%= node[:keystone][:domain_specific_drivers] ? "True" : "False" %>

--- a/chef/data_bags/crowbar/migrate/tempest/301_remove_alt_users.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/301_remove_alt_users.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs.delete("tempest_adm_username")
+  attrs.delete("tempest_adm_password")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["tempest_adm_username"] = template_attrs["tempest_adm_username"]
+  attrs["tempest_adm_password"] = template_attrs["tempest_adm_password"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -9,8 +9,6 @@
           "ppc64le": "http://<ADMINWEB>/files/tempest/FIXME",
           "s390x": "http://<ADMINWEB>/files/tempest/FIXME"
       },
-      "tempest_adm_password": "tempest",
-      "tempest_adm_username": "tempest",
       "tempest_user_password": "tempest",
       "tempest_user_username": "tempest",
       "tempest_user_tenant": "tempest",
@@ -41,7 +39,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 300,
+      "schema-revision": 301,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-tempest.schema
+++ b/chef/data_bags/crowbar/template-tempest.schema
@@ -13,8 +13,6 @@
           "required": true,
           "mapping": {
             "nova_instance": { "type": "str", "required": true },
-            "tempest_adm_username": { "type": "str", "required": true },
-            "tempest_adm_password": { "type": "str", "required": true },
             "tempest_user_password": { "type": "str", "required": true },
             "tempest_user_username": { "type": "str", "required": true },
             "tempest_user_tenant": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/tempest_service.rb
+++ b/crowbar_framework/app/models/tempest_service.rb
@@ -62,10 +62,8 @@ class TempestService < ServiceObject
     base["attributes"][@bc_name]["nova_instance"] = find_dep_proposal("nova")
 
     base["attributes"]["tempest"]["tempest_user_username"] = "tempest-user-" + random_password
-    base["attributes"]["tempest"]["tempest_adm_username"] = "tempest-adm-" + random_password
     base["attributes"]["tempest"]["tempest_user_tenant"] = "tempest-tenant-" + random_password
     base["attributes"]["tempest"]["tempest_user_password"] = random_password
-    base["attributes"]["tempest"]["tempest_adm_password"] = random_password
 
     @logger.debug("Tempest create_proposal: exiting")
     base

--- a/crowbar_framework/app/views/barclamp/tempest/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/tempest/_edit_attributes.html.haml
@@ -12,5 +12,3 @@
       = string_field %w(tempest_user_username)
       = password_field %w(tempest_user_password)
       = string_field %w(tempest_user_tenant)
-      = string_field %w(tempest_adm_username)
-      = password_field %w(tempest_adm_password)

--- a/crowbar_framework/config/locales/tempest/en.yml
+++ b/crowbar_framework/config/locales/tempest/en.yml
@@ -66,8 +66,6 @@ en:
         tempest_user: 'Tempest user and a tenant that will be created for test run'
         tempest_user_username: 'Choose username'
         tempest_user_password: 'Choose password'
-        tempest_adm_username: 'Choose Tempest admin username'
-        tempest_adm_password: 'Choose Tempest admin password'
         tempest_user_tenant: 'Choose tenant'
         nova_instance: 'Nova'
 


### PR DESCRIPTION
The tag extension is deprecated as of Queens, and has been
replaced by tagging.