### PR TITLE
[5.0] swift: Reset syncmarks when applying proposal

### DIFF
--- a/chef/data_bags/crowbar/template-swift.json
+++ b/chef/data_bags/crowbar/template-swift.json
@@ -105,10 +105,10 @@
       },
       "elements": {},
       "element_order": [
+        [ "swift-proxy" ],
         [ "swift-storage" ],  
         [ "swift-ring-compute" ], 
         [ "swift-storage" ],
-        [ "swift-proxy" ],
         [ "swift-dispersion" ]
       ],
       "element_run_list_order": {

--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -126,6 +126,7 @@ class SwiftService < OpenstackServiceObject
     return if all_nodes.empty?
 
     proxy_elements, proxy_nodes, ha_enabled = role_expand_elements(role, "swift-proxy")
+    reset_sync_marks_on_clusters_founders(proxy_elements)
     Openstack::HA.set_controller_role(proxy_nodes) if ha_enabled
 
     vip_networks = ["admin", "public"]


### PR DESCRIPTION
Each barclamp which uses HA should reset syncmarks when applying proposal.

backport of #2122 