### PR TITLE
Do not read data from barclamp that has not been saved yet.

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -65,8 +65,7 @@ vni_start = [node[:neutron][:vxlan][:vni_start], 0].max
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-neutron_config = Barclamp::Config.load("openstack", "neutron")
-ssl_insecure = CrowbarOpenStackHelper.insecure(neutron_config) || keystone_settings["insecure"]
+ssl_insecure = CrowbarOpenStackHelper.insecure(node[:neutron]) || keystone_settings["insecure"]
 
 env = "OS_USERNAME='#{keystone_settings["service_user"]}' "
 env << "OS_PASSWORD='#{keystone_settings["service_password"]}' "

--- a/chef/cookbooks/nova/libraries/availability_zone.rb
+++ b/chef/cookbooks/nova/libraries/availability_zone.rb
@@ -18,8 +18,7 @@ module NovaAvailabilityZone
   def self.fetch_set_az_command_no_arg(node, cookbook_name)
     keystone_settings = KeystoneHelper.keystone_settings(node, cookbook_name)
 
-    nova_config = BarclampLibrary::Barclamp::Config.load("openstack", "nova")
-    ssl_insecure = CrowbarOpenStackHelper.insecure(nova_config) || keystone_settings["insecure"]
+    ssl_insecure = CrowbarOpenStackHelper.insecure(node[:nova]) || keystone_settings["insecure"]
 
     auth_url = KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],
                                                     keystone_settings["internal_url_host"],

--- a/chef/cookbooks/nova/recipes/flavors.rb
+++ b/chef/cookbooks/nova/recipes/flavors.rb
@@ -72,8 +72,7 @@ flavors =
   }
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
-nova_config = Barclamp::Config.load("openstack", "nova")
-ssl_insecure = CrowbarOpenStackHelper.insecure(nova_config) || keystone_settings["insecure"]
+ssl_insecure = CrowbarOpenStackHelper.insecure(node[:nova]) || keystone_settings["insecure"]
 
 env = "OS_USERNAME='#{keystone_settings["service_user"]}' "
 env << "OS_PASSWORD='#{keystone_settings["service_password"]}' "

--- a/chef/cookbooks/octavia/recipes/api.rb
+++ b/chef/cookbooks/octavia/recipes/api.rb
@@ -16,8 +16,7 @@
 include_recipe "apache2"
 include_recipe "apache2::mod_wsgi"
 
-octavia_config = Barclamp::Config.load("openstack", "octavia")
-cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
 
 octavia_conf "api" do
   cmd cmd

--- a/chef/cookbooks/octavia/recipes/health_manager.rb
+++ b/chef/cookbooks/octavia/recipes/health_manager.rb
@@ -13,8 +13,7 @@
 # limitations under the License.
 #
 
-octavia_config = Barclamp::Config.load("openstack", "octavia")
-cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
 
 octavia_conf "health-manager" do
   cmd cmd

--- a/chef/cookbooks/octavia/recipes/housekeeping.rb
+++ b/chef/cookbooks/octavia/recipes/housekeeping.rb
@@ -13,8 +13,7 @@
 # limitations under the License.
 #
 
-octavia_config = Barclamp::Config.load("openstack", "octavia")
-cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
 
 octavia_conf "housekeeping" do
   cmd cmd

--- a/chef/cookbooks/octavia/recipes/nova.rb
+++ b/chef/cookbooks/octavia/recipes/nova.rb
@@ -19,8 +19,7 @@ require "chef/mixin/shell_out"
 image = "openstack-octavia-amphora-image-x86_64"
 ha_enabled = node[:octavia][:ha][:enabled]
 package image if !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)
-octavia_config = Barclamp::Config.load("openstack", "octavia")
-cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
 
 sec_group = node[:octavia][:amphora][:sec_group]
 project_name = node[:octavia][:amphora][:project]

--- a/chef/cookbooks/octavia/recipes/worker.rb
+++ b/chef/cookbooks/octavia/recipes/worker.rb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-octavia_config = Barclamp::Config.load("openstack", "octavia")
-cmd = OctaviaHelper.get_openstack_command(node, octavia_config)
+cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
 
 octavia_conf "worker" do
   cmd cmd


### PR DESCRIPTION
Recipe X should not access barclamp data looking for X in the same
run where this data should be saved for the first time.

This actually seems to have only one effect: not getting the "insecure"
value correctly if SSL was set up only for one component (neutron or nova)
but not for keystone.