### PR TITLE
Revert "designate: Mark as user managed (SOC-10233)"

### DIFF
--- a/designate.yml
+++ b/designate.yml
@@ -19,7 +19,8 @@ barclamp:
   display: 'Designate'
   description: 'OpenStack DNSaaS: Multi-Tenant DNSaaS service for OpenStack'
   version: 0
-  user_managed: true
+  # Change to true when complete
+  user_managed: false
   requires:
     - 'keystone'
     - 'rabbitmq'


### PR DESCRIPTION
Designate is not ready for customers.

This reverts commit 3b753ac93d36410c72ffc8a81e97e4320c603e97.