### PR TITLE
Octavia: Barclamp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,7 @@
 
 **/*keystone*  @rhafer
 **/*monasca*  @jgrassler
+**/*octavia*  @ilausuch
 
 ha*.rb  @aspiers
 *_ha.rb  @aspiers

--- a/bin/crowbar_octavia
+++ b/bin/crowbar_octavia
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
+@barclamp = "octavia"
+@timeout = 3600
+
+main

--- a/chef/cookbooks/octavia/README.rdoc
+++ b/chef/cookbooks/octavia/README.rdoc
@@ -1,0 +1,33 @@
+DESCRIPTION
+===========
+
+Chef Cookbook to install and configure OpenStack Octavia.
+
+REQUIREMENTS
+============
+
+Barclamp-Keystone
+Barclamp-Glance
+Barclamp-Neutron
+Barclamp-Nova
+Barclamp-Barbican
+
+
+License
+=======
+
+Author:: Ivan Lausuch <ilausuch@suse.com>
+
+Copyright:: 2019, SUSE Linux GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/chef/cookbooks/octavia/attributes/default.rb
+++ b/chef/cookbooks/octavia/attributes/default.rb
@@ -1,0 +1,67 @@
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default[:octavia][:user] = "octavia"
+default[:octavia][:group] = "octavia"
+default[:octavia][:debug] = false
+default[:octavia][:octavia_log_dir] = "/var/log/octavia"
+default[:octavia][:octavia_config_dir] = "/etc/octavia"
+
+default[:octavia][:api][:port] = 9876
+default[:octavia][:api][:protocol] = "http"
+
+default[:octavia][:db][:user] = "octavia"
+default[:octavia][:db][:database] = "octavia"
+default[:octavia][:db][:password] = nil
+
+default[:octavia][:oslo][:rpc_thread_pool_size] = 2
+default[:octavia][:networking][:port_detach_timeout] = 900
+
+default[:octavia][:health_manager][:port] = 5555
+default[:octavia][:health_manager][:heartbeat_interval] = 10
+default[:octavia][:health_manager][:heartbeat_timeout] = 180
+default[:octavia][:health_manager][:health_check_interval] = 3
+default[:octavia][:health_manager][:heartbeat_key] = nil
+
+default[:octavia][:sudoers_file] = "/etc/sudoers.d/octavia"
+
+default[:octavia][:certs][:country] = "US"
+default[:octavia][:certs][:province] = "Oregon"
+default[:octavia][:certs][:organization] = "Home"
+default[:octavia][:certs][:domain] = "example.com"
+default[:octavia][:certs][:cert_path] = "/etc/octavia/certs/"
+default[:octavia][:certs][:passphrase] = "foobar"
+default[:octavia][:certs][:server_ca_cert_path] = "server_ca/certs/ca.cert.pem"
+default[:octavia][:certs][:server_ca_key_path] = "server_ca/private/ca.key.pem"
+default[:octavia][:certs][:client_ca_cert_path] = "client_ca/certs/ca.cert.pem"
+default[:octavia][:certs][:client_cert_and_key_path] = "client_ca/private/client.cert-and-key.pem"
+
+default[:octavia][:amphora][:flavor] = "m1.lbaas.amphora"
+default[:octavia][:amphora][:sec_group] = "lb-mgmt-sec-group"
+default[:octavia][:amphora][:manage_net] = "lb-mgmt-net"
+default[:octavia][:amphora][:image_tag] = "amphora"
+default[:octavia][:amphora][:project] = "service"
+
+default[:octavia][:amphora][:ssh_access][:enabled] = false
+default[:octavia][:amphora][:ssh_access][:keypair] = ""
+
+default[:octavia][:ssl][:certfile] = "/etc/octavia/ssl/certs/signing_cert.pem"
+default[:octavia][:ssl][:keyfile] = "/etc/octavia/ssl/private/signing_key.pem"
+default[:octavia][:ssl][:generate_certs] = false
+default[:octavia][:ssl][:insecure] = false
+default[:octavia][:ssl][:cert_required] = false
+default[:octavia][:ssl][:ca_certs] = "/etc/octavia/ssl/certs/ca.pem"
+
+default[:octavia][:ha][:ports][:api] = 19876

--- a/chef/cookbooks/octavia/definitions/octavia_conf.rb
+++ b/chef/cookbooks/octavia/definitions/octavia_conf.rb
@@ -1,0 +1,56 @@
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+define :octavia_conf do
+  cmd = params[:cmd]
+  network_settings = OctaviaHelper.network_settings(node)
+
+  if params[:name] == "api"
+    conf = "/etc/octavia/octavia.conf"
+    bind_host = network_settings[:api][:bind_host]
+    bind_port = network_settings[:api][:bind_port]
+  else
+    conf = "/etc/octavia/octavia-#{params[:name]}.conf"
+    bind_host = network_settings[:health_manager][:bind_host]
+    bind_port = network_settings[:health_manager][:bind_port]
+  end
+
+  net_name = node[:octavia][:amphora][:manage_net]["name"]
+  sec_group_id = shell_out("#{cmd} security group show #{node[:octavia][:amphora][:sec_group]} "\
+                           "-f value -c id").stdout
+  flavor_id = shell_out("#{cmd} flavor show #{node[:octavia][:amphora][:flavor]} "\
+                           "-f value -c id").stdout
+  net_id = shell_out("#{cmd} network show #{net_name} -f value -c id").stdout
+
+  template conf do
+    source "octavia.conf.erb"
+    owner node[:octavia][:user]
+    group node[:octavia][:group]
+    mode 0o640
+    variables(
+      bind_host: bind_host,
+      bind_port: bind_port,
+      octavia_db_connection: fetch_database_connection_string(node[:octavia][:db]),
+      neutron_endpoint: OctaviaHelper.get_neutron_endpoint(node),
+      nova_endpoint: OctaviaHelper.get_nova_endpoint(node),
+      octavia_keystone_settings: KeystoneHelper.keystone_settings(node, "octavia"),
+      rabbit_settings: fetch_rabbitmq_settings,
+      octavia_nova_flavor_id: flavor_id,
+      octavia_mgmt_net_id: net_id,
+      octavia_mgmt_sec_group_id: sec_group_id,
+      octavia_healthmanager_hosts: OctaviaHelper.get_healthmanager_nodes(node, net_name).join(",")
+    )
+  end
+end

--- a/chef/cookbooks/octavia/definitions/octavia_service.rb
+++ b/chef/cookbooks/octavia/definitions/octavia_service.rb
@@ -1,0 +1,33 @@
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+define :octavia_service do
+  package "openstack-octavia-#{params[:name]}" if ["rhel", "suse"].include? node[:platform_family]
+
+  conf = if params[:name] == "api"
+    "/etc/octavia/octavia.conf"
+  else
+    "/etc/octavia/octavia-#{params[:name]}.conf"
+  end
+
+  service "octavia-#{params[:name]}" do
+    service_name "openstack-octavia-#{params[:name]}"
+    supports status: true, restart: true
+    action [:enable, :start]
+    subscribes :restart, resources(template: conf)
+  end
+
+  utils_systemd_service_restart "openstack-octavia-#{params[:name]}"
+end

--- a/chef/cookbooks/octavia/libraries/helpers.rb
+++ b/chef/cookbooks/octavia/libraries/helpers.rb
@@ -1,0 +1,106 @@
+# Copyright 2019 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module OctaviaHelper
+  class << self
+    def get_neutron_endpoint(node)
+      neutron = CrowbarUtilsSearch.node_search_with_cache(node, "roles:neutron-server").first || {}
+      neutron_protocol = neutron[:neutron][:api][:protocol]
+      neutron_ha = neutron[:neutron][:ha][:server][:enabled]
+      neutron_server_host = CrowbarHelper.get_host_for_admin_url(neutron, neutron_ha)
+      neutron_server_port = neutron[:neutron][:api][:service_port]
+      neutron_protocol + "://" + neutron_server_host + ":" + neutron_server_port.to_s
+    end
+
+    def get_nova_endpoint(node)
+      nova = CrowbarUtilsSearch.node_search_with_cache(node, "roles:nova-controller").first || {}
+      nova_protocol = nova[:nova][:ssl][:enabled] ? "https" : "http"
+      nova_server_host = CrowbarHelper.get_host_for_admin_url(nova, nova[:nova][:ha][:enabled])
+      nova_server_port = nova[:nova][:ports][:api]
+      nova_protocol + "://" + nova_server_host + ":" + nova_server_port.to_s + "/v2.1"
+    end
+
+    def get_openstack_command(node, config)
+      key_settings = KeystoneHelper.keystone_settings(node, "octavia")
+
+      env = "OS_USERNAME='#{key_settings["service_user"]}' "
+      env << "OS_PASSWORD='#{key_settings["service_password"]}' "
+      env << "OS_PROJECT_NAME='#{key_settings["service_tenant"]}' "
+      env << "OS_AUTH_URL='#{key_settings["internal_auth_url"]}' "
+      env << "OS_REGION_NAME='#{key_settings["endpoint_region"]}' "
+      env << "OS_INTERFACE=internal "
+      env << "OS_USER_DOMAIN_NAME=Default "
+      env << "OS_PROJECT_DOMAIN_NAME=Default "
+      env << "OS_IDENTITY_API_VERSION=3"
+
+      ssl_insecure = CrowbarOpenStackHelper.insecure(config) || key_settings["insecure"]
+      "#{env} openstack #{ssl_insecure ? "--insecure" : ""}"
+    end
+
+    def get_healthmanager_nodes(node, net_name)
+      list = CrowbarUtilsSearch.node_search_with_cache(node, "roles:octavia-health-manager") || {}
+
+      hm_port = node[:octavia]["health_manager"][:port]
+      hm_node_list = []
+      list.each do |e|
+        address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(e, net_name).address
+        str = address + ":" + hm_port.to_s
+        hm_node_list << str unless hm_node_list.include?(str)
+      end
+
+      hm_node_list
+    end
+
+    def find_cluster_ips(node)
+      @cluster_admin_ip ||= nil
+
+      cluster_vhostname = CrowbarPacemakerHelper.cluster_vhostname(node)
+      @cluster_admin_ip = CrowbarPacemakerHelper.cluster_vip(node, "admin", cluster_vhostname)
+      @cluster_public_ip = CrowbarPacemakerHelper.cluster_vip(node, "public", cluster_vhostname)
+
+      [@cluster_admin_ip, @cluster_public_ip]
+    end
+
+    def find_ips(node)
+      @admin_ip ||= Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+      @public_ip ||= Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
+      [@admin_ip, @public_ip]
+    end
+
+    def network_settings(node)
+      ha_enabled = node[:octavia][:ha][:enabled]
+
+      if ha_enabled
+        admin_ip, public_ip = find_cluster_ips(node)
+      else
+        admin_ip, public_ip = find_ips(node)
+      end
+
+      api_bind_host = node[:octavia][:api][:bind_open_address] ? "0.0.0.0" : public_ip
+      hm_host = node[:octavia][:health_manager][:bind_open_address] ? "0.0.0.0" : admin_ip
+
+      @network_settings ||= {
+        api: {
+          bind_host: api_bind_host,
+          bind_port: ha_enabled ? node[:octavia][:ha][:ports][:api] : node[:octavia][:api][:port],
+          ha_port: node[:octavia][:api][:port]
+        },
+        health_manager: {
+          bind_host: hm_host
+        },
+      }
+    end
+  end
+end

--- a/chef/cookbooks/octavia/metadata.json
+++ b/chef/cookbooks/octavia/metadata.json
@@ -1,0 +1,41 @@
+{
+  "replacing": {
+
+  },
+  "platforms": {
+
+  },
+  "license": "Apache 2.0 License, Copyright (c) 2019 SUSE Linux GmbH. - http://www.apache.org/licenses/LICENSE-2.0",
+  "maintainer_email": "crowbar@Dell.com",
+  "groupings": {
+
+  },
+  "recommendations": {
+
+  },
+  "suggestions": {
+
+  },
+  "description": "Openstack Octavia server deployment recipes.",
+  "version": "1.0.0",
+  "conflicting": {
+
+  },
+  "attributes": {
+
+  },
+  "long_description": "This cookbook deployes the openstack octavia LBaaS\r\n ",
+  "name": "octavia",
+  "recipes": {
+
+  },
+  "providing": {
+
+  },
+  "dependencies": {
+    "apt": [
+
+    ]
+  },
+  "maintainer": "SUSE Linux, GmbH."
+}

--- a/chef/cookbooks/octavia/metadata.rb
+++ b/chef/cookbooks/octavia/metadata.rb
@@ -1,0 +1,18 @@
+name "octavia"
+maintainer "Crowbar project"
+maintainer_email "crowbar@googlegroups.com"
+license "Apache 2.0 License, Copyright (c) 2019 SUSE Linux GmbH. - http://www.apache.org/licenses/LICENSE-2.0"
+description "Openstack Octavia server deployment recipes."
+long_description IO.read(File.join(File.dirname(__FILE__), "README.rdoc"))
+version "1.0"
+
+depends "database"
+depends "crowbar-openstack"
+depends "crowbar-pacemaker"
+depends "keystone"
+depends "neutron"
+depends "nova"
+depends "cinder"
+depends "glance"
+depends "barbican"
+depends "utils"

--- a/chef/cookbooks/octavia/recipes/api.rb
+++ b/chef/cookbooks/octavia/recipes/api.rb
@@ -1,0 +1,41 @@
+# Copyright 2019 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+file node[:octavia][:octavia_log_dir] + "/octavia-api.log" do
+  action :touch
+  owner node[:octavia][:user]
+  group node[:octavia][:group]
+  mode 0o640
+end
+
+file node[:octavia][:octavia_log_dir] + "/octavia-api-json.log" do
+  action :touch
+  owner node[:octavia][:user]
+  group node[:octavia][:group]
+  mode 0o640
+end
+
+octavia_config = Barclamp::Config.load("openstack", "octavia")
+cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+
+octavia_conf "api" do
+  cmd cmd
+end
+
+package "openstack-octavia-api" if ["rhel", "suse"].include? node[:platform_family]
+
+include_recipe "#{@cookbook_name}::database"
+
+octavia_service "api"

--- a/chef/cookbooks/octavia/recipes/api_ha.rb
+++ b/chef/cookbooks/octavia/recipes/api_ha.rb
@@ -1,0 +1,19 @@
+unless node[:octavia][:ha][:enabled]
+  log "HA support for octavia is disabled"
+  return
+end
+
+log "HA support for octavia is enabled"
+
+network_settings = OctaviaHelper.network_settings(node)
+
+include_recipe "crowbar-pacemaker::haproxy"
+
+haproxy_loadbalancer "octavia-api" do
+  address network_settings[:api][:bind_host]
+  port node[:octavia][:api][:port]
+  use_ssl node[:octavia][:api][:protocol] == "https"
+  servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "octavia", "octavia-api", "api")
+  rate_limit node[:octavia][:ha_rate_limit]["octavia-api"]
+  action :nothing
+end.run_action(:create)

--- a/chef/cookbooks/octavia/recipes/common.rb
+++ b/chef/cookbooks/octavia/recipes/common.rb
@@ -1,0 +1,41 @@
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+group "octavia" do
+  group_name node[:octavia][:group]
+  system true
+end
+
+user "octavia" do
+  shell "/bin/bash"
+  comment "Octavia user Server"
+  gid node[:octavia][:group]
+  system true
+  supports manage_home: false
+end
+
+directory node[:octavia][:octavia_log_dir] do
+  owner node[:octavia][:user]
+  group node[:octavia][:group]
+  recursive true
+end
+
+directory node[:octavia][:octavia_config_dir] do
+  owner node[:octavia][:user]
+  group node[:octavia][:group]
+  recursive true
+end
+
+package "python-octaviaclient"

--- a/chef/cookbooks/octavia/recipes/database.rb
+++ b/chef/cookbooks/octavia/recipes/database.rb
@@ -1,0 +1,66 @@
+# Copyright 2019 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ha_enabled = node[:octavia][:ha][:enabled]
+
+db_settings = fetch_database_settings
+crowbar_pacemaker_sync_mark "wait-octavia_database" if ha_enabled
+
+db_user = node[:octavia][:db][:user]
+db_pass = node[:octavia][:db][:password]
+db_name = node[:octavia][:db][:database]
+
+# Create the Octavia Database
+
+database "create #{db_name} octavia database" do
+  connection db_settings[:connection]
+  database_name db_name
+  provider db_settings[:provider]
+  action :create
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+database_user "create #{db_user} user in #{db_name} octavia database" do
+  connection db_settings[:connection]
+  username db_user
+  password db_pass
+  host "%"
+  provider db_settings[:user_provider]
+  action :create
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+database_user "grant database access for #{db_user} user in #{db_name} octavia database" do
+  connection db_settings[:connection]
+  username db_user
+  password db_pass
+  database_name db_name
+  host "%"
+  privileges db_settings[:privs]
+  provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
+  action :grant
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+execute "create database initial content" do
+  command "octavia-db-manage upgrade head"
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+crowbar_pacemaker_sync_mark "create-octavia_database" if ha_enabled

--- a/chef/cookbooks/octavia/recipes/health_manager.rb
+++ b/chef/cookbooks/octavia/recipes/health_manager.rb
@@ -1,0 +1,30 @@
+# Copyright 2019 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+file node[:octavia][:octavia_log_dir] + "/octavia-health-manager.log" do
+  action :touch
+  owner node[:octavia][:user]
+  group node[:octavia][:group]
+  mode 0o640
+end
+
+octavia_config = Barclamp::Config.load("openstack", "octavia")
+cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+
+octavia_conf "health-manager" do
+  cmd cmd
+end
+
+octavia_service "health-manager"

--- a/chef/cookbooks/octavia/recipes/housekeeping.rb
+++ b/chef/cookbooks/octavia/recipes/housekeeping.rb
@@ -1,0 +1,37 @@
+# Copyright 2019 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+file node[:octavia][:octavia_log_dir] + "/octavia-housekeeping.log" do
+  action :touch
+  owner node[:octavia][:user]
+  group node[:octavia][:group]
+  mode 0o640
+end
+
+file node[:octavia][:octavia_log_dir] + "/octavia-housekeeping-json.log" do
+  action :touch
+  owner node[:octavia][:user]
+  group node[:octavia][:group]
+  mode 0o640
+end
+
+octavia_config = Barclamp::Config.load("openstack", "octavia")
+cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+
+octavia_conf "housekeeping" do
+  cmd cmd
+end
+
+octavia_service "housekeeping"

--- a/chef/cookbooks/octavia/recipes/https.rb
+++ b/chef/cookbooks/octavia/recipes/https.rb
@@ -1,0 +1,25 @@
+# Copyright 2019 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if node[@cookbook_name][:api][:protocol] == "https"
+  ssl_setup "setting up ssl for octavia" do
+    generate_certs node[@cookbook_name][:ssl][:generate_certs]
+    certfile node[@cookbook_name][:ssl][:certfile]
+    keyfile node[@cookbook_name][:ssl][:keyfile]
+    group node[@cookbook_name][:group]
+    fqdn node[:fqdn]
+    cert_required node[@cookbook_name][:ssl][:cert_required]
+    ca_certs node[@cookbook_name][:ssl][:ca_certs]
+  end
+end

--- a/chef/cookbooks/octavia/recipes/keystone.rb
+++ b/chef/cookbooks/octavia/recipes/keystone.rb
@@ -1,0 +1,97 @@
+# Copyright 2019 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+
+octavia_port = node[:octavia][:api][:port]
+octavia_protocol = node[:octavia][:api][:protocol]
+
+ha_enabled = node[:octavia][:ha][:enabled]
+
+my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
+my_public_host = CrowbarHelper.get_host_for_public_url(
+  node, node[:octavia][:api][:protocol] == "https", ha_enabled
+)
+
+register_auth_hash = { user: keystone_settings["admin_user"],
+                       password: keystone_settings["admin_password"],
+                       project: keystone_settings["admin_project"] }
+
+crowbar_pacemaker_sync_mark "wait-octavia_register" if ha_enabled
+
+keystone_register "octavia api wakeup keystone" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+keystone_register "register octavia user" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  user_password keystone_settings["service_password"]
+  project_name keystone_settings["service_tenant"]
+  action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+keystone_register "give octavia user access" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  user_name keystone_settings["service_user"]
+  project_name keystone_settings["service_tenant"]
+  role_name "admin"
+  action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+keystone_register "register octavia service" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  service_name "octavia"
+  service_type "load-balancer"
+  service_description "Openstack Octavia - Load Balancer"
+  action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+keystone_register "register octavia endpoint" do
+  protocol keystone_settings["protocol"]
+  insecure keystone_settings["insecure"]
+  host keystone_settings["internal_url_host"]
+  port keystone_settings["admin_port"]
+  auth register_auth_hash
+  endpoint_service "octavia"
+  endpoint_region keystone_settings["endpoint_region"]
+  endpoint_publicURL "#{octavia_protocol}://#{my_public_host}:#{octavia_port}/"
+  endpoint_adminURL "#{octavia_protocol}://#{my_admin_host}:#{octavia_port}/"
+  endpoint_internalURL "#{octavia_protocol}://#{my_admin_host}:#{octavia_port}/"
+  action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+crowbar_pacemaker_sync_mark "create-octavia_register" if ha_enabled

--- a/chef/cookbooks/octavia/recipes/lb_net_accessible_by_workers.rb
+++ b/chef/cookbooks/octavia/recipes/lb_net_accessible_by_workers.rb
@@ -1,0 +1,72 @@
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "ipaddr"
+
+def mask_to_bits(mask)
+  IPAddr.new(mask).to_i.to_s(2).count("1")
+end
+
+ha_enabled = node[:octavia][:ha][:enabled]
+octavia_config = Barclamp::Config.load("openstack", "octavia")
+cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+
+octavia_net = node[:octavia][:amphora][:manage_net]
+net_name = octavia_net[:name]
+router_name = "lb-router"
+
+octavia_range = "#{octavia_net["subnet"]}/#{mask_to_bits(octavia_net["netmask"])}"
+
+execute "create_octavia_router" do
+  command "#{cmd} router create #{router_name}"
+  only_if { octavia_net }
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  not_if "out=$(#{cmd} router list); [ $? != 0 ] || echo ${out} | grep -q ' #{router_name} '"
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+execute "add_octavia_subnet_to_router" do
+  command "#{cmd} router add subnet #{router_name} #{net_name}"
+  only_if { octavia_net }
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  not_if "out=$(#{cmd} router show #{router_name}); [ $? != 0 ] || echo ${out} | grep -q " \
+    "$(#{cmd} subnet show #{net_name} | tr -d ' ' | grep '|id|' | cut -d '|' -f 3)"
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+execute "set_octavia_set_external_gateway" do
+  command "#{cmd} router set --external-gateway floating #{router_name}"
+  only_if { octavia_net }
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+crowbar_pacemaker_sync_mark "sync-octavia-network-creation" if ha_enabled
+
+ruby_block "add_octavia_network_route" do
+  block do
+    filter = '| tr ":" "\n" | grep -A 1 ip_address | tail -n 1 | tr -d "\"|}|]|\\\\" | tr -d " "'
+    gateway_id = shell_out("#{cmd} router show #{router_name} -c external_gateway_info " \
+        " -f json #{filter}").stdout
+
+    shell_out("ip r add #{octavia_range} via #{gateway_id}")
+  end
+end

--- a/chef/cookbooks/octavia/recipes/networking.rb
+++ b/chef/cookbooks/octavia/recipes/networking.rb
@@ -1,0 +1,51 @@
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "ipaddr"
+
+def mask_to_bits(mask)
+  IPAddr.new(mask).to_i.to_s(2).count("1")
+end
+
+ha_enabled = node[:octavia][:ha][:enabled]
+octavia_config = Barclamp::Config.load("openstack", "octavia")
+cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+
+net_name = node[:octavia][:amphora][:manage_net]["name"]
+octavia_subnet = node[:octavia][:amphora][:manage_net][:subnet]
+octavia_mask = node[:octavia][:amphora][:manage_net][:netmask]
+octavia_range = "#{octavia_subnet}/#{mask_to_bits(octavia_mask)}"
+octavia_pool_start = node[:octavia][:amphora][:manage_net][:pool_start]
+octavia_pool_end = node[:octavia][:amphora][:manage_net][:pool_end]
+
+execute "create_octavia_network" do
+  command "#{cmd} network create --share #{net_name}"
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  not_if "out=$(#{cmd} network list); [ $? != 0 ] || echo ${out} | grep -q ' #{net_name} '"
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+execute "create_octavia_subnet" do
+  command "#{cmd} subnet create --network #{net_name} --ip-version=4 " \
+      "--allocation-pool start=#{octavia_pool_start},end=#{octavia_pool_end} " \
+      "--subnet-range #{octavia_range} --dhcp #{net_name}"
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  not_if "out=$(#{cmd} subnet list); [ $? != 0 ] || echo ${out} | grep -q ' #{net_name} '"
+  retries 5
+  retry_delay 10
+  action :run
+end

--- a/chef/cookbooks/octavia/recipes/nova.rb
+++ b/chef/cookbooks/octavia/recipes/nova.rb
@@ -1,0 +1,90 @@
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/mixin/shell_out"
+
+package "openstack-octavia-amphora-image-x86_64"
+
+ha_enabled = node[:octavia][:ha][:enabled]
+octavia_config = Barclamp::Config.load("openstack", "octavia")
+cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+
+sec_group = node[:octavia][:amphora][:sec_group]
+project_name = node[:octavia][:amphora][:project]
+
+execute "create_security_group" do
+  command "#{cmd} security group create #{sec_group} --project #{project_name} "\
+    "--description \"Octavia Management Security Group\""
+  not_if "out=$(#{cmd} security group list); [ $? != 0 ] || echo ${out} | grep -q ' #{sec_group} '"
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+execute "add_amphora_port_to_amphora_security_group" do
+  command "#{cmd} security group rule create --protocol tcp --dst-port 9443:9443 #{sec_group}"
+  not_if "out=$(#{cmd} security group show #{sec_group}); [ $? != 0 ] || echo ${out} | " \
+    "grep -q \"'9443'\""
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+execute "add_ssh_to_amphora_security_group" do
+  command "#{cmd} security group rule create --protocol tcp --dst-port 22:22 #{sec_group}"
+  not_if "out=$(#{cmd} security group show #{sec_group}); [ $? != 0 ] || echo ${out} | " \
+    "grep -q \"'22'\""
+  only_if { node[:octavia][:amphora][:ssh_access] }
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+execute "add_icmp_to_amphora_security_group" do
+  command "#{cmd} security group rule create --protocol icmp #{sec_group}"
+  not_if "out=$(#{cmd} security group show #{sec_group}); [ $? != 0 ] || echo ${out} | " \
+    "grep -q \"'icmp'\""
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+flavor = node[:octavia][:amphora][:flavor]
+
+execute "create_amphora_flavor" do
+  command "#{cmd} flavor create --public --ram 1024 --disk 2 --vcpus 1 #{flavor}"
+  not_if "out=$(#{cmd} flavor list); [ $? != 0 ] || echo ${out} | grep -q ' #{flavor} '"
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  retries 5
+  retry_delay 10
+  action :run
+end
+
+package = "openstack-octavia-amphora-image-x86_64"
+image_tag = node[:octavia][:amphora][:image_tag]
+
+execute "create_amphora_flavor" do
+  command "#{cmd} image create --disk-format qcow2 --container-format bare "\
+    "--file $(rpm -ql #{package} | grep qcow2 | head -n 1) --tag #{image_tag} #{image_tag}"
+  not_if "out=$(#{cmd} image list); [ $? != 0 ] || echo ${out} | grep -q ' #{image_tag} '"
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  retries 5
+  retry_delay 10
+  action :run
+end

--- a/chef/cookbooks/octavia/recipes/role_octavia_api.rb
+++ b/chef/cookbooks/octavia/recipes/role_octavia_api.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2019, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "octavia", "octavia-api")
+  include_recipe "#{@cookbook_name}::common"
+  include_recipe "#{@cookbook_name}::https"
+  include_recipe "#{@cookbook_name}::keystone"
+  include_recipe "#{@cookbook_name}::networking"
+  include_recipe "#{@cookbook_name}::nova"
+  include_recipe "#{@cookbook_name}::api_ha"
+  include_recipe "#{@cookbook_name}::api"
+end

--- a/chef/cookbooks/octavia/recipes/role_octavia_health_manager.rb
+++ b/chef/cookbooks/octavia/recipes/role_octavia_health_manager.rb
@@ -1,0 +1,20 @@
+#
+# Copyright 2019, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "octavia", "octavia-health-manager")
+  include_recipe "#{@cookbook_name}::common"
+  include_recipe "#{@cookbook_name}::health_manager"
+end

--- a/chef/cookbooks/octavia/recipes/role_octavia_housekeeping.rb
+++ b/chef/cookbooks/octavia/recipes/role_octavia_housekeeping.rb
@@ -1,0 +1,20 @@
+#
+# Copyright 2019, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "octavia", "octavia-housekeeping")
+  include_recipe "#{@cookbook_name}::common"
+  include_recipe "#{@cookbook_name}::housekeeping"
+end

--- a/chef/cookbooks/octavia/recipes/role_octavia_worker.rb
+++ b/chef/cookbooks/octavia/recipes/role_octavia_worker.rb
@@ -1,0 +1,21 @@
+#
+# Copyright 2019, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "octavia", "octavia-worker")
+  include_recipe "#{@cookbook_name}::common"
+  include_recipe "#{@cookbook_name}::lb_net_accessible_by_workers"
+  include_recipe "#{@cookbook_name}::worker"
+end

--- a/chef/cookbooks/octavia/recipes/worker.rb
+++ b/chef/cookbooks/octavia/recipes/worker.rb
@@ -1,0 +1,29 @@
+# Copyright 2019 SUSE Linux GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+file node[:octavia][:octavia_log_dir] + "/octavia-worker.log" do
+  action :touch
+  owner node[:octavia][:user]
+  group node[:octavia][:group]
+  mode 0o640
+end
+
+octavia_config = Barclamp::Config.load("openstack", "octavia")
+cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+
+octavia_conf "worker" do
+  cmd cmd
+end
+
+octavia_service "worker"

--- a/chef/cookbooks/octavia/templates/default/octavia.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/octavia.conf.erb
@@ -1,0 +1,130 @@
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[DEFAULT]
+debug = <%= @node[:octavia][:debug] %>
+transport_url = <%= @rabbit_settings[:url] %>
+
+[api_settings]
+api_handler = queue_producer
+bind_host = <%= @bind_host %>
+bind_port = <%= @bind_port %>
+
+[certificates]
+cert_generator = local_cert_generator
+cert_manager = barbican_cert_manager
+ca_certificate = <%= @node[:octavia][:certs][:cert_path] %><%= @node[:octavia][:certs][:server_ca_cert_path] %>
+ca_private_key = <%= @node[:octavia][:certs][:cert_path] %><%= @node[:octavia][:certs][:server_ca_key_path] %>
+ca_private_key_passphrase = <%= @node[:octavia][:certs][:passphrase] %>
+
+[controller_worker]
+amp_active_retries = 40
+amp_active_wait_sec = 10
+amp_flavor_id = <%= @octavia_nova_flavor_id %>
+amp_image_tag = <%= @node[:octavia][:amphora][:image_tag] %>
+amp_boot_network_list = <%= @octavia_mgmt_net_id %>
+amp_secgroup_list = <%= @octavia_mgmt_sec_group_id %>
+client_ca = <%= @node[:octavia][:certs][:cert_path]%><%=@node[:octavia][:certs][:client_ca_cert_path] %>
+compute_driver = compute_nova_driver
+amphora_driver = amphora_haproxy_rest_driver
+network_driver = allowed_address_pairs_driver
+loadbalancer_topology = SINGLE
+<% if @node[:octavia][:amphora][:ssh_access][:enabled] -%>
+amp_ssh_key_name = "<%= @node[:octavia][:amphora][:ssh_access][:keyname]%>"
+<% end %>
+
+[database]
+connection = <%= @octavia_db_connection %>
+
+[haproxy_amphora]
+client_cert = <%= @node[:octavia][:certs][:cert_path]%><%=@node[:octavia][:certs][:client_cert_and_key_path] %>
+server_ca = <%= @node[:octavia][:certs][:cert_path]%><%=@node[:octavia][:certs][:server_ca_cert_path] %>
+key_path = <%= @node[:octavia][:certs][:cert_path]%><%= @node[:octavia][:amphora][:keypair_private_cert]%>
+base_path = /var/lib/octavia
+base_cert_dir = <%= @node[:octavia][:certs][:cert_path]%>
+connection_max_retries = <%= @node[:octavia][:amphora][:connection_max_retries] %>
+connection_retry_interval = <%= @node[:octavia][:amphora][:connection_retry_interval] %>
+
+[health_manager]
+bind_ip = <%= @bind_host %>
+bind_port = <%= @node[:octavia][:health_manager][:port] %>
+controller_ip_port_list = <%= @octavia_healthmanager_hosts %>
+heartbeat_key = <%= @node[:octavia][:health_manager][:heartbeat_key] %>
+event_streamer_driver = queue_event_streamer
+heartbeat_interval = <%= @node[:octavia][:health_manager][:heartbeat_interval] %>
+heartbeat_timeout = <%= @node[:octavia][:health_manager][:heartbeat_timeout] %>
+health_check_interval = <%= @node[:octavia][:health_manager][:health_check_interval] %>
+
+[house_keeping]
+
+[keystone_authtoken]
+auth_version = <%= @octavia_keystone_settings['api_version'] %>
+www_authenticate_uri = <%= @octavia_keystone_settings["public_auth_url"] %>
+auth_url = <%= KeystoneHelper.versioned_service_URL(@octavia_keystone_settings["protocol"],
+                                                    @octavia_keystone_settings["internal_url_host"],
+                                                    @octavia_keystone_settings["service_port"],
+                                                    @octavia_keystone_settings['api_version']) %>
+auth_type = password
+project_name = <%= @octavia_keystone_settings['service_tenant'] %>
+project_domain_name = Default
+user_domain_name = Default
+username = <%= @octavia_keystone_settings['service_user'] %>
+password =  <%= @octavia_keystone_settings['service_password'] %>
+region_name = <%= @octavia_keystone_settings['endpoint_region'] %>
+
+[networking]
+port_detach_timeout = <%= @node[:octavia][:networking][:port_detach_timeout] %>
+
+[neutron]
+endpoint = <%= @neutron_endpoint %>
+endpoint_type = "internalURL"
+
+[nova]
+endpoint = <%= @nova_endpoint %>
+endpoint_type = "internalURL"
+
+[oslo_messaging]
+topic = octavia_prov
+rpc_thread_pool_size = <%= @node[:octavia][:oslo][:rpc_thread_pool_size] %>
+
+[oslo_messaging_rabbit]
+amqp_durable_queues = <%= @rabbit_settings[:durable_queues] %>
+rabbit_ha_queues = <%= @rabbit_settings[:ha_queues] %>
+ssl = <%= @rabbit_settings[:use_ssl] %>
+<% if @rabbit_settings[:client_ca_certs] -%>
+ssl_ca_file = <%= @rabbit_settings[:client_ca_certs] %>
+<% end -%>
+heartbeat_timeout_threshold = <%= @rabbit_settings[:heartbeat_timeout] %>
+
+[service_auth]
+auth_version = <%= @octavia_keystone_settings['api_version'] %>
+www_authenticate_uri = <%= @octavia_keystone_settings["public_auth_url"] %>
+auth_url = <%= KeystoneHelper.versioned_service_URL(@octavia_keystone_settings["protocol"],
+                                                    @octavia_keystone_settings["internal_url_host"],
+                                                    @octavia_keystone_settings["service_port"],
+                                                    @octavia_keystone_settings['api_version']) %>
+auth_type = password
+project_name = <%= @octavia_keystone_settings['service_project'] %>
+project_domain_name = Default
+user_domain_name = Default
+username = <%= @octavia_keystone_settings['service_user'] %>
+password =  <%= @octavia_keystone_settings['service_password'] %>
+region_name = <%= @octavia_keystone_settings['endpoint_region'] %>
+cafile = /etc/ssl/ca-bundle.pem
+
+<% if @node[:octavia][:debug] %>
+[task_flow]
+disable_revert = False
+<% end %>

--- a/chef/data_bags/crowbar/template-octavia.json
+++ b/chef/data_bags/crowbar/template-octavia.json
@@ -1,0 +1,111 @@
+{
+  "id": "template-octavia",
+  "description": "API-enabled, pluggable virtual network service for OpenStack",
+  "attributes": {
+    "octavia": {
+      "user": "octavia",
+      "group": "octavia",
+      "debug": false,
+      "nova_instance": "none",
+      "neutron_instance": "none",
+      "barbican_instance": "none",
+      "keystone_instance": "none",
+      "glance_instance": "none",
+      "service_user": "octavia",
+      "service_password": "",
+      "api": {
+        "bind_open_address": true,
+        "protocol": "http"
+      },
+      "db": {
+        "user": "octavia",
+        "password": "none",
+        "database": "octavia"
+      },
+      "oslo": {
+        "rpc_thread_pool_size": 2
+      },
+      "networking": {
+        "port_detach_timeout": 900
+      },
+      "health_manager": {
+        "bind_open_address": false,
+        "heartbeat_interval": 10,
+        "heartbeat_timeout": 180,
+        "health_check_interval": 3,
+        "heartbeat_key": ""
+      },
+      "certs": {
+        "passphrase": "",
+        "server_ca_cert_path": "server_ca/certs/ca.cert.pem",
+        "server_ca_key_path": "server_ca/private/ca.key.pem",
+        "client_ca_cert_path": "client_ca/certs/ca.cert.pem",
+        "client_cert_and_key_path": "client_ca/private/client.cert-and-key.pem"
+      },
+      "amphora": {
+        "connection_max_retries": 300,
+        "connection_retry_interval": 10,
+        "flavor": "m1.lbaas.amphora",
+        "sec_group": "lb-mgmt-sec-group",
+        "manage_net": {
+          "name": "lb-mgmt-net",
+          "subnet": "192.168.127.0",
+          "netmask": "255.255.255.0",
+          "pool_start": "192.168.127.10",
+          "pool_end": "192.168.127.254"
+        },
+        "image_tag": "amphora",
+        "project": "service",
+        "ssh_access": {
+          "enabled": false,
+          "keyname": ""
+        }
+      },
+      "ssl": {
+        "certfile": "/etc/octavia/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/octavia/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
+        "cert_required": false,
+        "ca_certs": "/etc/octavia/ssl/certs/ca.pem"
+      },
+      "ha": {
+        "ports": {
+          "api": 19876
+        }
+      },
+      "ha_rate_limit": {
+        "octavia-api": 0
+      }
+    }
+  },
+  "deployment": {
+    "octavia": {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "schema-revision": 300,
+      "element_states": {
+        "octavia-api": [ "readying", "ready", "applying" ],
+        "octavia-health-manager": [ "readying", "ready", "applying" ],
+        "octavia-housekeeping": [ "readying", "ready", "applying" ],
+        "octavia-worker": [ "readying", "ready", "applying" ]
+      },
+      "elements": {},
+      "element_order": [
+         ["octavia-api", "octavia-health-manager", "octavia-housekeeping", "octavia-worker"]
+      ],
+      "element_run_list_order": {
+        "octavia-api": 102,
+        "octavia-health-manager": 103,
+        "octavia-housekeeping": 104,
+        "octavia-worker": 105
+      },
+      "config": {
+        "environment": "octavia-config-base",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": []
+      }
+    }
+  }
+}

--- a/chef/data_bags/crowbar/template-octavia.schema
+++ b/chef/data_bags/crowbar/template-octavia.schema
@@ -1,0 +1,162 @@
+{
+  "type": "map", "required": true,
+  "mapping": {
+    "id": { "type": "str", "required": true, "pattern": "/^octavia-|^template-octavia$/" },
+    "description": { "type": "str", "required": true },
+    "attributes": { "type": "map", "required": true,
+      "mapping": {
+        "octavia": { "type": "map", "required": true,
+             "mapping": {
+                    "user": { "type": "str", "required": true },
+                    "group": { "type": "str", "required": true },
+                    "debug": { "type": "bool", "required": true },
+                    "nova_instance": { "type": "str", "required": true },
+                    "neutron_instance": { "type": "str", "required": true },
+                    "barbican_instance": { "type": "str", "required": true },
+                    "keystone_instance": { "type": "str", "required": true },
+                    "glance_instance": { "type": "str", "required": true },
+                    "service_user": { "type": "str", "required": true },
+                    "service_password": { "type": "str", "required": true },
+                    "api": { "type": "map", "required": true,
+                      "mapping": {
+                        "bind_open_address": { "type": "bool", "required": true },
+                        "protocol": { "type": "str", "required": true }
+                      }
+                    },
+                    "db": { "type": "map", "required": true,
+                      "mapping": {
+                        "user": { "type": "str", "required": true },
+                        "password": { "type": "str", "required": true },
+                        "database": { "type": "str", "required": true }
+                      }
+                    },
+                    "oslo": { "type": "map", "required": true,
+                      "mapping": {
+                        "rpc_thread_pool_size": { "type": "int", "required": true }
+                      }
+                    },
+                    "networking": { "type": "map", "required": true,
+                      "mapping": {
+                        "port_detach_timeout": { "type": "int", "required": true }
+                      }
+                    },
+                    "health_manager": { "type": "map", "required": true,
+                      "mapping": {
+                        "bind_open_address": { "type": "bool", "required": true },
+                        "heartbeat_interval": { "type": "int", "required": true },
+                        "heartbeat_timeout": { "type": "int", "required": true },
+                        "health_check_interval": { "type": "int", "required": true },
+                        "heartbeat_key": { "type": "str", "required": true }
+                      }
+                    },
+                    "certs": { "type": "map", "required": true,
+                      "mapping": {
+                        "passphrase": { "type": "str", "required": true },
+                        "server_ca_cert_path": { "type": "str", "required": true },
+                        "server_ca_key_path": { "type": "str", "required": true },
+                        "client_ca_cert_path": { "type": "str", "required": true },
+                        "client_cert_and_key_path": { "type": "str", "required": true }
+                      }
+                    },
+                    "amphora": { "type": "map", "required": true,
+                      "mapping": {
+                        "connection_max_retries": { "type": "int", "required": true },
+                        "connection_retry_interval": { "type": "int", "required": true },
+                        "flavor": { "type": "str", "required": true },
+                        "sec_group": { "type": "str", "required": true },
+                        "manage_net": { "type": "map", "required": true,
+                          "mapping": {
+                            "name": { "type": "str", "required": true },
+                            "subnet": { "type": "str", "required": true },
+                            "netmask": { "type": "str", "required": true },
+                            "pool_start": { "type": "str", "required": true },
+                            "pool_end": { "type": "str", "required": true }
+                          }
+                        },
+                        "image_tag": { "type": "str", "required": true },
+                        "project": { "type": "str", "required": true },
+                        "ssh_access": { "type": "map", "required": true,
+                          "mapping": {
+                            "enabled": { "type": "bool", "required": true },
+                            "keyname": { "type": "str", "required": true }
+                          }
+                        }
+                      }
+                    },
+                    "ssl": { "type": "map", "required": true, "mapping": {
+                      "certfile": { "type" : "str", "required" : true },
+                      "keyfile": { "type" : "str", "required" : true },
+                      "generate_certs": { "type" : "bool", "required" : true },
+                      "insecure": { "type" : "bool", "required" : true },
+                      "cert_required": { "type" : "bool", "required" : true },
+                      "ca_certs": { "type" : "str", "required" : true }
+                    }},
+                    "ha": { "type": "map", "required": true, "mapping": {
+                      "ports": { "type": "map", "required": true, "mapping": {
+                        "api": { "type": "int", "required": true }
+                      }}
+                    }},
+                    "ha_rate_limit": {
+                      "type": "map", "required": true, "mapping": {
+                        "octavia-api": { "type": "int", "required": true }
+                      }
+                    }
+              }
+        }
+     }},
+    "deployment": { "type": "map", "required": true,
+      "mapping": {
+        "octavia": { "type": "map", "required": true,
+          "mapping": {
+            "crowbar-revision": { "type": "int", "required": true },
+            "crowbar-committing": { "type": "bool" },
+            "crowbar-applied": { "type": "bool" },
+            "crowbar-status": { "type": "str" },
+            "crowbar-failed": { "type": "str" },
+            "crowbar-queued": { "type": "bool" },
+            "schema-revision": { "type": "int" },
+            "element_states": { "type": "map", "mapping": {
+                = : { "type": "seq", "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
+            "elements": { "type": "map", "required": true,
+              "mapping": {
+                = : {"type": "seq", "required": true,
+                  "sequence": [   { "type": "str" }  ]
+                }
+              }
+            },
+            "element_order": { "type": "seq", "required": true,
+              "sequence": [ {
+                "type": "seq",
+                "sequence": [ { "type": "str" } ]
+              } ]
+            },
+            "element_run_list_order": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                = : {
+                  "type": "int",
+                  "required": true
+                }
+              }
+            },
+            "config": { "type": "map", "required": true,
+              "mapping": {
+                "environment": { "type": "str", "required": true },
+                "mode": { "type": "str", "required": true },
+                "transitions": { "type": "bool", "required": true },
+                "transition_list": { "type": "seq", "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/chef/roles/octavia-api.rb
+++ b/chef/roles/octavia-api.rb
@@ -1,0 +1,6 @@
+name "octavia-api"
+description "Octavia API"
+
+run_list("recipe[octavia::role_octavia_api]")
+default_attributes
+override_attributes

--- a/chef/roles/octavia-health-manager.rb
+++ b/chef/roles/octavia-health-manager.rb
@@ -1,0 +1,6 @@
+name "octavia-health-manager"
+description "Octavia Health Manager"
+
+run_list("recipe[octavia::role_octavia_health_manager]")
+default_attributes
+override_attributes

--- a/chef/roles/octavia-housekeeping.rb
+++ b/chef/roles/octavia-housekeeping.rb
@@ -1,0 +1,6 @@
+name "octavia-housekeeping"
+description "Octavia Housekeeping"
+
+run_list("recipe[octavia::role_octavia_housekeeping]")
+default_attributes
+override_attributes

--- a/chef/roles/octavia-worker.rb
+++ b/chef/roles/octavia-worker.rb
@@ -1,0 +1,6 @@
+name "octavia-worker"
+description "Octavia Worker"
+
+run_list("recipe[octavia::role_octavia_worker]")
+default_attributes
+override_attributes

--- a/crowbar_framework/app/controllers/octavia_controller.rb
+++ b/crowbar_framework/app/controllers/octavia_controller.rb
@@ -1,0 +1,23 @@
+#
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class OctaviaController < BarclampController
+  protected
+
+  def initialize_service
+    @service_object = OctaviaService.new logger
+  end
+end

--- a/crowbar_framework/app/helpers/barclamp/octavia_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/octavia_helper.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Barclamp
+  module OctaviaHelper
+    def api_protocols_for_octavia(selected)
+      options_for_select(
+        [
+          ["HTTP", "http"],
+          ["HTTPS", "https"]
+        ],
+        selected.to_s
+      )
+    end
+  end
+end

--- a/crowbar_framework/app/models/octavia_service.rb
+++ b/crowbar_framework/app/models/octavia_service.rb
@@ -1,0 +1,186 @@
+#
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "openssl"
+
+class OctaviaService < OpenstackServiceObject
+  def initialize(thelogger = nil)
+    super(thelogger)
+    @bc_name = "octavia"
+  end
+
+  # Turn off multi proposal support till it really works and people ask for it.
+  def self.allow_multiple_proposals?
+    false
+  end
+
+  class << self
+    def role_constraints
+      {
+        "octavia-api" => {
+          "unique" => false,
+          "count" => 1,
+          "exclude_platform" => {
+            "suse" => "< 12.4",
+            "windows" => "/.*/"
+          },
+          "cluster" => true
+        },
+        "octavia-health-manager" => {
+          "unique" => false,
+          "count" => 1,
+          "exclude_platform" => {
+            "suse" => "< 12.4",
+            "windows" => "/.*/"
+          },
+          "cluster" => true
+        },
+        "octavia-housekeeping" => {
+          "unique" => false,
+          "count" => 1,
+          "exclude_platform" => {
+            "suse" => "< 12.4",
+            "windows" => "/.*/"
+          },
+          "cluster" => true
+        },
+        "octavia-worker" => {
+          "unique" => false,
+          "count" => 1,
+          "exclude_platform" => {
+            "suse" => "< 12.4",
+            "windows" => "/.*/"
+          },
+          "cluster" => true
+        }
+      }
+    end
+  end
+
+  def proposal_dependencies(role)
+    answer = []
+    answer << {
+      "barclamp" => "nova",
+      "inst" => role.default_attributes["octavia"]["nova_instance"]
+    }
+    answer << {
+      "barclamp" => "neutron",
+      "inst" => role.default_attributes["octavia"]["neutron_instance"]
+    }
+    answer << {
+      "barclamp" => "barbican",
+      "inst" => role.default_attributes["octavia"]["barbican_instance"]
+    }
+    answer << {
+      "barclamp" => "keystone",
+      "inst" => role.default_attributes["octavia"]["keystone_instance"]
+    }
+    answer << {
+      "barclamp" => "glance",
+      "inst" => role.default_attributes["octavia"]["glance_instance"]
+    }
+    answer
+  end
+
+  def save_proposal!(prop, options = {})
+    super(prop, options)
+  end
+
+  def validate_proposal_after_save(proposal)
+    certs = proposal["attributes"]["octavia"]["certs"]
+
+    if certs["server_ca_cert_path"] == "" || certs["server_ca_key_path"] == "" ||
+        certs["client_ca_cert_path"] == "" || certs["client_cert_and_key_path"] == ""
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.certificates_not_empty")
+    end
+
+    if certs["passphrase"] == ""
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.passphrase_not_empty")
+    end
+
+    ssh_access = proposal["attributes"]["octavia"]["amphora"]["ssh_access"]
+
+    if ssh_access["enabled"] && ssh_access["keyname"] == ""
+      validation_error I18n.t("barclamp.#{@bc_name}.validation.keyname_not_empty")
+    end
+
+    super
+  end
+
+  def create_poposal_password(base)
+    base["attributes"][@bc_name][:db][:password] = random_password
+    base["attributes"][@bc_name][:health_manager][:heartbeat_key] = random_password
+    base["attributes"][@bc_name][:service_password] = random_password
+  end
+
+  def create_proposal_set_nodes(base, nodes)
+    controller_nodes = nodes.select { |n| n.intended_role == "controller" }
+    controller_node = controller_nodes.first
+    controller_node ||= nodes.first
+
+    unless nodes.nil? || nodes.empty?
+      base["deployment"]["octavia"]["elements"] = {
+        "octavia-api" => [controller_node[:fqdn]],
+        "octavia-health-manager" => [controller_node[:fqdn]],
+        "octavia-housekeeping" => [controller_node[:fqdn]],
+        "octavia-worker" => [controller_node[:fqdn]]
+      }
+    end
+  end
+
+  def create_proposal
+    base = super
+
+    nodes = NodeObject.all
+    nodes.delete_if { |n| n.nil? || n.admin? }
+
+    base["attributes"][@bc_name]["nova_instance"] = find_dep_proposal("nova")
+    base["attributes"][@bc_name]["neutron_instance"] = find_dep_proposal("neutron")
+    base["attributes"][@bc_name]["barbican_instance"] = find_dep_proposal("barbican")
+    base["attributes"][@bc_name]["keystone_instance"] = find_dep_proposal("keystone")
+    base["attributes"][@bc_name]["glance_instance"] = find_dep_proposal("glance")
+
+    create_proposal_set_nodes(base, nodes)
+    create_poposal_password(base)
+
+    base
+  end
+
+  def apply_role_pre_chef_call(old_role, role, all_nodes)
+    @logger.debug("octavia apply_role_pre_chef_call: entering #{all_nodes.inspect}")
+    return if all_nodes.empty?
+
+    vip_networks = ["admin", "public"]
+
+    server_elements, server_nodes, ha_enabled = role_expand_elements(role, "octavia-api")
+    reset_sync_marks_on_clusters_founders(server_elements)
+    Openstack::HA.set_controller_role(server_nodes) if ha_enabled
+
+    role.save if prepare_role_for_ha_with_haproxy(role, ["octavia", "ha", "enabled"],
+                                                  ha_enabled, server_elements, vip_networks)
+
+    net_svc = NetworkService.new @logger
+    # All nodes must have a public IP, even if part of a cluster; otherwise
+    # the VIP can't be moved to the nodes
+    server_nodes.each do |n|
+      net_svc.allocate_ip "default", "public", "host", n
+    end
+
+    allocate_virtual_ips_for_any_cluster_in_networks(server_elements, vip_networks)
+
+    @logger.debug("octavia apply_role_pre_chef_call: leaving")
+  end
+end

--- a/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
@@ -1,0 +1,27 @@
+= attributes_for @proposal do
+  .panel-sub
+    = header show_raw_deployment?, true
+
+  .panel-body
+
+    %fieldset
+      %legend
+        = t(".certs_header")
+
+      = string_field %w(certs server_ca_cert_path)
+      = string_field %w(certs server_ca_key_path)
+      = string_field %w(certs client_ca_cert_path)
+      = string_field %w(certs client_cert_and_key_path)
+      = string_field %w(certs passphrase)
+
+    %fieldset
+      %legend
+        = t(".amphora_header")
+
+      = boolean_field %w(amphora ssh_access enabled),
+        "data-showit" => "true",
+        "data-showit-target" => "#ssh_access_keyname_containe",
+        "data-showit-direct" => "true"
+
+      #ssh_access_keyname_containe
+        = string_field %w(amphora ssh_access keyname)

--- a/crowbar_framework/config/locales/octavia/en.yml
+++ b/crowbar_framework/config/locales/octavia/en.yml
@@ -1,0 +1,40 @@
+#
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+en:
+  barclamp:
+    octavia:
+      edit_attributes:
+        api_header: 'Api'
+        api:
+          port: 'Port'
+          host: 'Host IP'
+        certs_header: 'CA Certificate Info'
+        certs:
+          server_ca_cert_path: 'Server CA certificate'
+          server_ca_key_path: 'Server CA key'
+          client_ca_cert_path: 'Client CA certificate'
+          client_cert_and_key_path: 'Client certificate concat key'
+          passphrase: 'Passphrase'
+        amphora_header: "Amphora Virtual Machines"
+        amphora:
+          ssh_access:
+            enabled: "Allow SSH Access"
+            keyname: "SSH Access Keypair Name"
+      validation:
+        certificates_not_empty: 'The certificates paths cannot be empty.'
+        passphrase_not_empty: 'Passphrase cannot be empty.'
+        keyname_not_empty: 'Keypair name cannot be empty if you enable ssh access.'

--- a/octavia.yml
+++ b/octavia.yml
@@ -1,0 +1,39 @@
+#
+# Copyright 2019, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp:
+  name: 'octavia'
+  display: 'Octavia'
+  description: 'Operator-scale load balancing solution designed to work with OpenStack.'
+  version: 0
+  user_managed: false
+  requires:
+    - 'nova'
+    - 'glance'
+    - 'neutron'
+    - 'barbican'
+    - 'keystone'
+    - 'rabbitmq'
+    - 'database'
+  member:
+    - 'openstack'
+
+crowbar:
+  layout: 1
+  order: 101
+  run_order: 101
+  chef_order: 101
+  proposal_schema_version: 1


### PR DESCRIPTION
This is the barclamp to deploy Octavia in crowbar.

Octavia: ha fixed and other fixes

Important changes
- Octavia-api is now in ha using haproxy
- all octavia services will be restarted by systemd if fails
- syncronization to create the octavia network route in each worker

Octavia: small fixes

octavia: various cosmetic fixes

* Fix barclamp name capitalization.
* Add ilausuch as Octavia codeowner
* Polish Octavia barclamp's README.rdoc.
* Removed API section in Octavia barclamp UI
* Added validation for certificate country code.

octavia: bind host/port fixes

* Remove bind host/port for API and health manager from data bag
* Add  bind_open_address setting for API and health manager to data bag
* Determine listen address/port based on bind_open_address and cloud type
  (single controller/HA)
* Move logic for determining bind host/port from template to octavia_conf
  definition.

octavia: network definiton in Octavia barclamp

This commit moves the definition of the Octavia management
network to the Octavia barclamp. Previously the Octavia
barclamp worked on the assumption that this network would be
defined in the Network barclamp.

octavia: use IP address for binding.

Some octavia services can only bind to raw IP addresses (i.e.
they won't perform reverse lookups on host names). They wil
fail when using the result of CrowbarHelper.get_host_for_admin_url().
Hence his commit switches over to raw IP addresses.

Octavia: Fix undeclared cluster_vhostname

Octavia: Clean up openstack calls

octavia: Fix name of octavia barclamp

It needs to be lowercase, as the template file for proposal is using
lowercase.

octavia: Only show the keyname attribute if ssh access is enbled

octavia: Fix text in the UI

There were some capitalization issues, and more.

Octavia: Fix router creation

Octavia: Prepare the octavia database form the cookbook

octavia: create and use OctaviaHelper.

This also shortens do block in octavia_conf define to a Hound
friendly length by using OctaviaHelper.

Make service specific config file sections conditional.

octavia: address Hound comments in helper.

Revert "Make service specific config file sections conditional."

This reverts commit 136bfe09555fc057b82d14c67b435debf6d285cd.

octavia: switch back to static health manager bind port

Octavia: fixed helpers

octavio: add timeout settings for amphora build.

Octavia: removed subdoers

Octavia: Fix database creation content

Octavia: Simplification of openstack command

+ some hound problems solved

Octavia: simplify network_settings method

Octavia: Deleted certificates generation & more

- Removed migrations
- Fix problem when octavia router is created

Octavia: removed random passphrase initialization (certificates)

octavia: fix non-HA port for API.