### PR TITLE
neutron: use crm_resource restart for restarting neutron-l3-ha-service

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -109,10 +109,10 @@ if use_l3_agent
     end
 
     service "neutron-l3-ha-service" do
-      supports status: true, restart: true
-      subscribes :restart, resources(file: "/etc/neutron/neutron-l3-ha-service.yaml")
-      subscribes :restart, resources(template: "/root/.openrc")
-      subscribes :restart, resources(file: "/etc/neutron/os_password")
+      supports status: true, restart: true, restart_crm_resource: true
+      subscribes :restart, resources(file: "/etc/neutron/neutron-l3-ha-service.yaml"), :immediately
+      subscribes :restart, resources(template: "/root/.openrc"), :immediately
+      subscribes :restart, resources(file: "/etc/neutron/os_password"), :immediately
 
       provider Chef::Provider::CrowbarPacemakerService
     end


### PR DESCRIPTION
When we restart via systemd, it can happen that the service already
crashed and then 'service neutron-l3-ha-service status" will (correctly)
report that the service isn't running. And then the restart is not being
executed due to:

  INFO: Ignoring restart action for neutron-l3-ha-service service since not running on this node (d52-54-77-77-01-01)

which will then later cause a pacemaker failcount. the pacemaker
resource restart hopefully does not have this problem.