### PR TITLE
[4.0] Install openstack client for neutron recipes (SOC-11039)

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -119,6 +119,8 @@ else
   Chef::Log.error("networking plugin '#{networking_plugin}' invalid for creating provider networks")
 end
 
+package "python-openstackclient"
+
 execute "create_fixed_network" do
   command "#{neutron_cmd} net-create fixed --shared #{fixed_network_type}"
   not_if "out=$(#{neutron_cmd} net-list); [ $? != 0 ] || echo ${out} | grep -q ' fixed '"


### PR DESCRIPTION
This is only relevant when neutron nodes are in separate cluster
and openstack client is not installed by some other (most likely keystone)
dependency.

(cherry picked from commit f5249b2)