### PR TITLE
ironic: Use IP instead of DNS name for Swift

### DIFF
--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -44,7 +44,7 @@ project_domain_name=<%= @keystone_settings["admin_domain"]%>
 user_domain_name=<%= @keystone_settings["admin_domain"] %>
 <% if @swift_settings %>
 swift_temp_url_key=<%= @swift_settings[:tempurl_key] %>
-swift_endpoint_url=<%= @swift_settings[:protocol] %>://<%= @swift_settings[:host] %>:<%= @swift_settings[:port] %>
+swift_endpoint_url=<%= @swift_settings[:protocol] %>://<%= @swift_settings[:ip] %>:<%= @swift_settings[:port] %>
 swift_container=<%= @swift_settings[:glance_container] %>
 swift_account=<%= @swift_settings[:glance_account] %>
 <% end %>


### PR DESCRIPTION
Swift endpoint in Glance section is used to build TempURLs. These
are then used by Ironic agent running from a ramdisk image. It is
better to use IP here as proper DNS configuration might not be
available in the image and Swift host would not be resolved.