### PR TITLE
neutron: Revert remove .openrc creation from neutron cookbooks (SOC-10378)

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -41,6 +41,19 @@ if use_l3_agent
     action :create
   end
 
+  # We need .openrc present at network node so the node can use neutron-ha-tool even
+  # when located in separate cluster
+  template "/root/.openrc" do
+    source "openrc.erb"
+    cookbook "keystone"
+    owner "root"
+    group "root"
+    mode 0o600
+    variables(
+      keystone_settings: keystone_settings
+    )
+  end
+
   # skip neutron-ha-tool resource creation during upgrade
   unless CrowbarPacemakerHelper.being_upgraded?(node)
 


### PR DESCRIPTION
This reverts commit 4dc961328fdde9b02071ce0f6881311066d5b330.
While the .openrc was not needed on network nodes during normal operation,
it was needed for proper upgrade of HA clouds with separate network cluster
(e.g. for router evacuation).

partial revert of #2140 