### PR TITLE
IPV6 - Horizon:barclamp make IPV6 compliant (SOC-6397)

### DIFF
--- a/chef/cookbooks/horizon/libraries/helper.rb
+++ b/chef/cookbooks/horizon/libraries/helper.rb
@@ -25,7 +25,7 @@ module MonascaUiHelper
     # protocol = node[:monasca][:api][:ssl] ? "https" : "http"
     protocol = "http"
     port = node[:monasca][:api][:bind_port]
-    "#{protocol}://#{host}:#{port}/v2.0"
+    "#{protocol}://#{NetworkHelper.wrap_ip(host)}:#{port}/v2.0"
   end
 
   def self.dashboard_ip(node)
@@ -51,21 +51,21 @@ module MonascaUiHelper
     if ha_enabled
       port = node[:horizon][:ha][:ports][:plain]
       port = node[:horizon][:ha][:ports][:ssl] if ssl_enabled
-      return "#{protocol}://#{admin_ip}:#{port}"
+      return "#{protocol}://#{NetworkHelper.wrap_ip(admin_ip)}:#{port}"
     end
 
-    "#{protocol}://#{public_ip}"
+    "#{protocol}://#{NetworkHelper.wrap_ip(public_ip)}"
   end
 
   def self.dashboard_public_url(node)
     protocol = "http"
     protocol = "https" if node[:horizon][:apache][:ssl]
 
-    "#{protocol}://#{dashboard_ip(node)}"
+    "#{protocol}://#{NetworkHelper.wrap_ip(dashboard_ip(node))}"
   end
 
   def self.grafana_service_url(node)
-    "http://#{monasca_public_host(node)}:3000"
+    "http://#{NetworkHelper.wrap_ip(monasca_public_host(node))}:3000"
   end
 end
 

--- a/chef/cookbooks/horizon/recipes/ha.rb
+++ b/chef/cookbooks/horizon/recipes/ha.rb
@@ -15,8 +15,15 @@
 
 include_recipe "crowbar-pacemaker::haproxy"
 
+admin_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+
 haproxy_loadbalancer "horizon" do
-  address "0.0.0.0"
+  # Support IPv4 and IPv6
+  if NetworkHelper.ipv6(admin_address)
+    address "::"
+  else
+    address "0.0.0.0"
+  end
   port 80
   use_ssl false
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "horizon", "horizon-server", "plain")
@@ -25,7 +32,12 @@ end.run_action(:create)
 
 if node[:horizon][:apache][:ssl]
   haproxy_loadbalancer "horizon-ssl" do
-    address "0.0.0.0"
+    # Support IPv4 and IPv6
+    if NetworkHelper.ipv6(admin_address)
+      address "::"
+    else
+      address "0.0.0.0"
+    end
     port 443
     use_ssl true
     servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "horizon", "horizon-server", "ssl")

--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -83,7 +83,7 @@ end
 template "/etc/grafana/grafana.ini" do
   source "grafana.ini.erb"
   variables(
-    database_host: db_settings[:address],
+    database_host: NetworkHelper.wrap_ip(db_settings[:address]),
     grafana_password: grafana_password
   )
   owner "root"

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -444,7 +444,8 @@ crowbar_pacemaker_sync_mark "create-horizon_config" if ha_enabled
 if ha_enabled
   log "HA support for horizon is enabled"
   admin_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  bind_host = admin_address
+  bind_host_ipv6 = NetworkHelper.ipv6(admin_address)
+  bind_host = NetworkHelper.wrap_ip(admin_address)
   bind_port = node[:horizon][:ha][:ports][:plain]
   bind_port_ssl = node[:horizon][:ha][:ports][:ssl]
 else
@@ -507,6 +508,7 @@ template "#{node[:apache][:dir]}/sites-available/openstack-dashboard.conf" do
   variables(
     behind_proxy: ha_enabled,
     bind_host: bind_host,
+    bind_host_ipv6: bind_host_ipv6,
     bind_port: bind_port,
     bind_port_ssl: bind_port_ssl,
     horizon_dir: dashboard_path,

--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -4,27 +4,51 @@
 
 Listen <%= @bind_host %>:<%= @bind_port %>
 
-# Redirect non-SSL traffic to SSL
-<VirtualHost <%= @bind_host %>:<%= @bind_port %>>
-    RewriteEngine On
+    <% if @bind_host_ipv6 %>
+    # Redirect non-SSL traffic to SSL for ipv6
+    <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
+        RewriteEngine On
 
-    # If request was explicit about this port, then we redirect with the
-    # explicit SSL port. This is needed in the HA case, where we use
-    # non-standard ports.
-    RewriteCond %{REQUEST_URI} !^/server-status
-    # Extract port
-    RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
-    RewriteCond %2 ^:<%= @bind_port %>$
-    # Remove port from HTTP_HOST
-    RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
-    RewriteRule / https://%1:<%= @bind_port_ssl %>%{REQUEST_URI} [L,R]
+        # If request was explicit about this port, then we redirect with the
+        # explicit SSL port. This is needed in the HA case, where we use
+        # non-standard ports.
+        RewriteCond %{REQUEST_URI} !^/server-status
+        # Extract port
+        RewriteCond %{HTTP_HOST} ^(\[\S+\])(:[0-9]+)?$
+        RewriteCond %2 ^:<%= @bind_port %>$
+        # Remove port from HTTP_HOST
+        RewriteCond %{HTTP_HOST} ^(\[\S+\])(:[0-9]+)?$
+        RewriteRule / https://%1:<%= @bind_port_ssl %>%{REQUEST_URI} [L,R]
 
-    # Otherwise, we simply redirect to https.
-    RewriteCond %{REQUEST_URI} !^/server-status
-    # Remove port from HTTP_HOST
-    RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
-    RewriteRule / https://%1%{REQUEST_URI} [L,R]
-</VirtualHost>
+        # Otherwise, we simply redirect to https.
+        RewriteCond %{REQUEST_URI} !^/server-status
+        # Remove port from HTTP_HOST
+        RewriteCond %{HTTP_HOST} ^(\[\S+\])(:[0-9]+)?$
+        RewriteRule / https://%1%{REQUEST_URI} [L,R]
+    </VirtualHost>
+    <% else %>
+    # Redirect non-SSL traffic to SSL for ipv4
+    <VirtualHost <%= @bind_host %>:<%= @bind_port %>>
+        RewriteEngine On
+
+        # If request was explicit about this port, then we redirect with the
+        # explicit SSL port. This is needed in the HA case, where we use
+        # non-standard ports.
+        RewriteCond %{REQUEST_URI} !^/server-status
+        # Extract port
+        RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
+        RewriteCond %2 ^:<%= @bind_port %>$
+        # Remove port from HTTP_HOST
+        RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
+        RewriteRule / https://%1:<%= @bind_port_ssl %>%{REQUEST_URI} [L,R]
+
+        # Otherwise, we simply redirect to https.
+        RewriteCond %{REQUEST_URI} !^/server-status
+        # Remove port from HTTP_HOST
+        RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
+        RewriteRule / https://%1%{REQUEST_URI} [L,R]
+    </VirtualHost>
+    <% end %>
 
 Listen <%= @bind_host %>:<%= @bind_port_ssl %>
 

--- a/crowbar_framework/app/models/horizon_service.rb
+++ b/crowbar_framework/app/models/horizon_service.rb
@@ -165,10 +165,12 @@ class HorizonService < OpenstackServiceObject
       end
 
       node.crowbar["crowbar"]["links"].delete("Nova Dashboard (public)")
-      node.crowbar["crowbar"]["links"]["OpenStack Dashboard (public)"] = "#{protocol}://#{public_server_ip}/"
+      node.crowbar["crowbar"]["links"]["OpenStack Dashboard (public)"] =
+        "#{protocol}://#{NetworkHelper.wrap_ip(public_server_ip)}/"
 
       node.crowbar["crowbar"]["links"].delete("Nova Dashboard (admin)")
-      node.crowbar["crowbar"]["links"]["OpenStack Dashboard (admin)"] = "#{protocol}://#{admin_server_ip}/"
+      node.crowbar["crowbar"]["links"]["OpenStack Dashboard (admin)"] =
+        "#{protocol}://#{NetworkHelper.wrap_ip(admin_server_ip)}/"
 
       node.save
     end


### PR DESCRIPTION
This commit depends on crowbar/crowbar-core#1906  and  includes the followings:

1) Used NetworkHepler's wrap_ip to wrap any host, node or address that
can be used in a url form. Assume host or node in barclamp Horizon is
usually an ip address.
2) Upated "0.0.0.0" (any address) to use "::" which can be handled in both
IPV4 and IPV6 environment.
3) Added apache rewriterule in suse/openstack-dashboard.conf.erb to deal
with IPV6 when bind_host is in IPV6 form.
                       