### PR TITLE
neutron: raise validation error if domain names dont end with a dot(.)

### DIFF
--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -411,6 +411,11 @@ class NeutronService < OpenstackServiceObject
       validate_external_networks proposal["attributes"]["neutron"]["additional_external_networks"]
     end
 
+    ["dns_domain", "floating_dns_domain"].each do |domain|
+      validation_error "#{domain} should end with a dot"\
+          unless proposal["attributes"]["neutron"][domain].end_with?(".")
+    end
+
     super
   end
 


### PR DESCRIPTION

This is needed for designate. Designate will try to create zones
based on these names which get updated into the fixed and floating
network.