### PR TITLE
[4.0] magnum: retry flavor creation (SOC-9991)

### DIFF
--- a/chef/cookbooks/magnum/recipes/post_install.rb
+++ b/chef/cookbooks/magnum/recipes/post_install.rb
@@ -67,6 +67,8 @@ execute "create_magnum_flavor" do
   command "#{openstack_cmd} #{openstack_args_nova} flavor create --ram 1024 --disk 10 \
   --vcpus 1 m1.magnum"
   not_if "#{openstack_cmd} #{openstack_args_nova} flavor list --all | grep -q m1.magnum"
+  retries 5
+  retry_delay 10
   action :nothing
 end
 


### PR DESCRIPTION
Creating magnum flavors is done as a delayed action, alongside
all other delayed actions, such as restarting services.
If one of those restarted services is apache (e.g. because it
was triggered by another barclamp configuration change), then
keystone and other API services might not be available right
away, in which case the magnum flavor creation will fail.

Re-attempting magnum flavor creation fixes this issue.