### PR TITLE
[5.0] swift: Sync HA nodes (SOC-9683)

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -162,6 +162,15 @@ case proxy_config[:auth_method]
      proxy_config[:reseller_prefix] = node[:swift][:reseller_prefix]
      proxy_config[:keystone_delay_auth_decision] = node["swift"]["keystone_delay_auth_decision"]
 
+     # Because syncmarks are not reset when applying Swift proposal, nodes
+     # can be out of sync beyond normal syncmark timeout. This 'sync' syncmark
+     # should line them up and correct any time offsets.
+     if ha_enabled
+       crowbar_pacemaker_sync_mark "sync-swift_before_register" do
+         timeout 300
+       end
+     end
+
      crowbar_pacemaker_sync_mark "wait-swift_register" if ha_enabled
 
      register_auth_hash = { user: keystone_settings["admin_user"],


### PR DESCRIPTION
In most barclamps using syncmarks existing syncmarks are reset when applying
proposal. In Swift barclamp, swift-proxy is the only "HA" role and it is not
executed as the first one (swift-storage and swift-ring-compute need to be
run first). Because of that, first chef-client run during proposal commit
might not include the founder node and syncmark mechanism would fail in all
cookbooks.

Because syncmarks are not reset when applying Swift proposal, nodes can be
out of sync beyond normal syncmark timeout. This 'sync' syncmark should
line them up and correct any time offsets.

port of #2161 