### PR TITLE
[5.0] No rndc key if no public DNS server (SOC-10835)

### DIFF
--- a/chef/cookbooks/designate/recipes/mdns.rb
+++ b/chef/cookbooks/designate/recipes/mdns.rb
@@ -74,12 +74,17 @@ file "/etc/designate/pools.crowbar.yaml" do
   not_if { ::File.exist?("/etc/designate/pools.crowbar.yaml") }
 end
 
-template "/etc/designate/rndc.key" do
-  source "rndc.key.erb"
-  owner "root"
-  group node[:designate][:group]
-  mode "0640"
-  variables(rndc_key: dns_all.first[:dns][:designate_rndc_key])
+if dns_all.empty?
+  Chef::Log.warn("Designate will not be integrated with external DNS server," \
+		 "as no DNS server is running on publicly accessible (non admin) node.")
+else
+  template "/etc/designate/rndc.key" do
+    source "rndc.key.erb"
+    owner "root"
+    group node[:designate][:group]
+    mode "0640"
+    variables(rndc_key: dns_all.first[:dns][:designate_rndc_key])
+  end
 end
 
 ha_enabled = node[:designate][:ha][:enabled]


### PR DESCRIPTION
In case where DNS server is only running on the admin node, which
is not publicly accessible, we are left with no DNS servers for
Designate integration. For such cases, we do not need to template
the rndc key file used for Bind9 rndc calls.

In this patch we check for such case, if true, we write a warning log
and only template the rndc key file if the case is not valid.

(cherry picked from commit 5f34b2477a95e3b3c3ee2a9956c7912e35f5c53f)