### PR TITLE
[5.0] nova: Enable ephemeral volumes on SES (SOC-11119)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -120,6 +120,7 @@ if cinder_servers.length > 0
     cinder_server[:cinder][:volumes].each do |volume|
       next unless volume["backend_driver"] == "rbd"
       rbd_enabled = true
+      next unless node[:nova][:use_rbd_ephemeral]
       # use first rbd cinder backend for ephemeral storage settings
       ephemeral_rbd_settings = volume[:rbd].clone
       # override pool with nova section from settings

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -108,6 +108,7 @@ directory "/etc/nova" do
 end
 
 rbd_enabled = false
+ephemeral_rbd_settings = nil
 
 cinder_servers = node_search_with_cache("roles:cinder-controller")
 if cinder_servers.length > 0
@@ -117,7 +118,14 @@ if cinder_servers.length > 0
 
   if node.roles.include? "nova-compute-kvm"
     cinder_server[:cinder][:volumes].each do |volume|
-      rbd_enabled = true if volume["backend_driver"] == "rbd"
+      next unless volume["backend_driver"] == "rbd"
+      rbd_enabled = true
+      # use first rbd cinder backend for ephemeral storage settings
+      ephemeral_rbd_settings = volume[:rbd].clone
+      # override pool with nova section from settings
+      ses_config = SesHelper.ses_settings
+      ephemeral_rbd_settings[:pool] = ses_config[:nova][:rbd_store_pool]
+      break
     end
   end
 else
@@ -420,6 +428,7 @@ template node[:nova][:config_file] do
     use_baremetal_filters: use_baremetal_filters,
     track_instance_changes: track_instance_changes,
     ironic_settings: ironic_settings,
+    ephemeral_rbd_settings: ephemeral_rbd_settings,
     default_log_levels: node[:nova][:default_log_levels]
   )
 end

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -237,7 +237,6 @@ rbd_user = <%= @ephemeral_rbd_settings[:user] %>
 rbd_secret_uuid = <%= @ephemeral_rbd_settings[:secret_uuid] %>
 images_rbd_pool = <%= @ephemeral_rbd_settings[:pool] %>
 images_rbd_ceph_conf = <%= @ephemeral_rbd_settings[:config_file] %>
-disk_cachemodes = network=writeback
 hw_disk_discard = unmap
 <% end %>
 

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -231,6 +231,15 @@ disk_cachemodes = <%= node[:nova][:kvm][:disk_cachemodes] %>
 <% if @rng_device %>
 rng_dev_path = <%= @rng_device %>
 <% end %>
+<% if @ephemeral_rbd_settings %>
+images_type = rbd
+rbd_user = <%= @ephemeral_rbd_settings[:user] %>
+rbd_secret_uuid = <%= @ephemeral_rbd_settings[:secret_uuid] %>
+images_rbd_pool = <%= @ephemeral_rbd_settings[:pool] %>
+images_rbd_ceph_conf = <%= @ephemeral_rbd_settings[:config_file] %>
+disk_cachemodes = network=writeback
+hw_disk_discard = unmap
+<% end %>
 
 [neutron]
 service_metadata_proxy = true

--- a/chef/data_bags/crowbar/migrate/nova/212_add_use_rbd_ephemeral.rb
+++ b/chef/data_bags/crowbar/migrate/nova/212_add_use_rbd_ephemeral.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "use_rbd_ephemeral"
+  attributes[key] = template_attributes[key] unless attributes.key? key
+  return attributes, deployment
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "use_rbd_ephemeral"
+  attributes.delete(key) unless template_attributes.key? key
+  return attributes, deployment
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -16,6 +16,7 @@
       "libvirt_type": "kvm",
       "use_novnc": true,
       "use_serial": false,
+      "use_rbd_ephemeral": false,
       "debug": false,
       "max_header_line": 16384,
       "setup_shared_instance_storage": false,
@@ -185,7 +186,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 211,
+      "schema-revision": 212,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -26,6 +26,7 @@
             "libvirt_type": { "type": "str", "required": true },
             "use_novnc": { "type": "bool", "required": true },
             "use_serial": { "type": "bool", "required": true },
+            "use_rbd_ephemeral": { "type": "bool", "required": true },
             "max_header_line": { "type": "int", "required": true },
             "trusted_flavors": { "type": "bool", "required": true },
             "use_migration": { "type": "bool", "required": true },

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -203,6 +203,9 @@ class NovaService < OpenstackServiceObject
       rm -f $t ${t}.pub
     ]
 
+    # enable SES/Ceph based ephemeral storage for new deployments
+    base["attributes"]["nova"]["use_rbd_ephemeral"] = true
+
     @logger.debug("Nova create_proposal: exiting")
     base
   end

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -116,3 +116,9 @@
 
         = string_field %w(novnc ssl certfile)
         = string_field %w(novnc ssl keyfile)
+
+    %fieldset
+      %legend
+        = t(".storage_header")
+
+      = boolean_field %w(use_rbd_ephemeral)

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -91,6 +91,8 @@ en:
             generate_certs: 'Generate (self-signed) certificates (implies insecure)'
             cert_required: 'Require Client Certificate'
             ca_certs: 'SSL CA Certificates File'
+        storage_header: 'Storage Settings'
+        use_rbd_ephemeral: 'Use Ceph RBD Ephemeral Backend (if available)'
       validation:
         no_shared_storage_cluster: 'Shared storage cannot be automatically setup when a cluster has the nova-controller role. Please consider using the NFS Client barclamp instead.'
         setup_use_shared_storage: 'When automatically setting up shared storage, it must also be used.'


### PR DESCRIPTION
Add required configuration to enable usage of SES/Ceph storage backend
for ephemeral storage in nova.
If multiple SES/Ceph backends are defined in cinder, first one is used
by nova for ephemeral strorage.

port of #2362 and #2373