### PR TITLE
Aci 4.1 multivmm

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -33,6 +33,7 @@ default[:neutron][:ml2_config_file] = "/etc/neutron/neutron.conf.d/110-ml2.conf"
 default[:neutron][:nsx_config_file] = "/etc/neutron/neutron.conf.d/110-nsx.conf"
 default[:neutron][:ml2_cisco_config_file] = "/etc/neutron/neutron.conf.d/115-ml2_cisco.conf"
 default[:neutron][:ml2_cisco_apic_config_file] = "/etc/neutron/neutron.conf.d/115-ml2_cisco_apic.conf"
+default[:neutron][:opflex_config_file] = "/etc/opflex-agent-ovs/conf.d/10-opflex-agent-ovs.conf"
 default[:neutron][:rpc_workers] = 1
 
 default[:neutron][:db][:database] = "neutron"
@@ -128,8 +129,8 @@ when "suse"
     cisco_apic_pkgs: ["python-apicapi",
                       "python-neutron-ml2-driver-apic"],
     cisco_apic_gbp_pkgs: ["openstack-neutron-gbp",
-                          "python-gbpclient"],
-    cisco_opflex_pkgs: ["agent-ovs",
+                          "python-group-based-policy-client"],
+    cisco_opflex_pkgs: ["opflex-agent",
                         "lldpd",
                         "openstack-neutron-opflex-agent"],
     infoblox_pkgs: ["python-infoblox-client",
@@ -174,8 +175,8 @@ when "rhel"
     cisco_apic_pkgs: ["python-apicapi",
                       "python-neutron-ml2-driver-apic"],
     cisco_apic_gbp_pkgs: ["openstack-neutron-gbp",
-                          "python-gbpclient"],
-    cisco_opflex_pkgs: ["agent-ovs",
+                          "python-group-based-policy-client"],
+    cisco_opflex_pkgs: ["opflex-agent",
                         "lldpd",
                         "neutron-opflex-agent"],
     infoblox_pkgs: [],

--- a/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
+++ b/chef/cookbooks/neutron/recipes/cisco_apic_agents.rb
@@ -91,15 +91,14 @@ template agent_config_path do
 end
 
 # Update config file from template
-opflex_agent_conf = "/etc/opflex-agent-ovs/conf.d/10-opflex-agent-ovs.conf"
 apic = neutron[:neutron][:apic]
 opflex_list = apic[:opflex].select { |i| i[:nodes].include? node[:hostname] }
 opflex_list.any? || raise("Opflex instance not found for node '#{node[:hostname]}'")
 opflex_list.one? || raise("Multiple opflex instances found for node '#{node[:hostname]}'")
 opflex = opflex_list.first
-template opflex_agent_conf do
+template node[:neutron][:opflex_config_file] do
   cookbook "neutron"
-  source "10-opflex-agent-ovs.conf.erb"
+  source "opflex-agent-ovs.conf.erb"
   mode "0755"
   owner "root"
   group neutron[:neutron][:platform][:group]
@@ -109,6 +108,8 @@ template opflex_agent_conf do
     socketgroup: neutron[:neutron][:platform][:group],
     opflex_peer_ip: opflex[:peer_ip],
     opflex_peer_port: opflex[:peer_port],
+    opflex_int_bridge: opflex[:integration_bridge],
+    opflex_access_bridge: opflex[:access_bridge],
     opflex_vxlan_encap_iface: opflex[:vxlan][:encap_iface],
     opflex_vxlan_uplink_iface: opflex[:vxlan][:uplink_iface],
     opflex_vxlan_uplink_vlan: opflex[:vxlan][:uplink_vlan],

--- a/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf_cisco_apic.ini.erb
@@ -2,7 +2,7 @@
 apic_system_id=<%= node[:neutron][:apic][:system_id] %>
 [opflex]
 networks = *
-[ml2_cisco_apic]
+[apic]
 apic_hosts=<%= node[:neutron][:apic][:hosts] %>
 apic_username=<%= node[:neutron][:apic][:username] %>
 apic_password=<%= node[:neutron][:apic][:password] %>
@@ -11,8 +11,8 @@ apic_name_mapping = use_name
 apic_clear_node_profiles = True
 enable_aci_routing = True
 apic_arp_flooding = True
-enable_optimized_metadata = <%= node[:neutron][:apic][:optimized_metadata] %>
-enable_optimized_dhcp = <%= node[:neutron][:apic][:optimized_dhcp] %>
+enable_optimized_metadata = <%= @optimized_metadata %>
+enable_optimized_dhcp = <%= @optimized_dhcp] %>
 apic_provision_infra = True
 apic_provision_hostlinks = True
 <%  unless @vpc_pairs.nil? -%>
@@ -41,3 +41,12 @@ enable_nat = <%= node[:neutron][:apic][:ext_net][:nat_enabled] %>
 <% end -%>
 external_epg = <%= node[:neutron][:apic][:ext_net][:ext_epg] %>
 host_pool_cidr = <%= node[:neutron][:apic][:ext_net][:host_pool_cidr] %>
+
+<% @apic_vmms.each do |vmm_domain| -%>
+[apic_vmdom:<%= vmm_domain[:vmm_name]%>]
+vmm_type = <%= vmm_domain[:vmm_type]%>
+<%   if vmm_domain[:vlan_ranges] -%>
+vlan_ranges = <%= vmm_domain[:vlan_ranges] %> 
+<%   end -%>
+<% end -%>
+

--- a/chef/cookbooks/neutron/templates/default/opflex-agent-ovs.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/opflex-agent-ovs.conf.erb
@@ -36,7 +36,8 @@
 
   "renderers": {
     "stitched-mode": {
-      "ovs-bridge-name": "br-int",
+      "int-bridge-name": "<%= @opflex_int_bridge %>",
+      "access-bridge-name": "<%= @opflex_access_bridge %>",
       "encap": {
         "vxlan" : {
           "encap-iface": "<%= @opflex_vxlan_encap_iface %>",

--- a/chef/data_bags/crowbar/migrate/neutron/308_add_opflex_access_integration_bridge.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/308_add_opflex_access_integration_bridge.rb
@@ -1,0 +1,21 @@
+def upgrade(tattr, tdep, attr, dep)
+  unless attr["apic"]["opflex"].key?("integration_bridge")
+    attr["apic"]["opflex"]["integration_bridge"] = tattr["apic"]["opflex"]["integration_bridge"]
+  end
+  unless attr["apic"]["opflex"].key?("access_bridge")
+    attr["apic"]["opflex"]["access_bridge"] = tattr["apic"]["opflex"]["access_bridge"]
+  end
+
+  return attr, dep
+end
+
+def downgrade(tattr, tdep, attr, dep)
+  unless tattr["apic"]["opflex"].key?("integration_bridge")
+    attr["apic"]["opflex"].delete("integration_bridge") if attr.key?("integration_bridge")
+  end
+  unless tattr["apic"]["opflex"].key?("access_bridge")
+    attr["apic"]["opflex"].delete("access_bridge") if attr.key?("access_bridge")
+  end
+
+  return attr, dep
+end

--- a/chef/data_bags/crowbar/migrate/neutron/309_add_apic_multi_vmm_domains.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/309_add_apic_multi_vmm_domains.rb
@@ -1,0 +1,15 @@
+def upgrade(tattr, tdep, attr, dep)
+  unless attr["apic"].key?("apic_vmms")
+    attr["apic"]["apic_vmms"] = tattr["apic"]["apic_vmms"]
+  end
+
+  return attr, dep
+end
+
+def downgrade(tattr, tdep, attr, dep)
+  unless tattr["apic"].key?("apic_vmms")
+    attr["apic"].delete("apic_vmms") if attr.key?("apic_vmms")
+  end
+
+  return attr, dep
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -64,8 +64,10 @@
           "peer_ip": "",
           "peer_port": 8009,
           "encap": "vxlan",
+          "integration_bridge": "br-int",
+          "access_bridge": "br-fabric",
           "vxlan": {
-              "encap_iface": "br-int_vxlan0",
+              "encap_iface": "br-fab_vxlan0",
               "uplink_iface": "vlan.4093",
               "uplink_vlan": 4093,
               "remote_ip": "",
@@ -193,7 +195,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 307,
+      "schema-revision": 308,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -98,7 +98,17 @@
               }
             }
           }
-        }
+        },
+        "apic_vmms": [{
+          "vmm_name": "soc_kvm_domain",
+          "vmm_type": "openstack",
+          "vlan_ranges": ""
+        },
+        {
+          "vmm_name": "soc_vm_domain",
+          "vmm_type": "vmware",
+          "vlan_ranges": ""
+        }]
       },
       "allow_overlapping_ips": true,
       "use_syslog": false,
@@ -195,7 +205,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 308,
+      "schema-revision": 309,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -94,7 +94,14 @@
                             }}
                           }}
                         }}
-                      }
+                      },
+                      "apic_vmms": { "type" : "seq", "required" : true, "sequence" : [ {
+                        "type" : "map", "required" : true, "mapping" : {
+                          "vmm_name": { "type": "str", "required": true },
+                          "vmm_type": { "type": "str", "required": true },
+                          "vlan_ranges": { "type": "str", "required": true }
+                        }
+                      } ] }
                     }},
                     "allow_overlapping_ips": { "type": "bool", "required": true },
                     "cisco_switches": {

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -72,6 +72,8 @@
                           "peer_ip": { "type": "str", "required" : true },
                           "peer_port": { "type": "int", "required" : true },
                           "encap": { "type": "str", "required": true },
+                          "integration_bridge": { "type": "str", "required": true },
+                          "access_bridge": { "type": "str", "required": true },
                           "vxlan": { "type": "map", "required": true, "mapping" : {
                             "encap_iface": {"type": "str", "required": true },
                             "uplink_iface": { "type": "str", "required": true },


### PR DESCRIPTION
This PR enables the following feature for Cisco ACI:

Allows Crowbar configuration for enabling multiple VMM domain features for ACI. It was painful for the customer to change in the config file manually and avoid the chef-client from overriding the config. Both KVM and VMWare based VMM domains can be configured using this feature.

Each [apic_vmdom:<vmm_domain_name>] corresponds to a VMM configuration. In these sections, [apic] configurations can be overridden for more granular infrastructure sharing.
What is configured in the [apic] sharing will be the default used in case a more specific configuration is missing for the domain.

For example:

[apic_vmdom:soc_kvm_domain]
vlan_ranges=1000:2000

[apic_vmdom:soc_vmware_domain]
apic_vmm_type=vmware

In case of a VMWare based VMM domain, the respective VMM domain MUST be created in APIC prior to configuring in neutron. For KVM, neutron will create the VMM domain if not already created.

Note: The intended target of this PR is Cloud 7 and is updated here due to the standard process being followed for all PRs (master-update followed by cloud 7 backport). The tests were only done for Cloud 7 based deployments.