### PR TITLE
keystone: fix keystone node lookup (SOC-11333)

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -213,7 +213,13 @@ module KeystoneHelper
       return @keystone_node[instance]
     end
 
-    nodes, _, _ = Chef::Search::Query.new.search(:node, "roles:keystone-server AND keystone_config_environment:keystone-config-#{instance}")
+    nodes, = Chef::Search::Query.new.search(
+      :node,
+      "roles:keystone-server" \
+      " AND keystone_config_environment:keystone-config-#{instance}" \
+      " AND NOT state:crowbar_upgrade"
+    )
+
     if nodes.first
       keystone_node = nodes.first
       keystone_node = node if keystone_node.name == node.name


### PR DESCRIPTION
In a cloud where a controller was added after initial
deployment and MAC addresses are out of sequence, the
search_for_keystone() method may return the wrong controller
in the first upgraded controller's crowbar_join phase. This
commit ensures this does not happen by removing controllers in
still in the 'prepare-os-upgrade' stage from the list of
controllers.

Note: I'm not sure if we actually need this for Cloud 9 (currently testing whether it's affected). If we turn out not to need it, I'll abandon this pull request and create one for Cloud 8 only.