### PR TITLE
[5.0] cinder: Set cinder pool to exclusive by default when using embedded ceph

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -208,8 +208,11 @@ rbd_pool = <%= volume['rbd']['pool'] %>
 rbd_user = <%= volume['rbd']['user'] %>
     <% end -%>
     <% if volume['rbd']['use_crowbar'] -%>
+rbd_exclusive_cinder_pool = True
 rbd_ceph_conf = /etc/ceph/ceph.conf
     <% else -%>
+# Setting it to True would be highly recommended here as well
+rbd_exclusive_cinder_pool = False
 rbd_ceph_conf = <%= volume['rbd']['config_file'] %>
     <% end -%>
 rbd_secret_uuid = <%= volume['rbd']['secret_uuid'] %>


### PR DESCRIPTION
Pike has been adding support for managing concurrently used pools, so
it spends more than half of its time on assessing the disk usage.
With https://review.openstack.org/#/c/625970/1 this should become better
but until then we can disable the cinder pool size calculation for
embedded ceph, which removes a perceived hang of multiple minutes
when the disk size calculation kicks in.

When using the RBD pool exclusively for Cinder we can now set
`rbd_exclusive_cinder_pool` to `true` and Cinder will use DB information
to calculate provisioned size instead of querying all volumes in the
backend, which will reduce the load on the Ceph cluster and the volume
service.

Backport-of: #1949 

(cherry picked from commit c9da83110db4a126452327463483c999a25ee421)