### PR TITLE
nova: Don't autoselect nodes for Xen (continued) (bsc#1147144)

### DIFF
--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -168,7 +168,7 @@ class NovaService < OpenstackServiceObject
       "nova-controller" => [controller.name],
       "nova-compute-kvm" => kvm.map(&:name),
       "nova-compute-qemu" => qemu.map(&:name),
-      "nova-compute-xen" => xen.map(&:name)
+      "nova-compute-xen" => []
     }
 
     base["attributes"][@bc_name]["itxt_instance"] = find_dep_proposal("itxt", true)


### PR DESCRIPTION
Fix Xen node autoselection.