### PR TITLE
neutron: Don't restart l3-ha on .openrc change + timeout extension

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -271,6 +271,6 @@ default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:router_migration][:te
 default[:neutron][:ha][:neutron_l3_ha_service][:timeouts][:router_migration][:kill] = 50
 default[:neutron][:ha][:neutron_l3_ha_service][:hatool][:program] = "/usr/bin/neutron-ha-tool"
 default[:neutron][:ha][:neutron_l3_ha_service][:hatool][:env] = {}
-default[:neutron][:ha][:neutron_l3_ha_service][:seconds_to_sleep_between_checks] = 10
+default[:neutron][:ha][:neutron_l3_ha_service][:seconds_to_sleep_between_checks] = 30
 default[:neutron][:ha][:neutron_l3_ha_service][:max_errors_tolerated] = 10
 default[:neutron][:ha][:neutron_l3_ha_service][:log_file] = "/var/log/neutron/neutron-l3-ha-service.log"

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -41,19 +41,6 @@ if use_l3_agent
     action :create
   end
 
-  # We need .openrc present at network node so the node can use neutron-ha-tool even
-  # when located in separate cluster
-  template "/root/.openrc" do
-    source "openrc.erb"
-    cookbook "keystone"
-    owner "root"
-    group "root"
-    mode 0o600
-    variables(
-      keystone_settings: keystone_settings
-    )
-  end
-
   # skip neutron-ha-tool resource creation during upgrade
   unless CrowbarPacemakerHelper.being_upgraded?(node)
 

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -111,7 +111,6 @@ if use_l3_agent
     service "neutron-l3-ha-service" do
       supports status: true, restart: true, restart_crm_resource: true
       subscribes :restart, resources(file: "/etc/neutron/neutron-l3-ha-service.yaml"), :immediately
-      subscribes :restart, resources(template: "/root/.openrc"), :immediately
       subscribes :restart, resources(file: "/etc/neutron/os_password"), :immediately
 
       provider Chef::Provider::CrowbarPacemakerService


### PR DESCRIPTION
l3-ha service doesn't use .openrc so it doesn't need to be restarted
when that file is modified.

Second commit removes redundant generation of .openrc in neutron cookbook.
Third one increases grace period for l3-ha service from 10x10s to 10x30s. This is needed to improve reliability of CI running in ECP.