### PR TITLE
[5.0] Make sure the input file with ssh key exists (SOC-10133)

### DIFF
--- a/chef/cookbooks/nova/recipes/compute.rb
+++ b/chef/cookbooks/nova/recipes/compute.rb
@@ -325,19 +325,27 @@ if node["roles"].include?("nova-compute-zvm")
   ssh_auth_keys += node[:nova][:zvm][:zvm_xcat_ssh_key]
 end
 
+ssh_key_file = "#{node[:nova][:home_dir]}/.ssh/id_ed25519"
+
 unless node[:nova][:compute_remotefs_sshkey].empty?
   # Create and distribute ssh keys for nova user on all compute nodes
-  file "#{node[:nova][:home_dir]}/.ssh/id_ed25519" do
+  file ssh_key_file do
     mode 0o600
     owner node[:nova][:user]
     content "#{node[:nova][:compute_remotefs_sshkey]}\n"
   end
+end
 
-  ssh_auth_keys += %x[ssh-keygen -y -f "#{node[:nova][:home_dir]}/.ssh/id_ed25519"].chomp
+ruby_block "Add ssh keys from file" do
+  block do
+    cmd = "ssh-keygen -y -f #{ssh_key_file}"
+    ssh_auth_keys += Mixlib::ShellOut.new(cmd).run_command.stdout.chomp
+  end
+  only_if { File.exist?(ssh_key_file) }
 end
 
 file "#{node[:nova][:home_dir]}/.ssh/authorized_keys" do
-  content ssh_auth_keys
+  content lazy { ssh_auth_keys.to_s }
   owner node[:nova][:user]
 end
 


### PR DESCRIPTION
Postpone the command into the convergence phase and make
sure it is executed when the input file is there.
Also, postpone the authorized_keys file creation with the use
of lazy evaluation of the variable that was adapted in convergence
phase.

(cherry picked from commit 921e931aea4ce758b3601e465f245a41408fdcf8)

Backport of https://github.com/crowbar/crowbar-openstack/pull/2293