### PR TITLE
[5.0] Tempest: blacklist test_volume_boot_pattern (SOC-10874)

### DIFF
--- a/chef/cookbooks/tempest/files/default/run_filters/cinder.txt
+++ b/chef/cookbooks/tempest/files/default/run_filters/cinder.txt
@@ -1,3 +1,6 @@
 +tempest.api.volume.*
 +tempest.scenario.test_volume.*
 +tempest.scenario.test_encrypted.*
+
+# BUG: SOC-10874
+-tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern


### PR DESCRIPTION
As this test is affecting the gating jobs for cloud 8 and LVM is not a
supported backend for Cinder, blacklist it until it is fixed or support
for a new Cinder backend is added on the CI.