### PR TITLE
designate: show barclamp

### DIFF
--- a/designate.yml
+++ b/designate.yml
@@ -19,8 +19,6 @@ barclamp:
   display: 'Designate'
   description: 'OpenStack DNSaaS: Multi-Tenant DNSaaS service for OpenStack'
   version: 0
-  # Change to true when complete
-  user_managed: false
   requires:
     - 'keystone'
     - 'rabbitmq'


### PR DESCRIPTION
This commit makes the Designate barclamp visible by removing
the `user_managed: false` barclamp attribute.