### PR TITLE
[5.0] Octavia: Hide UI until complete (SOC-10550)

### DIFF
--- a/aodh.yml
+++ b/aodh.yml
@@ -19,7 +19,8 @@ barclamp:
   display: 'Aodh'
   description: 'OpenStack Telemetry: Alarming service'
   version: 0
-  user_managed: true
+  # Change to true when complete
+  user_managed: false
   requires:
     - '@crowbar'
     - 'pacemaker'


### PR DESCRIPTION
This patch sets `user_managed: false` so that the UI doesn't appear
in crowbar. This will be changed back to `true` once we've finished the
barclamp and it's been released.

(cherry picked from commit 6b519401044aa3689bf1138fd612a19cf18eefb0)