### PR TITLE
memcache: lookup memcached servers port only on local node (SOC-10173)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -6,10 +6,6 @@ include_recipe "apache2"
 is_controller = node["roles"].include?("ceilometer-server")
 ha_enabled = node[:ceilometer][:ha][:server][:enabled]
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "ceilometer-server") : [node]
-)
-
 memcached_instance("ceilometer-server") if is_controller
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
@@ -85,7 +81,8 @@ template node[:ceilometer][:config_file] do
       rabbit_settings: fetch_rabbitmq_settings,
       keystone_settings: keystone_settings,
       monasca_project: monasca_project,
-      memcached_servers: memcached_servers,
+      memcached_servers: MemcachedHelper.get_memcached_servers(node,
+        CrowbarPacemakerHelper.cluster_nodes(node, "ceilometer-server")),
       bind_host: bind_host,
       bind_port: bind_port,
       metering_secret: node[:ceilometer][:metering_secret],

--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -106,14 +106,6 @@ if need_shared_lock_path
   include_recipe "crowbar-openstack::common"
 end
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:cinder][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "cinder-controller")
-  else
-    [node]
-  end
-)
-
 memcached_instance("cinder") if node["roles"].include?("cinder-controller")
 
 profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
@@ -141,7 +133,8 @@ template node[:cinder][:config_file] do
     strict_ssh_host_key_policy: node[:cinder][:strict_ssh_host_key_policy],
     default_availability_zone: node[:cinder][:default_availability_zone],
     default_volume_type: node[:cinder][:default_volume_type],
-    memcached_servers: memcached_servers,
+    memcached_servers: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "cinder-controller")),
     profiler_settings: profiler_settings
     )
 end

--- a/chef/cookbooks/designate/recipes/common.rb
+++ b/chef/cookbooks/designate/recipes/common.rb
@@ -30,14 +30,6 @@ public_host = CrowbarHelper.get_host_for_public_url(designate_server_node,
 # get Database data
 sql_connection = fetch_database_connection_string(node[:designate][:db])
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:designate][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "designate-server")
-  else
-    [node]
-  end
-)
-
 memcached_instance("designate") if node["roles"].include?("designate-server")
 
 api_protocol = node[:designate][:api][:protocol]
@@ -74,7 +66,8 @@ template node[:designate][:config_file] do
     sql_connection: sql_connection,
     rabbit_settings: fetch_rabbitmq_settings,
     keystone_settings: keystone_settings,
-    memcached_servers: memcached_servers,
+    memcached_servers: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "designate-server")),
     resource_project_id: resource_project_id
   )
 end

--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -40,11 +40,6 @@ else
   bind_port_s3 = node[:nova][:ports][:ec2_s3]
 end
 
-# use memcached as a cache backend for ec2-api-metadata
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "ec2-api") : [node]
-)
-
 memcached_instance "ec2-api"
 
 crowbar_pacemaker_sync_mark "wait-ec2_api_database" if ha_enabled
@@ -219,7 +214,8 @@ template node[:nova]["ec2-api"][:config_file] do
     bind_port_metadata: bind_port_metadata,
     bind_port_s3: bind_port_s3,
     nova_metadata_settings: nova_metadata_settings,
-    memcached_servers: memcached_servers
+    memcached_servers: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "ec2-api"))
   )
 end
 

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -44,9 +44,6 @@ ironics = node_search_with_cache("roles:ironic-server") || []
 network_settings = GlanceHelper.network_settings(node)
 
 ha_enabled = node[:glance][:ha][:enabled]
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "glance-server") : [node]
-)
 
 glance_stores = node.default[:glance][:glance_stores].dup
 glance_stores += ["vmware"] unless node[:glance][:vsphere][:host].empty?
@@ -72,7 +69,8 @@ template node[:glance][:api][:config_file] do
       bind_host: network_settings[:api][:bind_host],
       bind_port: network_settings[:api][:bind_port],
       keystone_settings: keystone_settings,
-      memcached_servers: memcached_servers,
+      memcached_servers: MemcachedHelper.get_memcached_servers(node,
+        CrowbarPacemakerHelper.cluster_nodes(node, "glance-server")),
       rabbit_settings: fetch_rabbitmq_settings,
       swift_api_insecure: swift_insecure,
       cinder_api_insecure: cinder_insecure,

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -102,9 +102,6 @@ if node[:heat][:api][:protocol] == "https"
   end
 end
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "heat-server") : [node]
-)
 memcached_instance("heat-server")
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
@@ -389,7 +386,8 @@ template "/etc/heat/heat.conf.d/100-heat.conf" do
         debug: node[:heat][:debug],
         rabbit_settings: fetch_rabbitmq_settings,
         keystone_settings: keystone_settings,
-        memcached_servers: memcached_servers,
+        memcached_servers: MemcachedHelper.get_memcached_servers(node,
+          CrowbarPacemakerHelper.cluster_nodes(node, "heat-server")),
         database_connection: db_connection,
         bind_host: bind_host,
         api_port: api_port,

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -351,11 +351,6 @@ else
   neutron_ml2_type_drivers = "'*'"
 end
 
-# We're going to use memcached as a cache backend for Django
-memcached_locations = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "horizon-server") : [node]
-)
-
 memcached_instance "openstack-dashboard"
 
 crowbar_pacemaker_sync_mark "wait-horizon_config" if ha_enabled
@@ -428,7 +423,8 @@ template local_settings do
     help_url: node[:horizon][:help_url],
     session_timeout: node[:horizon][:session_timeout],
     secret_key: node["horizon"]["secret_key"],
-    memcached_locations: memcached_locations,
+    memcached_locations: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "horizon-server")),
     can_set_mount_point: node["horizon"]["can_set_mount_point"],
     can_set_password: node["horizon"]["can_set_password"],
     multi_domain_support: multi_domain_support,

--- a/chef/cookbooks/ironic/recipes/server.rb
+++ b/chef/cookbooks/ironic/recipes/server.rb
@@ -165,8 +165,6 @@ end
 
 ironic_net_name = "ironic"
 
-memcached_servers = MemcachedHelper.get_memcached_servers([node])
-
 memcached_instance("ironic")
 
 template node[:ironic][:config_file] do
@@ -206,7 +204,7 @@ template node[:ironic][:config_file] do
         api_port: api_port,
         api_url: api_url,
         auth_version: auth_version,
-        memcached_servers: memcached_servers
+        memcached_servers: MemcachedHelper.get_memcached_servers(node)
       }
     }
   )

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -59,10 +59,6 @@ cluster_nodes = ha_enabled ? node[:pacemaker][:elements]["pacemaker-cluster-memb
 cluster_nodes = cluster_nodes.map { |n| Chef::Node.load(n) }
 cluster_nodes.sort_by! { |n| n[:hostname] }
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? cluster_nodes : [node]
-)
-
 memcached_instance "keystone"
 
 # resource to set a flag when apache2 is restarted so we now which cookbook was the
@@ -262,7 +258,7 @@ template node[:keystone][:config_file] do
         node[:keystone][:api][:protocol],
         my_admin_host, node[:keystone][:api][:admin_port]
       ),
-      memcached_servers: memcached_servers,
+      memcached_servers: MemcachedHelper.get_memcached_servers(node, cluster_nodes),
       token_format: node[:keystone][:token_format],
       token_expiration: node[:keystone][:token_expiration],
       max_active_keys: max_active_keys,

--- a/chef/cookbooks/magnum/recipes/common.rb
+++ b/chef/cookbooks/magnum/recipes/common.rb
@@ -21,9 +21,6 @@ network_settings = MagnumHelper.network_settings(node)
 
 ha_enabled = node[:magnum][:ha][:enabled]
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "magnum-server") : [node]
-)
 memcached_instance("magnum-server")
 
 include_recipe "database::client"
@@ -55,6 +52,7 @@ template node[:magnum][:config_file] do
     sql_connection: sql_connection,
     rabbit_settings: fetch_rabbitmq_settings,
     keystone_settings: KeystoneHelper.keystone_settings(node, :magnum),
-    memcached_servers: memcached_servers
+    memcached_servers: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "magnum-server"))
   )
 end

--- a/chef/cookbooks/manila/recipes/common.rb
+++ b/chef/cookbooks/manila/recipes/common.rb
@@ -109,14 +109,6 @@ cinder_insecure = CrowbarOpenStackHelper.insecure(cinder_config)
 enabled_share_protocols = ["NFS", "CIFS"]
 enabled_share_protocols << ["CEPHFS"] if ManilaHelper.has_cephfs_share? node
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:manila][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "manila-server")
-  else
-    [node]
-  end
-)
-
 memcached_instance("manila") if node["roles"].include?("manila-server")
 
 template node[:manila][:config_file] do
@@ -145,7 +137,8 @@ template node[:manila][:config_file] do
     cinder_insecure: cinder_insecure,
     cinder_admin_username: cinder_admin_username,
     cinder_admin_password: cinder_admin_password,
-    memcached_servers: memcached_servers
+    memcached_servers: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "manila-server"))
   )
 end
 

--- a/chef/cookbooks/memcached/libraries/helpers.rb
+++ b/chef/cookbooks/memcached/libraries/helpers.rb
@@ -1,14 +1,10 @@
 module MemcachedHelper
-  def self.get_memcached_servers(memcached_nodes)
+  def self.get_memcached_servers(node, memcached_nodes = [])
+    memcached_nodes = [node] if memcached_nodes.empty?
     memcached_servers = memcached_nodes.map do |n|
       node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(n,
                                                                             "admin").address
-      port = if n.key?(:memcached) && n[:memcached].key?(:port)
-        n[:memcached][:port]
-      else
-        memcached_nodes.first[:memcached][:port]
-      end
-      "#{node_admin_ip}:#{port}"
+      "#{node_admin_ip}:#{node[:memcached][:port]}"
     end
     memcached_servers.sort!
     memcached_servers

--- a/chef/cookbooks/monasca/recipes/monasca_api.rb
+++ b/chef/cookbooks/monasca/recipes/monasca_api.rb
@@ -24,14 +24,6 @@ monasca_net_ip = MonascaHelper.get_host_for_monitoring_url(monasca_servers[0])
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:monasca][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "monasca-server")
-  else
-    [node]
-  end
-)
-
 memcached_instance("monasca") if node["roles"].include?("monasca-server")
 
 # get Database data
@@ -46,7 +38,8 @@ template "/etc/monasca/api.conf" do
   mode "0640"
   variables(
     keystone_settings: keystone_settings,
-    memcached_servers: memcached_servers,
+    memcached_servers: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "monasca-server")),
     kafka_host: monasca_net_ip,
     tsdb_host: monasca_net_ip,
     sql_connection: sql_connection,

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -70,9 +70,6 @@ keystone_settings = KeystoneHelper.keystone_settings(neutron, @cookbook_name)
 profiler_settings = KeystoneHelper.profiler_settings(node, @cookbook_name)
 
 ha_enabled = node[:neutron][:ha][:server][:enabled]
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "neutron-server") : [node]
-)
 
 memcached_instance("neutron-server") if is_neutron_server
 
@@ -167,7 +164,8 @@ template neutron[:neutron][:config_file] do
       rabbit_settings: CrowbarOpenStackHelper.rabbitmq_settings(neutron, "neutron"),
       keystone_settings: keystone_settings,
       profiler_settings: profiler_settings,
-      memcached_servers: memcached_servers,
+      memcached_servers: MemcachedHelper.get_memcached_servers(node,
+        CrowbarPacemakerHelper.cluster_nodes(node, "neutron-server")),
       ssl_enabled: neutron[:neutron][:api][:protocol] == "https",
       ssl_cert_file: neutron[:neutron][:ssl][:certfile],
       ssl_key_file: neutron[:neutron][:ssl][:keyfile],

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -100,11 +100,6 @@ glance_config = Barclamp::Config.load("openstack", "glance", node[:nova][:glance
 glance_insecure = CrowbarOpenStackHelper.insecure(glance_config) || keystone_settings["insecure"]
 Chef::Log.info("Glance server at #{glance_server_host}")
 
-# use memcached as a cache backend for nova-novncproxy
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  api_ha_enabled ? CrowbarPacemakerHelper.cluster_nodes(node, "nova-controller") : [node]
-)
-
 memcached_instance "nova" if is_controller
 
 directory "/etc/nova" do
@@ -388,7 +383,8 @@ template node[:nova][:config_file] do
     vncproxy_cert_file: api_novnc_ssl_certfile,
     vncproxy_key_file: api_novnc_ssl_keyfile,
     serialproxy_public_host: public_api_host,
-    memcached_servers: memcached_servers,
+    memcached_servers: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "nova-controller")),
     neutron_protocol: neutron_protocol,
     neutron_server_host: neutron_server_host,
     neutron_server_port: neutron_server_port,

--- a/chef/cookbooks/sahara/recipes/common.rb
+++ b/chef/cookbooks/sahara/recipes/common.rb
@@ -42,14 +42,6 @@ nova_insecure = CrowbarOpenStackHelper.insecure(nova_config)
 
 use_ceilometer = !Barclamp::Config.load("openstack", "ceilometer").empty?
 
-memcached_servers = MemcachedHelper.get_memcached_servers(
-  if node[:sahara][:ha][:enabled]
-    CrowbarPacemakerHelper.cluster_nodes(node, "sahara-server")
-  else
-    [node]
-  end
-)
-
 memcached_instance("sahara") if node["roles"].include?("sahara-server")
 
 template node[:sahara][:config_file] do
@@ -65,7 +57,8 @@ template node[:sahara][:config_file] do
     keystone_settings: KeystoneHelper.keystone_settings(node, :sahara),
     cinder_insecure: cinder_insecure,
     heat_insecure: heat_insecure,
-    memcached_servers: memcached_servers,
+    memcached_servers: MemcachedHelper.get_memcached_servers(node,
+      CrowbarPacemakerHelper.cluster_nodes(node, "sahara-server")),
     neutron_insecure: neutron_insecure,
     nova_insecure: nova_insecure,
     use_ceilometer: use_ceilometer

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -274,7 +274,7 @@ end
 memcached_instance "swift-proxy"
 
 proxy_config[:memcached_ips] =
-  MemcachedHelper.get_memcached_servers(node_search_with_cache("roles:swift-proxy"))
+  MemcachedHelper.get_memcached_servers(node, node_search_with_cache("roles:swift-proxy"))
 
 ## Create the proxy server configuraiton file
 template node[:swift][:proxy_config_file] do

--- a/chef/cookbooks/swift/recipes/storage.rb
+++ b/chef/cookbooks/swift/recipes/storage.rb
@@ -45,7 +45,7 @@ end
 
 storage_ip = Swift::Evaluator.get_ip_by_type(node,:storage_ip_expr)
 
-memcached_ips = MemcachedHelper.get_memcached_servers(node_search_with_cache("roles:swift-proxy"))
+memcached_ips = MemcachedHelper.get_memcached_servers(node, node_search_with_cache("roles:swift-proxy"))
 
 %w{account-server object-expirer object-server container-server}.each do |service|
   template "/etc/swift/#{service}.conf" do


### PR DESCRIPTION
With #2073 merged
we were looking up the port on the node with the lowest mac address,
which however in compilation phase might not yet have that attribute.

By passing in the local node and moving to execution phase we should
always have the default attributes for memcached port visible.