### PR TITLE
[5.0] glance: Set barbican auth endpoint (bsc#1123191)

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -119,3 +119,6 @@ trace_sqlalchemy = <%= @profiler_settings[:trace_sqlalchemy] ? "true" : "false" 
 hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
 connection_string = <%= @profiler_settings[:connection_string] %>
 <% end -%>
+
+[barbican]
+auth_endpoint = <%= @keystone_settings['internal_auth_url'] %>


### PR DESCRIPTION
By default, the castellan key manager library uses
'http://localhost/identity/v3' as its keystone auth endpoint (works in
devstack!). When barbican uploads a signed image to glance, if glance
doesn't override the auth endpoint it will fail to use the key manager.
The symptom of this is a tempest error that looks like:

  TypeError: sendall() argument 1 must be string or buffer, not callable-iterator

which arises from a combination of barbican, glance, and tempest
handling the authentication error very very poorly.

(cherry picked from commit cf46a4461f08234daf06d7ff77e5ea7196e0078e)