### PR TITLE
nova: set default attribute for max_threads_per_process

### DIFF
--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -71,7 +71,7 @@ default[:nova][:libvirt_type] = "kvm"
 #
 
 default[:nova][:kvm][:ksm_enabled] = false
-
+default[:nova][:kvm][:max_threads_per_process] = 0
 #
 # VMware Settings
 #


### PR DESCRIPTION
Otherwise there will be a syntax error in the libvirt config
and the cloud is down afterwards.