### PR TITLE
monasca: use string keys for attrs in migrations

### DIFF
--- a/chef/data_bags/crowbar/migrate/monasca/302_add_mondb.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/302_add_mondb.rb
@@ -1,20 +1,24 @@
 def upgrade(template_attrs, template_deployment, attrs, deployment)
   unless attrs.key? "db_monapi"
-    attrs[:db_monapi] = template_attrs[:db_monapi]
+    attrs["db_monapi"] = template_attrs[:db_monapi]
     service = ServiceObject.new "fake-logger"
-    attrs[:db_monapi][:password] = service.random_password
+    attrs["db_monapi"]["password"] = service.random_password
   end
+
   # use the database password that is already available
-  if attrs[:master].key? "database_monapi_password"
-    attrs[:db_monapi][:password] = attrs[:master][:database_monapi_password]
-    attrs[:master].delete(:database_monapi_password)
+  if attrs.key? "master"
+    if attrs["master"].key? "database_monapi_password"
+      attrs["db_monapi"]["password"] = attrs["master"]["database_monapi_password"]
+      attrs["master"].delete(:database_monapi_password)
+    end
   end
+
   return attrs, deployment
 end
 
 def downgrade(template_attrs, template_deployment, attrs, deployment)
   # copy password to old place
-  attrs[:master][:database_monapi_password] = attrs[:db_monapi][:password]
-  attrs.delete(:db_monapi)
+  attrs["master"]["database_monapi_password"] = attrs["db_monapi"]["password"]
+  attrs.delete("db_monapi")
   return attrs, deployment
 end

--- a/chef/data_bags/crowbar/migrate/monasca/303_add_grafanadb.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/303_add_grafanadb.rb
@@ -1,20 +1,20 @@
 def upgrade(template_attrs, template_deployment, attrs, deployment)
   unless attrs.key? "db_grafana"
-    attrs[:db_grafana] = template_attrs[:db_grafana]
+    attrs["db_grafana"] = template_attrs[:db_grafana]
     service = ServiceObject.new "fake-logger"
-    attrs[:db_grafana][:password] = service.random_password
+    attrs["db_grafana"]["password"] = service.random_password
   end
   # use the database password that is already available
-  if attrs[:master].key? "database_grafana_password"
-    attrs[:db_grafana][:password] = attrs[:master][:database_grafana_password]
-    attrs[:master].delete(:database_grafana_password)
+  if attrs["master"].key? "database_grafana_password"
+    attrs["db_grafana"]["password"] = attrs["master"]["database_grafana_password"]
+    attrs["master"].delete("database_grafana_password")
   end
   return attrs, deployment
 end
 
 def downgrade(template_attrs, template_deployment, attrs, deployment)
   # copy password to old place
-  attrs[:master][:database_grafana_password] = attrs[:db_grafana][:password]
-  attrs.delete(:db_grafana)
+  attrs["master"]["database_grafana_password"] = attrs["db_grafana"]["password"]
+  attrs.delete("db_grafana")
   return attrs, deployment
 end

--- a/chef/data_bags/crowbar/migrate/monasca/304_rename_elastic_params.rb
+++ b/chef/data_bags/crowbar/migrate/monasca/304_rename_elastic_params.rb
@@ -1,19 +1,25 @@
 def upgrade(template_attrs, template_deployment, attrs, deployment)
-  attrs[:elasticsearch][:tunables][:limit_nproc] = attrs[:elasticsearch][:tunables][:max_procs]
-  attrs[:elasticsearch][:tunables][:limit_nofile] = attrs[:elasticsearch][:tunables][:max_open_files_hard_limit]
-  attrs[:elasticsearch][:tunables][:limit_memlock] = attrs[:elasticsearch][:tunables][:max_locked_memory]
-  attrs[:elasticsearch][:tunables].delete("max_procs")
-  attrs[:elasticsearch][:tunables].delete("max_open_files_hard_limit")
-  attrs[:elasticsearch][:tunables].delete("max_locked_memory")
+  attrs["elasticsearch"]["tunables"]["limit_nproc"] =
+    attrs["elasticsearch"]["tunables"]["max_procs"]
+  attrs["elasticsearch"]["tunables"]["limit_nofile"] =
+    attrs["elasticsearch"]["tunables"]["max_open_files_hard_limit"]
+  attrs["elasticsearch"]["tunables"]["limit_memlock"] =
+    attrs["elasticsearch"]["tunables"]["max_locked_memory"]
+  attrs["elasticsearch"]["tunables"].delete("max_procs")
+  attrs["elasticsearch"]["tunables"].delete("max_open_files_hard_limit")
+  attrs["elasticsearch"]["tunables"].delete("max_locked_memory")
   return attrs, deployment
 end
 
 def downgrade(template_attrs, template_deployment, attrs, deployment)
-  attrs[:elasticsearch][:tunables][:max_procs] = attrs[:elasticsearch][:tunables][:limit_nproc]
-  attrs[:elasticsearch][:tunables][:max_open_files_hard_limit] = attrs[:elasticsearch][:tunables][:limit_nofile]
-  attrs[:elasticsearch][:tunables][:max_locked_memory] = attrs[:elasticsearch][:tunables][:limit_memlock]
-  attrs[:elasticsearch][:tunables].delete("limit_nproc")
-  attrs[:elasticsearch][:tunables].delete("limit_nofile")
-  attrs[:elasticsearch][:tunables].delete("limit_memlock")
+  attrs["elasticsearch"]["tunables"]["max_procs"] =
+    attrs["elasticsearch"]["tunables"]["limit_nproc"]
+  attrs["elasticsearch"]["tunables"]["max_open_files_hard_limit"] =
+    attrs["elasticsearch"]["tunables"]["limit_nofile"]
+  attrs["elasticsearch"]["tunables"]["max_locked_memory"] =
+    attrs["elasticsearch"]["tunables"]["limit_memlock"]
+  attrs["elasticsearch"]["tunables"].delete("limit_nproc")
+  attrs["elasticsearch"]["tunables"].delete("limit_nofile")
+  attrs["elasticsearch"]["tunables"].delete("limit_memlock")
   return attrs, deployment
 end


### PR DESCRIPTION
Symbolic keys cause the migrations to fail during upgrade due
to these keys not being found. This commit fixes the problem.