### PR TITLE
database: really fix migration 102 (SOC-10717)

### DIFF
--- a/chef/data_bags/crowbar/migrate/database/302_add_presync_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/database/302_add_presync_timeout.rb
@@ -1,6 +1,6 @@
 def upgrade(template_attrs, template_deployment, attrs, deployment)
-  unless attrs["mysql"]["presync_timeout"]
-    attrs["mysql"]["presync_timeout"] = template_attrs["mysql"].key?("presync_timeout")
+  unless attrs["mysql"].key?("presync_timeout")
+    attrs["mysql"]["presync_timeout"] = template_attrs["mysql"]["presync_timeout"]
   end
   return attrs, deployment
 end


### PR DESCRIPTION
I ended up on the wrong line in commit e9d4b69d033eac6c103a1cf8aedfc83a03e39238
thus accidently dropping a Boolean value in the database. This commit fixes
this error.

Note: the faulty commit is Cloud 9 only. Thus the other commit in pull request https://github.com/crowbar/crowbar-openstack/pull/2248/ (for the Cloud 8 migrations) remains as-is. I did double-check that one just to be sure, though and the Cloud 8 migrations all look good.