### PR TITLE
Tempest fixes for nova and magnum (SOC-9298)

### DIFF
--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -27,6 +27,9 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
 [database]
 connection = <%= @sql_connection %>
 
+[drivers]
+verify_ca = false
+
 [glance_client]
 region_name = <%= @keystone_settings['endpoint_region'] %>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -212,52 +212,81 @@ function findfirst() {
 echo "Downloading image ... "
 wget --no-verbose $IMAGE_URL --directory-prefix=$TEMP 2>&1 || exit $?
 
-echo "Unpacking image ... "
 mkdir $IMG_DIR
-tar -xvzf $TEMP/$IMG_FILE -C $IMG_DIR || exit $?
 rm -rf #{node[:tempest][:tempest_path]}/etc/cirros/*
-cp -v $(findfirst '*-vmlinuz') $(findfirst '*-initrd') $(findfirst '*.img') #{node[:tempest][:tempest_path]}/etc/cirros/ || exit $?
 
-echo -n "Adding kernel ... "
-KERNEL_ID=$(glance #{insecure} image-create \
-    --name "$IMG_NAME-tempest-kernel" \
-    --visibility public --container-format aki \
-    --disk-format aki < $(findfirst '*-vmlinuz') | extract_id)
-echo "done."
-[ -n "$KERNEL_ID" ] || exit 1
+if [[ $IMAGE_URL == *".img" ]]; then
+  mv $TEMP/$IMG_FILE $IMG_DIR/ || exit $?
+  cp -v $(findfirst '*.img') #{node[:tempest][:tempest_path]}/etc/cirros/ || exit $?
 
-echo -n "Adding ramdisk ... "
-RAMDISK_ID=$(glance #{insecure} image-create \
-    --name="$IMG_NAME-tempest-ramdisk" \
-    --visibility public --container-format ari \
-    --disk-format ari < $(findfirst '*-initrd') | extract_id)
-echo "done."
-[ -n "$RAMDISK_ID" ] || exit 1
+  echo -n "Adding alt image ... "
+  ALT_MACHINE_ID=$(glance #{insecure} image-create \
+      --name="$IMG_NAME-tempest-alt" \
+      --visibility public --container-format bare --disk-format qcow2 \
+      < $(findfirst '*.img') | extract_id)
+  echo "done."
+  [ -n "$ALT_MACHINE_ID" ] || exit 1
 
-echo -n "Adding alt image ... "
-ALT_MACHINE_ID=$(glance #{insecure} image-create \
-    --name="$IMG_NAME-tempest-machine-alt" \
-    --visibility public --container-format ami --disk-format ami \
-    --property kernel_id=$KERNEL_ID \
-    --property ramdisk_id=$RAMDISK_ID < $(findfirst '*.img') | extract_id)
-echo "done."
-[ -n "$ALT_MACHINE_ID" ] || exit 1
+  echo -n "Saving alt machine id ..."
+  echo $ALT_MACHINE_ID > #{alt_machine_id_file}
 
-echo -n "Saving alt machine id ..."
-echo $ALT_MACHINE_ID > #{alt_machine_id_file}
+  echo -n "Adding image ... "
+  MACHINE_ID=$(glance #{insecure} image-create \
+      --name="$IMG_NAME-tempest" \
+      --visibility public --container-format bare --disk-format qcow2 \
+      < $(findfirst '*.img') | extract_id)
+  echo "done."
+  [ -n "$MACHINE_ID" ] || exit 1
 
-echo -n "Adding image ... "
-MACHINE_ID=$(glance #{insecure} image-create \
-    --name="$IMG_NAME-tempest-machine" \
-    --visibility public --container-format ami --disk-format ami \
-    --property kernel_id=$KERNEL_ID \
-    --property ramdisk_id=$RAMDISK_ID < $(findfirst '*.img') | extract_id)
-echo "done."
-[ -n "$MACHINE_ID" ] || exit 1
+  echo -n "Saving machine id ..."
+  echo $MACHINE_ID > #{machine_id_file}
+  echo "done."
+else
+  echo "Unpacking image ... "
+  tar -xvzf $TEMP/$IMG_FILE -C $IMG_DIR || exit $?
+  cp -v $(findfirst '*-vmlinuz') $(findfirst '*-initrd') $(findfirst '*.img') #{node[:tempest][:tempest_path]}/etc/cirros/ || exit $?
 
-echo -n "Saving machine id ..."
-echo $MACHINE_ID > #{machine_id_file}
-echo "done."
+  echo -n "Adding kernel ... "
+  KERNEL_ID=$(glance #{insecure} image-create \
+      --name "$IMG_NAME-tempest-kernel" \
+      --visibility public --container-format aki \
+      --disk-format aki < $(findfirst '*-vmlinuz') | extract_id)
+  echo "done."
+  [ -n "$KERNEL_ID" ] || exit 1
+
+  echo -n "Adding ramdisk ... "
+  RAMDISK_ID=$(glance #{insecure} image-create \
+      --name="$IMG_NAME-tempest-ramdisk" \
+      --visibility public --container-format ari \
+      --disk-format ari < $(findfirst '*-initrd') | extract_id)
+  echo "done."
+  [ -n "$RAMDISK_ID" ] || exit 1
+
+  echo -n "Adding alt image ... "
+  ALT_MACHINE_ID=$(glance #{insecure} image-create \
+      --name="$IMG_NAME-tempest-machine-alt" \
+      --visibility public --container-format ami --disk-format ami \
+      --property kernel_id=$KERNEL_ID \
+      --property ramdisk_id=$RAMDISK_ID < $(findfirst '*.img') | extract_id)
+  echo "done."
+  [ -n "$ALT_MACHINE_ID" ] || exit 1
+
+  echo -n "Saving alt machine id ..."
+  echo $ALT_MACHINE_ID > #{alt_machine_id_file}
+
+  echo -n "Adding image ... "
+  MACHINE_ID=$(glance #{insecure} image-create \
+      --name="$IMG_NAME-tempest-machine" \
+      --visibility public --container-format ami --disk-format ami \
+      --property kernel_id=$KERNEL_ID \
+      --property ramdisk_id=$RAMDISK_ID < $(findfirst '*.img') | extract_id)
+  echo "done."
+  [ -n "$MACHINE_ID" ] || exit 1
+
+  echo -n "Saving machine id ..."
+  echo $MACHINE_ID > #{machine_id_file}
+  echo "done."
+fi
 
 rm -rf $TEMP
 

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -519,10 +519,16 @@ else
 end
 
 # Extra roles to assign to the tempest user
-tempest_roles = []
+tempest_roles = ["member"]
 
 barbicans = search(:node, "roles:barbican-controller") || []
 tempest_roles += ["creator"] unless barbicans.empty?
+
+dns_server_node = node_search_with_cache("roles:dns-server").first
+dns_server_node_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
+  dns_server_node,
+  "admin"
+).address
 
 template "/etc/tempest/tempest.conf" do
   source "tempest.conf.erb"
@@ -603,7 +609,8 @@ template "/etc/tempest/tempest.conf" do
         # magnum (container) settings
         magnum_settings: tempest_magnum_settings,
         # heat (orchestration) settings
-        heat_settings: tempest_heat_settings
+        heat_settings: tempest_heat_settings,
+        dns_server_node_ip: dns_server_node_ip
       }
     }
   )

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -13,9 +13,7 @@ admin_username = <%= @keystone_settings['admin_user'] %>
 admin_project_name = <%= @keystone_settings['default_tenant'] %>
 admin_password = <%= @keystone_settings['admin_password'] %>
 admin_domain_name = Default
-<%- unless @tempest_roles.empty? %>
 tempest_roles = <%= @tempest_roles %>
-<%- end %>
 <%- if @enabled_services.include? "baremetal" %>
 create_isolated_networks = False
 <%- end %>
@@ -134,6 +132,7 @@ image_id = <%= @magnum_settings['image_id'] %>
 nic_id = floating
 flavor_id = <%= @magnum_settings['flavor_id'] %>
 master_flavor_id = <%= @magnum_settings['master_flavor_id'] %>
+dns_nameserver = <%= @dns_server_node_ip %>
 
 [monitoring]
 region = <%= @keystone_settings['endpoint_region'] %>

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -63,7 +63,7 @@ personality = True
 # only supported by LVM driver
 # see https://docs.openstack.org/cinder/rocky/reference/support-matrix.html#operation_multi_attach
 volume_multiattach = False
-swap_volume = True
+swap_volume = <%= @storage_protocol != 'ceph' ? 'true' : 'false' %>
 attach_encrypted_volume = <%= @use_attach_encrypted_volume %>
 api_extensions = all
 
@@ -174,7 +174,7 @@ lock_path = /run/tempest
 
 [scenario]
 img_dir = <%= @tempest_path %>/etc/cirros/
-img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-blank.img
+img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-disk.img
 ami_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-blank.img
 ari_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-initrd
 aki_img_file = cirros-<%= @cirros_version %>-<%= @cirros_arch %>-vmlinuz

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -5,7 +5,7 @@
     "tempest": {
       "tempest_test_images": {
           "aarch64": "http://<ADMINWEB>/files/tempest/cirros-0.4.0-aarch64-uec.tar.gz",
-          "x86_64": "http://<ADMINWEB>/files/tempest/cirros-0.4.0-x86_64-uec.tar.gz",
+          "x86_64": "http://<ADMINWEB>/files/tempest/cirros-0.4.0-x86_64-disk.img",
           "ppc64le": "http://<ADMINWEB>/files/tempest/FIXME",
           "s390x": "http://<ADMINWEB>/files/tempest/FIXME"
       },


### PR DESCRIPTION
Nova:
- disable `swap_volume` tests when cinder is using ceph backend as it is
not supported.
- replaced cirros uec used by tempest to qcow2 image

Fix for: `tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario`

Magnum:
- magnum barclamp: set `verify_ca = false`. The magnum barclamp does not
support setting `openstack_ca_file` which leaves magnum unusable when
deploying crowbar using self-signed certificates. Setting `verify_ca =
false` ensures that it will work for any case.
- tempest barclamp: for magnum set `dns_nameserver` with the crowbar DNS
server; and add `member` role to the list of roles given to users created by tempest.

Fix for: `magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters`