### PR TITLE
[5.0] designate: No longer care about master/slave (SOC-10456)

### DIFF
--- a/chef/cookbooks/designate/recipes/mdns.rb
+++ b/chef/cookbooks/designate/recipes/mdns.rb
@@ -13,16 +13,15 @@
 # limitations under the License.
 #
 # Cookbook Name:: designate
-# Recipe:: api
+# Recipe:: mdns
 #
 
 require "yaml"
 
 dns_all = node_search_with_cache("roles:dns-server")
-dns = dns_all.first
-dnsmaster = dns[:dns][:master_ip]
-dnsslaves = dns[:dns][:slave_ips].to_a
-dnsservers = [dnsmaster] + dnsslaves
+dnsservers = dns_all.map do |n|
+  Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
+end
 
 designate_servers = node_search_with_cache("roles:designate-server")
 


### PR DESCRIPTION
The mdns recipe was cleaned up to no longer distingush between master
and slave DNS servers. To that end, clean up the code that assigned them
with a simple map, which also handles the case that the dns-server role
was only applied to one node.

Also drive-by correcting the recipe name in the header comment.

(cherry picked from commit 740d78672fc8d44ab15fd81e72c831762e921f5e)