### PR TITLE
designate: Fix the migrations of ssl values (SOC-11030)

### DIFF
--- a/chef/data_bags/crowbar/migrate/designate/302_add_ssl_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/designate/302_add_ssl_attributes.rb
@@ -1,9 +1,9 @@
 def upgrade(ta, td, a, d)
-  a["ssl"] = ta["ssl"]
+  a["ssl"] = ta["ssl"] unless a.key? "ssl"
   return a, d
 end
 
 def downgrade(ta, td, a, d)
-  a.delete("ssl")
+  a.delete("ssl") unless ta.key? "ssl"
   return a, d
 end


### PR DESCRIPTION
Make sure to use the template values only if attributes
do not exist yet, i.e. because we are upgrading.