### PR TITLE
[5.0] designate: Correct missing variable (SOC-10549)

### DIFF
--- a/chef/cookbooks/designate/recipes/mdns.rb
+++ b/chef/cookbooks/designate/recipes/mdns.rb
@@ -79,7 +79,7 @@ template "/etc/designate/rndc.key" do
   owner "root"
   group node[:designate][:group]
   mode "0640"
-  variables(rndc_key: dns[:dns][:designate_rndc_key])
+  variables(rndc_key: dns_all.first[:dns][:designate_rndc_key])
 end
 
 ha_enabled = node[:designate][:ha][:enabled]


### PR DESCRIPTION
The previous PR missed changing one use of the removed variables, switch
to the correct variable.

(cherry picked from commit 1e88db88ce8d00c1969a0e6f79e0938e1a95e8a3)