### PR TITLE
octavia: configuration fixes (SOC-10989,SOC-10990)

### DIFF
--- a/chef/cookbooks/octavia/definitions/octavia_conf.rb
+++ b/chef/cookbooks/octavia/definitions/octavia_conf.rb
@@ -56,6 +56,7 @@ define :octavia_conf do
             octavia_db_connection: fetch_database_connection_string(node[:octavia][:db]),
             neutron_endpoint: OctaviaHelper.get_neutron_endpoint(node),
             nova_endpoint: OctaviaHelper.get_nova_endpoint(node),
+            barbican_endpoint: OctaviaHelper.get_barbican_endpoint(node),
             octavia_keystone_settings: KeystoneHelper.keystone_settings(node, "octavia"),
             rabbit_settings: fetch_rabbitmq_settings,
             octavia_nova_flavor_id: node[:octavia][:flavor_id],

--- a/chef/cookbooks/octavia/libraries/helpers.rb
+++ b/chef/cookbooks/octavia/libraries/helpers.rb
@@ -32,6 +32,18 @@ module OctaviaHelper
       nova_protocol + "://" + nova_server_host + ":" + nova_server_port.to_s + "/v2.1"
     end
 
+    def get_barbican_endpoint(node)
+      barbican = CrowbarUtilsSearch.node_search_with_cache(node, "roles:barbican-controller").first
+      if !barbican.nil?
+        barbican_protocol = barbican[:barbican][:api][:protocol]
+        barbican_server_host = CrowbarHelper.get_host_for_admin_url(barbican, barbican[:barbican][:ha][:enabled])
+        barbican_server_port = barbican[:barbican][:api][:bind_port]
+        barbican_protocol + "://" + barbican_server_host + ":" + barbican_server_port.to_s
+      else
+        ""
+      end
+    end
+
     def get_openstack_command(node, config)
       key_settings = KeystoneHelper.keystone_settings(node, "octavia")
 

--- a/chef/cookbooks/octavia/templates/default/100-octavia.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/100-octavia.conf.erb
@@ -50,6 +50,8 @@ user_domain_name = <%= @octavia_keystone_settings['default_user_domain'] %>
 username = <%= @octavia_keystone_settings['service_user'] %>
 password =  <%= @octavia_keystone_settings['service_password'] %>
 region_name = <%= @octavia_keystone_settings['endpoint_region'] %>
+service_token_roles_required = true
+service_token_roles = admin
 memcached_servers = <%= @memcached_servers.join(',') %>
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = <%= node[:octavia][:memcache_secret_key] %>

--- a/chef/cookbooks/octavia/templates/default/100-octavia.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/100-octavia.conf.erb
@@ -20,6 +20,9 @@ transport_url = <%= @rabbit_settings[:url] %>
 [certificates]
 cert_generator = local_cert_generator
 cert_manager = barbican_cert_manager
+endpoint = <%= @barbican_endpoint %>
+endpoint_type = "internalURL"
+insecure = <%= @octavia_keystone_settings['insecure'] %>
 ca_certificate = <%= @node[:octavia][:certs][:cert_path] %><%= @node[:octavia][:certs][:server_ca_cert_path] %>
 ca_private_key = <%= @node[:octavia][:certs][:cert_path] %><%= @node[:octavia][:certs][:server_ca_key_path] %>
 ca_private_key_passphrase = <%= @node[:octavia][:certs][:passphrase] %>
@@ -63,10 +66,12 @@ port_detach_timeout = <%= @node[:octavia][:networking][:port_detach_timeout] %>
 [neutron]
 endpoint = <%= @neutron_endpoint %>
 endpoint_type = "internalURL"
+insecure = <%= @octavia_keystone_settings['insecure'] %>
 
 [nova]
 endpoint = <%= @nova_endpoint %>
 endpoint_type = "internalURL"
+insecure = <%= @octavia_keystone_settings['insecure'] %>
 
 [oslo_messaging]
 topic = octavia_prov

--- a/chef/cookbooks/octavia/templates/default/110-api.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-api.conf.erb
@@ -2,4 +2,4 @@
 api_handler = queue_producer
 bind_host = <%= @bind_host %>
 bind_port = <%= @bind_port %>
-
+api_v1_enabled = false


### PR DESCRIPTION
This PR fixes some Octavia configuration options, either deprecated or missing.

Remaining Octavia deprecated configuration options:
 - disables deprecated V1 API [1]
 - use the service_token_roles_required and service_token_roles
 parameters in the keystone auth config. Adding this will ensure that
 token validation sent to keystone by Octavia service has the configured
 service token role to pass otherwise keystone will reject that request [2]

Even though Octavia uses the service catalogue to auto-configure
the Barbican service endpoint, it helps if we use an endpoint
hard-coded in the configuration files because there is no other
way to restart Octavia services in case the Barbican endpoint
also changes (e.g. switch from HTTP to HTTPs or vice-versa).

This commit also sets the insecure option not just for Barbican,
but also for other services that Octavia interacts with (Nova
and Neutron).

[1] https://wiki.openstack.org/wiki/Neutron/LBaaS/Deprecation#What_about_the_Octavia_v1_API.3F
[2] https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html