### PR TITLE
tempest: Update default image on schema (SOC-11023)

### DIFF
--- a/chef/data_bags/crowbar/migrate/tempest/302_update_tempest_image.rb
+++ b/chef/data_bags/crowbar/migrate/tempest/302_update_tempest_image.rb
@@ -1,0 +1,10 @@
+def upgrade(ta, td, a, d)
+  a["tempest_test_images"]["x86_64"] = ta["tempest_test_images"]["x86_64"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["tempest_test_images"]["x86_64"] = ta["tempest_test_images"]["x86_64"]
+  return a, d
+end
+

--- a/chef/data_bags/crowbar/template-tempest.json
+++ b/chef/data_bags/crowbar/template-tempest.json
@@ -39,7 +39,7 @@
     "tempest": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 301,
+      "schema-revision": 302,
       "element_states": {
         "tempest": [ "ready", "applying" ]
       },


### PR DESCRIPTION
This change adds a schema migrate function for updating the default
tempest image which has been changed in [1].

1. https://github.com/crowbar/crowbar-openstack/commit/07864bdff573b4ad150530168f879e2e215c896b