### PR TITLE
[5.0] designate: Configure resource settings (SOC-9633)

### DIFF
--- a/chef/cookbooks/designate/templates/default/designate.conf.erb
+++ b/chef/cookbooks/designate/templates/default/designate.conf.erb
@@ -19,6 +19,12 @@ enabled_extensions_v2 = quotas, reports
 enable_host_header = True
 api_base_uri = <%= @api_base_uri %>
 
+<%if @with_authtoken -%>
+[service:central]
+managed_resource_email = <%= node[:designate][:resource_email] %>
+managed_resource_tenant_id = <%= @resource_project_id %>
+<% end -%>
+
 [service:worker]
 enabled = True
 notify = False

--- a/chef/data_bags/crowbar/migrate/designate/201_add_resources.rb
+++ b/chef/data_bags/crowbar/migrate/designate/201_add_resources.rb
@@ -1,0 +1,12 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["resource_email"] = template_attrs["resource_email"] unless attrs.keys? "resource_email"
+  template_project = template_attrs["resource_project"]
+  attrs["resource_project"] = template_project unless attrs.keys? "resource_project"
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs.delete("resource_email") unless template_attrs.keys? "resource_email"
+  attrs.delete("resource_project") unless template_attrs.keys? "resource_project"
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-designate.json
+++ b/chef/data_bags/crowbar/template-designate.json
@@ -8,6 +8,8 @@
       "keystone_instance": "none",
       "database_instance": "none",
       "rabbitmq_instance": "none",
+      "resource_email": "",
+      "resource_project": "openstack",
       "service_user": "designate",
       "service_password": "",
       "memcache_secret_key": "",
@@ -27,7 +29,7 @@
     "designate": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "designate-server": [ "readying", "ready", "applying" ],
         "designate-worker": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-designate.schema
+++ b/chef/data_bags/crowbar/template-designate.schema
@@ -17,6 +17,8 @@
             "database_instance": { "type": "str", "required": true },
             "keystone_instance": { "type": "str", "required": true },
             "rabbitmq_instance": { "type": "str", "required": true },
+            "resource_email": { "type": "str", "required": true },
+            "resource_project": { "type" : "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
             "memcache_secret_key": { "type": "str", "required": true },

--- a/crowbar_framework/app/models/designate_service.rb
+++ b/crowbar_framework/app/models/designate_service.rb
@@ -93,6 +93,15 @@ class DesignateService < OpenstackServiceObject
     validate_one_for_role proposal, "designate-server"
     validate_one_for_role proposal, "designate-worker"
 
+    designate_bc = proposal["attributes"][@bc_name]
+    email = designate_bc["resource_email"]
+    if email !~ /\w@[^.]+\.\w+/
+      validation_error I18n.t(
+        "barclamp.#{@bc_name}.validation.invalid_email_address",
+        email: email
+      )
+    end
+
     super
   end
 

--- a/crowbar_framework/app/views/barclamp/designate/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/designate/_edit_attributes.html.haml
@@ -5,3 +5,6 @@
   .panel-body
     = instance_field :rabbitmq
     = instance_field :keystone
+
+    = string_field :resource_email
+    = string_field :resource_project

--- a/crowbar_framework/config/locales/designate/en.yml
+++ b/crowbar_framework/config/locales/designate/en.yml
@@ -21,3 +21,7 @@ en:
         rabbitmq_instance: 'RabbitMQ'
         database_instance: 'Database Instance'
         keystone_instance: 'Keystone'
+        resource_email: 'E-mail address of hostmaster'
+        resource_project: 'Project that will own created resources'
+      validation:
+        invalid_email_address: 'E-mail address %{email} is invalid.'


### PR DESCRIPTION
Designate requires a project and a responsible person contact for any
zones it creates, add them into the barclamp configuration with the
first migratation for designate.

(cherry picked from commit 852859e692f53c5d39772a89d6ee4a2684a4449d)