### PR TITLE
tempest: fix lbaasv2 tests with Octavia lbaasv2-proxy service plugin (SOC-10907)

### DIFF
--- a/chef/cookbooks/octavia/templates/default/110-health-manager.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-health-manager.conf.erb
@@ -3,7 +3,7 @@ bind_ip = <%= @bind_host %>
 bind_port = <%= @bind_port %>
 controller_ip_port_list = <%= @octavia_healthmanager_hosts %>
 heartbeat_key = <%= @node[:octavia][:health_manager][:heartbeat_key] %>
-event_streamer_driver = queue_event_streamer
+event_streamer_driver = noop_event_streamer
 heartbeat_interval = <%= @node[:octavia][:health_manager][:heartbeat_interval] %>
 heartbeat_timeout = <%= @node[:octavia][:health_manager][:heartbeat_timeout] %>
 health_check_interval = <%= @node[:octavia][:health_manager][:health_check_interval] %>

--- a/chef/cookbooks/tempest/files/default/run_filters/lbaas-octavia.txt
+++ b/chef/cookbooks/tempest/files/default/run_filters/lbaas-octavia.txt
@@ -1,0 +1,17 @@
++neutron_lbaas.*
+
+# The lbaasv2-proxy service plugin doesn't handle the `http_method` attribute correctly (SOC-10965)
+# Upstream bug https://storyboard.openstack.org/#!/story/2006909
+-neutron_lbaas.tests.tempest.v2.api.test_health_monitors_non_admin.TestHealthMonitors.test_list_health_monitors_two
+
+# There is no Octavia counterpart for neutron service flavors and flavors
+# cannot be transparently handled by the lbaasv2-proxy service plugin
+-neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.LoadBalancersTestJSON.test_create_load_balancer_invalid_flavor_field
+
+# Updating a load balancer with an empty body is not handled by the lbaasv2-proxy service plugin
+-neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.LoadBalancersTestJSON.test_update_load_balancer_missing_admin_state_up
+-neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.LoadBalancersTestJSON.test_update_load_balancer_missing_description
+-neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.LoadBalancersTestJSON.test_update_load_balancer_missing_name
+
+# Updating a pool with a null session_persistence value is not handled by the lbaasv2-proxy service plugin
+-neutron_lbaas.tests.tempest.v2.scenario.test_session_persistence.TestSessionPersistence.test_session_persistence

--- a/chef/cookbooks/tempest/files/default/run_filters/smoke.txt
+++ b/chef/cookbooks/tempest/files/default/run_filters/smoke.txt
@@ -1,1 +1,6 @@
 +.*smoke
+
+# When Octavia is deployed, the lbaasv2-proxy service plugin doesn't handle the `http_method` attribute correctly (SOC-10965)
+# Upstream bug: https://storyboard.openstack.org/#!/story/2006909
+-neutron_lbaas.tests.tempest.v2.api.test_health_monitors_non_admin.TestHealthMonitors.test_list_health_monitors_two
+

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -272,4 +272,7 @@ test_with_ipv6 = false
 
 [loadbalancer-feature-enabled]
 terminated_tls_enabled = false
+
+[lbaas]
+test_with_noop = true
 <% end -%>


### PR DESCRIPTION
According to [1], if Octavia is deployed, the `lbaasv2-proxy` neutron service
plugin should replace the `lbaasv2` service plugin to allow users to continue
using the deprecated neutron API to manage Octavia load balancers.
However, some of the `neutron_lbaas.tests.tempest.v2.api` tempest test cases
no longer pass with the `lbaasv2-proxy` service plugin configured, mainly
because the regular neutron lbaas tempest test cases are not entirely
compatible with the Octavia API. Even if the Octavia API is backwards
compatible with the neutron LBaaS v2 API, there are runtime timing
considerations that these test cases don't cover, such as load balancer
state transitions.

To continue running these test cases, the lbaas tempest configuration needs
to be slightly changed to disable tracking the operational status of
load balancer objects (i.e. the `test_with_noop` option needs to be set).

With the `lbaasv2-proxy` neutron service plugin configured,
the Octavia health manager no longer needs the event streamer
to keep the Neutron and Octavia databases in sync, because
Octavia load balancers are only stored in the Octavia database.
In addition to that, the `queue_event_streamer` has a known issue
with memory leaks (also see [2] and [3]).

This PR also creates a tempest filter to be run against Octavia with the
lbaasv2-proxy service plugin. The following test cases are
black-listed because they are not compatible with the
Octavia lbaasv2-proxy service plugin:
    
 - neutron_lbaas.tests.tempest.v2.api.test_health_monitors_non_admin.
 TestHealthMonitors.test_list_health_monitors_two
   - lbaas-proxy doesn't handle the `http_method` attribute correctly
   - see https://jira.suse.com/browse/SOC-10965
    
 - neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.
 LoadBalancersTestJSON.test_create_load_balancer_invalid_flavor_field
   - the concept of neutron service flavors doesn't yet have an Octavia
   counterpart in Rocky, so the lbaasv2-proxy service plugin cannot
   transparently convert these attributes
   - see https://blueprints.launchpad.net/octavia/+spec/octavia-lbaas-flavors
    
 - neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.
 LoadBalancersTestJSON.test_update_load_balancer_missing*
   - these test cases update an existing load-balancer with an empty
   body (i.e. without actually changing anything)
   - this use case isn't correctly handled by the lbaasv2-proxy
   service plugin

 - neutron_lbaas.tests.tempest.v2.scenario.test_session_persistence.
 TestSessionPersistence.test_session_persistence
   - this test case updates an existing pool with a null
   session_persistence value 
   - this use case isn't correctly handled by the lbaasv2-proxy
   service plugin

[1] https://wiki.openstack.org/wiki/Neutron/LBaaS/Deprecation
[2] https://bugzilla.suse.com/show_bug.cgi?id=1154235
[3] https://bugzilla.redhat.com/show_bug.cgi?id=1631234
