### PR TITLE
octavia: add SSL support to octavia-api (SOC-10906)

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -159,7 +159,7 @@ hmac_keys = <%= @profiler_settings[:hmac_keys].join(",") %>
 connection_string = <%= @profiler_settings[:connection_string] %>
 <% end -%>
 
-<% if @octavia_api %>
+<% if @octavia_admin_uri %>
 [octavia]
-base_url = <%= @octavia_api %>
+base_url = <%= @octavia_admin_uri %>
 <% end %>

--- a/chef/cookbooks/octavia/recipes/common.rb
+++ b/chef/cookbooks/octavia/recipes/common.rb
@@ -17,3 +17,9 @@ package "python-octaviaclient"
 package "octavia" do
   package_name "openstack-octavia" if %w[rhel suse].include?(node[:platform_family])
 end
+
+execute "chown certs path" do
+  command "chown -R #{node[:octavia][:user]}:#{node[:octavia][:group]} \
+    #{node[:octavia][:certs][:cert_path]}"
+  action :run
+end


### PR DESCRIPTION
The Octavia API service doesn't have intrinsic support for
terminating SSL traffic. The alternatives are to terminate
SSL traffic at haproxy level (which isn't done anywhere else
in Crowbar), or to deploy the API service as an Apacke WSGI
application. This PR implements the latter and it also solves
the problem described in the following paragraphs.

The octavia system group and user are created when the
openstack-octavia package is installed on the controller nodes.
This happens automatically when the octavia barclamp is
applied.
However, setting up the paths for the certificates required for
the two-way SSL amphorae communication needs to be done in advance,
before applying the octavia barclamp, and those paths need to have
their ownership set to the octavia system user/group, which aren't
yet available at that time.

This change proposes a solution to this problem, where the admin
can set up those certificate paths on the controller nodes with
root (or other user) as owner, while the Octavia barclamp is
responsible for switching ownership over to the octavia user/group
during application.

This PR is complemented by a [corresponding automation PR](https://github.com/SUSE-Cloud/automation/pull/3767).