### PR TITLE
enable LDAP chase_referrals configuration (SOC-7364)

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -25,6 +25,7 @@ default[:keystone][:user] = "keystone"
 default[:keystone][:group] = "keystone"
 
 default[:keystone][:debug] = false
+default[:keystone][:insecure_debug] = false
 default[:keystone][:frontend] = "apache"
 default[:keystone][:domain_specific_drivers] = false
 default[:keystone][:domain_config_dir] = "/etc/keystone/domains"
@@ -63,6 +64,7 @@ default[:keystone][:ldap][:password] = ""
 default[:keystone][:ldap][:suffix] = "cn=example,cn=com"
 default[:keystone][:ldap][:page_size] = 0
 default[:keystone][:ldap][:alias_dereferencing] = "default"
+default[:keystone][:ldap][:chase_referrals] = ""
 default[:keystone][:ldap][:query_scope] = "one"
 
 default[:keystone][:ldap][:user_tree_dn] = ""

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -320,6 +320,7 @@ template node[:keystone][:config_file] do
       sql_connection: sql_connection,
       sql_idle_timeout: node[:keystone][:sql][:idle_timeout],
       debug: node[:keystone][:debug],
+      insecure_debug: node[:keystone][:insecure_debug],
       admin_endpoint: KeystoneHelper.service_URL(
         node[:keystone][:api][:protocol],
         my_admin_host, node[:keystone][:api][:admin_port]

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -1,6 +1,7 @@
 [DEFAULT]
 admin_endpoint = <%= @admin_endpoint %>
 debug = <%= @debug ? "True" : "False" %>
+insecure_debug = <%= @insecure_debug ? "True": "False" %>
 log_file = keystone.log
 log_dir = /var/log/keystone
 transport_url = <%= @rabbit_settings[:url] %>
@@ -47,6 +48,9 @@ suffix = <%= node[:keystone][:ldap][:suffix] %>
 query_scope = <%= node[:keystone][:ldap][:query_scope] %>
 page_size = <%= node[:keystone][:ldap][:page_size] %>
 alias_dereferencing = <%= node[:keystone][:ldap][:alias_dereferencing] %>
+<%  unless node[:keystone][:ldap][:chase_referrals].nil? or node[:keystone][:ldap][:chase_referrals].empty? -%>
+chase_referrals = <%= node[:keystone][:ldap][:chase_referrals] %>
+<% end -%>
 user_tree_dn = <%= node[:keystone][:ldap][:user_tree_dn] %>
 user_filter = <%= node[:keystone][:ldap][:user_filter] %>
 user_objectclass = <%= node[:keystone][:ldap][:user_objectclass] %>

--- a/chef/cookbooks/keystone/templates/default/keystone.domain.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.domain.conf.erb
@@ -9,6 +9,9 @@ suffix = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:suffix] %
 query_scope = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:query_scope] %>
 page_size = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:page_size] %>
 alias_dereferencing = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:alias_dereferencing] %>
+<%  unless node[:keystone][:domain_specific_config][@domain][:ldap][:chase_referrals].nil? or node[:keystone][:domain_specific_config][@domain][:ldap][:chase_referrals].empty? -%>
+chase_referrals = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:chase_referrals] %>
+<% end -%>
 user_tree_dn = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_tree_dn] %>
 user_filter = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_filter] %>
 user_objectclass = <%= node[:keystone][:domain_specific_config][@domain][:ldap][:user_objectclass] %>

--- a/chef/data_bags/crowbar/migrate/keystone/305_add_ldap_configs_and_insecure_debug.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/305_add_ldap_configs_and_insecure_debug.rb
@@ -1,0 +1,26 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  unless attrs["ldap"].key?("chase_referrals")
+    attrs["ldap"]["chase_referrals"] = template_attrs["ldap"]["chase_referrals"]
+  end
+  attrs["domain_specific_config"].keys.each do |domain|
+    unless attrs["domain_specific_config"][domain]["ldap"].key?("chase_referrals")
+      attrs["domain_specific_config"][domain]["ldap"]["chase_referrals"] =
+        template_attrs["domain_specific_config"]["ldap_users"]["ldap"]["chase_referrals"]
+    end
+  end
+  attrs["insecure_debug"] = template_attrs["insecure_debug"] unless attrs.key?("insecure_debug")
+
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["ldap"].delete("chase_referrals") unless template_attrs["ldap"].key?("chase_referrals")
+  unless template_attrs["domain_specific_config"]["ldap_users"]["ldap"].key?("chase_referrals")
+    attrs["domain_specific_config"].keys.each do |domain|
+      attrs["domain_specific_config"][domain]["ldap"].delete("chase_referrals")
+    end
+  end
+  attrs.delete("insecure_debug") unless template_attrs.key?("insecure_debug")
+
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-keystone.json
+++ b/chef/data_bags/crowbar/template-keystone.json
@@ -4,6 +4,7 @@
   "attributes": {
     "keystone": {
       "debug": false,
+      "insecure_debug": false,
       "frontend": "apache",
       "policy_file": "policy.json",
       "database_instance": "none",
@@ -67,6 +68,7 @@
         "suffix": "cn=example,cn=com",
         "page_size": 0,
         "alias_dereferencing": "default",
+        "chase_referrals": "",
         "query_scope": "one",
         "user_tree_dn": "",
         "user_filter": "",
@@ -122,6 +124,7 @@
             "suffix": "cn=example,cn=com",
             "page_size": 0,
             "alias_dereferencing": "default",
+            "chase_referrals": "",
             "query_scope": "one",
             "user_tree_dn": "",
             "user_filter": "",
@@ -199,7 +202,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 304,
+      "schema-revision": 305,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-keystone.schema
+++ b/chef/data_bags/crowbar/template-keystone.schema
@@ -8,6 +8,7 @@
         "keystone": { "type": "map", "required": true,
              "mapping": {
                     "debug": { "type": "bool", "required": true },
+                    "insecure_debug": { "type": "bool", "required": true },
                     "frontend": { "type": "str", "required": true },
                     "policy_file": { "type": "str", "required": true },
                     "database_instance": { "type": "str", "required": true },
@@ -73,6 +74,7 @@
                       "suffix": { "type": "str" },
                       "page_size": { "type": "int" },
                       "alias_dereferencing": { "type": "str" },
+                      "chase_referrals": { "type": "str" },
                       "query_scope": { "type": "str" },
                       "user_tree_dn": { "type": "str" },
                       "user_filter": { "type": "str" },
@@ -129,6 +131,7 @@
                             "suffix": { "type": "str" },
                             "page_size": { "type": "int" },
                             "alias_dereferencing": { "type": "str" },
+                            "chase_referrals": { "type": "str" },
                             "query_scope": { "type": "str" },
                             "user_tree_dn": { "type": "str" },
                             "user_filter": { "type": "str" },


### PR DESCRIPTION
For Microsoft Active Directory deployments where users are not
visible/accessible via the global catalog, list users operation, as a
whole, will fail when one or more referrals are returned on an LDAP
lookup and the current (admin) user have no access to a given referral.

This patch exposes the chase_referrals option in Keystone to enable
customers who got stuck in the above situation to optionally turn
off referrals chasing.

By default, chase_referrals is set to an empty value to preserve
backward compatibility. This is a three state configuration.

Empty value means use the system default. This is all depended on the
underlying LDAP SDK and the system configuration (i.e. /etc/ldap.conf).
"0" means disable referrals chasing.
"1" means enable referrals chasing.

This patch is also exposes the insecure_debug option to help customers and
field engineers to quicky pinpoint the problem when needed.