### PR TITLE
helper: move config_for_role_exists from horizon to crowbar-openstack (SOC-10191)

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -37,6 +37,10 @@ class Chef
       monasca_server = node_search_with_cache("roles:monasca-server").first
       monasca_server.nil?
     end
+
+    def config_for_role_exists?(name)
+      CrowbarOpenStackHelper.config_for_role_exists?(name)
+    end
   end
 end
 
@@ -273,6 +277,13 @@ class CrowbarOpenStackHelper
     end
 
     use_ssl && attributes["ssl"]["insecure"]
+  end
+
+  def self.config_for_role_exists?(name)
+    shouldbe = "#{name}-config-"
+    @cached_roles ||= Chef::Role.list.keys
+    res = @cached_roles.find { |rname| rname.start_with? shouldbe }
+    res != nil
   end
 
   private

--- a/chef/cookbooks/horizon/libraries/helper.rb
+++ b/chef/cookbooks/horizon/libraries/helper.rb
@@ -68,12 +68,3 @@ module MonascaUiHelper
     "http://#{NetworkHelper.wrap_ip(monasca_public_host(node))}:3000"
   end
 end
-
-module RoleHelper
-  def self.config_for_role_exists?(name)
-    shouldbe = "#{name}-config-"
-    @cached_roles = @cached_roles || Chef::Role.list.keys
-    res = @cached_roles.find { |rname| rname.start_with? shouldbe }
-    res != nil
-  end
-end

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -95,10 +95,10 @@ neutron_fwaas_ui_pkgname =
   end
 
 unless neutron_fwaas_ui_pkgname.nil?
+  neutron_role_exists = config_for_role_exists?("neutron")
   package neutron_fwaas_ui_pkgname do
     action :install
-    notifies :reload, "service[horizon]"
-    only_if { RoleHelper.config_for_role_exists?("neutron") }
+    only_if { neutron_role_exists }
   end
 end
 
@@ -112,10 +112,10 @@ manila_ui_pkgname =
   end
 
 unless manila_ui_pkgname.nil?
+  manila_role_exists = config_for_role_exists?("manila")
   package manila_ui_pkgname do
     action :install
-    notifies :reload, "service[horizon]"
-    only_if { RoleHelper.config_for_role_exists?("manila") }
+    only_if { manila_role_exists }
   end
 end
 
@@ -129,10 +129,10 @@ magnum_ui_pkgname =
   end
 
 unless magnum_ui_pkgname.nil?
+  magnum_role_exists = config_for_role_exists?("magnum")
   package magnum_ui_pkgname do
     action :install
-    notifies :reload, "service[horizon]"
-    only_if { RoleHelper.config_for_role_exists?("magnum") }
+    only_if { magnum_role_exists }
   end
 end
 
@@ -146,10 +146,10 @@ designate_ui_pkgname =
   end
 
 unless designate_ui_pkgname.nil?
+  designate_role_exists = config_for_role_exists?("designate")
   package designate_ui_pkgname do
     action :install
-    notifies :reload, "service[horizon]"
-    only_if { RoleHelper.config_for_role_exists?("designate") }
+    only_if { designate_role_exists }
   end
 end
 
@@ -163,10 +163,10 @@ sahara_ui_pkgname =
   end
 
 unless sahara_ui_pkgname.nil?
+  sahara_role_exists = config_for_role_exists?("sahara")
   package sahara_ui_pkgname do
     action :install
-    notifies :reload, "service[horizon]"
-    only_if { RoleHelper.config_for_role_exists?("sahara") }
+    only_if { sahara_role_exists }
   end
 end
 
@@ -180,10 +180,10 @@ ironic_ui_pkgname =
   end
 
 unless ironic_ui_pkgname.nil?
+  ironic_role_exists = config_for_role_exists?("ironic")
   package ironic_ui_pkgname do
     action :install
-    notifies :reload, "service[horizon]"
-    only_if { RoleHelper.config_for_role_exists?("ironic") }
+    only_if { ironic_role_exists }
   end
 end
 
@@ -218,10 +218,10 @@ end
 
 # install horizon heat plugin if needed
 heat_ui_pkgname = "openstack-horizon-plugin-heat-ui"
+heat_role_exists = config_for_role_exists?("heat")
 package heat_ui_pkgname do
   action :install
-  notifies :reload, "service[horizon]"
-  only_if { RoleHelper.config_for_role_exists?("heat") }
+  only_if { heat_role_exists }
 end
 
 if node[:platform_family] == "suse"
@@ -595,11 +595,11 @@ monasca_ui_pkgname =
   end
 
 unless monasca_ui_pkgname.nil?
-  if RoleHelper.config_for_role_exists?("monasca")
+  monasca_role_exists = config_for_role_exists?("monasca")
+  if monasca_role_exists
     include_recipe "#{@cookbook_name}::monasca_ui"
     package monasca_ui_pkgname do
       action :install
-      notifies :reload, "service[horizon]"
     end
   end
 end

--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -63,5 +63,5 @@ end
   "neutron",
   "octavia"
 ].each do |component|
-  package "python-#{component}-tempest-plugin" if RoleHelper.config_for_role_exists?(component)
+  package "python-#{component}-tempest-plugin" if config_for_role_exists?(component)
 end


### PR DESCRIPTION
This is clean up ,as we need to use helper outside horizon barclamp
would be more convenient  to move it to crowbar-openstack.
