### PR TITLE
monasca: move Grafana DB creation

### DIFF
--- a/chef/cookbooks/monasca/recipes/database.rb
+++ b/chef/cookbooks/monasca/recipes/database.rb
@@ -31,37 +31,37 @@ ha_enabled = node[:monasca][:ha][:enabled]
 
 crowbar_pacemaker_sync_mark "wait-monasca_database"
 
-[node[:monasca][:db_monapi], node[:monasca][:db_grafana]].each do |d|
-  database "create #{d[:database]} database" do
-    connection db_settings[:connection]
-    database_name d[:database]
-    provider db_settings[:provider]
-    action :create
-    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
+monasca_db = node[:monasca][:db_monapi]
 
-  database_user "create #{d[:user]} database user" do
-    connection db_settings[:connection]
-    username d[:user]
-    password d[:password]
-    provider db_settings[:user_provider]
-    host "%"
-    action :create
-    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
+database "create #{monasca_db[:database]} database" do
+  connection db_settings[:connection]
+  database_name monasca_db[:database]
+  provider db_settings[:provider]
+  action :create
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
 
-  database_user "grant privileges to the #{d[:user]} database user" do
-    connection db_settings[:connection]
-    database_name d[:database]
-    username d[:user]
-    password d[:password]
-    host "%"
-    privileges db_settings[:privs]
-    provider db_settings[:user_provider]
-    require_ssl db_settings[:connection][:ssl][:enabled]
-    action :grant
-    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
-  end
+database_user "create #{monasca_db[:user]} database user" do
+  connection db_settings[:connection]
+  username monasca_db[:user]
+  password monasca_db[:password]
+  provider db_settings[:user_provider]
+  host "%"
+  action :create
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+database_user "grant privileges to the #{monasca_db[:user]} database user" do
+  connection db_settings[:connection]
+  database_name monasca_db[:database]
+  username monasca_db[:user]
+  password monasca_db[:password]
+  host "%"
+  privileges db_settings[:privs]
+  provider db_settings[:user_provider]
+  require_ssl db_settings[:connection][:ssl][:enabled]
+  action :grant
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 tsdb = node["monasca"]["tsdb"]


### PR DESCRIPTION
This commit moves Grafana DB creation to the Horizon barclamp
since this is where the Grafana service is being deployed.