### PR TITLE
Add Crowbar UI options for mgmt net (SOC-10904)

### DIFF
--- a/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
@@ -16,6 +16,13 @@
 
     %fieldset
       %legend
+        = t(".mgmt_net_header")
+
+      = string_field %w(amphora manage_net)
+      = string_field %w(amphora manage_cidr)
+
+    %fieldset
+      %legend
         = t(".ssl_header")
 
       = select_field %w(api protocol),

--- a/crowbar_framework/config/locales/octavia/en.yml
+++ b/crowbar_framework/config/locales/octavia/en.yml
@@ -41,6 +41,10 @@ en:
           insecure: 'SSL Certificate is insecure (for instance, self-signed)'
           cert_required: 'Require Client Certificate'
           ca_certs: 'SSL CA Certificates File'
+        mgmt_net_header: 'Octavia Management Network Settings'
+        amphora:
+          manage_net: 'Management Network Name'
+          manage_cidr: 'Management Network CIDR'
       validation:
         certificates_not_empty: 'The certificates paths cannot be empty.'
         passphrase_not_empty: 'Passphrase cannot be empty.'


### PR DESCRIPTION
This change adds two configuration options for the Octavia barclamp in the Crowbar UI. The user can change the management network name and CIDR.
