### PR TITLE
designate: initialize email in default designate proposal

### DIFF
--- a/crowbar_framework/app/models/designate_service.rb
+++ b/crowbar_framework/app/models/designate_service.rb
@@ -75,6 +75,7 @@ class DesignateService < OpenstackServiceObject
         "designate-server" => [controller[:fqdn]],
         "designate-worker" => [controller[:fqdn]]
       }
+      base["attributes"][@bc_name]["resource_email"] = "crowbar@#{controller[:domain]}"
     end
 
     base["attributes"][@bc_name]["database_instance"] = find_dep_proposal("database")


### PR DESCRIPTION
The implicit assumption of mkcloud(1) is that a create_proposal()
default proposal can be applied. the empty default of designate's
resource email broke that, so lets set it to a validating default.