### PR TITLE
neutron: enable designate integration

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -37,16 +37,17 @@ default_log_levels = <%= @default_log_levels.join(", ") %>
 external_dns_driver = designate
 
 [designate]
+auth_type = password
 url = <%= @designate_public_uri %>
-admin_auth_url = <%= @keystone_settings['internal_auth_url'] %>
-admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
-admin_username = <%= @keystone_settings['service_user'] %>
-admin_password = <%= @keystone_settings['service_password'] %>
+username = <%= @keystone_settings['service_user'] %>
+password = <%= @keystone_settings['service_password'] %>
+auth_url = <%= @keystone_settings['internal_auth_url'] %>
 region_name = <%= @keystone_settings['endpoint_region'] %>
-admin_user_domain = <%= @keystone_settings['admin_domain'] %>
-admin_project_domain = <%= @keystone_settings['admin_domain'] %>
+project_domain_name = <%= @keystone_settings['default_user_domain'] %>
+user_domain_name = <%= @keystone_settings['default_user_domain'] %>
+project_name = <%= @keystone_settings['service_tenant'] %>
+allow_reverse_dns_lookup = False
 <% end -%>
-
 
 [agent]
 root_helper = sudo neutron-rootwrap /etc/neutron/rootwrap.conf

--- a/chef/data_bags/crowbar/migrate/neutron/306_fix_domains_names.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/306_fix_domains_names.rb
@@ -1,0 +1,10 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  ["floating_dns_domain", "dns_domain"].each do |key|
+    attributes[key] = attributes[key] + "." unless attributes[key].end_with? "."
+  end
+  return attributes, deployment
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  return attributes, deployment
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -10,8 +10,8 @@
       "max_header_line": 16384,
       "debug": false,
       "create_default_networks": true,
-      "dns_domain": "openstack.local",
-      "floating_dns_domain": "floating.openstack.local",
+      "dns_domain": "openstack.local.",
+      "floating_dns_domain": "floating.openstack.local.",
       "rpc_workers": 1,
       "use_lbaas": true,
       "lbaasv2_driver": "haproxy",
@@ -192,7 +192,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 305,
+      "schema-revision": 306,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],


### PR DESCRIPTION
the config enabled by this flag lets neutron create dns records when
floating ip are created and assigned.
The config was previously added but was not enabled as the barclamp was
still under development 

This config is not really needed for designate or neutron to work, but they help enable certain features
this is where the flag is used https://github.com/crowbar/crowbar-openstack/blob/a671c048ec071a13170d055b4dfc5a6906596cd0/chef/cookbooks/neutron/templates/default/neutron.conf.erb#L36-L48
