### PR TITLE
Make ovs of_inactivity_probe configurable from neutron barclamp

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -272,7 +272,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
             (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
-        bridge_mappings: bridge_mappings
+        bridge_mappings: bridge_mappings,
+        of_inactivity_probe: neutron[:neutron][:ovs][:of_inactivity_probe]
       )
     end
   when ml2_mech_drivers.include?("linuxbridge")

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -24,5 +24,6 @@ tunnel_bridge = br-tunnel
 local_ip = <%= node.address("os_sdn").addr %>
 <% end -%>
 bridge_mappings = <%= @bridge_mappings %>
+of_inactivity_probe = <%= @of_inactivity_probe %>
 [securitygroup]
 firewall_driver = iptables_hybrid

--- a/chef/data_bags/crowbar/migrate/neutron/307_add_ovs_of_inactivity_probe.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/307_add_ovs_of_inactivity_probe.rb
@@ -1,0 +1,15 @@
+def upgrade(tattr, tdep, attr, dep)
+  unless attr["ovs"].key?("of_inactivity_probe")
+    attr["ovs"]["of_inactivity_probe"] = tattr["ovs"]["of_inactivity_probe"]
+  end
+
+  return attr, dep
+end
+
+def downgrade(tattr, tdep, attr, dep)
+  unless tattr["ovs"].key?("of_inactivity_probe")
+    attr["ovs"].delete("of_inactivity_probe") if attr.key?("ovs")
+  end
+
+  return attr, dep
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -42,7 +42,8 @@
         "multicast_group": "239.1.1.1"
       },
       "ovs": {
-        "tunnel_csum": false
+        "tunnel_csum": false,
+        "of_inactivity_probe": 10
       },
       "apic": {
         "hosts": "",
@@ -192,7 +193,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 306,
+      "schema-revision": 307,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -47,7 +47,8 @@
                       "multicast_group": { "type" : "str", "required": true }
                     }},
                     "ovs": { "type": "map", "required": true, "mapping": {
-                      "tunnel_csum": { "type": "bool", "required": true }
+                      "tunnel_csum": { "type": "bool", "required": true },
+                      "of_inactivity_probe": { "type": "int", "required": true }
                     }},
                     "apic": { "type": "map", "required": true, "mapping": {
                       "hosts": { "type" : "str", "required" : true },


### PR DESCRIPTION
This patch allows the user to change
the ovs inactivity_probe timeout from the neutron barclamp, in the 'raw'
view. Previously, this value was always set to the OVS default, 5.

It provides crowbar support for this upstream patch:

https://review.opendev.org/#/c/641681