### PR TITLE
case-insensitive role name lookup (SOC-9339)

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -412,7 +412,12 @@ def find_id(item_name, path, dir, key = "name", ret = "id")
       data2hash = {}
 
       data.each do |item|
-        my_item_id = item[ret] if item[key] == item_name
+        # NOTE: for Keystone with MySQL backend, which is the default since
+        # Cloud 8, we should be doing case-insensitive comparison when lookup
+        # ID by name. For more information, see
+        # https://docs.openstack.org/keystone/rocky/admin
+        # /identity-case-insensitive.html
+        my_item_id = item[ret] if item[key].casecmp(item_name).zero?
         data2hash[[path, item[key]]] = item[ret]
       end
       KeystoneHelper.cache_update(data2hash) if my_item_id


### PR DESCRIPTION
We should be using case-insensitive role name comparison
when doing a role lookup since we only support mysql backend
now. See

https://docs.openstack.org/keystone/rocky/admin/identity-case-insensitive.html#roles