### PR TITLE
rabbitmq: sync startup definitions.json with recipe (SOC-11077)

### DIFF
--- a/chef/cookbooks/rabbitmq/libraries/crowbar.rb
+++ b/chef/cookbooks/rabbitmq/libraries/crowbar.rb
@@ -28,4 +28,22 @@ module CrowbarRabbitmqHelper
   def self.get_management_address(node)
     get_listen_address(node)
   end
+
+  def self.ha_policy_regex
+    # don't mirror queues that are 'amq.*' or '*_fanout_*' or `reply_*` in their names
+    "^(?!(amq.)|(.*_fanout_)|(reply_)).*"
+  end
+
+  def self.get_ha_policy_definition(node)
+    quorum = 1
+    if node[:rabbitmq][:enable_queue_mirroring] && node[:rabbitmq][:ha][:enabled]
+      quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
+    end
+
+    {
+      "ha-mode"      => "exactly",
+      "ha-params"    => quorum,
+      "ha-sync-mode" => "automatic"
+    }
+  end
 end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -27,7 +27,6 @@ end
 ha_enabled = node[:rabbitmq][:ha][:enabled]
 # we only do cluster if we do HA
 cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
-quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
 crm_resource_stop_cmd = cluster_enabled ? "force-demote" : "force-stop"
 crm_resource_start_cmd = cluster_enabled ? "force-promote" : "force-start"
 
@@ -137,7 +136,8 @@ template "/etc/rabbitmq/definitions.json" do
     json_trove_password: node[:rabbitmq][:trove][:password].to_json,
     json_trove_vhost: node[:rabbitmq][:trove][:vhost].to_json,
     ha_all_policy: cluster_enabled,
-    quorum: quorum,
+    json_policy_definition: CrowbarRabbitmqHelper.get_ha_policy_definition(node).to_json,
+    queue_regex: CrowbarRabbitmqHelper.ha_policy_regex,
     extra_users: node[:rabbitmq][:users]
   )
   # no notification to restart rabbitmq, as we still do changes with

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -146,17 +146,8 @@ node[:rabbitmq][:users].each do |user|
 end
 
 if cluster_enabled
-  if node[:rabbitmq][:enable_queue_mirroring]
-    quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
-  else
-    quorum = 1
-  end
-
-  # don't mirror queues that are 'amq.*' or '*_fanout_*' or `reply_*` in their names
-  queue_regex = "^(?!(amq\.)|(.*_fanout_)|(reply_)).*"
-  # policy doesnt need spaces between elements as they will be removed when listing them
-  # making it more difficult to check for them
-  policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum},\"ha-sync-mode\":\"automatic\"}"
+  queue_regex = CrowbarRabbitmqHelper.ha_policy_regex
+  policy = CrowbarRabbitmqHelper.get_ha_policy_definition(node).to_json
   vhost = node[:rabbitmq][:vhost]
   # we need to scape the regex properly so we can use it on the grep command
   queue_regex_escaped = ""

--- a/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
@@ -16,12 +16,9 @@
     "policies": [
         {
             "apply-to": "queues",
-            "definition": {
-                "ha-mode": "exactly",
-               "ha-params": <%= @quorum %>
-            },
+            "definition": <%= @json_policy_definition %>,
             "name": "ha-queues",
-            "pattern": "^(?!amq.).*",
+            "pattern": "<%= @queue_regex %>",
             "priority": 0,
             "vhost": <%= @json_vhost %>
         }


### PR DESCRIPTION
Keep the policy configured in the generated definitions.json
file used during startup in sync with the policy configured
at runtime by the rabbitmq chef recipe, to avoid inconsistencies.

The policy configuration is kept in the CrowbarRabbitmqHelper
and invoked both to generate the definitions.json file and to
configure the rabbitmq policy.

Also see #1448 for more information on how we use definitions.json.