### PR TITLE
Disable "OpenStack RC File (identity API v2)" in horizon (bsc#1163444)

### DIFF
--- a/chef/cookbooks/horizon/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/local_settings.py.erb
@@ -265,3 +265,5 @@ WEBSSO_CHOICES = (
     ("openid", _("OpenID Connect")),
 )
 <% end %>
+
+SHOW_KEYSTONE_V2_RC = False


### PR DESCRIPTION
Identity v2 API doesn't exist in SOC 9 and the openrc file with URL to
it will not work.

Hide the download link from horizon using the provided for it option.