### PR TITLE
[5.0] Fix barbican SSL support (SOC-9799)

### DIFF
--- a/chef/cookbooks/barbican/recipes/ha.rb
+++ b/chef/cookbooks/barbican/recipes/ha.rb
@@ -22,7 +22,7 @@ log "Setting up barbican HA support"
 
 network_settings = BarbicanHelper.network_settings(node)
 
-ssl_enabled = node[:barbican][:api][:ssl]
+ssl_enabled = node["barbican"]["api"]["protocol"] == "https"
 
 include_recipe "crowbar-pacemaker::haproxy"
 

--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -257,11 +257,8 @@ class CrowbarOpenStackHelper
 
   def self.insecure(attributes)
     use_ssl = if attributes.key?("api") && attributes["api"].key?("protocol")
-      # aodh, cinder, glance, heat, keystone, manila, neutron
+      # aodh, barbican, cinder, glance, heat, keystone, manila, neutron
       attributes["api"]["protocol"] == "https"
-    elsif attributes.key?("api") && attributes["api"].key?("ssl")
-      # barbican
-      attributes["api"]["ssl"]
     elsif attributes.key?("ssl") && attributes["ssl"].key?("enabled")
       # nova
       attributes["ssl"]["enabled"]


### PR DESCRIPTION
The check to identify if SSL is enabled on the barbican barclamp was
incorrect, there is no `ssl` entry on the barbican/api schema.

This change uses the api.protocol value (http/https) to check if SSL is
enabled or not, the same way other barclamps do (eg. keystone).

(cherry picked from commit ea5ba2576ae2ef43bd41ce35a34750cde2ee2539)