### PR TITLE
[5.0] designate: allow worker on cluster (SOC-9632)

### DIFF
--- a/crowbar_framework/app/models/designate_service.rb
+++ b/crowbar_framework/app/models/designate_service.rb
@@ -52,7 +52,7 @@ class DesignateService < OpenstackServiceObject
         "designate-worker" => {
           "unique" => false,
           "count" => 1,
-          "cluster" => false,
+          "cluster" => true,
           "admin" => false,
           "exclude_platform" => {
             "suse" => "< 12.3",


### PR DESCRIPTION
[1] suggests that workers are there for designate-central to get work
done. So having more of them is a good idea.
A worker does not really have an idea of api so no vip or haproxy
config is required.

1 - https://docs.openstack.org/designate/rocky/contributor/architecture.html

(cherry picked from commit a0a087728dbd15559852bc58cb6400ed23a43a95)