### PR TITLE
Install barbican tempest plugin for SOC8 (SOC-10191)

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -31,6 +31,8 @@ package "euca2ools"
 
 package "openstack-tempest-test"
 
+package "python-barbican-tempest-plugin"
+
 ["keystone", "swift", "glance", "cinder", "neutron", "nova",
  "heat", "ceilometer", "sahara"].each do |component|
   package "python-#{component}client"


### PR DESCRIPTION
Barbican tests curently not running on SOC8 because
python-barbican-tempest-plugin not installed.