### PR TITLE
[4.0] database: Hardcode ruby version for package installation (SOC-10010)

### DIFF
--- a/chef/cookbooks/mysql/recipes/client.rb
+++ b/chef/cookbooks/mysql/recipes/client.rb
@@ -30,7 +30,7 @@ if platform_family?(%w{debian rhel fedora suse})
   package "mysql-ruby" do
     package_name value_for_platform_family(
       ["rhel", "fedora"] => "ruby-mysql",
-      "suse" => "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-mysql2",
+      "suse" => "ruby2.1-rubygem-mysql2",
       "default" => "libmysql-ruby"
     )
     action :install

--- a/chef/cookbooks/postgresql/attributes/default.rb
+++ b/chef/cookbooks/postgresql/attributes/default.rb
@@ -132,14 +132,18 @@ when "suse"
     default["postgresql"]["contrib"]["packages"] = ["postgresql-contrib"]
   when node["platform_version"].to_f < 12.0
     default["postgresql"]["version"] = "9.1"
-    default["postgresql"]["client"]["packages"] = ["postgresql91",
-      "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-pg"]
+    default["postgresql"]["client"]["packages"] = [
+      "postgresql91",
+      "ruby2.1-rubygem-pg"
+    ]
     default["postgresql"]["server"]["packages"] = ["postgresql91-server"]
     default["postgresql"]["contrib"]["packages"] = ["postgresql91-contrib"]
   when node["platform_version"].to_f == 12.0
     default["postgresql"]["version"] = "9.3"
-    default["postgresql"]["client"]["packages"] = ["postgresql93",
-      "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-pg"]
+    default["postgresql"]["client"]["packages"] = [
+      "postgresql93",
+      "ruby2.1-rubygem-pg"
+    ]
     default["postgresql"]["server"]["packages"] = ["postgresql93-server"]
     default["postgresql"]["contrib"]["packages"] = ["postgresql93-contrib"]
   else
@@ -160,7 +164,7 @@ when "opensuse"
   default["postgresql"]["version"] = "9.4"
   default["postgresql"]["client"]["packages"] = [
     "postgresql94",
-    "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-pg"
+    "ruby2.1-rubygem-pg"
   ]
   default["postgresql"]["server"]["packages"] = ["postgresql94-server"]
   default["postgresql"]["contrib"]["packages"] = ["postgresql94-contrib"]


### PR DESCRIPTION
Sometimes there is a race condition and ohai didn't collect the ruby
version. to_f evalutes then the version to 0.0 and zypper fails to
install the rubygem `ruby0.0-rubygem-cstruct' not found in package
names`.

(cherry picked from commit 6c02091fc2ffbadfb8fa12f7537b91586e6e112b)