### PR TITLE
neutron: Stop creating / watching .openrc

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -41,19 +41,6 @@ if use_l3_agent
     action :create
   end
 
-  # We need .openrc present at network node so the node can use neutron-ha-tool even
-  # when located in separate cluster
-  template "/root/.openrc" do
-    source "openrc.erb"
-    cookbook "keystone"
-    owner "root"
-    group "root"
-    mode 0o600
-    variables(
-      keystone_settings: keystone_settings
-    )
-  end
-
   # skip neutron-ha-tool resource creation during upgrade
   unless CrowbarPacemakerHelper.being_upgraded?(node)
 
@@ -111,7 +98,6 @@ if use_l3_agent
     service "neutron-l3-ha-service" do
       supports status: true, restart: true, restart_crm_resource: true
       subscribes :restart, resources(file: "/etc/neutron/neutron-l3-ha-service.yaml"), :immediately
-      subscribes :restart, resources(template: "/root/.openrc"), :immediately
       subscribes :restart, resources(file: "/etc/neutron/os_password"), :immediately
 
       provider Chef::Provider::CrowbarPacemakerService


### PR DESCRIPTION
On a toggle of the keystone services configuration, the .openrc
is written too early and neutron-l3-ha-service is restarted
prior the configuration yaml being updated. So given that
the l3-ha-service only fetches information from the yaml, we don't
need to trigger restart and we don't need to write the .openrc.