### PR TITLE
tempest: configure Kibana version (SOC-10131)

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -92,6 +92,9 @@ alt_username = <%= @alt_comp_user %>
 alt_tenant_name = <%= @alt_comp_tenant %>
 alt_password = <%= @alt_comp_pass %>
 alt_domain_name = Default
+<% if @kibana_version -%>
+kibana_version = <%= @kibana_version %>
+<% end -%>
 
 [identity-feature-enabled]
 domain_specific_drivers = <%= node[:keystone][:domain_specific_drivers] ? "True" : "False" %>


### PR DESCRIPTION
For Monasca Tempest tests, the Kibana version in use must be
configured for that is the API version the Monasca Tempest
tests use to talk to Kibana (aka the logs-search endpoint). If
this is unconfigured, the tempest tests will use an out of
date version which causes the requests they issue to get
rejected by Kibana. This commit configures the Kibana version
to whatever is the most recent Kibana version available in
zypper, thus ensuring it matches what is installed or gets
installed on the monasca-server node.

Note: this does not need a forward port to stable/5.0 since Cloud 8 is not affected by this problem.