### PR TITLE
[4.0] Terminate ssl on haproxy (bsc#1149535)

### DIFF
--- a/chef/cookbooks/cinder/attributes/default.rb
+++ b/chef/cookbooks/cinder/attributes/default.rb
@@ -54,3 +54,9 @@ end
 default[:cinder][:ha][:op][:monitor][:interval] = "10s"
 # Ports to bind to when haproxy is used for the real ports
 default[:cinder][:ha][:ports][:api] = 5520
+
+#
+# SSL settings
+#
+default[:cinder][:ssl][:loadbalancer_terminate_ssl] = false
+default[:cinder][:ssl][:pemfile] = "/etc/ssl/private/cinder.pem"

--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -28,6 +28,8 @@ haproxy_loadbalancer "cinder-api" do
   address node[:cinder][:api][:bind_open_address] ? "0.0.0.0" : cluster_admin_ip
   port node[:cinder][:api][:bind_port]
   use_ssl (node[:cinder][:api][:protocol] == "https")
+  terminate_ssl node[:cinder][:ssl][:loadbalancer_terminate_ssl]
+  pemfile node[:cinder][:ssl][:pemfile]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "cinder", "cinder-controller", "api")
   rate_limit node[:cinder][:ha_rate_limit]["cinder-api"]
   action :nothing

--- a/chef/cookbooks/nova/attributes/default.rb
+++ b/chef/cookbooks/nova/attributes/default.rb
@@ -186,3 +186,9 @@ default[:nova][:serial][:ssl][:enabled] = false
 # metadata/vendordata
 #
 default[:nova][:metadata][:vendordata][:json] = "{}"
+
+#
+# SSL settings
+#
+default[:nova][:ssl][:loadbalancer_terminate_ssl] = false
+default[:nova][:ssl][:pemfile] = "/etc/ssl/private/nova.pem"

--- a/chef/cookbooks/nova/recipes/controller_ha.rb
+++ b/chef/cookbooks/nova/recipes/controller_ha.rb
@@ -28,6 +28,8 @@ haproxy_loadbalancer "nova-api" do
   address "0.0.0.0"
   port node[:nova][:ports][:api]
   use_ssl node[:nova][:ssl][:enabled]
+  terminate_ssl node[:nova][:ssl][:loadbalancer_terminate_ssl]
+  pemfile node[:nova][:ssl][:pemfile]
   servers CrowbarPacemakerHelper.haproxy_servers_for_service(node, "nova", "nova-controller", "api")
   rate_limit node[:nova][:ha_rate_limit]["nova-api"]
   action :nothing

--- a/chef/data_bags/crowbar/migrate/cinder/111_add_haproxy_mode_http.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/111_add_haproxy_mode_http.rb
@@ -1,0 +1,12 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  key = "loadbalancer_terminate_ssl"
+  template_value = template_attrs["cinder"]["ssl"][key]
+  attrs["cinder"]["ssl"][key] = template_value unless attrs["cinder"]["ssl"].key? key
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  key = "loadbalancer_terminate_ssl"
+  attrs["cinder"]["ssl"].delete(key) unless template_attrs["cinder"]["ssl"].key? key
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/nova/127_add_haproxy_mode_http.rb
+++ b/chef/data_bags/crowbar/migrate/nova/127_add_haproxy_mode_http.rb
@@ -1,0 +1,12 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  key = "loadbalancer_terminate_ssl"
+  template_value = template_attrs["nova"]["ssl"][key]
+  attrs["nova"]["ssl"][key] = template_value unless attrs["nova"]["ssl"].key? key
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  key = "loadbalancer_terminate_ssl"
+  attrs["nova"]["ssl"].delete(key) unless template_attrs["nova"]["ssl"].key? key
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-cinder.json
+++ b/chef/data_bags/crowbar/template-cinder.json
@@ -149,7 +149,9 @@
         "generate_certs": false,
         "insecure": false,
         "cert_required": false,
-        "ca_certs": "/etc/cinder/ssl/certs/ca.pem"
+        "ca_certs": "/etc/cinder/ssl/certs/ca.pem",
+        "loadbalancer_terminate_ssl": false,
+        "pemfile": "/etc/ssl/private/cinder.pem"
       },
       "db": {
         "password": "",
@@ -176,7 +178,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 110,
+      "schema-revision": 111,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-cinder.schema
+++ b/chef/data_bags/crowbar/template-cinder.schema
@@ -314,7 +314,9 @@
               "generate_certs": { "type" : "bool", "required" : true },
               "insecure": { "type" : "bool", "required" : true },
               "cert_required": { "type" : "bool", "required" : true },
-              "ca_certs": { "type" : "str", "required" : true }
+              "ca_certs": { "type" : "str", "required" : true },
+              "loadbalancer_terminate_ssl": { "type" : "bool", "required": true},
+              "pemfile": { "type" : "str", "required": true}
             }},
             "db": {
               "type": "map",

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -118,7 +118,9 @@
         "generate_certs": false,
         "insecure": false,
         "cert_required": false,
-        "ca_certs": "/etc/nova/ssl/certs/ca.pem"
+        "ca_certs": "/etc/nova/ssl/certs/ca.pem",
+        "loadbalancer_terminate_ssl": false,
+        "pemfile": "/etc/ssl/private/nova.pem"
       },
       "novnc": {
         "ssl": {
@@ -183,7 +185,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 126,
+      "schema-revision": 127,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -182,7 +182,9 @@
                 "generate_certs": { "type" : "bool", "required" : true },
                 "insecure": { "type" : "bool", "required" : true },
                 "cert_required": { "type" : "bool", "required" : true },
-                "ca_certs": { "type" : "str", "required" : true }
+                "ca_certs": { "type" : "str", "required" : true },
+                "loadbalancer_terminate_ssl": { "type" : "bool", "required": true},
+                "pemfile": { "type" : "str", "required": true}
               }
             },
             "novnc": {


### PR DESCRIPTION
If ssl is passed-thru on haproxy, the source ip gets replaced with
the one of the node where haproxy lives, and there is no way to get the
original ip on the services side.

Add ssl termination on haproxy. Two new hidden options are added:
loadbalancer_terminate_ssl (boolean) and pemfile (path to the
certificate to use in haproxy-recognized format).

The change depends on https://github.com/crowbar/crowbar-ha/pull/372