### PR TITLE
memcache: Use first array element as fallback (SCRD-8255)

### DIFF
--- a/chef/cookbooks/memcached/libraries/helpers.rb
+++ b/chef/cookbooks/memcached/libraries/helpers.rb
@@ -6,7 +6,7 @@ module MemcachedHelper
       port = if n.key?(:memcached) && n[:memcached].key?(:port)
         n[:memcached][:port]
       else
-        node[:memcached][:port]
+        memcached_nodes.first[:memcached][:port]
       end
       "#{node_admin_ip}:#{port}"
     end


### PR DESCRIPTION
When this code was refactored, a fallback of node[:memcache][:port] was
used, since the original code in the nova and horizon cookbooks used it.
However, node is not defined in this context, so the fallback causes a
NameError instead. Use the first array element as the fallback instead.