### PR TITLE
Revert "[4.0] rabbitmq: sync startup definitions.json with recipe (SOC-11077)"

### DIFF
--- a/chef/cookbooks/rabbitmq/libraries/crowbar.rb
+++ b/chef/cookbooks/rabbitmq/libraries/crowbar.rb
@@ -28,22 +28,4 @@ module CrowbarRabbitmqHelper
   def self.get_management_address(node)
     get_listen_address(node)
   end
-
-  def self.ha_policy_regex
-    # don't mirror queues that are 'amq.*' or '*_fanout_*' or `reply_*` in their names
-    "^(?!(amq.)|(.*_fanout_)|(reply_)).*"
-  end
-
-  def self.get_ha_policy_definition(node)
-    quorum = 1
-    if node[:rabbitmq][:enable_queue_mirroring] && node[:rabbitmq][:ha][:enabled]
-      quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
-    end
-
-    {
-      "ha-mode"      => "exactly",
-      "ha-params"    => quorum,
-      "ha-sync-mode" => "automatic"
-    }
-  end
 end

--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -27,6 +27,7 @@ end
 ha_enabled = node[:rabbitmq][:ha][:enabled]
 # we only do cluster if we do HA
 cluster_enabled = node[:rabbitmq][:cluster] && ha_enabled
+quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
 
 cluster_partition_handling = if cluster_enabled
   if CrowbarPacemakerHelper.num_corosync_nodes(node) > 2
@@ -137,8 +138,7 @@ template "/etc/rabbitmq/definitions.json" do
     json_trove_password: node[:rabbitmq][:trove][:password].to_json,
     json_trove_vhost: node[:rabbitmq][:trove][:vhost].to_json,
     ha_all_policy: cluster_enabled,
-    json_policy_definition: CrowbarRabbitmqHelper.get_ha_policy_definition(node).to_json,
-    queue_regex: CrowbarRabbitmqHelper.ha_policy_regex,
+    quorum: quorum,
     extra_users: node[:rabbitmq][:users]
   )
   # no notification to restart rabbitmq, as we still do changes with

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -146,8 +146,17 @@ node[:rabbitmq][:users].each do |user|
 end
 
 if cluster_enabled
-  queue_regex = CrowbarRabbitmqHelper.ha_policy_regex
-  policy = CrowbarRabbitmqHelper.get_ha_policy_definition(node).to_json
+  if node[:rabbitmq][:enable_queue_mirroring]
+    quorum = CrowbarPacemakerHelper.num_corosync_nodes(node) / 2 + 1
+  else
+    quorum = 1
+  end
+
+  # don't mirror queues that are 'amq.*' or '*_fanout_*' or `reply_*` in their names
+  queue_regex = "^(?!(amq\.)|(.*_fanout_)|(reply_)).*"
+  # policy doesnt need spaces between elements as they will be removed when listing them
+  # making it more difficult to check for them
+  policy = "{\"ha-mode\":\"exactly\",\"ha-params\":#{quorum},\"ha-sync-mode\":\"automatic\"}"
   vhost = node[:rabbitmq][:vhost]
   # we need to scape the regex properly so we can use it on the grep command
   queue_regex_escaped = ""

--- a/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/definitions.json.erb
@@ -16,9 +16,12 @@
     "policies": [
         {
             "apply-to": "queues",
-            "definition": <%= @json_policy_definition %>,
+            "definition": {
+                "ha-mode": "exactly",
+               "ha-params": <%= @quorum %>
+            },
             "name": "ha-queues",
-            "pattern": "<%= @queue_regex %>",
+            "pattern": "^(?!amq.).*",
             "priority": 0,
             "vhost": <%= @json_vhost %>
         }


### PR DESCRIPTION
Reverts crowbar/crowbar-openstack#2351

With this fix applied, we have problems rebooting controller nodes (see https://jira.suse.com/browse/SOC-11082). Reverting until a solution is found.