### PR TITLE
neutron: restore dhcp_domain in stable/4.0 (bsc#1145867)

### DIFF
--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -10,7 +10,7 @@ enable_isolated_metadata = <%= @enable_isolated_metadata %>
 enable_metadata_network = <%= @enable_metadata_network %>
 <% end -%>
 force_metadata = <%= @force_metadata %>
-dns_domain = <%= @dns_domain %>
+dhcp_domain = <%= @dhcp_domain %>
 <% if @nameservers -%>
 dnsmasq_dns_servers = <%= @nameservers %>
 <% end -%>


### PR DESCRIPTION
It was replaced with dns_domain in 9e96051,
but newton neutron dhcp needs dhcp_domain.