### PR TITLE
octavia: Add ssh key to health manager (SOC-11025)

### DIFF
--- a/chef/cookbooks/octavia/templates/default/110-health-manager.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-health-manager.conf.erb
@@ -7,3 +7,7 @@ event_streamer_driver = noop_event_streamer
 heartbeat_interval = <%= @node[:octavia][:health_manager][:heartbeat_interval] %>
 heartbeat_timeout = <%= @node[:octavia][:health_manager][:heartbeat_timeout] %>
 health_check_interval = <%= @node[:octavia][:health_manager][:health_check_interval] %>
+<% keyname = @node[:octavia][:amphora][:ssh_access][:keyname]
+   if !keyname.nil? and !keyname.empty? -%>
+amp_ssh_key_name = "<%= keyname%>"
+<% end %>

--- a/chef/cookbooks/octavia/templates/default/110-housekeeping.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-housekeeping.conf.erb
@@ -1,1 +1,5 @@
 [house_keeping]
+<% keyname = @node[:octavia][:amphora][:ssh_access][:keyname]
+   if !keyname.nil? and !keyname.empty? -%>
+amp_ssh_key_name = "<%= keyname%>"
+<% end %>

--- a/chef/cookbooks/octavia/templates/default/110-worker.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-worker.conf.erb
@@ -10,7 +10,7 @@ compute_driver = compute_nova_driver
 amphora_driver = amphora_haproxy_rest_driver
 network_driver = allowed_address_pairs_driver
 loadbalancer_topology = SINGLE
-<%  keyname = @node[:octavia][:amphora][:ssh_access][:keyname] -%>
-<%  if !keyname.nil? and !keyname.empty? -%>
+<% keyname = @node[:octavia][:amphora][:ssh_access][:keyname]
+   if !keyname.nil? and !keyname.empty? -%>
 amp_ssh_key_name = "<%= keyname%>"
 <% end %>


### PR DESCRIPTION
The amphora ssh key needs to be known by the health manager so that it
can respawn dead amphora with the correct ssh key.

Co-Authored-By: Keith Berger <keith.berger@suse.com>
Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>