### PR TITLE
rabbitmq: Turn off hipe compile

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -56,7 +56,6 @@ default[:rabbitmq][:ha][:clustered_rmq_features] = false
 case node[:platform_family]
 when "suse"
   if node[:platform] != "suse" || node[:platform_version].to_f > 12.2
-    default[:rabbitmq][:hipe_compile] = true
     default[:rabbitmq][:ha][:clustered_rmq_features] = true
   end
 end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -104,10 +104,6 @@ template "/etc/rabbitmq/rabbitmq-env.conf" do
   notifies :restart, "service[rabbitmq-server]"
 end
 
-`systemd-detect-virt -v -q`
-virtualized = $?.exitstatus.zero?
-hipe_compile = node[:rabbitmq][:hipe_compile] && !virtualized
-
 template "/etc/rabbitmq/rabbitmq.config" do
   source "rabbitmq.config.erb"
   owner "root"
@@ -118,7 +114,7 @@ template "/etc/rabbitmq/rabbitmq.config" do
     cluster_partition_handling: cluster_partition_handling,
     addresses: addresses,
     management_address: CrowbarRabbitmqHelper.get_management_address(node),
-    hipe_compile: hipe_compile
+    hipe_compile: node[:rabbitmq][:hipe_compile]
   )
   notifies :restart, "service[rabbitmq-server]"
 end


### PR DESCRIPTION
It interacts badly with the pacemaker health monitoring and
based on rumours does not work with IPv6.