### PR TITLE
neutron: restart neutron-ha-tool when the config file changes

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -108,6 +108,15 @@ if use_l3_agent
       )
     end
 
+    service "neutron-l3-ha-service" do
+      supports status: true, restart: true
+      subscribes :restart, resources(file: "/etc/neutron/neutron-l3-ha-service.yaml")
+      subscribes :restart, resources(template: "/root/.openrc")
+      subscribes :restart, resources(file: "/etc/neutron/os_password")
+
+      provider Chef::Provider::CrowbarPacemakerService
+    end
+
     # Reload systemd when unit file changed
     bash "reload systemd after neutron-l3-ha-service update" do
       code "systemctl daemon-reload"


### PR DESCRIPTION
When we toggle ssl/non-ssl in keystone, neutron-ha-tool
gets a new config file but doesn't get restarted, so it just
repeatedly crashes all the way until it causes a pacemaker
failcount exceeded and then its dead. We should try better.