### PR TITLE
tempest: add kibana_version to the identity senction of tempest.conf

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -92,6 +92,7 @@ alt_username = <%= @alt_comp_user %>
 alt_tenant_name = <%= @alt_comp_tenant %>
 alt_password = <%= @alt_comp_pass %>
 alt_domain_name = Default
+kibana_version = '4.6.3'
 
 [identity-feature-enabled]
 domain_specific_drivers = <%= node[:keystone][:domain_specific_drivers] ? "True" : "False" %>


### PR DESCRIPTION
kibana_version conf is needed by monasca_log_api_tempest testcases as
this key-value pair is added headers of requests to kibana
https://opendev.org/openstack/monasca-log-api/src/tag/newton-eol/monasca_log_api_tempest/config.py#L40

sample failure: https://ci.suse.de/job/openstack-mkcloud/8437/consoleText

