### PR TITLE
[4.0] magnum: retry magnum image creation (SOC-10015)

### DIFF
--- a/chef/cookbooks/magnum/recipes/post_install.rb
+++ b/chef/cookbooks/magnum/recipes/post_install.rb
@@ -60,6 +60,8 @@ execute "create_magnum_image" do
   --container-format bare --public --property os_distro=opensuse \
   #{service_sles_image_name}"
   not_if "#{openstack_cmd} #{openstack_args_glance} image list -f value -c Name | grep -q #{service_sles_image_name}"
+  retries 5
+  retry_delay 10
   action :nothing
 end
 


### PR DESCRIPTION
Creating the magnum image is done as a delayed action, alongside
all other delayed actions, such as restarting services.
If one of those restarted services is apache (e.g. because it
was triggered by another barclamp configuration change), then
keystone and other API services might not be available right
away, in which case the magnum image creation will fail.

Re-attempting magnum image creation fixes this issue.

NOTE: this is a follow-up to #2179