### PR TITLE
Upgrade: restore Monasca DB [SOC-9772]

### DIFF
--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -20,6 +20,7 @@ if monasca_server.nil?
 end
 grafana_password = monasca_server[:monasca][:db_grafana][:password]
 db_settings = fetch_database_settings
+db_host = db_settings[:address]
 
 # Used for creating data source
 grafana_base_url = ::File.join(MonascaUiHelper.dashboard_local_url(node), "/grafana")
@@ -78,6 +79,33 @@ database_user "grant privileges to the #{grafana_db[:user]} database user" do
   require_ssl db_settings[:connection][:ssl][:enabled]
   action :grant
   only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
+# When upgrading from Cloud 8, restore the Monasca database dumped from the
+# Monasca node and stamp it with Alembic revision information. We stop
+# grafana-server as part of this to make sure there's no concurrent write
+# access to the DB.
+if node["crowbar_upgrade_step"] == "done_os_upgrade"
+  service "stop grafana-server for DB restore" do
+    service_name "grafana-server"
+    supports status: true, restart: true, start: true, stop: true
+    action [:disable, :stop]
+    not_if { File.exist?("/var/lib/crowbar/upgrade/grafana_db_restored") }
+  end
+
+  execute "restore Grafana DB" do
+    command  " /usr/bin/zcat /var/lib/crowbar/upgrade/monasca-grafana-database.dump.gz"\
+             " | /usr/bin/mysql"\
+             "     -h #{db_host}"\
+             "     -u #{grafana_db[:user]}"\
+             "   \"-p#{grafana_db[:password]}\""\
+             " #{grafana_db[:database]}"\
+             " && touch /var/lib/crowbar/upgrade/grafana_db_restored"
+    subscribes :run, resources(service: "stop grafana-server for DB restore"), :immediately
+    action :run
+    not_if { File.exist?("/var/lib/crowbar/upgrade/grafana_db_restored") }
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
 end
 
 template "/etc/grafana/grafana.ini" do

--- a/crowbar_framework/lib/openstack/upgrade.rb
+++ b/crowbar_framework/lib/openstack/upgrade.rb
@@ -37,7 +37,7 @@ module Openstack
       # this point the nodes maybe don't have roles assigned anymore
       components = [
         :ceilometer, :cinder, :glance, :heat,
-        :manila, :neutron, :nova
+        :manila, :neutron, :nova, :monasca
       ]
       NodeObject.all.each do |node|
         save_it = false
@@ -46,7 +46,7 @@ module Openstack
         # run keystone db_sync only in non-ha scenarios
         complete_components << "keystone" if node["keystone"] && !node["keystone"]["ha"]["enabled"]
         complete_components.each do |component|
-          [:db_synced, :api_db_synced].each do |flag|
+          [:db_synced, :api_db_synced, :db_monapi_synced].each do |flag|
             if node[component] && node[component][flag]
               node[component][flag] = false
               save_it = true


### PR DESCRIPTION
This pull request will - once it's done - restore the Monasca and Grafana databases from the dump created by https://github.com/crowbar/crowbar-core/pull/1883 . This is necessary to move these databases from the MariaDB instance on the `monasca-server` node to the one on the controller node(s).