### PR TITLE
[4.0] rabbitmq: Fix ACL of SSL key after uid/gid change + keystone: Use correct paths when syncing certs

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -347,9 +347,9 @@ end
 ruby_block "synchronize signing keys for founder and remember them for non-HA case" do
   only_if { (!ha_enabled || (ha_enabled && CrowbarPacemakerHelper.is_cluster_founder?(node))) }
   block do
-    ca = File.open("/etc/keystone/ssl/certs/ca.pem", "rb", &:read)
-    signing_cert = File.open("/etc/keystone/ssl/certs/signing_cert.pem", "rb", &:read)
-    signing_key = File.open("/etc/keystone/ssl/private/signing_key.pem", "rb", &:read)
+    ca = File.open(node[:keystone][:signing][:ca_certs], "rb", &:read)
+    signing_cert = File.open(node[:keystone][:signing][:certfile], "rb", &:read)
+    signing_key = File.open(node[:keystone][:signing][:keyfile], "rb", &:read)
 
     node[:keystone][:certificates] ||= {}
     node[:keystone][:certificates][:content] ||= {}
@@ -376,9 +376,9 @@ end
 ruby_block "synchronize signing keys for non-founder" do
   only_if { ha_enabled && !CrowbarPacemakerHelper.is_cluster_founder?(node) }
   block do
-    ca = File.open("/etc/keystone/ssl/certs/ca.pem", "rb", &:read)
-    signing_cert = File.open("/etc/keystone/ssl/certs/signing_cert.pem", "rb", &:read)
-    signing_key = File.open("/etc/keystone/ssl/private/signing_key.pem", "rb", &:read)
+    ca = File.open(node[:keystone][:signing][:ca_certs], "rb", &:read)
+    signing_cert = File.open(node[:keystone][:signing][:certfile], "rb", &:read)
+    signing_key = File.open(node[:keystone][:signing][:keyfile], "rb", &:read)
 
     founder = CrowbarPacemakerHelper.cluster_founder(node)
 
@@ -390,19 +390,19 @@ ruby_block "synchronize signing keys for non-founder" do
     # the code below
     dirty = false
     if ca != cluster_ca
-      File.open("/etc/keystone/ssl/certs/ca.pem", "w") { |f|
+      File.open(node[:keystone][:signing][:ca_certs], "w") { |f|
         f.write(cluster_ca)
       }
       dirty = true
     end
     if signing_cert != cluster_signing_cert
-      File.open("/etc/keystone/ssl/certs/signing_cert.pem", "w") { |f|
+      File.open(node[:keystone][:signing][:certfile], "w") { |f|
         f.write(cluster_signing_cert)
       }
       dirty = true
     end
     if signing_key != cluster_signing_key
-      File.open("/etc/keystone/ssl/private/signing_key.pem", "w") { |f|
+      File.open(node[:keystone][:signing][:keyfile], "w") { |f|
         f.write(cluster_signing_key)
       }
       dirty = true

--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -77,6 +77,7 @@ rabbitmq_op["monitor"]["interval"] = "10s"
 # on anyway.
 static_uid = 91
 static_gid = 91
+ssl_keyfile = node[:rabbitmq][:ssl][:keyfile]
 bash "assign static uid to rabbitmq" do
   code <<EOC
 service rabbitmq-server stop > /dev/null;
@@ -86,6 +87,7 @@ chown -R rabbitmq:rabbitmq /var/lib/rabbitmq;
 chown rabbitmq:rabbitmq /var/run/rabbitmq /var/log/rabbitmq;
 chown rabbitmq:rabbitmq /var/run/rabbitmq/pid /var/log/rabbitmq/*.log* || :;
 chgrp rabbitmq /etc/rabbitmq/definitions.json;
+test -e #{ssl_keyfile} && chgrp rabbitmq #{ssl_keyfile} || :;
 EOC
   # Make any error in the commands fatal
   flags "-e"


### PR DESCRIPTION
In shared storage based HA setup, rabbitmq uses fixed uid/gid=91.
This user/group modification was done after (optional) SSL certificate
generation. The ACLs on the SSL key were incorrect making rabbitmq
unable to start because with EACCESS errors.

Second commit is taken from https://github.com/crowbar/crowbar-openstack/pull/2145 to avoid cross-PR dependencies in gating.

The sync failed when certs and/or keys were located in non-default paths.

**Note:** forward ports need to include only the rabbitmq part as the keystone change is not relevant for newer versions.