### PR TITLE
nova, neutron: Hide the ZVM attributes

### DIFF
--- a/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/neutron/_edit_attributes.html.haml
@@ -153,17 +153,6 @@
 
     %fieldset
       %legend
-        = t(".zvm_header")
-
-      = string_field %w(zvm zvm_xcat_server)
-      = string_field %w(zvm zvm_xcat_username)
-      = password_field %w(zvm zvm_xcat_password)
-      = string_field %w(zvm zvm_physnet_rdev)
-      = string_field %w(zvm xcat_mgt_ip)
-      = string_field %w(zvm xcat_mgt_mask)
-
-    %fieldset
-      %legend
         = t(".ssl_header")
 
       = select_field %w(api protocol), :collection => :api_protocols_for_neutron, "data-sslprefix" => "ssl", "data-sslcert" => "/etc/neutron/ssl/certs/signing_cert.pem", "data-sslkey" => "/etc/neutron/ssl/private/signing_key.pem"

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -56,21 +56,6 @@
 
     %fieldset
       %legend
-        = t(".zvm_header")
-
-      = string_field %w(zvm zvm_xcat_server)
-      = string_field %w(zvm zvm_xcat_username)
-      = password_field %w(zvm zvm_xcat_password)
-      = string_field %w(zvm zvm_diskpool)
-      = select_field %w(zvm zvm_diskpool_type), :collection => :zvm_diskpool_types
-      = string_field %w(zvm zvm_host)
-      = string_field %w(zvm zvm_user_profile)
-      = string_field %w(zvm zvm_scsi_pool)
-      = string_field %w(zvm zvm_xcat_master)
-      = string_field %w(zvm zvm_xcat_ssh_key)
-
-    %fieldset
-      %legend
         = t(".ssl_header")
 
       = boolean_field %w(ssl enabled), :collection => :ssl_protocols_for_nova, "data-sslprefix" => "ssl", "data-sslcert" => "/etc/nova/ssl/certs/signing_cert.pem", "data-sslkey" => "/etc/nova/ssl/private/signing_key.pem"

--- a/crowbar_framework/config/locales/neutron/en.yml
+++ b/crowbar_framework/config/locales/neutron/en.yml
@@ -85,14 +85,6 @@ en:
           controllers: 'VMware NSX Controllers'
           tz_uuid: 'UUID of the NSX Transport Zone'
           l3_gw_uuid: 'UUID of the NSX Gateway Service'
-        zvm_header: 'z/VM Configuration'
-        zvm:
-          zvm_xcat_server: 'xCAT Host/IP Address'
-          zvm_xcat_username: 'xCAT Username'
-          zvm_xcat_password: 'xCAT Password'
-          zvm_physnet_rdev: 'rdev list for physnet1 vswitch uplink (if available)'
-          xcat_mgt_ip: 'xCAT IP Address on Management Network'
-          xcat_mgt_mask: 'Net Mask of Management Network'
         ssl_header: 'SSL Support'
         api:
           protocol: 'Protocol'

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -52,18 +52,6 @@ en:
           insecure: 'vCenter SSL Certificate is insecure (for instance, self-signed)'
           vnc_keymap: 'Keymap'
         vmware_cluster_hint: 'A comma-separated list of cluster names'
-        zvm_header: 'z/VM Configuration'
-        zvm:
-          zvm_xcat_server: 'xCAT Host/IP Address'
-          zvm_xcat_username: 'xCAT Username'
-          zvm_xcat_password: 'xCAT Password'
-          zvm_diskpool: 'z/VM disk pool for ephemeral disks'
-          zvm_diskpool_type: 'z/VM disk pool type for ephemeral disks (ECKD or FBA)'
-          zvm_host: 'z/VM Host Managed By xCAT MN'
-          zvm_scsi_pool: 'Default zFCP SCSI Disk Pool'
-          zvm_user_profile: 'User profile for creating a z/VM userid'
-          zvm_xcat_master: 'The xCAT MN node name'
-          zvm_xcat_ssh_key: 'The xCAT MN node public SSH key'
         ssl_header: 'SSL Support'
         ssl:
           enabled: 'Protocol'


### PR DESCRIPTION
This is not supported, so keep the attributes for the raw view.