### PR TITLE
[5.0] Fix nova tempest tests (SOC-9298, SOC-10844)

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -119,3 +119,6 @@ trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" 
 hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
 connection_string = <%= @profiler_settings[:connection_string] %>
 <% end -%>
+
+[barbican]
+auth_endpoint = <%= @keystone_settings['internal_auth_url'] %>

--- a/chef/cookbooks/tempest/files/default/run_filters/barbican.txt
+++ b/chef/cookbooks/tempest/files/default/run_filters/barbican.txt
@@ -1,1 +1,4 @@
 +barbican_tempest_plugin.*
+
+# verify_glance_signatures not enabled on nova
+-barbican_tempest_plugin.tests.scenario.test_image_signing.ImageSigningTest.test_signed_image_upload_boot_failure

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -5,7 +5,7 @@
     "tempest": {
       "tempest_test_images": {
           "aarch64": "http://<ADMINWEB>/files/tempest/cirros-0.4.0-aarch64-uec.tar.gz",
-          "x86_64": "http://<ADMINWEB>/files/tempest/cirros-0.4.0-x86_64-uec.tar.gz",
+          "x86_64": "http://<ADMINWEB>/files/tempest/cirros-0.4.0-x86_64-disk.img",
           "ppc64le": "http://<ADMINWEB>/files/tempest/FIXME",
           "s390x": "http://<ADMINWEB>/files/tempest/FIXME"
       },


### PR DESCRIPTION
- disable `swap_volume` tests when cinder is using ceph backend as it is
not supported.
- replace the uec image used in tempest for a qcow2 image

(cherry picked from commit 07864bdff573b4ad150530168f879e2e215c896b)