### PR TITLE
tempest: Improve ironic test results (was: Use fake-hardware driver)

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -24,7 +24,7 @@ aws_secret = <%= @ec2_secret %>
 aws_access = <%= @ec2_access %>
 
 [baremetal]
-endpoint_type = internalURL
+endpoint_type = public
 max_microversion = latest
 driver = fake-hardware
 

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -26,6 +26,7 @@ aws_access = <%= @ec2_access %>
 [baremetal]
 endpoint_type = internalURL
 max_microversion = latest
+driver = fake-hardware
 
 [compute]
 image_ref = <%= img_id %>

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -178,7 +178,7 @@ trove = <%= @enabled_services.include? "database" %>
 manila = <%= @enabled_services.include? "sharev2" %>
 magnum = <%= @enabled_services.include? "container-infra" %>
 ironic = <%= @enabled_services.include? "baremetal" %>
-ironic_inspector = <%= @enabled_services.include? "baremetal" %>
+ironic_inspector = false
 designate = <%= @enabled_services.include? "dns" %>
 logs = <%= @enabled_services.include? "logs_v2" %>
 logs-search = <%= @enabled_services.include? "logs-search" %>


### PR DESCRIPTION
Following changes are included to make basic ironic testing possible:
1. Use fake-hardware driver
Current default in ironic_tempest_plugin config is still "fake"
with comment: "change to fake-hardware when Ocata is no longer supported".
2. Change endpoint type to public
Two tests in ironic suite check endpoint urls and they expect public ones.
3. Disable ironic inspector tests
Ironic barclamp doesn't support Inspector yet.

With above plus https://github.com/SUSE-Cloud/automation/pull/3295 I got following results:
```
======
Totals
======
Ran: 201 tests in 1949.0000 sec.
 - Passed: 178
 - Skipped: 21
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 2
Sum of execute time for each test: 578.9197 sec.
```

Remaining two failed tests are for:
- BFV (Boot From Volume) - not implemented in Ironic barclamp yet
- BaremetalBasicOps - some "real" testing of Ironic node operations. This seems to require more complete environment setup (e.g. pre-created node with specific driver and features).
