### PR TITLE
designate: Mark as user managed (SOC-10233)

### DIFF
--- a/designate.yml
+++ b/designate.yml
@@ -19,8 +19,7 @@ barclamp:
   display: 'Designate'
   description: 'OpenStack DNSaaS: Multi-Tenant DNSaaS service for OpenStack'
   version: 0
-  # Change to true when complete
-  user_managed: false
+  user_managed: true
   requires:
     - 'keystone'
     - 'rabbitmq'


### PR DESCRIPTION
Designate is now fully tested and documented so re-enabling it from
the UI.

(cherry picked from commit 317cdcc798bb4eee339d71c53e18998b803cc9c2)