### PR TITLE
[5.0] Revert "Octavia: Hide UI until complete (SOC-10550)"

### DIFF
--- a/aodh.yml
+++ b/aodh.yml
@@ -19,8 +19,7 @@ barclamp:
   display: 'Aodh'
   description: 'OpenStack Telemetry: Alarming service'
   version: 0
-  # Change to true when complete
-  user_managed: false
+  user_managed: true
   requires:
     - '@crowbar'
     - 'pacemaker'


### PR DESCRIPTION
This reverts commit 75c75298a5330c9c76becf997feb2365d052c871.

NOTE: there is no Octavia in SOC8 and worse, the reverted commit was actually hiding the AODH barclamp.