### PR TITLE
5.0: designate: Fix the keys syntax error on migrations (SOC-10660)

### DIFF
--- a/chef/data_bags/crowbar/migrate/designate/201_add_resources.rb
+++ b/chef/data_bags/crowbar/migrate/designate/201_add_resources.rb
@@ -1,12 +1,12 @@
 def upgrade(template_attrs, template_deployment, attrs, deployment)
-  attrs["resource_email"] = template_attrs["resource_email"] unless attrs.keys? "resource_email"
+  attrs["resource_email"] = template_attrs["resource_email"] unless attrs.key? "resource_email"
   template_project = template_attrs["resource_project"]
-  attrs["resource_project"] = template_project unless attrs.keys? "resource_project"
+  attrs["resource_project"] = template_project unless attrs.key? "resource_project"
   return attrs, deployment
 end
 
 def downgrade(template_attrs, template_deployment, attrs, deployment)
-  attrs.delete("resource_email") unless template_attrs.keys? "resource_email"
-  attrs.delete("resource_project") unless template_attrs.keys? "resource_project"
+  attrs.delete("resource_email") unless template_attrs.key? "resource_email"
+  attrs.delete("resource_project") unless template_attrs.key? "resource_project"
   return attrs, deployment
 end


### PR DESCRIPTION
To check the existence of a key in a ruby map is the `.key?` method not
`.keys?`.

This patch corrects the designate migrations to use the proper key method.