### PR TITLE
[4.0] Configurable timeout for Galera pre-sync

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -183,6 +183,7 @@ end
 # all the required packages and configurations installed before we create the
 # pacemaker resources
 crowbar_pacemaker_sync_mark "sync-database_before_ha" do
+  timeout node[:database][:mysql][:presync_timeout]
   revision node[:database]["crowbar-revision"]
 end
 

--- a/chef/data_bags/crowbar/migrate/database/112_add_presync_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/database/112_add_presync_timeout.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  unless attrs["mysql"]["presync_timeout"]
+    attrs["mysql"]["presync_timeout"] = template_attrs["mysql"]["presync_timeout"]
+  end
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["mysql"].delete("presync_timeout") unless template_attrs["mysql"].key?("presync_timeout")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -14,6 +14,7 @@
         "max_heap_table_size": 64,
         "expire_logs_days": 10,
         "bootstrap_timeout": 600,
+        "presync_timeout": 180,
         "wsrep_slave_threads" : 1,
         "gcs_fc_limit_multiplier" : 5,
         "gcs_fc_factor" : 0.8,
@@ -86,7 +87,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 111,
+      "schema-revision": 112,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ],
         "mysql-server": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -31,6 +31,7 @@
                 "max_heap_table_size": { "type": "int", "required": true },
                 "expire_logs_days": { "type": "int", "required": true },
                 "bootstrap_timeout": { "type": "int", "required": true },
+                "presync_timeout": { "type": "int", "required": true },
                 "wsrep_slave_threads": { "type": "int", "required": true },
                 "gcs_fc_limit_multiplier": { "type": "int", "required": true },
                 "gcs_fc_factor": { "type": "float", "required": true },


### PR DESCRIPTION
We have a pacemaker sync-mark to wait for all nodes to have all galera
packages and configuration files installed. The default timeout is 60
seconds for these sync-marks.

While installing all cluster members at once, like in an initial
installation, all nodes take about the same time to install the packages
and reach the sync-mark about the same time as well. But when adding a
new node to the cluster, the already installed nodes reach the sync-mark
much faster and the default timeout proves insuficient.

Based on tests in developer environments, this takes roughly 70 seconds.
We will be setting this to 180 seconds to give enough margin.

(cherry picked from commit 4f1d42ed8beb5e35b4428904adccde5cbd6ab570)
(cherry picked from commit 4c6f3f332d2fc8d7919da80004c4d1e74bccb9c9)


Originally https://github.com/crowbar/crowbar-openstack/pull/2154