### PR TITLE
Fix tempest config for cinder using ceph as backend (SOC-9298)

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -244,13 +244,16 @@ backend1_name = <%= @cinder_backend1_name %>
 backend2_name = <%= @cinder_backend2_name %>
 <% end -%>
 storage_protocol = <%= @storage_protocol %>
+<% if @storage_protocol == 'ceph' %>
+manage_snapshot_ref = source-name,snapshot-%s
+<% end %>
 vendor_name = <%= @vendor_name %>
 max_microversion = latest
 
 [volume-feature-enabled]
 multi_backend = <%= @cinder_multi_backend ? 'true' : 'false' %>
 backup = false
-extend_attached_volume = True
+extend_attached_volume = <%= @storage_protocol != 'ceph' ? 'true' : 'false' %>
 manage_volume = True
 manage_snapshot = True
 api_v3 = True


### PR DESCRIPTION
- Disable `extend_attached_volume`, for RBD this feature was implemented
  only in Stein [1]
- Set the correct `manage_snapshot_ref` for ceph backend.

1. https://github.com/openstack/nova/commit/eab58069ea6afba875fb0a7d7ac68c7e83ebf14a