### PR TITLE
[5.0] Designate: Filter out the admin node (SOC-10658)

### DIFF
--- a/chef/cookbooks/designate/recipes/mdns.rb
+++ b/chef/cookbooks/designate/recipes/mdns.rb
@@ -19,6 +19,10 @@
 require "yaml"
 
 dns_all = node_search_with_cache("roles:dns-server")
+
+# filter out the crowbar node
+dns_all.select! { |node| node["crowbar"]["admin_node"].nil? }
+
 dnsservers = dns_all.map do |n|
   Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address
 end


### PR DESCRIPTION
The admin node shouldn't be listening on the public network. As such it
can't used as a designate server.

This patch filters it out of the pools list, as crowbar already has a
check to not use the admin node in barclamps that is all we need.

Co-Authored-By: Steve Kowalik

(cherry picked from commit 9a35e8b266e4280c858c8c004380d87c63fd14e5)