### PR TITLE
database: Raise and align promote/demote timeouts (bsc#1131791)

### DIFF
--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -43,10 +43,10 @@
               "timeout": "60s"
             },
             "promote": {
-              "timeout": "300s"
+              "timeout": "600s"
             },
             "demote": {
-              "timeout": "60s"
+              "timeout": "600s"
             }
           }
         }


### PR DESCRIPTION
Looks like 5 minutes is too short in some cases
when a new node is joining. I have observed the 5 min timeout
in a small cloud of 100 nodes already that has been operated
for some time, so we might be better off being conservative.