### PR TITLE
[5.0] tempest: don't rely on service catalogue (SOC-10633)

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -78,15 +78,25 @@ comp_environment << "OS_AUTH_URL='#{auth_url}' "
 comp_environment << "OS_IDENTITY_API_VERSION='#{keystone_settings["api_version"]}'"
 openstackcli = "#{comp_environment} openstack --insecure"
 
-# for admin usage (listing the available services)
-adm_environment = "OS_USERNAME='#{tempest_adm_user}' "
-adm_environment << "OS_PASSWORD='#{tempest_adm_pass}' "
-adm_environment << "OS_PROJECT_NAME='#{tempest_comp_tenant}' "
-adm_environment << "OS_AUTH_URL='#{auth_url}' "
-adm_environment << "OS_IDENTITY_API_VERSION='#{keystone_settings["api_version"]}'"
-openstackcli_adm = "#{adm_environment} openstack --insecure"
+# maps a keystone catalog service name to its corresponding barclamp role
+service_role_map = {
+  "metering" => "ceilometer-server",
+  "orchestration" => "heat-server",
+  "dns" => "designate-server",
+  "data-processing" => "sahara-server",
+  "database" => "trove-server",
+  "sharev2" => "manila-server",
+  "container-infra" => "magnum-server",
+  "baremetal" => "ironic-server",
+  "logs_v2" => "monasca-server",
+  "logs-search" => "monasca-server",
+  "monitoring" => "monasca-server",
+  "alarming" => "aodh-server"
+}
 
-enabled_services = `#{openstackcli_adm} service list -f value -c Type`.split
+enabled_services = service_role_map.reject do |service_name, role_name|
+  search(:node, "roles:#{role_name}").first.nil?
+end.keys
 
 users = [
           {"name" => tempest_comp_user, "pass" => tempest_comp_pass, "role" => "Member"},
@@ -105,8 +115,8 @@ if enabled_services.include?("metering")
   end
 end
 
-heat_server = search(:node, "roles:heat-server").first
-if enabled_services.include?("orchestration") && !heat_server.nil?
+if enabled_services.include?("orchestration")
+  heat_server = search(:node, "roles:heat-server").first
   heat_trusts_delegated_roles = heat_server[:heat][:trusts_delegated_roles]
   heat_trusts_delegated_roles.each do |role|
     users.push("name" => tempest_comp_user, "pass" => tempest_comp_pass, "role" => role)


### PR DESCRIPTION
(backport of #2255)

The way that the tempest chef recipe figures out which OpenStack
services can be tested is by inspecting the openstack service
catalogue to retrieve a list of enabled services, instead of
using the barclamp configuration which is more accurate. Worse
even, it does so in the chef compilation phase, before the
running openstack configuration is updated to reflect changes
in the barclamp configuration.

Sometimes, this results in a tempest configuration that doesn't
reflect the list of services that are actuallly deployed. In some of
the more extreme cases, such as updating the admin password, the
OpenStack CLI command used to retrieve the service catalogue
fails completely and returns an empty list, which results in tempest
disabling all services in its configuration.

Inspecting the barclamp role assignments is a more reliable way of
determining which services are actually enabled.

(cherry picked from commit 82eac9d338bdb337a9fc154a1626ed9baa05befb)

NOTE: updated to include the "alarming" service (aodh), which was not present in cloud9.