### PR TITLE
tempest: Fail when enabled_services call failes

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -83,6 +83,12 @@ openstackcli_adm = "#{adm_environment} openstack --insecure"
 
 enabled_services = `#{openstackcli_adm} service list -f value -c Type`.split
 
+unless $?.success?
+  message = "Failed to execute `#{openstackcli_adm} service list -f value -c Type`."
+  Chef::Log.fatal(message)
+  raise message
+end
+
 users = [
   { "name" => tempest_comp_user, "pass" => tempest_comp_pass, "role" => "member" }
 ]


### PR DESCRIPTION
Sometimes e.g. when changeing the keystone password it seams that
enabled_services is empty this is due to that the openstack cmd call
failes. In any case we should fail if the openstack cmd call fail as
otherwise tempest will set the enabled services to false and we will
actually test nothing.