### PR TITLE
Revert "designate: show barclamp"

### DIFF
--- a/designate.yml
+++ b/designate.yml
@@ -19,6 +19,8 @@ barclamp:
   display: 'Designate'
   description: 'OpenStack DNSaaS: Multi-Tenant DNSaaS service for OpenStack'
   version: 0
+  # Change to true when complete
+  user_managed: false
   requires:
     - 'keystone'
     - 'rabbitmq'


### PR DESCRIPTION
This reverts commit 64e7ad98f3ed075c3948ca542cfcd61ac9215a10.

We've are very close to the release and have multiple pull requests still open
for Designate:

* https://github.com/crowbar/crowbar-openstack/pull/2095
* https://github.com/crowbar/crowbar-openstack/pull/2104
* https://github.com/crowbar/crowbar-openstack/pull/2105
* https://github.com/SUSE-Cloud/doc-cloud/pull/931

There are way too many question marks on this so I am
switching the barclamp back to invisible mode. Lets get these
pull requests squared away carefully and without the rush of
imminent release.