### PR TITLE
Designate: make sure dns-server is active on a non-admin node (SOC-10…

### DIFF
--- a/crowbar_framework/config/locales/designate/en.yml
+++ b/crowbar_framework/config/locales/designate/en.yml
@@ -36,3 +36,4 @@ en:
           ca_certs: 'SSL CA Certificates File'
       validation:
         invalid_email_address: 'E-mail address %{email} is invalid.'
+        non_admin_dns_nodes_not_found: 'No DNS server found on non-admin nodes. Dns-server role must be applied to at least one non-admin node prior to deploying Designate.'


### PR DESCRIPTION
…636)

Designate uses Bind9 backend by default. Bind9 is managed by the
dns-server role. Since Designate does not rely on the DNS server
on the Crowbar admin node, we need to make sure DNS server is running
on at least one non-admin node. If HA is enabled, DNS server should be
running on all the Designate worker nodes. If not, we need to warn users
the need to do so.