### PR TITLE
designate: Mark as user managed (SOC-10233)

### DIFF
--- a/designate.yml
+++ b/designate.yml
@@ -19,8 +19,7 @@ barclamp:
   display: 'Designate'
   description: 'OpenStack DNSaaS: Multi-Tenant DNSaaS service for OpenStack'
   version: 0
-  # Change to true when complete
-  user_managed: false
+  user_managed: true
   requires:
     - 'keystone'
     - 'rabbitmq'


### PR DESCRIPTION
The designate barclamp has been marked as not user manageable since it
had some issues. Since those have been corrected, mark it as user
manageable, so it appears in the web UI.