### PR TITLE
Revert "designate: Mark as user managed (SOC-10233)"

### DIFF
--- a/designate.yml
+++ b/designate.yml
@@ -19,7 +19,8 @@ barclamp:
   display: 'Designate'
   description: 'OpenStack DNSaaS: Multi-Tenant DNSaaS service for OpenStack'
   version: 0
-  user_managed: true
+  # Change to true when complete
+  user_managed: false
   requires:
     - 'keystone'
     - 'rabbitmq'


### PR DESCRIPTION
Designate is not ready for customers.

This reverts commit f9a0441889a1e44dbbf19fc01ba82ffc449998c5.