### PR TITLE
octavia: Add anti-affinity settings (SOC-11026)

### DIFF
--- a/chef/cookbooks/octavia/attributes/default.rb
+++ b/chef/cookbooks/octavia/attributes/default.rb
@@ -49,7 +49,7 @@ default[:octavia][:amphora][:sec_group] = "lb-mgmt-sec-group"
 default[:octavia][:amphora][:manage_net] = "lb-mgmt-net"
 default[:octavia][:amphora][:image_tag] = "amphora"
 default[:octavia][:amphora][:project] = "service"
-
+default[:octavia][:amphora][:enable_anti_affinity] = false
 default[:octavia][:amphora][:ssh_access][:keyname] = ""
 
 default[:octavia][:ssl][:certfile] = "/etc/octavia/ssl/certs/signing_cert.pem"

--- a/chef/cookbooks/octavia/templates/default/110-health-manager.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-health-manager.conf.erb
@@ -11,3 +11,7 @@ health_check_interval = <%= @node[:octavia][:health_manager][:health_check_inter
    if !keyname.nil? and !keyname.empty? -%>
 amp_ssh_key_name = "<%= keyname%>"
 <% end %>
+<% anti_affinity = @node[:octavia][:amphora][:enable_anti_affinity]
+   if !anti_affinity.nil? -%>
+enable_anti_affinity = <%= anti_affinity %>
+<% end %>

--- a/chef/cookbooks/octavia/templates/default/110-housekeeping.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-housekeeping.conf.erb
@@ -3,3 +3,7 @@
    if !keyname.nil? and !keyname.empty? -%>
 amp_ssh_key_name = "<%= keyname%>"
 <% end %>
+<% anti_affinity = @node[:octavia][:amphora][:enable_anti_affinity]
+   if !anti_affinity.nil? -%>
+enable_anti_affinity = <%= anti_affinity %>
+<% end %>

--- a/chef/cookbooks/octavia/templates/default/110-worker.conf.erb
+++ b/chef/cookbooks/octavia/templates/default/110-worker.conf.erb
@@ -14,3 +14,7 @@ loadbalancer_topology = SINGLE
    if !keyname.nil? and !keyname.empty? -%>
 amp_ssh_key_name = "<%= keyname%>"
 <% end %>
+<% anti_affinity = @node[:octavia][:amphora][:enable_anti_affinity]
+   if !anti_affinity.nil? -%>
+enable_anti_affinity = <%= anti_affinity %>
+<% end %>

--- a/chef/data_bags/crowbar/migrate/octavia/302_add_anti_affinity.rb
+++ b/chef/data_bags/crowbar/migrate/octavia/302_add_anti_affinity.rb
@@ -1,0 +1,10 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs[:amphora][:enable_anti_affinity] = template_attrs[:amphora][:enable_anti_affinity] \
+    if attrs[:amphora][:enable_anti_affinity].nil?
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs[:amphora].delete("enable_anti_affinity")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-octavia.json
+++ b/chef/data_bags/crowbar/template-octavia.json
@@ -52,6 +52,7 @@
         "manage_cidr": "172.31.0.0/16",
         "image_tag": "amphora",
         "project": "service",
+        "enable_anti_affinity": false,
         "ssh_access": {
           "keyname": ""
         }
@@ -78,7 +79,7 @@
     "octavia": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 301,
+      "schema-revision": 302,
       "element_states": {
         "octavia-api": [ "readying", "ready", "applying" ],
         "octavia-backend": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-octavia.schema
+++ b/chef/data_bags/crowbar/template-octavia.schema
@@ -69,6 +69,7 @@
                         "manage_cidr": { "type": "str", "required": true },
                         "image_tag": { "type": "str", "required": true },
                         "project": { "type": "str", "required": true },
+                        "enable_anti_affinity": { "type": "bool", "required": true },
                         "ssh_access": { "type": "map", "required": true,
                           "mapping": {
                             "keyname": { "type": "str", "required": true }


### PR DESCRIPTION
Add the anti-affinity setting to the relevant configuration files. The
affected services are the worker, the health-manager, and the
house-keeping service.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>