### PR TITLE
[5.0] Make ovs of_inactivity_probe configurable from neutron barclamp

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -275,7 +275,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
         dvr_enabled: neutron[:neutron][:use_dvr],
         tunnel_csum: neutron[:neutron][:ovs][:tunnel_csum],
         ovsdb_interface: neutron[:neutron][:ovs][:ovsdb_interface],
-        bridge_mappings: bridge_mappings
+        bridge_mappings: bridge_mappings,
+        of_inactivity_probe: neutron[:neutron][:ovs][:of_inactivity_probe]
       )
     end
   when ml2_mech_drivers.include?("linuxbridge")

--- a/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/openvswitch_agent.ini.erb
@@ -25,5 +25,6 @@ ovsdb_interface = <%= @ovsdb_interface %>
 local_ip = <%= node.address("os_sdn").addr %>
 <% end -%>
 bridge_mappings = <%= @bridge_mappings %>
+of_inactivity_probe = <%= @of_inactivity_probe %>
 [securitygroup]
 firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver

--- a/chef/data_bags/crowbar/migrate/neutron/216_add_ovs_of_inactivity_probe.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/216_add_ovs_of_inactivity_probe.rb
@@ -1,0 +1,15 @@
+def upgrade(tattr, tdep, attr, dep)
+  unless attr["ovs"].key?("of_inactivity_probe")
+    attr["ovs"]["of_inactivity_probe"] = tattr["ovs"]["of_inactivity_probe"]
+  end
+
+  return attr, dep
+end
+
+def downgrade(tattr, tdep, attr, dep)
+  unless tattr["ovs"].key?("of_inactivity_probe")
+    attr["ovs"].delete("of_inactivity_probe") if attr.key?("ovs")
+  end
+
+  return attr, dep
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -43,7 +43,8 @@
       },
       "ovs": {
         "tunnel_csum": false,
-        "ovsdb_interface": "native"
+        "ovsdb_interface": "native",
+        "of_inactivity_probe": 10
       },
       "apic": {
         "hosts": "",
@@ -194,7 +195,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 215,
+      "schema-revision": 216,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -48,7 +48,8 @@
                     }},
                     "ovs": { "type": "map", "required": true, "mapping": {
                       "tunnel_csum": { "type": "bool", "required": true },
-                      "ovsdb_interface": { "type": "str", "required": true }
+                      "ovsdb_interface": { "type": "str", "required": true },
+                      "of_inactivity_probe": { "type": "int", "required": true }
                     }},
                     "apic": { "type": "map", "required": true, "mapping": {
                       "hosts": { "type" : "str", "required" : true },


### PR DESCRIPTION
*We should not be merging changes to attributes in 4.0 without fixing 5.0. *

This patch allows the user to change
the ovs inactivity_probe timeout from the neutron barclamp, in the 'raw'
view. Previously, this value was always set to the OVS default, 5.

It provides crowbar support for this upstream patch:

https://review.opendev.org/#/c/663024/
(cherry picked from commit c0a4d9e49d042c80b118404a3472727c41403145)