### PR TITLE
[5.0] Do not read data from barclamp that has not been saved (SOC-11028)

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -65,8 +65,7 @@ vni_start = [node[:neutron][:vxlan][:vni_start], 0].max
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
-neutron_config = Barclamp::Config.load("openstack", "neutron")
-ssl_insecure = CrowbarOpenStackHelper.insecure(neutron_config) || keystone_settings["insecure"]
+ssl_insecure = CrowbarOpenStackHelper.insecure(node[:neutron]) || keystone_settings["insecure"]
 
 env = "OS_USERNAME='#{keystone_settings["service_user"]}' "
 env << "OS_PASSWORD='#{keystone_settings["service_password"]}' "

--- a/chef/cookbooks/nova/libraries/availability_zone.rb
+++ b/chef/cookbooks/nova/libraries/availability_zone.rb
@@ -18,8 +18,7 @@ module NovaAvailabilityZone
   def self.fetch_set_az_command_no_arg(node, cookbook_name)
     keystone_settings = KeystoneHelper.keystone_settings(node, cookbook_name)
 
-    nova_config = BarclampLibrary::Barclamp::Config.load("openstack", "nova")
-    ssl_insecure = CrowbarOpenStackHelper.insecure(nova_config) || keystone_settings["insecure"]
+    ssl_insecure = CrowbarOpenStackHelper.insecure(node[:nova]) || keystone_settings["insecure"]
 
     auth_url = KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],
                                                     keystone_settings["internal_url_host"],

--- a/chef/cookbooks/nova/recipes/flavors.rb
+++ b/chef/cookbooks/nova/recipes/flavors.rb
@@ -72,8 +72,7 @@ flavors =
   }
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
-nova_config = Barclamp::Config.load("openstack", "nova")
-ssl_insecure = CrowbarOpenStackHelper.insecure(nova_config) || keystone_settings["insecure"]
+ssl_insecure = CrowbarOpenStackHelper.insecure(node[:nova]) || keystone_settings["insecure"]
 
 env = "OS_USERNAME='#{keystone_settings["service_user"]}' "
 env << "OS_PASSWORD='#{keystone_settings["service_password"]}' "


### PR DESCRIPTION
Recipe X should not access barclamp data looking for X in the same
run where this data should be saved for the first time.

Barclamp data are saved to data bag after the chef call: see
save_config_to_databag in app/models/openstack_service_object.rb

This actually seems to have only one effect: not getting the "insecure"
value correctly if SSL was set up only for one component (e.g. neutron)
but not for keystone.

(cherry picked from commit fd093c2828566314194ae1bc04e68f4b5899847f)

(partial) backport of https://github.com/crowbar/crowbar-openstack/pull/2333