### PR TITLE
nova: Don't put nova-compute roles on monasca node (SOC-10373)

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -145,6 +145,7 @@ class NovaService < OpenstackServiceObject
     nodes.delete_if { |n| n.nil? }
     nodes.delete_if { |n| n.admin? } if nodes.size > 1
     nodes.delete_if { |n| n.intended_role == "storage" }
+    nodes.delete_if { |n| n.intended_role == "monitoring" }
 
     controller  = nodes.delete nodes.detect { |n| n if n.intended_role == "controller" }
     controller ||= nodes.shift


### PR DESCRIPTION
Mixing compute with "controller" roles is not supported during upgrade.
Placing Monasca on a dedicated node is a good idea anyway as it consumes
a lot of resources.