### PR TITLE
Fix Cloud 8 no-op migrations (SOC-10623)

### DIFF
--- a/chef/data_bags/crowbar/migrate/cinder/205_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/205_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/database/205_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/database/205_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/database/206_add_bootstrap_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/database/206_add_bootstrap_timeout.rb
@@ -1,5 +1,6 @@
 def upgrade(ta, td, a, d)
-  a["mysql"]["bootstrap_timeout"] = ta["mysql"]["bootstrap_timeout"] unless a["mysql"]["bootstap_timeout"]
+  a["mysql"]["bootstrap_timeout"] = ta["mysql"]["bootstrap_timeout"] unless
+    a["mysql"].key?("bootstap_timeout")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/horizon/203_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/horizon/203_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/nova/207_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/nova/207_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/rabbitmq/200_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/200_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a["resource_limits"]
+  a["resource_limits"] = ta["resource_limits"] unless a.key?(["resource_limits"])
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/rabbitmq/201_heartbeat_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/201_heartbeat_timeout.rb
@@ -1,6 +1,6 @@
 def upgrade(ta, td, a, d)
   a["client"] ||= {}
-  unless a["client"]["heartbeat_timeout"]
+  unless a["client"].key?("heartbeat_timeout")
     a["client"]["heartbeat_timeout"] = ta["client"]["heartbeat_timeout"]
   end
   return a, d

--- a/chef/data_bags/crowbar/migrate/rabbitmq/202_add_mnesia_dump_log.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/202_add_mnesia_dump_log.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["mnesia"] = ta["mnesia"] unless a["mnesia"]
+  a["mnesia"] = ta["mnesia"] unless a.key?("mnesia")
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/rabbitmq/203_add_performance_config.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/203_add_performance_config.rb
@@ -1,6 +1,6 @@
 def upgrade(ta, td, a, d)
   ["tcp_listen_options", "collect_statistics_interval"].each do |option|
-    a[option] = ta[option] unless a[option]
+    a[option] = ta[option] unless a.key?(option)
   end
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/rabbitmq/204_add_extra_users.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/204_add_extra_users.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["extra_users"] = ta["extra_users"] unless a["extra_users"]
+  a["extra_users"] = ta["extra_users"] unless a.key?("extra_users")
   return a, d
 end
 


### PR DESCRIPTION
Various Cloud 8 proposal migrations have a bug where they
never add the fields they are supposed to add to the
proposal. This is caused by evaluating the proposal hash key
in question as a Boolean truth value the way it happens in
this example:

  unless a["resource_limits"]

This will return an empty string which evaluates to True in a
boolean context. The correct approach is to use Hash.key?().
This commit fixes all occurences of this problem for Cloud 8.

(cherry picked from commit f479dbe1063817967dbf8938f8d07786f1a05096)

This is a partial (only the Cloud 8 bits) backport of https://github.com/crowbar/crowbar-openstack/pull/2248/