### PR TITLE
designate: allow worker on cluster.

### DIFF
--- a/chef/cookbooks/designate/definitions/designate_service.rb
+++ b/chef/cookbooks/designate/definitions/designate_service.rb
@@ -16,7 +16,6 @@
 define :designate_service do
   designate_service_name = "designate-#{params[:name]}"
   ha_enabled = node[:designate][:ha][:enabled]
-  use_crowbar_pacemaker_service = ha_enabled && node[:pacemaker][:clone_stateless_services]
 
   package "openstack-designate-#{params[:name]}"
 
@@ -25,9 +24,8 @@ define :designate_service do
     supports status: true, restart: true
     action [:enable, :start]
     subscribes :restart, resources(template: node[:designate][:config_file])
-    provider Chef::Provider::CrowbarPacemakerService if use_crowbar_pacemaker_service
   end
   utils_systemd_service_restart designate_service_name do
-    action use_crowbar_pacemaker_service ? :disable : :enable
+    :enable
   end
 end

--- a/crowbar_framework/app/models/designate_service.rb
+++ b/crowbar_framework/app/models/designate_service.rb
@@ -52,7 +52,7 @@ class DesignateService < OpenstackServiceObject
         "designate-worker" => {
           "unique" => false,
           "count" => 1,
-          "cluster" => false,
+          "cluster" => true,
           "admin" => false,
           "exclude_platform" => {
             "suse" => "< 12.4",


### PR DESCRIPTION
[1] suggests that workers are there for designate-central to get work
done. So having more of them is a good idea.
A worker does not really have an idea of api so no vip or haproxy
config is required.

1 - https://docs.openstack.org/designate/rocky/contributor/architecture.html