### PR TITLE
Octavia: Hide UI until complete (SOC-10550)

### DIFF
--- a/octavia.yml
+++ b/octavia.yml
@@ -19,7 +19,8 @@ barclamp:
   display: 'Octavia'
   description: 'Operator-scale load balancing solution designed to work with OpenStack.'
   version: 0
-  user_managed: true
+  # Change to true when complete
+  user_managed: false
   requires:
     - 'nova'
     - 'glance'


### PR DESCRIPTION
This patch sets `user_managed: false` so that the UI doesn't appear
in crowbar. This will be changed back to `true` once we've finished the
barclamp and it's been released.