### PR TITLE
rabbitmq: fix migration 200 (SOC-10623)

### DIFF
--- a/chef/data_bags/crowbar/migrate/rabbitmq/200_add_resource_limits.rb
+++ b/chef/data_bags/crowbar/migrate/rabbitmq/200_add_resource_limits.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["resource_limits"] = ta["resource_limits"] unless a.key?(["resource_limits"])
+  a["resource_limits"] = ta["resource_limits"] unless a.key?("resource_limits")
   return a, d
 end
 


### PR DESCRIPTION
This commit request removes an extra pair of brackets that break
the check for the migration having been applied already.