### PR TITLE
[5.0] database: Make wsrep_provider_options configurable (fate#327745)

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -62,7 +62,10 @@ unless node[:database][:galera_bootstrapped]
         sstuser_password: "",
         expire_logs_days: node[:database][:mysql][:expire_logs_days],
         node_address: node_address,
-        wsrep_slave_threads: node[:database][:mysql][:wsrep_slave_threads]
+        wsrep_slave_threads: node[:database][:mysql][:wsrep_slave_threads],
+        gcs_fc_limit_multiplier: node[:database][:mysql][:gcs_fc_limit_multiplier],
+        gcs_fc_factor: node[:database][:mysql][:gcs_fc_factor],
+        wsrep_provider_options_custom: node[:database][:mysql][:wsrep_provider_options_custom].join(";")
       )
     end
 
@@ -143,7 +146,10 @@ template "/etc/my.cnf.d/75-galera.cnf" do
     sstuser_password: node[:database][:mysql][:sstuser_password],
     expire_logs_days: node[:database][:mysql][:expire_logs_days],
     node_address: node_address,
-    wsrep_slave_threads: node[:database][:mysql][:wsrep_slave_threads]
+    wsrep_slave_threads: node[:database][:mysql][:wsrep_slave_threads],
+    gcs_fc_limit_multiplier: node[:database][:mysql][:gcs_fc_limit_multiplier],
+    gcs_fc_factor: node[:database][:mysql][:gcs_fc_factor],
+    wsrep_provider_options_custom: node[:database][:mysql][:wsrep_provider_options_custom].join(";")
   )
 end
 

--- a/chef/cookbooks/mysql/templates/default/galera.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/galera.cnf.erb
@@ -3,7 +3,7 @@ wsrep_on = ON
 wsrep_provider = /usr/lib64/galera-3/libgalera_smm.so
 wsrep_cluster_address = "<%= @cluster_addresses %>"
 # values recommended by mysqltuner.pl
-wsrep_provider_options = "gmcast.listen_addr=tcp://<%= @node_address %>:4567;gcs.fc_limit = <%= @wsrep_slave_threads * 5 %>;gcs.fc_factor = 0.8"
+wsrep_provider_options = "gmcast.listen_addr=tcp://<%= @node_address %>:4567;gcs.fc_limit = <%= @wsrep_slave_threads * @gcs_fc_limit_multiplier %>;gcs.fc_factor = <%= @gcs_fc_factor %>;<%= @wsrep_provider_options_custom %>"
 wsrep_slave_threads = <%= @wsrep_slave_threads %>
 
 # Maximum number of rows in write set

--- a/chef/data_bags/crowbar/migrate/database/210_make_wsrep_provider_options_configurable.rb
+++ b/chef/data_bags/crowbar/migrate/database/210_make_wsrep_provider_options_configurable.rb
@@ -1,0 +1,13 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["mysql"]["wsrep_provider_options_custom"] = template_attrs["mysql"]["wsrep_provider_options_custom"] unless attrs["mysql"]["wsrep_provider_options_custom"]
+  attrs["mysql"]["gcs_fc_limit_multiplier"] = template_attrs["mysql"]["gcs_fc_limit_multiplier"] unless attrs["mysql"]["gcs_fc_limit_multiplier"]
+  attrs["mysql"]["gcs_fc_factor"] = template_attrs["mysql"]["gcs_fc_factor"] unless attrs["mysql"]["gcs_fc_factor"]
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["mysql"].delete("wsrep_provider_options_custom") unless template_attrs["mysql"].key?("wsrep_provider_options_custom")
+  attrs["mysql"].delete("gcs_fc_limit_multiplier") unless template_attrs["mysql"].key?("gcs_fc_limit_multiplier")
+  attrs["mysql"].delete("gcs_fc_factor") unless template_attrs["mysql"].key?("gcs_fc_factor")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -15,6 +15,9 @@
         "expire_logs_days": 10,
         "bootstrap_timeout": 600,
         "wsrep_slave_threads" : 1,
+        "gcs_fc_limit_multiplier" : 5,
+        "gcs_fc_factor" : 0.8,
+        "wsrep_provider_options_custom" : [],
         "innodb_buffer_pool_size": 256,
         "innodb_tunings": [
             "# log_file_size should be ~ 25% of buffer_pool_size",
@@ -83,7 +86,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 209,
+      "schema-revision": 210,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -32,6 +32,9 @@
                 "expire_logs_days": { "type": "int", "required": true },
                 "bootstrap_timeout": { "type": "int", "required": true },
                 "wsrep_slave_threads": { "type": "int", "required": true },
+                "gcs_fc_limit_multiplier": { "type": "int", "required": true },
+                "gcs_fc_factor": { "type": "float", "required": true },
+                "wsrep_provider_options_custom": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                 "ssl": {
                   "type": "map", "required": true, "mapping": {
                     "enabled": { "type": "bool", "required": true },


### PR DESCRIPTION
It is sometimes useful to be able to add extra options (like
gcache.size, gcs.fc_debug, ...) to the galera wsrep_provider_options
configuration variable.
This can now be done via the Crowbar RAW view.
Also make (the currently hardcoded) "gcs.fc_limit" multiplier
configurable.
Also make (the currently hardcoded) "gcs.fc_factor"
configurable.

(cherry picked from commit 94eb55905b28e3407187f54d9ada4b7e27214704)