### PR TITLE
designate: do not install the keystone_authtoken on worker nodes

### DIFF
--- a/chef/cookbooks/designate/recipes/common.rb
+++ b/chef/cookbooks/designate/recipes/common.rb
@@ -49,6 +49,7 @@ template node[:designate][:config_file] do
   variables(
     bind_host: network_settings[:api][:bind_host],
     bind_port: network_settings[:api][:bind_port],
+    with_authtoken: node["roles"].include?("designate-server"),
     api_base_uri: "#{api_protocol}://#{public_host}:#{node[:designate][:api][:bind_port]}",
     sql_connection: sql_connection,
     rabbit_settings: fetch_rabbitmq_settings,

--- a/chef/cookbooks/designate/templates/default/designate.conf.erb
+++ b/chef/cookbooks/designate/templates/default/designate.conf.erb
@@ -28,6 +28,7 @@ notify = False
 [storage:sqlalchemy]
 connection=<%= @sql_connection %>
 
+<%if @with_authtoken -%>
 [keystone_authtoken]
 auth_uri = <%= @keystone_settings["public_auth_url"] %>
 username = <%= @keystone_settings['service_user'] %>
@@ -45,6 +46,7 @@ memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:designate][:memcache_secret_key] %>
 memcache_pool_socket_timeout = 1
+<% end -%>
 
 [oslo_concurrency]
 lock_path = "/var/run/designate"


### PR DESCRIPTION
the desigante-worker does not need keystone auth token, it commnunicates
only with desginate-central over rpc.

the diagram gives a hint of this [1] or else one could look the code [2]

1 -
https://docs.openstack.org/designate/rocky/contributor/architecture.html
2-
https://opendev.org/openstack/designate/src/branch/master/designate/worker/service.py