### PR TITLE
nova: Show stdout/stderr when "openstack flavor list" fails

### DIFF
--- a/chef/cookbooks/nova/recipes/flavors.rb
+++ b/chef/cookbooks/nova/recipes/flavors.rb
@@ -104,7 +104,7 @@ package "python-openstackclient"
 ruby_block "Get current flavors" do
   block do
     cmd = Mixlib::ShellOut.new("#{openstack} flavor list -f value -c Name").run_command
-    raise "Flavor list not obtained, is the nova-api down?" unless cmd.exitstatus.zero?
+    raise "Flavor list not obtained, is the nova-api down?\n#{cmd.stdout}\n#{cmd.stderr}" unless cmd.exitstatus.zero?
     node.run_state["flavorlist"] = cmd.stdout.split("\n")
   end
   retries 10


### PR DESCRIPTION
When running into the problem that the "openstack flavor list" command
fails, we want to know the error and not only see a comment that the
nova api might be down.
This is useful for debugging.