### PR TITLE
tempest: Disable Barbican validation of signed image (SOC-8578)

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -256,3 +256,6 @@ manage_snapshot = True
 api_v3 = True
 snapshot = <%= @cinder_snapshot %>
 api_extensions = all
+
+[image_signature_verification]
+enforced = false


### PR DESCRIPTION
The change disables testing the signed image in Barbican. In the default
configuration of Nova, Glance signature verification is disabled and so
this test fails.

Depends On: https://build.opensuse.org/request/show/707799
Please also refer to: https://review.opendev.org/649670