### PR TITLE
octavia: Add topology setting (SOC-10876)

### DIFF
--- a/chef/cookbooks/octavia/attributes/default.rb
+++ b/chef/cookbooks/octavia/attributes/default.rb
@@ -38,7 +38,7 @@ default[:octavia][:health_manager][:heartbeat_key] = nil
 default[:octavia][:sudoers_file] = "/etc/sudoers.d/octavia"
 
 default[:octavia][:certs][:cert_path] = "/etc/octavia/certs/"
-default[:octavia][:certs][:passphrase] = "foobar"
+default[:octavia][:certs][:passphrase] = ""
 default[:octavia][:certs][:server_ca_cert_path] = "server_ca/certs/ca.cert.pem"
 default[:octavia][:certs][:server_ca_key_path] = "server_ca/private/ca.key.pem"
 default[:octavia][:certs][:client_ca_cert_path] = "client_ca/certs/ca.cert.pem"
@@ -50,6 +50,8 @@ default[:octavia][:amphora][:manage_net] = "lb-mgmt-net"
 default[:octavia][:amphora][:image_tag] = "amphora"
 default[:octavia][:amphora][:project] = "service"
 default[:octavia][:amphora][:enable_anti_affinity] = false
+default[:octavia][:amphora][:loadbalancer_topology] = "SINGLE"
+default[:octavia][:amphora][:spare_amphora_pool_size] = 0
 default[:octavia][:amphora][:ssh_access][:keyname] = ""
 
 default[:octavia][:ssl][:certfile] = "/etc/octavia/ssl/certs/signing_cert.pem"

--- a/chef/cookbooks/octavia/templates/default/110-housekeeping.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-housekeeping.conf.erb
@@ -7,3 +7,4 @@ amp_ssh_key_name = "<%= keyname%>"
    if !anti_affinity.nil? -%>
 enable_anti_affinity = <%= anti_affinity %>
 <% end %>
+spare_amphora_pool_size = <%= @node[:octavia][:amphora][:spare_amphora_pool_size] %>

--- a/chef/cookbooks/octavia/templates/default/110-worker.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-worker.conf.erb
@@ -9,7 +9,7 @@ client_ca = <%= @node[:octavia][:certs][:cert_path]%><%=@node[:octavia][:certs][
 compute_driver = compute_nova_driver
 amphora_driver = amphora_haproxy_rest_driver
 network_driver = allowed_address_pairs_driver
-loadbalancer_topology = SINGLE
+loadbalancer_topology = <%= @node[:octavia][:amphora][:loadbalancer_topology] %>
 <% keyname = @node[:octavia][:amphora][:ssh_access][:keyname]
    if !keyname.nil? and !keyname.empty? -%>
 amp_ssh_key_name = "<%= keyname%>"

--- a/chef/data_bags/crowbar/migrate/octavia/303_add_loadbalancer_topology.rb
+++ b/chef/data_bags/crowbar/migrate/octavia/303_add_loadbalancer_topology.rb
@@ -1,0 +1,14 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  t_amphora = template_deployment[:amphora]
+  attrs[:amphora][:loadbalancer_topology] = t_amphora[:loadbalancer_topology] \
+    unless attrs[:amphora].key? :loadbalancer_topology
+  attrs[:amphora][:spare_amphora_pool_size] = t_amphora[:spare_amphora_pool_size] \
+    unless attrs[:amphora].key? :spare_amphora_pool_size
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs[:amphora].delete(:loadbalancer_topology)
+  attrs[:amphora].delete(:spare_amphora_pool_size)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-octavia.json
+++ b/chef/data_bags/crowbar/template-octavia.json
@@ -53,6 +53,8 @@
         "image_tag": "amphora",
         "project": "service",
         "enable_anti_affinity": false,
+        "loadbalancer_topology": "SINGLE",
+        "spare_amphora_pool_size": 0,
         "ssh_access": {
           "keyname": ""
         }
@@ -79,7 +81,7 @@
     "octavia": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 302,
+      "schema-revision": 303,
       "element_states": {
         "octavia-api": [ "readying", "ready", "applying" ],
         "octavia-backend": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-octavia.schema
+++ b/chef/data_bags/crowbar/template-octavia.schema
@@ -70,6 +70,8 @@
                         "image_tag": { "type": "str", "required": true },
                         "project": { "type": "str", "required": true },
                         "enable_anti_affinity": { "type": "bool", "required": true },
+                        "loadbalancer_topology": { "type": "str", "required": true },
+                        "spare_amphora_pool_size": { "type": "int", "required": true },
                         "ssh_access": { "type": "map", "required": true,
                           "mapping": {
                             "keyname": { "type": "str", "required": true }

--- a/crowbar_framework/app/helpers/barclamp/octavia_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/octavia_helper.rb
@@ -25,5 +25,9 @@ module Barclamp
         selected.to_s
       )
     end
+
+    def loadbalancer_topology_for_octavia(selected)
+      options_for_select(OctaviaService.valid_loadbalancer_topologies { |i| [i, i] }, selected.to_s)
+    end
   end
 end

--- a/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
@@ -23,6 +23,15 @@
 
     %fieldset
       %legend
+        = t(".amphora_header")
+
+      = string_field %w(amphora ssh_access keyname)
+      = select_field %w(amphora loadbalancer_topology),
+        :collection => :loadbalancer_topology_for_octavia
+      = integer_field %w(amphora spare_amphora_pool_size)
+
+    %fieldset
+      %legend
         = t(".ssl_header")
 
       = select_field %w(api protocol),

--- a/crowbar_framework/config/locales/octavia/en.yml
+++ b/crowbar_framework/config/locales/octavia/en.yml
@@ -27,9 +27,13 @@ en:
           passphrase: 'Passphrase'
         amphora_header: "Amphora Virtual Machines"
         amphora:
+          loadbalancer_topology: "Loadbalancer Topology"
+          spare_amphora_pool_size: "Spare Amphora Pool Size"
           ssh_access:
             enabled: "Allow SSH Access"
             keyname: "SSH Access Keypair Name"
+          manage_net: 'Management Network Name'
+          manage_cidr: 'Management Network CIDR'
         api_header: 'API Settings'
         api:
           protocol: 'Protocol'
@@ -42,10 +46,9 @@ en:
           cert_required: 'Require Client Certificate'
           ca_certs: 'SSL CA Certificates File'
         mgmt_net_header: 'Octavia Management Network Settings'
-        amphora:
-          manage_net: 'Management Network Name'
-          manage_cidr: 'Management Network CIDR'
       validation:
         certificates_not_empty: 'The certificates paths cannot be empty.'
         passphrase_not_empty: 'Passphrase cannot be empty.'
         keyname_not_empty: 'Keypair name cannot be empty if you enable ssh access.'
+        unknown_topology: 'The specified topology is not known.'
+        negative_pool_size: 'The spare pool size can not be negative.'


### PR DESCRIPTION
Currently a user can not deploy Octavia in active/standby topology
because Crowbar does not allow changes to the corresponding setting in
the Octavia configuration file. This change makes the setting
configurable.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>