### PR TITLE
nova: verify glance signatures if able (SCRD-8578)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -347,6 +347,7 @@ template node[:nova][:placement_config_file] do
   notifies :reload, "service[nova-placement-api]"
 end
 
+barbican_available = node_search_with_cache("roles:barbican-controller").any?
 
 template node[:nova][:config_file] do
   source "nova.conf.erb"
@@ -415,7 +416,8 @@ template node[:nova][:config_file] do
     use_baremetal_filters: use_baremetal_filters,
     track_instance_changes: track_instance_changes,
     ironic_settings: ironic_settings,
-    default_log_levels: node[:nova][:default_log_levels]
+    default_log_levels: node[:nova][:default_log_levels],
+    barbican_available: barbican_available
   )
 end
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -147,6 +147,9 @@ cafile = <%= @ssl_ca_file %>
 <% end %>
 certfile = <%= @ssl_cert_file %>
 keyfile = <%= @ssl_key_file %>
+<% if @barbican_available %>
+verify_glance_signatures = true
+<% end %>
 
 <% unless @ironic_settings.nil? %>
 [ironic]


### PR DESCRIPTION
Without this patch, the `test_signed_image_upload_boot_failure` barbican
tempest tests fails because nova fails to prevent booting from an
unverified signed image. This test requires the
verify_glance_signatures option be set in the nova config on the compute
node. However, it must only be set if barbican is actually available,
otherwise nova can't boot anything.