### PR TITLE
ec2-api: run keystone_register on cluster founder only (SOC-11079)

### DIFF
--- a/chef/cookbooks/ec2-api/recipes/ec2api.rb
+++ b/chef/cookbooks/ec2-api/recipes/ec2api.rb
@@ -103,6 +103,7 @@ keystone_register "register ec2 user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give ec2 user access" do
@@ -115,6 +116,7 @@ keystone_register "give ec2 user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # Create ec2-api service
@@ -128,6 +130,7 @@ keystone_register "register ec2-api service" do
   service_type "ec2"
   service_description "EC2 Compatibility Layer"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register ec2-api endpoint" do
@@ -142,6 +145,7 @@ keystone_register "register ec2-api endpoint" do
   endpoint_adminURL "#{api_protocol}://#{my_admin_host}:#{ec2_api_port}"
   endpoint_internalURL "#{api_protocol}://#{my_admin_host}:#{ec2_api_port}"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # Create ec2-metadata service
@@ -155,6 +159,7 @@ keystone_register "register ec2-metadata service" do
   service_type "ec2"
   service_description "EC2 Compatibility Layer"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register ec2-metadata endpoint" do
@@ -169,6 +174,7 @@ keystone_register "register ec2-metadata endpoint" do
   endpoint_adminURL "#{api_protocol}://#{my_admin_host}:#{ec2_metadata_port}"
   endpoint_internalURL "#{api_protocol}://#{my_admin_host}:#{ec2_metadata_port}"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-ec2_api_register" if ha_enabled


### PR DESCRIPTION
The execution of the ec2-api cookbook includes restarting apache,
however, when apache is restarted while `keystone_register` is running on
the non-cluster founder nodes it fails as keystone (running under apache)
is also being restarted.

This change fixes that by including a condition for running the 
`keystone_register` operations only on the cluster founder node.