### PR TITLE
tempest:install designate tempest plugin for SOC8 (SOC-10288)

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -44,6 +44,7 @@ if node[:kernel][:machine] == "x86_64" &&
 end
 
 [
+  "designate",
   "barbican"
 ].each do |component|
   package "python-#{component}-tempest-plugin" if config_for_role_exists?(component)


### PR DESCRIPTION
python-designate-tempest-plugin need to be installed on SOC8