### PR TITLE
rabbitmq: fix migrations (SOC-10623)

### DIFF
--- a/chef/data_bags/crowbar/migrate/cinder/205_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/205_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/database/205_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/database/205_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/database/206_add_bootstrap_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/database/206_add_bootstrap_timeout.rb
@@ -1,5 +1,6 @@
 def upgrade(ta, td, a, d)
-  a["mysql"]["bootstrap_timeout"] = ta["mysql"]["bootstrap_timeout"] unless a["mysql"]["bootstap_timeout"]
+  a["mysql"]["bootstrap_timeout"] = ta["mysql"]["bootstrap_timeout"] unless
+    a["mysql"].key?("bootstap_timeout")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/database/302_add_presync_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/database/302_add_presync_timeout.rb
@@ -1,6 +1,6 @@
 def upgrade(template_attrs, template_deployment, attrs, deployment)
   unless attrs["mysql"]["presync_timeout"]
-    attrs["mysql"]["presync_timeout"] = template_attrs["mysql"]["presync_timeout"]
+    attrs["mysql"]["presync_timeout"] = template_attrs["mysql"].key?("presync_timeout")
   end
   return attrs, deployment
 end

--- a/chef/data_bags/crowbar/migrate/horizon/203_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/203_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/nova/207_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/nova/207_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/rabbitmq/200_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/200_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?(["resource_limits"])
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/rabbitmq/201_heartbeat_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/201_heartbeat_timeout.rb
@@ -1,6 +1,6 @@
 def upgrade(ta, td, a, d)
   a["client"] ||= {}
-  unless a["client"]["heartbeat_timeout"]
+  unless a["client"].key?("heartbeat_timeout")
     a["client"]["heartbeat_timeout"] = ta["client"]["heartbeat_timeout"]
   end
   return a, d

--- a/chef/data_bags/crowbar/migrate/rabbitmq/202_add_mnesia_dump_log.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/202_add_mnesia_dump_log.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["mnesia"] = ta["mnesia"] unless a["mnesia"]
+  a["mnesia"] = ta["mnesia"] unless a.key?("mnesia")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/rabbitmq/203_add_performance_config.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/203_add_performance_config.rb
@@ -1,6 +1,6 @@
 def upgrade(ta, td, a, d)
   ["tcp_listen_options", "collect_statistics_interval"].each do |option|
-    a[option] = ta[option] unless a[option]
+    a[option] = ta[option] unless a.key?(option)
   end
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/rabbitmq/204_add_extra_users.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/204_add_extra_users.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["extra_users"] = ta["extra_users"] unless a["extra_users"]
+  a["extra_users"] = ta["extra_users"] unless a.key?("extra_users")
   return a, d
 end
 


### PR DESCRIPTION
Two of the Cloud 8 migrations for RabbitMQ have a bug where
they never add the fields they are supposed to add to the
proposal. This commit fixes the issue.

See https://jira.suse.com/browse/SOC-10623 for details. This will need a backport to SOC8 as well since the missing migration breaks the Cloud 7 to Cloud 8 upgrade.

Setting "do not merge yet" since we are currently testing this on a QA cloud.