### PR TITLE
[5.0] designate: Deploy producer on a server node (SOC-9766)

### DIFF
--- a/chef/cookbooks/designate/recipes/api.rb
+++ b/chef/cookbooks/designate/recipes/api.rb
@@ -16,6 +16,8 @@
 # Recipe:: api
 #
 
+package "openstack-designate-producer"
+
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 designate_port = node[:designate][:api][:bind_port]
@@ -97,3 +99,4 @@ crowbar_pacemaker_sync_mark "create-designate_register" if ha_enabled
 
 designate_service "central"
 designate_service "api"
+designate_service "producer" unless ha_enabled


### PR DESCRIPTION
Designate has another service 'producer', which is used to run
long-running periodic tasks. Install the package and start the service
on one of the server nodes, monitored by pacemaker.

(cherry picked from commit 0a0c48c998c0f5555af8a9bdaf523014400c3219)