### PR TITLE
Designate: Remove enable worker config (SOC-10740)

### DIFF
--- a/chef/cookbooks/designate/templates/default/designate.conf.erb
+++ b/chef/cookbooks/designate/templates/default/designate.conf.erb
@@ -26,7 +26,6 @@ managed_resource_tenant_id = <%= @resource_project_id %>
 <% end -%>
 
 [service:worker]
-enabled = True
 notify = False
 # poll_max_retries
 # poll_retry_interval


### PR DESCRIPTION
Worker service is enabled by default in Rocky for Designate.
This also gets rid of the warning in the logs.