### PR TITLE
horizon: fix keystone node lookup (SOC-10978)

### DIFF
--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -19,6 +19,7 @@ include_recipe "apache2::mod_wsgi"
 include_recipe "apache2::mod_rewrite"
 
 monasca_server = node_search_with_cache("roles:monasca-server").first
+keystone_server = node_search_with_cache("roles:keystone-server").first
 
 grafana_url = ""
 
@@ -465,7 +466,8 @@ template local_settings do
     multi_domain_support: multi_domain_support,
     policy_file_path: node["horizon"]["policy_file_path"],
     policy_file: node["horizon"]["policy_file"],
-    websso_keystone_url: keystone_settings["websso_keystone_url"]
+    websso_keystone_url: keystone_settings["websso_keystone_url"],
+    openidc_enabled: keystone_server[:keystone][:federation][:openidc][:enabled]
   )
   action :create
   notifies :reload, "service[horizon]"

--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -253,7 +253,7 @@ SECRET_KEY = "<%= @secret_key %>"
 
 # FIXME(gyee): if we ever going to support multiple protocols or multiple
 # IDPs, we'll need to refactor this accordingly.
-<% if node[:keystone][:federation][:openidc][:enabled] %>
+<% if @openidc_enabled %>
 WEBSSO_ENABLED = True
 
 # NOTE(gyee): this need to be versioned public Keystone URL as this is used


### PR DESCRIPTION
The WebSSO code for local_settings.py attempted to retrieve
Keystone settings for WebSSO from the Horizon barclamp's node
object, which failed. This commit adds an explicit lookup of
the Keystone barclamp's node object which contains the data in
question.