### PR TITLE
ceilometer: Remove old ceilometer-api vhosts (SOC-9483)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -13,6 +13,15 @@
 # limitations under the License.
 #
 
+# delete obsolete ceilometer-api configs (even if monasca was not detected)
+apache_site "ceilometer-api.conf" do
+  enable false
+end
+crowbar_openstack_wsgi "delete WSGI entry for ceilometer-api" do
+  daemon_process "ceilometer-api"
+  action :delete
+end
+
 monasca_server = node_search_with_cache("roles:monasca-server").first
 if monasca_server.nil?
   Chef::Log.warn("No monasca-server found. Skip Ceilometer setup.")


### PR DESCRIPTION
When cloud8 is upgraded to cloud9, old ceilometer-api configs could
be left abandoned as Crowbar doesn't manage these anymore.
Explicit config removal should be enough to wipe remaining pieces of
ceilometer-api.