### PR TITLE
[5.0] ceilometer: Install package which contains cron file (bsc#1130414)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -23,6 +23,10 @@ haproxy_loadbalancer "ceilometer-api" do
   action :nothing
 end.run_action(:create)
 
+# install openstack-ceilometer-collector - the package contains the cron file
+# /usr/share/ceilometer/openstack-ceilometer-expirer.cron
+package "openstack-ceilometer-collector"
+
 # setup the expirer cronjob only on a single node to not
 # run into DB deadlocks (bsc#1113107)
 crowbar_pacemaker_sync_mark "wait-ceilometer_expirer_cron"


### PR DESCRIPTION
Commit 2f441560b uses pacemaker to handle the cron symlink. But to
work correctly, the link
destination (/usr/share/ceilometer/openstack-ceilometer-expirer.cron)
needs to be there and this file is in the
openstack-ceilometer-collector package.
So install the package to solve this.