### PR TITLE
database: Increase the default "promote" timeout (bsc#1131791)

### DIFF
--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -43,7 +43,7 @@
               "timeout": "60s"
             },
             "promote": {
-              "timeout": "300s"
+              "timeout": "600s"
             },
             "demote": {
               "timeout": "60s"


### PR DESCRIPTION
When a galera cluster is out of sync and needs a resync, the cluster
may decide to wipe the available data on the out-of-sync nodes and do
a full resync to *all* (except the bootstrap node of course) cluster
nodes. In a 3-node cluster, it means that the data needs to be
transfered 2x.
To not run into timeouts in that case, increase the timeout to 10
minutes.