### PR TITLE
[5.0] Designate: Add dns_domain_ports config (SOC-10740)

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -136,7 +136,7 @@ when "ml2"
   os_sdn_net = Barclamp::Inventory.get_network_definition(node, "os_sdn")
   mtu_value = os_sdn_net.nil? ? 1500 : os_sdn_net["mtu"].to_i
 
-  ml2_extension_drivers = ["dns", "port_security"]
+  ml2_extension_drivers = ["dns_domain_ports", "port_security"]
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup
   if use_hyperv


### PR DESCRIPTION
We need replace 'dns' with 'dns_domain_ports' in ml2.conf extension_drivers.
This adds the capability to assign dns-domain to ports.