### PR TITLE
[5.0] designate: Use server node for VIP look ups (SOC-9631)

### DIFF
--- a/chef/cookbooks/designate/recipes/common.rb
+++ b/chef/cookbooks/designate/recipes/common.rb
@@ -15,14 +15,15 @@
 
 package "openstack-designate"
 
-network_settings = DesignateHelper.network_settings(node)
+designate_server_node = node_search_with_cache("roles:designate-server").first
+network_settings = DesignateHelper.network_settings(designate_server_node)
 db_settings = fetch_database_settings
 
 include_recipe "database::client"
 include_recipe "#{db_settings[:backend_name]}::client"
 include_recipe "#{db_settings[:backend_name]}::python-client"
 
-public_host = CrowbarHelper.get_host_for_public_url(node,
+public_host = CrowbarHelper.get_host_for_public_url(designate_server_node,
                                                     node[:designate][:api][:protocol] == "https",
                                                     node[:designate][:ha][:enabled])
 


### PR DESCRIPTION
If designate is deployed across two clusters, one for the server and the
other for the workers, when the worker recipe applies, it will use the
current node to look up the VIP it should use to talk to the server,
which will fail, since it doesn't have one. Since we can guarantee a
server role exists, make use of the first server role node for those
look ups.

(cherry picked from commit 6683938332f019053bea4d4eb9c4efde143f5a9e)