### PR TITLE
designate: don't use pacemaker for designate-producer (SOC-XXXX)

### DIFF
--- a/chef/cookbooks/designate/recipes/api.rb
+++ b/chef/cookbooks/designate/recipes/api.rb
@@ -109,4 +109,4 @@ crowbar_pacemaker_sync_mark "create-designate_register" if ha_enabled
 
 designate_service "central"
 designate_service "api"
-designate_service "producer" unless ha_enabled
+designate_service "producer"


### PR DESCRIPTION
The designate-producer service has active-active capabilities
now [1], which means it doesn't need to be managed by pacemaker.

[1] https://docs.openstack.org/designate/rocky/admin/ha.html