### PR TITLE
Allow setting ElasticSearch path.repo from Crowbar (SOC-10440)

### DIFF
--- a/chef/cookbooks/monasca/attributes/default.rb
+++ b/chef/cookbooks/monasca/attributes/default.rb
@@ -95,7 +95,6 @@ default[:monasca][:elasticsearch][:is_master_node] = "true"
 default[:monasca][:elasticsearch][:is_data_node] = "true"
 default[:monasca][:elasticsearch][:data_dirs] = ["/var/data/elasticsearch"]
 default[:monasca][:elasticsearch][:log_dir] = "/var/log/elasticsearch"
-default[:monasca][:elasticsearch][:repo_dirs] = []
 default[:monasca][:elasticsearch][:bootstrap_memory_lock] = "true"
 
 # storm

--- a/chef/cookbooks/monasca/recipes/elasticsearch.rb
+++ b/chef/cookbooks/monasca/recipes/elasticsearch.rb
@@ -70,7 +70,7 @@ node[:monasca][:elasticsearch][:data_dirs].each do |d|
   end
 end
 
-node[:monasca][:elasticsearch][:repo_dirs].each do |d|
+node[:monasca][:elasticsearch][:repo_dir].each do |d|
   directory d do
     mode "0755"
     owner "elasticsearch"
@@ -98,7 +98,7 @@ template "/etc/elasticsearch/elasticsearch.yml" do
     elasticsearch_is_data_node: node[:monasca][:elasticsearch][:is_data_node],
     elasticsearch_data_dirs: node[:monasca][:elasticsearch][:data_dirs],
     elasticsearch_log_dir: node[:monasca][:elasticsearch][:log_dir],
-    elasticsearch_repo_dirs: node[:monasca][:elasticsearch][:repo_dirs],
+    elasticsearch_repo_dir: node[:monasca][:elasticsearch][:repo_dir],
     elasticsearch_bootstrap_memory_lock: node[:monasca][:elasticsearch][:bootstrap_memory_lock],
     elasticsearch_bind_host: monasca_net_ip,
     elasticsearch_public_host: monasca_net_ip

--- a/chef/cookbooks/monasca/templates/default/elasticsearch.yml.erb
+++ b/chef/cookbooks/monasca/templates/default/elasticsearch.yml.erb
@@ -162,8 +162,8 @@ path.logs: <%= @elasticsearch_log_dir %>
 #path.conf: /path/to/conf
 
 # Path to Shared File System Repository
-<% unless @elasticsearch_repo_dirs.empty? %>
-path.repo: [<%= @elasticsearch_repo_dirs.join(",") %>]
+<% unless @elasticsearch_repo_dir.empty? %>
+path.repo: [<%= @elasticsearch_repo_dir.join(",") %>]
 <% else %>
 # path.repo:
 <% end %>


### PR DESCRIPTION
To create database backup the directory for storing snapshots must be
configured. Administrator should be able to specify target directories
for these snapshots and so the variable should be exposed in Crowbar
proposal.

Although [monasca][elasticsearch][repo_dir] variable has been present in
the data_bag, it hasn't been used in the template. This change allows
setting path.repo configuration setting in Crowbar proposal as
documented.