### PR TITLE
ironic: Use IP also in [swift] section

### DIFF
--- a/chef/cookbooks/ironic/templates/default/ironic.conf.erb
+++ b/chef/cookbooks/ironic/templates/default/ironic.conf.erb
@@ -58,6 +58,9 @@ password=<%= if @swift_settings then @swift_settings[:service_password] else '' 
 project_name=<%= @keystone_settings['service_tenant'] %>
 project_domain_name=<%= @keystone_settings["admin_domain"]%>
 user_domain_name=<%= @keystone_settings["admin_domain"] %>
+<% if @swift_settings %>
+endpoint_override=<%= @swift_settings[:protocol] %>://<%= @swift_settings[:ip] %>:<%= @swift_settings[:port] %>/v1/<%= @swift_settings[:glance_account] %>
+<% end %>
 
 [keystone]
 region_name=<%= @keystone_settings['endpoint_region'] %>


### PR DESCRIPTION
Swift settings in [glance] already use IP for endpoint URL. This
is used for deployment images.

If config drive is enabled and stored in Swift, this endpoint URL
is not used but instead standard keystone adapter is created based
on [swift] section of Ironic configuration. Added override makes
it possible to use deploy image which can't resolve Crowbar's
internal domain names.