### PR TITLE
Improve Mnesia IO performances

### DIFF
--- a/chef/data_bags/crowbar/template-rabbitmq.json
+++ b/chef/data_bags/crowbar/template-rabbitmq.json
@@ -50,7 +50,7 @@
         }
       },
       "mnesia": {
-        "dump_log_write_threshold": 100,
+        "dump_log_write_threshold": 300,
         "dump_log_time_threshold": 180000
       },
       "tcp_listen_options": {


### PR DESCRIPTION
With this configuration, the database Mnesia reduces the activity to the disk.
It is useful when a huge of queues/exchanges/bindings are created and destroyed.
With the default value (100), RabbitMQ could log {Mnesia is overloaded}. Moved to 300.
The range should be between 100 and 1000. Read [1] for more info. [1]
http://erlang.org/doc/man/mnesia.html#dump_log_write_threshold

main stream ref: https://review.openstack.org/#/c/648437/

(cherry picked from commit e0bdd7dc762c84b33074b6a2e1a78b64d8543ffc)