### PR TITLE
[5.0] neutron-lbaas: remove loadbalancer/pool limit

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
@@ -1,6 +1,12 @@
 [DEFAULT]
 interface_driver = <%= @interface_driver %>
+
 [quotas]
+#quota_loadbalancer = 10
+quota_loadbalancer = -1
+#quota_pool = 10
+quota_pool = -1
+
 [service_auth]
 auth_url = <%= @keystone_settings['internal_auth_url'] %>
 admin_tenant_name = <%= @keystone_settings['service_tenant'] %>


### PR DESCRIPTION
This is not really configurable via CLI, and 10 is not a production
default. better have no limit.

(cherry picked from commit 45fc3dad4325d7e584cf37d84d76e19be99b961b)