### PR TITLE
glance: don't reuse sync mark names (SOC-10348)

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -180,7 +180,7 @@ template node[:glance][:manage][:config_file] do
   mode 0o640
 end
 
-crowbar_pacemaker_sync_mark "wait-glance_database" if ha_enabled
+crowbar_pacemaker_sync_mark "wait-glance_db_sync" if ha_enabled
 
 is_founder = CrowbarPacemakerHelper.is_cluster_founder?(node)
 
@@ -215,6 +215,6 @@ ruby_block "mark node for glance db_sync" do
   subscribes :create, "execute[glance-manage db_load_metadefs]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-glance_database" if ha_enabled
+crowbar_pacemaker_sync_mark "create-glance_db_sync" if ha_enabled
 
 glance_service "api"


### PR DESCRIPTION
Using the same sync mark name for two different sections can lead
to unexpected results. In this particular case, nodes running into
the second glance_database sync mark occurrence find that the sync mark
has already been set by the founder node and will proceed without
waiting for the founder node, which causes the non founder nodes to
start the openstack-glance-api service while the founder node
is running "glance-manage db sync", thus causing all sorts of conflicts.