### PR TITLE
[5.0] monasca: Set hostname for monasca-agent as FQDN (SCRD-8705)

### DIFF
--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -118,7 +118,7 @@ template "/etc/monasca/agent/agent.yaml" do
   group agent_settings[:group]
   mode "0640"
   variables(
-    hostname: node[:hostname],
+    hostname: node[:fqdn],
     monasca_api_url: monasca_api_url,
     agent_dimensions: agent_dimensions,
     log_dir: agent_settings["log_dir"],


### PR DESCRIPTION
All agents should set FQDN as hostname to allow unambiguous
identification of the measurement source. Right now FQDN is set on
Monasca server and hostname on OpenStack nodes.

Release note should be provided as customers upgrading from existing
installation will observe new time series.

backport of #2084
(cherry picked from commit f1d7809fe19f81f13999d334aeb9f160f7ca6353)