### PR TITLE
monasca: Add openvswitch plugin (SCRD-7571)

### DIFF
--- a/chef/cookbooks/monasca/providers/agent_plugin_ovs.rb
+++ b/chef/cookbooks/monasca/providers/agent_plugin_ovs.rb
@@ -1,0 +1,49 @@
+#
+# Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "json"
+require "yaml"
+
+action :create do
+  config = {
+    "username" => new_resource.username,
+    "user_domain_name" => new_resource.user_domain_name,
+    "password" => new_resource.password,
+    "project_name" => new_resource.project_name,
+    "project_domain_name" => new_resource.project_domain_name,
+    "auth_url" => new_resource.auth_url,
+    "region_name" => new_resource.region_name,
+    "check_router_ha" => new_resource.check_router_ha
+  }.merge(node[:monasca][:agent][:plugins][:ovs])
+
+  # be sure the package is installed. that way "/etc/monasca/agent/conf.d/" is available
+  # and also the user and group are there
+  package "openstack-monasca-agent"
+
+  # NOTE(toabctl): convert/parse first to/from json. Otherwise we have unwanted markers
+  # like "- !ruby/hash:Mash" in the yaml output
+  ovs_conf = JSON.parse({ "init_config" => config,
+                          "instances" => [] }.to_json).to_yaml
+
+  # write OVS plugin config
+  file "/etc/monasca/agent/conf.d/ovs.yaml" do
+    content ovs_conf
+    owner node[:monasca][:agent][:user]
+    group node[:monasca][:agent][:group]
+    mode "0640"
+    notifies :restart, resources(service: node[:monasca][:agent][:agent_service_name]), :delayed
+  end
+end

--- a/chef/cookbooks/monasca/recipes/role_monasca_server.rb
+++ b/chef/cookbooks/monasca/recipes/role_monasca_server.rb
@@ -33,10 +33,10 @@ if CrowbarRoleRecipe.node_state_valid_for_role?(node, "monasca", "monasca-server
   include_recipe "#{@cookbook_name}::monasca_log_metrics"
   include_recipe "#{@cookbook_name}::storm"
   include_recipe "#{@cookbook_name}::monasca_thresh"
-  include_recipe "#{@cookbook_name}::monasca_notification"
   include_recipe "#{@cookbook_name}::monasca_persister" if tsdb == "influxdb"
   include_recipe "#{@cookbook_name}::monasca_persister_java" if tsdb == "cassandra"
   include_recipe "#{@cookbook_name}::monasca_api"
+  include_recipe "#{@cookbook_name}::monasca_notification"
   include_recipe "#{@cookbook_name}::server"
   include_recipe "#{@cookbook_name}::monitor_monasca"
 end

--- a/chef/cookbooks/monasca/resources/agent_plugin_ovs.rb
+++ b/chef/cookbooks/monasca/resources/agent_plugin_ovs.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :username, kind_of: String, required: true
+attribute :password, kind_of: String, required: true
+attribute :project_name, kind_of: String, required: true
+attribute :auth_url, kind_of: String, required: true
+attribute :user_domain_name, kind_of: String, required: true
+attribute :project_domain_name, kind_of: String, required: true
+attribute :region_name, kind_of: String, required: true
+attribute :check_router_ha, kind_of: [TrueClass, FalseClass], required: true
+
+attr_accessor :exists

--- a/chef/cookbooks/monasca/templates/default/monasca-api.conf.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-api.conf.erb
@@ -623,7 +623,7 @@ agent_authorized_roles = monasca-agent
 # Roles that are allowed to POST metrics on
 # behalf of another tenant
 #  (list value)
-#delegate_authorized_roles = admin
+delegate_authorized_roles = monasca-agent
 
 [keystone_authtoken]
 www_authenticate_uri = <%= @keystone_settings['public_auth_url'] %>

--- a/chef/cookbooks/monasca/templates/default/monasca-reconfigure-server.erb
+++ b/chef/cookbooks/monasca/templates/default/monasca-reconfigure-server.erb
@@ -33,6 +33,7 @@ run_setup()
       --amplifier '<%= @agent_settings["amplifier"] %>' \
       --skip_enable \
       --agent_service_name '<%= @agent_settings["agent_service_name"].gsub(/\.target$/, '') %>' \
+      --skip_detection_plugins ovs \
       "$@"
     }
 

--- a/chef/cookbooks/neutron/recipes/monitor_monasca_ovs.rb
+++ b/chef/cookbooks/neutron/recipes/monitor_monasca_ovs.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2019 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+return unless node["roles"].include?("monasca-agent")
+
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+
+if node[:monasca][:agent][:monitor_ovs]
+  node["roles"].each do |role|
+
+    next unless node[:neutron][:ml2_mechanism_drivers].include?("openvswitch")
+
+    monasca_agent_plugin_ovs "OVS check for neutron" do
+      user_domain_name "Default"
+      project_domain_name "Default"
+      region_name keystone_settings["endpoint_region"]
+      username keystone_settings["service_user"]
+      password keystone_settings["service_password"]
+      project_name keystone_settings["service_tenant"]
+      auth_url keystone_settings["internal_auth_url"]
+      check_router_ha node[:neutron][:l3_ha][:use_l3_ha]
+    end
+  end
+end

--- a/chef/cookbooks/neutron/recipes/role_neutron_network.rb
+++ b/chef/cookbooks/neutron/recipes/role_neutron_network.rb
@@ -16,4 +16,5 @@
 
 if CrowbarRoleRecipe.node_state_valid_for_role?(node, "neutron", "neutron-network")
   include_recipe "neutron::network_agents"
+  include_recipe "neutron::monitor_monasca_ovs"
 end

--- a/chef/data_bags/crowbar/migrate/monasca/315_add_ovs_plugin_settings.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/315_add_ovs_plugin_settings.rb
@@ -1,0 +1,19 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["agent"]["monitor_ovs"] = template_attrs["agent"]["monitor_ovs"] unless
+    attrs["agent"].key?("monitor_ovs")
+
+  attrs["agent"]["plugins"]["ovs"] = template_attrs["agent"]["plugins"]["ovs"] unless
+    attrs["agent"]["plugins"].key?("ovs")
+
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["agent"].delete("monitor_ovs") unless
+      template_attrs["agent"].key?("monitor_ovs")
+
+  attrs["agent"]["plugins"].delete("ovs") unless
+      template_attrs["agent"]["plugins"].key?("ovs")
+
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -32,6 +32,17 @@
             "vm_ping_check_enable": true,
             "vm_probation": 300,
             "vnic_collection_period": 0
+          },
+          "ovs": {
+            "cache_dir": "/dev/shm",
+            "neutron_refresh": 14400,
+            "network_use_bits": false,
+            "included_interface_re": "qg.*|vhu.*|sg.*",
+            "ovs_cmd": "sudo /usr/bin/ovs-vsctl",
+            "use_absolute_metrics": true,
+            "use_rate_metrics": true,
+            "use_health_metrics": true,
+            "collect_period": 300
           }
         },
         "insecure": true,
@@ -40,6 +51,7 @@
         "log_level": "INFO",
         "monitor_ceph": true,
         "monitor_libvirt": true,
+        "monitor_ovs": true,
         "statsd_port": 8125,
         "check_frequency": 15,
         "num_collector_threads": 1,
@@ -155,7 +167,7 @@
     "monasca": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 314,
+      "schema-revision": 315,
       "element_states": {
         "monasca-server": [ "readying", "ready", "applying" ],
         "monasca-agent": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-monasca.schema
+++ b/chef/data_bags/crowbar/template-monasca.schema
@@ -49,6 +49,21 @@
                         "vm_probation": { "type": "int", "required": true },
                         "vnic_collection_period": { "type": "int", "required": true }
                       }
+                    },
+                    "ovs": {
+                      "required": true,
+                      "type": "map",
+                      "mapping": {
+                        "cache_dir": { "type": "str", "required": true },
+                        "neutron_refresh": { "type": "int", "required": true },
+                        "network_use_bits": { "type": "bool", "required": true },
+                        "included_interface_re": { "type": "str", "required": true },
+                        "ovs_cmd": { "type": "str", "required": true },
+                        "use_absolute_metrics": { "type": "bool", "required": true },
+                        "use_rate_metrics": { "type": "bool", "required": true },
+                        "use_health_metrics": { "type": "bool", "required": true },
+                        "collect_period": { "type": "int", "required": true }
+                      }
                     }
                   }
                 },
@@ -58,6 +73,7 @@
                 "log_level": { "type": "str", "required": true },
                 "monitor_ceph": { "type": "bool", "required": true },
                 "monitor_libvirt": { "type": "bool", "required": true },
+                "monitor_ovs": { "type": "bool", "required": true },
                 "statsd_port": { "type": "int", "required": true },
                 "check_frequency": { "type": "int", "required": true },
                 "num_collector_threads": { "type": "int", "required": true },

--- a/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/monasca/_edit_attributes.html.haml
@@ -12,6 +12,7 @@
       = integer_field %w(agent statsd_port)
       = boolean_field %w(agent monitor_ceph)
       = boolean_field %w(agent monitor_libvirt)
+      = boolean_field %w(agent monitor_ovs)
       = integer_field %w(agent check_frequency)
       = integer_field %w(agent num_collector_threads)
       = integer_field %w(agent pool_full_max_retries)

--- a/crowbar_framework/config/locales/monasca/en.yml
+++ b/crowbar_framework/config/locales/monasca/en.yml
@@ -37,6 +37,7 @@ en:
           log_level: 'Log level'
           monitor_ceph: 'Monitor Ceph'
           monitor_libvirt: 'Monitor libvirt'
+          monitor_ovs: 'Monitor Open vSwitch'
           statsd_port: 'Monasca Statsd port'
           check_frequency: 'Time to wait between collection runs (check_frequency)'
           num_collector_threads: 'Number of Collector Threads to run (num_collector_threads)'


### PR DESCRIPTION
Add Monasca OVS plugin configuration on all neutron-network nodes.
Plugin configuration is automatically enabled and can be disabled in
Crowbar UI.

Monasca OVS plugin autodetection is disabled on Monasca server node.

Add `monasca-agent` role to `delegate_authorized_roles` to enable
collecting tenant metrics.