### PR TITLE
nova: raise neutron client timeout to 5 minutes

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -109,7 +109,7 @@ default[:nova][:home_dir] = "/var/lib/nova"
 default[:nova][:instances_path] = "/var/lib/nova/instances"
 
 default[:nova][:neutron_metadata_proxy_shared_secret] = ""
-default[:nova][:neutron_url_timeout] = 30
+default[:nova][:neutron_url_timeout] = 300
 
 default[:nova][:service_user] = "nova"
 default[:nova][:service_password] = "nova"

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -29,7 +29,7 @@
         "network": "admin"
       },
       "use_syslog": false,
-      "neutron_url_timeout": 30,
+      "neutron_url_timeout": 300,
       "force_config_drive": false,
       "scheduler": {
         "ram_allocation_ratio": 1.0,


### PR DESCRIPTION
The 30s is definitely too low for environments with many
thousand ports in active state. 300 is also the set value
in Ardana.