### PR TITLE
horizon: Disable Ceph dashboard if not monitored (SOC-7573)

### DIFF
--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -95,16 +95,19 @@ end
 cookbook_file "/var/lib/grafana/dashboards/monasca.json" do
   source "grafana-monasca.json"
   owner "root"
-  group "root"
-  mode "0644"
+  group "grafana"
+  mode "0640"
   notifies :restart, resources(service: "grafana-server")
 end
 
-cookbook_file "/var/lib/grafana/dashboards/openstack.json" do
-  source "grafana-openstack.json"
+template "/var/lib/grafana/dashboards/openstack.json" do
+  source "grafana-openstack.json.erb"
+  variables(
+    ceph_enabled: monasca_server[:monasca][:agent][:monitor_ceph]
+  )
   owner "root"
-  group "root"
-  mode "0644"
+  group "grafana"
+  mode "0640"
   notifies :restart, resources(service: "grafana-server")
 end
 

--- a/chef/cookbooks/horizon/templates/default/grafana-openstack.json.erb
+++ b/chef/cookbooks/horizon/templates/default/grafana-openstack.json.erb
@@ -3493,7 +3493,7 @@
       "showTitle": true,
       "title": "VM Counts",
       "titleSize": "h6"
-    },
+    }<% if @ceph_enabled %>,
     {
       "collapse": true,
       "height": 250,
@@ -4184,6 +4184,7 @@
       "title": "Ceph Storage",
       "titleSize": "h6"
     }
+<% end -%>
   ],
   "schemaVersion": 14,
   "style": "dark",


### PR DESCRIPTION
Grafana OpenStack dashboard should show Ceph panels if Ceph monitoring
is enabled.