### PR TITLE
designate: Handle one dns-server node for mdns (SOC-10456)

### DIFF
--- a/chef/cookbooks/designate/recipes/mdns.rb
+++ b/chef/cookbooks/designate/recipes/mdns.rb
@@ -13,16 +13,15 @@
 # limitations under the License.
 #
 # Cookbook Name:: designate
-# Recipe:: api
+# Recipe:: mdns
 #
 
 require "yaml"
 
 dns_all = node_search_with_cache("roles:dns-server")
-dns = dns_all.first
-dnsmaster = dns[:dns][:master_ip]
-dnsslaves = dns[:dns][:slave_ips].to_a
-dnsservers = [dnsmaster] + dnsslaves
+dnsservers = dns_all.map do |n|
+  Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
+end
 
 designate_servers = node_search_with_cache("roles:designate-server")
 


### PR DESCRIPTION
The mdns recipe was written with the assumption that the dns-server role
would be applied to multiple servers, which means one of them would be
elected master with a master_ip property set. This does not exist if
dns-server is only applied to one role, so handle that case as well.

Also drive-by correcting the recipe name in the header comment.