### PR TITLE
[5.0] rabbitmq: Fix ACL of SSL key after uid/gid change

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -74,6 +74,7 @@ rabbitmq_op["monitor"]["interval"] = "10s"
 # on anyway.
 static_uid = 91
 static_gid = 91
+ssl_keyfile = node[:rabbitmq][:ssl][:keyfile]
 bash "assign static uid to rabbitmq" do
   code <<EOC
 service rabbitmq-server stop > /dev/null;
@@ -83,6 +84,7 @@ chown -R rabbitmq:rabbitmq /var/lib/rabbitmq;
 chown rabbitmq:rabbitmq /var/run/rabbitmq /var/log/rabbitmq;
 chown rabbitmq:rabbitmq /var/run/rabbitmq/pid /var/log/rabbitmq/*.log* || :;
 chgrp rabbitmq /etc/rabbitmq/definitions.json;
+test -e #{ssl_keyfile} && chgrp rabbitmq #{ssl_keyfile} || :;
 EOC
   # Make any error in the commands fatal
   flags "-e"


### PR DESCRIPTION
In shared storage based HA setup, rabbitmq uses fixed uid/gid=91.
This user/group modification was done after (optional) SSL certificate
generation. The ACLs on the SSL key were incorrect making rabbitmq
unable to start because with EACCESS errors.

(cherry picked from commit 086216018065b9855b27bfb73d556e70f7e336b2)

partial port of #2146 