### PR TITLE
Install barbican tempest plugin for SOC8 (SOC-10191)

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -42,3 +42,9 @@ if node[:kernel][:machine] == "x86_64" &&
     package "python-monasca-#{component}"
   end
 end
+
+[
+  "barbican"
+].each do |component|
+  package "python-#{component}-tempest-plugin" if config_for_role_exists?(component)
+end


### PR DESCRIPTION
Barbican tests curently not running on SOC8 because
python-barbican-tempest-plugin not installed.