### PR TITLE
[5.0] keystone: Add OS_INTERFACE env var to .openrc (SOC-11006)

### DIFF
--- a/chef/cookbooks/keystone/templates/default/openrc.erb
+++ b/chef/cookbooks/keystone/templates/default/openrc.erb
@@ -2,6 +2,7 @@
 export OS_USERNAME='<%= @keystone_settings['admin_user'] %>'
 export OS_PASSWORD='<%= @keystone_settings['admin_password'] %>'
 export OS_ENDPOINT_TYPE='internalURL'
+export OS_INTERFACE='internal'
 <% if @keystone_settings['api_version'] != '2.0' %>
 export OS_IDENTITY_API_VERSION='<%= @keystone_settings['api_version'] %>'
 export OS_USER_DOMAIN_NAME='Default'


### PR DESCRIPTION
New openstack client(s) use OS_INTERFACE instead of OS_ENDPOINT_TYPE.
The default is 'public' so if we don't set it, clients will use mix of
internal and public calls depending on the implementation.

(cherry picked from commit 352e358e2c9e0f6dfefc034746f9bf13ffbce7a8)

port of #2323 