### PR TITLE
add max_threads_per_process tuneable (SOC-10001)

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -198,7 +198,8 @@ case node[:nova][:libvirt_type]
         mode 0644
         variables(
             user: libvirt_user,
-            group: libvirt_group
+            group: libvirt_group,
+            max_threads_per_process: node[:nova][:kvm][:max_threads_per_process]
         )
         notifies :create, "ruby_block[restart_libvirtd]", :immediately
       end

--- a/chef/cookbooks/nova/templates/default/qemu.conf.erb
+++ b/chef/cookbooks/nova/templates/default/qemu.conf.erb
@@ -400,7 +400,16 @@ group = "<%= @group %>"
 #max_processes = 0
 #max_files = 0
 
+# If max_threads_per_process is set to a positive integer, libvirt
+# will use it to set the maximum number of threads that can be
+# created by a qemu process. Some VM configurations can result in
+# qemu processes with tens of thousands of threads. systemd-based
+# systems typically limit the number of threads per process to
+# 16k. max_threads_per_process can be used to override default
+# limits in the host OS.
+#
 
+max_threads_per_process = <%= @max_threads_per_process %>
 
 # mac_filter enables MAC addressed based filtering on bridge ports.
 # This currently requires ebtables to be installed.

--- a/chef/data_bags/crowbar/migrate/nova/305_add_max_threads.rb
+++ b/chef/data_bags/crowbar/migrate/nova/305_add_max_threads.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "max_threads_per_process"
+  attributes["kvm"][key] = template_attributes["kvm"][key] unless attributes["kvm"].key? key
+  return attributes, deployment
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "max_threads_per_process"
+  attributes["kvm"].delete(key) unless template_attributes["kvm"].key? key
+  return attributes, deployment
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -73,7 +73,8 @@
       "kvm": {
         "nested_virt": false,
         "ksm_enabled": false,
-        "disk_cachemodes": "network=writeback"
+        "disk_cachemodes": "network=writeback",
+        "max_threads_per_process": 0
       },
       "vcenter": {
         "host": "",
@@ -180,7 +181,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 304,
+      "schema-revision": 305,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -129,7 +129,8 @@
               "type": "map", "required": true, "mapping": {
                 "nested_virt": { "type": "bool", "required": false },
                 "ksm_enabled": { "type": "bool", "required": true },
-                "disk_cachemodes": { "type": "str", "required": true }
+                "disk_cachemodes": { "type": "str", "required": true },
+                "max_threads_per_process": { "type": "int", "required": true }
               }
             },
             "vcenter": {


### PR DESCRIPTION
In some cases, VMs my contain more threads than permissible by
the systemd set default of 16000. In this case, this tuneable
makes it possible to set a higher limit in qemu.conf through
the Nova barclamp.