### PR TITLE
[5.0] nova: Don't retry creating existing flavors

### DIFF
--- a/chef/cookbooks/nova/recipes/flavors.rb
+++ b/chef/cookbooks/nova/recipes/flavors.rb
@@ -127,6 +127,8 @@ ruby_block "Flavor creation" do
         )
         flavor_create.command command
         flavor_create.retries 5
+        # don't retry after "Flavor with ID ... already exists"
+        flavor_create.not_if "#{openstack} flavor show #{id}"
 
         # delay the run of this resource until the end of the run
         run_context.notifies_delayed(
@@ -145,6 +147,8 @@ ruby_block "Flavor creation" do
         )
         flavor_create.command command
         flavor_create.retries 5
+        # don't retry after "Flavor with ID ... already exists"
+        flavor_create.not_if "#{openstack} flavor show #{id}"
 
         # delay the run of this resource until the end of the run
         run_context.notifies_delayed(


### PR DESCRIPTION
In some cases the flavor create call succeeds but client still returns
non-zero status. Retries of the create call fail with "Flavor already
exists" and the retry loop never succeeds. Added check is executed in
every loop turn and will stop reytring if the flavor already exists.

Example scenario where flavor might be correctly created but client
doesn't return zero is when one of HA nodes executes flavor create
commands while others perform delayed restart of nova API after config
files are modified. If the "create" request hits the API just before
restart it could be accepted but the client might not get the correct
response back.

port of #2142 