### PR TITLE
[5.0] Install openstack client for neutron recipes (SOC-11039)

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -117,6 +117,8 @@ else
   Chef::Log.error("networking plugin '#{networking_plugin}' invalid for creating provider networks")
 end
 
+package "python-openstackclient"
+
 execute "create_fixed_network" do
   command "#{openstack_cmd} network create --share #{fixed_network_type} fixed"
   not_if "out=$(#{openstack_cmd} network list); [ $? != 0 ] || echo ${out} | grep -q ' fixed '"


### PR DESCRIPTION
This is only relevant when neutron nodes are in separate cluster
and openstack client is not installed by some other (most likely keystone)
dependency.

(cherry picked from commit f5249b2725c9bd2f5c1a8ff4ffe2fd029f3ab213)

Port of https://github.com/crowbar/crowbar-openstack/pull/2337