### PR TITLE
[5.0] designate backports

### DIFF
--- a/chef/cookbooks/designate/attributes/default.rb
+++ b/chef/cookbooks/designate/attributes/default.rb
@@ -26,6 +26,13 @@ default[:designate][:ha][:enabled] = false
 # Ports to bind to when haproxy is used for the real ports
 default[:designate][:ha][:ports][:api_port] = 5574
 
+default[:designate][:ssl][:certfile] = "/etc/designate/ssl/certs/signing_cert.pem"
+default[:designate][:ssl][:keyfile] = "/etc/designate/ssl/private/signing_key.pem"
+default[:designate][:ssl][:generate_certs] = false
+default[:designate][:ssl][:insecure] = false
+default[:designate][:ssl][:cert_required] = false
+default[:designate][:ssl][:ca_certs] = "/etc/designate/ssl/certs/ca.pem"
+
 default[:designate][:ha][:api][:ra] = if ["rhel", "suse"].include? node[:platform_family]
   "systemd:openstack-designate-api"
 else

--- a/chef/cookbooks/designate/recipes/api.rb
+++ b/chef/cookbooks/designate/recipes/api.rb
@@ -23,6 +23,18 @@ designate_protocol = node[:designate][:api][:protocol]
 
 ha_enabled = node[:designate][:ha][:enabled]
 
+if node[:designate][:api][:protocol] == "https"
+  ssl_setup "setting up ssl for designate" do
+    generate_certs node[:designate][:ssl][:generate_certs]
+    certfile node[:designate][:ssl][:certfile]
+    keyfile node[:designate][:ssl][:keyfile]
+    group node[:designate][:group]
+    fqdn node[:fqdn]
+    cert_required node[:designate][:ssl][:cert_required]
+    ca_certs node[:designate][:ssl][:ca_certs]
+  end
+end
+
 my_admin_host = CrowbarHelper.get_host_for_admin_url(node, ha_enabled)
 my_public_host = CrowbarHelper.get_host_for_public_url(
   node, node[:designate][:api][:protocol] == "https", ha_enabled

--- a/chef/cookbooks/designate/recipes/mdns.rb
+++ b/chef/cookbooks/designate/recipes/mdns.rb
@@ -31,13 +31,8 @@ designate_servers = node_search_with_cache("roles:designate-server")
 
 # hidden masters are designate-mdns services, in ha this service will be running on multiple
 # hosts and any host can be asked to update a zone on the pool target(s).
-# We use the vip for the cluster in case of HA.
-hiddenmasters = if node[:designate][:ha][:enabled]
-  [CrowbarPacemakerHelper.cluster_vip(node, "admin")]
-else
-  designate_servers.map do |n|
-    Barclamp::Inventory.get_network_by_type(n, "admin").address
-  end
+hiddenmasters = designate_servers.map do |n|
+  Barclamp::Inventory.get_network_by_type(n, "admin").address
 end
 
 # One could have multiple pools in desginate. And

--- a/chef/cookbooks/designate/templates/default/designate.conf.erb
+++ b/chef/cookbooks/designate/templates/default/designate.conf.erb
@@ -12,11 +12,19 @@ admin_project_domain_name = <%= @keystone_settings["admin_domain"]%>
 os_region_name = <%= @keystone_settings['endpoint_region'] %>
 api_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 
+# Quota
+quota_zones = 100
+quota_zone_recordsets = 500
+quota_zone_records = 500
+quota_recordset_records = 20
+quota_api_export_size = 1000
+
 [service:api]
 listen = <%= @bind_host %>:<%= @bind_port %>
 auth_strategy = keystone
-enabled_extensions_v2 = quotas, reports
 enable_host_header = True
+enable_api_admin = True
+enabled_extensions_admin = quotas, zones
 api_base_uri = <%= @api_base_uri %>
 
 <%if @with_authtoken -%>

--- a/chef/cookbooks/designate/templates/default/designate.conf.erb
+++ b/chef/cookbooks/designate/templates/default/designate.conf.erb
@@ -42,6 +42,16 @@ notify = False
 [storage:sqlalchemy]
 connection=<%= @sql_connection %>
 
+[ssl]
+<% if node[:designate][:api][:protocol] == 'https' %>
+<% if node[:designate][:ssl][:cert_required] %>
+ca_file = <%= node[:designate][:ssl][:ca_certs] %>
+<% end %>
+cert_file = <%= node[:designate][:ssl][:certfile] %>
+key_file = <%= node[:designate][:ssl][:keyfile] %>
+<% end %>
+
+
 <%if @with_authtoken -%>
 [keystone_authtoken]
 auth_uri = <%= @keystone_settings["public_auth_url"] %>

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -381,6 +381,7 @@ nova_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack
 aodh_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "aodh"))
 barbican_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "barbican"))
 ceilometer_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "ceilometer"))
+designate_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "designate"))
 heat_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "heat"))
 manila_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "manila"))
 magnum_insecure = CrowbarOpenStackHelper.insecure(Barclamp::Config.load("openstack", "magnum"))
@@ -457,7 +458,7 @@ template local_settings do
     || trove_insecure \
     || sahara_insecure \
     || manila_insecure \
-    || ceilometer_insecure,
+    || designate_insecure,
     db_settings: django_db_settings,
     db_ca_certs: db_ca_certs,
     timezone: (node[:provisioner][:timezone] rescue "UTC") || "UTC",

--- a/chef/data_bags/crowbar/migrate/designate/202_add_ssl_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/designate/202_add_ssl_attributes.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["ssl"] = ta["ssl"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("ssl")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-designate.json
+++ b/chef/data_bags/crowbar/template-designate.json
@@ -18,6 +18,14 @@
         "bind_open_address": true,
         "bind_port": 9001
       },
+      "ssl": {
+        "certfile": "/etc/designate/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/designate/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
+        "cert_required": false,
+        "ca_certs": "/etc/designate/ssl/certs/ca.pem"
+      },
       "db": {
         "password": "",
         "user": "designate",
@@ -29,7 +37,7 @@
     "designate": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 201,
+      "schema-revision": 202,
       "element_states": {
         "designate-server": [ "readying", "ready", "applying" ],
         "designate-worker": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-designate.schema
+++ b/chef/data_bags/crowbar/template-designate.schema
@@ -29,6 +29,16 @@
                 "bind_port": { "type": "int", "required": true }
               }
             },
+            "ssl": {
+              "type": "map", "required": true, "mapping": {
+                "certfile": { "type" : "str", "required" : true },
+                "keyfile": { "type" : "str", "required" : true },
+                "generate_certs": { "type" : "bool", "required" : true },
+                "insecure": { "type" : "bool", "required" : true },
+                "cert_required": { "type" : "bool", "required" : true },
+                "ca_certs": { "type" : "str", "required" : true }
+              }
+            },
             "db": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/helpers/barclamp/designate_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/designate_helper.rb
@@ -1,0 +1,30 @@
+#
+# Copyright 2011-2013, Dell
+# Copyright 2013-2014, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Barclamp
+  module DesignateHelper
+    def api_protocols_for_designate(selected)
+      options_for_select(
+        [
+          ["HTTP", "http"],
+          ["HTTPS", "https"]
+        ],
+        selected.to_s
+      )
+    end
+  end
+end

--- a/crowbar_framework/app/views/barclamp/designate/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/designate/_edit_attributes.html.haml
@@ -8,3 +8,23 @@
 
     = string_field :resource_email
     = string_field :resource_project
+
+    %fieldset
+      %legend
+        = t(".ssl_header")
+
+      = select_field %w(api protocol),
+        :collection => :api_protocols_for_designate,
+        "data-sslprefix" => "ssl",
+        "data-sslcert" => "/etc/designate/ssl/certs/signing_cert.pem",
+        "data-sslkey" => "/etc/designate/ssl/private/signing_key.pem"
+
+      #ssl_container
+        = boolean_field %w(ssl generate_certs)
+        = string_field %w(ssl certfile)
+        = string_field %w(ssl keyfile)
+        = boolean_field %w(ssl insecure)
+        = boolean_field %w(ssl cert_required),
+          "data-enabler" => "true",
+          "data-enabler-target" => "#ssl_ca_certs"
+        = string_field %w(ssl ca_certs)

--- a/crowbar_framework/config/locales/designate/en.yml
+++ b/crowbar_framework/config/locales/designate/en.yml
@@ -23,5 +23,16 @@ en:
         keystone_instance: 'Keystone'
         resource_email: 'E-mail address of hostmaster'
         resource_project: 'Project that will own created resources'
+        api_header: 'API Settings'
+        api:
+          protocol: 'Protocol'
+        ssl_header: 'SSL Support'
+        ssl:
+          generate_certs: 'Generate (self-signed) certificates (implies insecure)'
+          certfile: 'SSL Certificate File'
+          keyfile: 'SSL (Private) Key File'
+          insecure: 'SSL Certificate is insecure (for instance, self-signed)'
+          cert_required: 'Require Client Certificate'
+          ca_certs: 'SSL CA Certificates File'
       validation:
         invalid_email_address: 'E-mail address %{email} is invalid.'


### PR DESCRIPTION
Besides bringing the configuration closer to the ardana configuration,
those changes also gets all designate tempest tests to pass.

The configuration changes are:
  - Increase the default quota for zones from 10 to 100
  - Enable admin api
  - Enable `quotas` and `zones` admin extensions
  - Enable all extensions from v2 api

(cherry picked from commit 48dfc155dc4847979652e9e7ce869258e7416a42)

designate: add support for SSL (SOC-10877)

This change adds support for configuring designate with SSL.

(cherry picked from commit c1bf75c)

designate: declare all mdns servers as master on pool config (SOC-10952)

When creating zones the DNS server notify other servers about the new
zone, however the notification is only accepted when it comes from
masters

Using the VIP as master causes the zone creation to fail as the
notification is refused because it does not come from the VIP, but from
the node IP address. This change fixes it by declaring all mdns server
as master on the default pool defined by crowbar.

(cherry picked from commit 92848ad)