### PR TITLE
ceilometer: add a polling section in ceilometer conf (SCRD-8720)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -129,6 +129,18 @@ template "/etc/ceilometer/pipeline.yaml" do
   end
 end
 
+template "/etc/ceilometer/polling_pipeline.yaml" do
+  source "polling_pipeline.yaml.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+  variables(
+    swift_interval: node[:ceilometer][:swift_interval],
+    monasca_api_url: monasca_api_url
+  )
+  notifies :restart, "service[swift-proxy]" if is_swift_proxy
+end
+
 template "/etc/ceilometer/event_pipeline.yaml" do
   source "event_pipeline.yaml.erb"
   owner "root"

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -54,10 +54,10 @@ interface = internalURL
 auth_type = password
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 project_name = <%= @monasca_project %>
-default_domain_id = <%= @keystone_settings["admin_domain_id"] %>
-default_domain_name = <%= @keystone_settings["admin_domain"] %>
 username = <%= @keystone_settings['service_user'] %>
 password = <%= @keystone_settings['service_password'] %>
+user_domain_name = <%= @keystone_settings["admin_domain"] %>
+project_domain_name = <%= @keystone_settings["admin_domain"]%>
 
 [service_types]
 neutron_lbaas_version = v2
@@ -105,3 +105,6 @@ service_region_name= <%= @keystone_settings['endpoint_region'] %>
 
 [publisher_notifier]
 metering_topic=metering
+
+[polling]
+cfg_file=/etc/ceilometer/polling_pipeline.yaml

--- a/chef/cookbooks/ceilometer/templates/default/polling_pipeline.yaml.erb
+++ b/chef/cookbooks/ceilometer/templates/default/polling_pipeline.yaml.erb
@@ -1,0 +1,15 @@
+---
+sources:
+    - name: swift_source
+      interval: <%= @swift_interval %>
+      meters:
+        - "storage.objects"
+        - "storage.objects.size"
+        - "storage.objects.containers"
+      sinks:
+        - meter_sink
+sinks:
+    - name: meter_sink
+      transformers:
+      publishers:
+          - monasca://<%= @monasca_api_url %>


### PR DESCRIPTION
* Add a [polling] section to ceilometer.conf with cfg_file property which
  points to polling_pipeline.yaml

* removed default_domain_id and default_domain_name from  [service_credentials]
  and added project_domain_name and user_domain name to [service_credentials]
  in polling.conf to prevent ceilometer polling agent from failing with
  "need user domain" and "need project domain" error.

* added a new pipeline yaml file for polling agent, called polling_pipeline.yml

* added swift meters which are polling meters to polling_pipeline.yml