### PR TITLE
[5.0] glance: don't reuse sync mark names (SOC-10348)

### DIFF
--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -40,7 +40,7 @@ end
 ha_enabled = node[:glance][:ha][:enabled]
 is_founder = CrowbarPacemakerHelper.is_cluster_founder?(node)
 
-crowbar_pacemaker_sync_mark "wait-glance_database" if ha_enabled
+crowbar_pacemaker_sync_mark "wait-glance_db_sync" if ha_enabled
 
 execute "glance-manage db sync" do
   user node[:glance][:user]
@@ -73,6 +73,6 @@ ruby_block "mark node for glance db_sync" do
   subscribes :create, "execute[glance-manage db_load_metadefs]", :immediately
 end
 
-crowbar_pacemaker_sync_mark "create-glance_database" if ha_enabled
+crowbar_pacemaker_sync_mark "create-glance_db_sync" if ha_enabled
 
 glance_service "registry"


### PR DESCRIPTION
(backport of #2262)

Using the same sync mark name for two different sections can lead
to unexpected results. In this particular case, nodes running into
the second glance_database sync mark occurrence find that the sync mark
has already been set by the founder node and will proceed without
waiting for the founder node, which causes the non founder nodes to
start the openstack-glance-api service while the founder node
is running "glance-manage db sync", thus causing all sorts of conflicts.

(cherry picked from commit 7fd941e1e8b33714b9a9ee79a643086fa57146a6)