### PR TITLE
designate: declare all mdns servers as master on pool config (SOC-10952)

### DIFF
--- a/chef/cookbooks/designate/recipes/mdns.rb
+++ b/chef/cookbooks/designate/recipes/mdns.rb
@@ -31,13 +31,8 @@ designate_servers = node_search_with_cache("roles:designate-server")
 
 # hidden masters are designate-mdns services, in ha this service will be running on multiple
 # hosts and any host can be asked to update a zone on the pool target(s).
-# We use the vip for the cluster in case of HA.
-hiddenmasters = if node[:designate][:ha][:enabled]
-  [CrowbarPacemakerHelper.cluster_vip(node, "admin")]
-else
-  designate_servers.map do |n|
-    Barclamp::Inventory.get_network_by_type(n, "admin").address
-  end
+hiddenmasters = designate_servers.map do |n|
+  Barclamp::Inventory.get_network_by_type(n, "admin").address
 end
 
 # One could have multiple pools in designate. And


### PR DESCRIPTION
When creating zones the DNS server notify other servers about the new
zone, however the notification is only accepted when it comes from
masters.

Using the VIP as master causes the zone creation to fail as the
notification is refused because it does not come from the VIP, but from
the node IP address. This change fixes it by declaring all mdns server
as master on the default pool defined by crowbar.