### PR TITLE
Changes to integrate with ACI 4.1 and new packages (SOC-10403)

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -33,6 +33,7 @@ default[:neutron][:ml2_config_file] = "/etc/neutron/neutron.conf.d/110-ml2.conf"
 default[:neutron][:nsx_config_file] = "/etc/neutron/neutron.conf.d/110-nsx.conf"
 default[:neutron][:ml2_cisco_config_file] = "/etc/neutron/neutron.conf.d/115-ml2_cisco.conf"
 default[:neutron][:ml2_cisco_apic_config_file] = "/etc/neutron/neutron.conf.d/115-ml2_cisco_apic.conf"
+default[:neutron][:opflex_config_file] = "/etc/opflex-agent-ovs/conf.d/10-opflex-agent-ovs.conf"
 default[:neutron][:rpc_workers] = 1
 
 default[:neutron][:db][:database] = "neutron"
@@ -128,8 +129,8 @@ when "suse"
     cisco_apic_pkgs: ["python-apicapi",
                       "python-neutron-ml2-driver-apic"],
     cisco_apic_gbp_pkgs: ["openstack-neutron-gbp",
-                          "python-gbpclient"],
-    cisco_opflex_pkgs: ["agent-ovs",
+                          "python-group-based-policy-client"],
+    cisco_opflex_pkgs: ["opflex-agent",
                         "lldpd",
                         "openstack-neutron-opflex-agent"],
     infoblox_pkgs: ["python-infoblox-client",
@@ -174,8 +175,8 @@ when "rhel"
     cisco_apic_pkgs: ["python-apicapi",
                       "python-neutron-ml2-driver-apic"],
     cisco_apic_gbp_pkgs: ["openstack-neutron-gbp",
-                          "python-gbpclient"],
-    cisco_opflex_pkgs: ["agent-ovs",
+                          "python-group-based-policy-client"],
+    cisco_opflex_pkgs: ["opflex-agent",
                         "lldpd",
                         "neutron-opflex-agent"],
     infoblox_pkgs: [],

--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -91,15 +91,14 @@ template agent_config_path do
 end
 
 # Update config file from template
-opflex_agent_conf = "/etc/opflex-agent-ovs/conf.d/10-opflex-agent-ovs.conf"
 apic = neutron[:neutron][:apic]
 opflex_list = apic[:opflex].select { |i| i[:nodes].include? node[:hostname] }
 opflex_list.any? || raise("Opflex instance not found for node '#{node[:hostname]}'")
 opflex_list.one? || raise("Multiple opflex instances found for node '#{node[:hostname]}'")
 opflex = opflex_list.first
-template opflex_agent_conf do
+template node[:neutron][:opflex_config_file] do
   cookbook "neutron"
-  source "10-opflex-agent-ovs.conf.erb"
+  source "opflex-agent-ovs.conf.erb"
   mode "0755"
   owner "root"
   group neutron[:neutron][:platform][:group]
@@ -109,6 +108,8 @@ template opflex_agent_conf do
     socketgroup: neutron[:neutron][:platform][:group],
     opflex_peer_ip: opflex[:peer_ip],
     opflex_peer_port: opflex[:peer_port],
+    opflex_int_bridge: opflex[:integration_bridge],
+    opflex_access_bridge: opflex[:access_bridge],
     opflex_vxlan_encap_iface: opflex[:vxlan][:encap_iface],
     opflex_vxlan_uplink_iface: opflex[:vxlan][:uplink_iface],
     opflex_vxlan_uplink_vlan: opflex[:vxlan][:uplink_vlan],

--- a/chef/cookbooks/neutron/templates/default/opflex-agent-ovs.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/opflex-agent-ovs.conf.erb
@@ -36,7 +36,8 @@
 
   "renderers": {
     "stitched-mode": {
-      "ovs-bridge-name": "br-int",
+      "int-bridge-name": "<%= @opflex_int_bridge %>",
+      "access-bridge-name": "<%= @opflex_access_bridge %>",
       "encap": {
         "vxlan" : {
           "encap-iface": "<%= @opflex_vxlan_encap_iface %>",

--- a/chef/data_bags/crowbar/migrate/neutron/308_add_opflex_access_integration_bridge.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/308_add_opflex_access_integration_bridge.rb
@@ -1,0 +1,21 @@
+def upgrade(tattr, tdep, attr, dep)
+  unless attr["apic"]["opflex"].key?("integration_bridge")
+    attr["apic"]["opflex"]["integration_bridge"] = tattr["apic"]["opflex"]["integration_bridge"]
+  end
+  unless attr["apic"]["opflex"].key?("access_bridge")
+    attr["apic"]["opflex"]["access_bridge"] = tattr["apic"]["opflex"]["access_bridge"]
+  end
+
+  return attr, dep
+end
+
+def downgrade(tattr, tdep, attr, dep)
+  unless tattr["apic"]["opflex"].key?("integration_bridge")
+    attr["apic"]["opflex"].delete("integration_bridge") if attr.key?("integration_bridge")
+  end
+  unless tattr["apic"]["opflex"].key?("access_bridge")
+    attr["apic"]["opflex"].delete("access_bridge") if attr.key?("access_bridge")
+  end
+
+  return attr, dep
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -64,8 +64,10 @@
           "peer_ip": "",
           "peer_port": 8009,
           "encap": "vxlan",
+          "integration_bridge": "br-int",
+          "access_bridge": "br-fabric",
           "vxlan": {
-              "encap_iface": "br-int_vxlan0",
+              "encap_iface": "br-fab_vxlan0",
               "uplink_iface": "vlan.4093",
               "uplink_vlan": 4093,
               "remote_ip": "",
@@ -193,7 +195,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 307,
+      "schema-revision": 308,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -72,6 +72,8 @@
                           "peer_ip": { "type": "str", "required" : true },
                           "peer_port": { "type": "int", "required" : true },
                           "encap": { "type": "str", "required": true },
+                          "integration_bridge": { "type": "str", "required": true },
+                          "access_bridge": { "type": "str", "required": true },
                           "vxlan": { "type": "map", "required": true, "mapping" : {
                             "encap_iface": {"type": "str", "required": true },
                             "uplink_iface": { "type": "str", "required": true },


### PR DESCRIPTION
This commit provides changes in plugin packages and config files
needed for integration of SOC with ACI 4.1 and higher versions.
ACI 4.1 uses a slightly different set of plugin packages and configs
for integration with OpenStack. This includes:
 - python-gbpclient renamed to python-group-based-policy-client
 - ovs-bridge-name in opflex-agent-ovs.conf removed
 - addition of int-bridge-name and access-bridge-name in opflex-agent-ovs.conf
 - Renaming of agent-ovs to opflex-agent
For uniformity, the template for opflex-agent-ovs.conf is now renamed
from 10-opflex-agent-ovs.conf.erb to opflex-agent-ovs.conf.erb
- The neutron template schema and json templates are updated to provide
integration_bridge and access_bridge details with default values. The
corresponding migration scripts are also updated.

Note: The changes are initially intended for SOC 7 based on customer demand and hence tested with SOC7. 