### PR TITLE
tempest: Enable BaremetalBasicOps test

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -279,11 +279,16 @@ end
 flavor_ref = "6"
 alt_flavor_ref = "7"
 heat_flavor_ref = "20"
+ironic_flavor_ref = "21"
 
 bash "create_yet_another_tiny_flavor" do
   code <<-EOH
   nova flavor-show tempest-stuff &> /dev/null || nova flavor-create tempest-stuff #{flavor_ref} 128 0 1 || exit 0
   nova flavor-show tempest-stuff-2 &> /dev/null || nova flavor-create tempest-stuff-2 #{alt_flavor_ref} 196 0 1 || exit 0
+  # note: this should be created based on the actual size of test ironic node
+  # note: ironic flavor disk size needs to be a bit smaller than actual physical disk to
+  #       make sure rootfs will fit if deploying with partition image
+  nova flavor-show tempest-ironic &> /dev/null || nova flavor-create tempest-ironic #{ironic_flavor_ref} 2048 19 2 || exit 0
   nova flavor-show tempest-heat &> /dev/null || nova flavor-create tempest-heat #{heat_flavor_ref} 512 0 1 || exit 0
 EOH
   environment ({
@@ -518,6 +523,7 @@ template "/etc/tempest/tempest.conf" do
         # compute settings
         flavor_ref: flavor_ref,
         alt_flavor_ref: alt_flavor_ref,
+        ironic_flavor_ref: ironic_flavor_ref,
         nova_api_v3: nova[:nova][:enable_v3_api],
         use_rescue: use_rescue,
         use_resize: use_resize,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -16,6 +16,9 @@ admin_domain_name = Default
 <%- unless @tempest_roles.empty? %>
 tempest_roles = <%= @tempest_roles %>
 <%- end %>
+<%- if @enabled_services.include? "baremetal" %>
+create_isolated_networks = False
+<%- end %>
 
 [aws]
 ec2_url = <%= @ec2_protocol %>://<%= @ec2_host %>:<%= @ec2_port %>/
@@ -27,17 +30,27 @@ aws_access = <%= @ec2_access %>
 endpoint_type = public
 max_microversion = latest
 driver = fake-hardware
+unprovision_timeout = 600
 
 [compute]
 image_ref = <%= img_id %>
 image_ref_alt = <%= alt_img_id %>
+<%- if @enabled_services.include? "baremetal" %>
+flavor_ref = <%= @ironic_flavor_ref %>
+<%- else %>
 flavor_ref = <%= @flavor_ref %>
+<%- end %>
 flavor_ref_alt = <%= @alt_flavor_ref %>
+<%- if @enabled_services.include? "baremetal" %>
+fixed_network_name = ironic
+<%- else %>
 fixed_network_name = fixed
+<%- end %>
 region = <%= @keystone_settings['endpoint_region'] %>
 endpoint_type = internalURL
 min_compute_nodes = <%= @use_livemigration ? 2 : 1 %>
 max_microversion = latest
+build_timeout = 600
 
 [compute-feature-enabled]
 resize = <%= @use_resize %>


### PR DESCRIPTION
This is currently the only "integration" test for Ironic. It requires
"real" Ironic node to be present and some adjustments in Tempest config
to pass.