### PR TITLE
SOC-10001: add max_threads_per_process tuneable

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -200,7 +200,8 @@ case node[:nova][:libvirt_type]
         mode 0644
         variables(
             user: libvirt_user,
-            group: libvirt_group
+            group: libvirt_group,
+            max_threads_per_process: node[:nova][:kvm][:max_threads_per_process]
         )
         notifies :create, "ruby_block[restart_libvirtd]", :immediately
       end

--- a/chef/cookbooks/nova/templates/default/qemu.conf.erb
+++ b/chef/cookbooks/nova/templates/default/qemu.conf.erb
@@ -400,7 +400,16 @@ group = "<%= @group %>"
 #max_processes = 0
 #max_files = 0
 
+# If max_threads_per_process is set to a positive integer, libvirt
+# will use it to set the maximum number of threads that can be
+# created by a qemu process. Some VM configurations can result in
+# qemu processes with tens of thousands of threads. systemd-based
+# systems typically limit the number of threads per process to
+# 16k. max_threads_per_process can be used to override default
+# limits in the host OS.
+#
 
+max_threads_per_process = <%= @max_threads_per_process %>
 
 # mac_filter enables MAC addressed based filtering on bridge ports.
 # This currently requires ebtables to be installed.

--- a/chef/data_bags/crowbar/migrate/nova/126_add_max_threads.rb
+++ b/chef/data_bags/crowbar/migrate/nova/126_add_max_threads.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "max_threads_per_process"
+  attributes["kvm"][key] = template_attributes["kvm"][key] unless attributes["kvm"].key? key
+  return attributes, deployment
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "max_threads_per_process"
+  attributes["kvm"].delete(key) unless template_attributes["kvm"].key? key
+  return attributes, deployment
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -77,7 +77,8 @@
       "kvm": {
         "nested_virt": false,
         "ksm_enabled": false,
-        "disk_cachemodes": "network=writeback"
+        "disk_cachemodes": "network=writeback",
+        "max_threads_per_process": 0
       },
       "vcenter": {
         "host": "",
@@ -182,7 +183,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 125,
+      "schema-revision": 126,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -135,7 +135,8 @@
               "type": "map", "required": true, "mapping": {
                 "nested_virt": { "type": "bool", "required": false },
                 "ksm_enabled": { "type": "bool", "required": true },
-                "disk_cachemodes": { "type": "str", "required": true }
+                "disk_cachemodes": { "type": "str", "required": true },
+                "max_threads_per_process": { "type": "int", "required": true }
               }
             },
             "vcenter": {


### PR DESCRIPTION
In some cases, VMs my contain more threads than permissible by
the systemd set default of 16000. In this case, this tuneable
makes it possible to set a higher limit in qemu.conf through
the Nova barclamp.

(cherry picked from commit 1ec1f30b6b594ad61b8e4b6940f259e8ddacb1e9)

Backport changes: migration renamed to 126_add_max_threads.rb and schema
                  revision adjusted accordingly.

Note: please hold off on merging this until https://github.com/crowbar/crowbar-openstack/pull/2185 lands. If that pull request undergoes any changes in the course of review, they need to be mirrored here.