### PR TITLE
Upgrade nova

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -97,7 +97,6 @@ execute "nova-manage api_db sync" do
   # are the founder of the HA cluster (so that it's really only done once).
   only_if do
     !node[:nova][:api_db_synced] &&
-      !CrowbarPacemakerHelper.being_upgraded?(node) &&
       (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node))
   end
 end
@@ -121,20 +120,6 @@ execute "nova-manage create cell1" do
   action :run
   only_if do
     !node[:nova][:db_synced] &&
-      (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node))
-  end
-end
-
-# During upgrade to Pike, execute api_db sync after 'cell_v2 map_cell0' and 'cell_v2 create_cell'
-execute "nova-manage api_db sync" do
-  user node[:nova][:user]
-  group node[:nova][:group]
-  command "nova-manage api_db sync"
-  action :run
-  # We only do the sync the first time, and only if we're not doing HA or if we
-  # are the founder of the HA cluster (so that it's really only done once).
-  only_if do
-    !node[:nova][:api_db_synced] &&
       (!node[:nova][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node))
   end
 end

--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -116,7 +116,8 @@ end
 execute "nova-manage create cell1" do
   user node[:nova][:user]
   group node[:nova][:group]
-  command "nova-manage cell_v2 create_cell --name cell1 --verbose"
+  command "nova-manage cell_v2 list_cells | grep -q ' cell1 ' "\
+          "|| nova-manage cell_v2 create_cell --name cell1 --verbose"
   action :run
   only_if do
     !node[:nova][:db_synced] &&


### PR DESCRIPTION
These two commits get the nova part of the Cloud 8 to Cloud 9 upgrade working to the point where the chef run during the `crowbarctl upgrade nodes controllers` step finishes without crashing for a minimal cloud (only Keystone, Cinder, Glance, Neutron, Nova).