### PR TITLE
monasca: Retry grafana startup

### DIFF
--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -64,6 +64,9 @@ service "grafana-server" do
   supports status: true, restart: true, start: true, stop: true
   action [:enable, :start]
   subscribes :restart, resources(template: "/etc/grafana/grafana.ini")
+  # grafana-server runs database migrations on startup, these tend to fail sometimes but
+  # they usually self-correct when retried
+  retries 2
 end
 
 ["monasca-grafana-datasource", "grafana-natel-discrete-panel",


### PR DESCRIPTION
Grafana startup script executes database migrations which sometimes
fail but retrying usually fixes the problem.