### PR TITLE
upgrade: Fix HA detection for keystone db_sync (SOC-9981)

### DIFF
--- a/crowbar_framework/lib/openstack/upgrade.rb
+++ b/crowbar_framework/lib/openstack/upgrade.rb
@@ -44,7 +44,7 @@ module Openstack
 
         complete_components = components.clone
         # run keystone db_sync only in non-ha scenarios
-        complete_components << "keystone" unless node["pacemaker"]
+        complete_components << "keystone" if node["keystone"] && !node["keystone"]["ha"]["enabled"]
         complete_components.each do |component|
           [:db_synced, :api_db_synced].each do |flag|
             if node[component] && node[component][flag]


### PR DESCRIPTION
Detection of HA scenario for keystone db_sync during upgrade used
incorrect logic relying on pacemaker attribute which is present also
in non-HA deployment.