### PR TITLE
nova: Enable ephemeral volumes on SES (SOC-5269)

### DIFF
--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -230,6 +230,15 @@ disk_cachemodes = <%= node[:nova][:kvm][:disk_cachemodes] %>
 <% if @rng_device %>
 rng_dev_path = <%= @rng_device %>
 <% end %>
+<% if @ephemeral_rbd_settings %>
+images_type = rbd
+rbd_user = <%= @ephemeral_rbd_settings[:user] %>
+rbd_secret_uuid = <%= @ephemeral_rbd_settings[:secret_uuid] %>
+images_rbd_pool = <%= @ephemeral_rbd_settings[:pool] %>
+images_rbd_ceph_conf = <%= @ephemeral_rbd_settings[:config_file] %>
+disk_cachemodes = network=writeback
+hw_disk_discard = unmap
+<% end %>
 
 [neutron]
 service_metadata_proxy = true


### PR DESCRIPTION
Add required configuration to enable usage of SES/Ceph storage backend
for ephemeral storage in nova.
If multiple SES/Ceph backends are defined in cinder, first one is used
by nova for ephemeral strorage.