### PR TITLE
Revert 'tempest: Set port_admin_state_change to false when using linuxbridge' (SOC-10029)

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -409,7 +409,6 @@ neutron_api_extensions = [
   "trunk-details"
 ].join(", ")
 
-neutron_ml2_mechanism_drivers = []
 unless neutrons[0].nil?
   neutron_attr = neutrons[0][:neutron]
   if neutron_attr[:use_lbaas]
@@ -419,10 +418,6 @@ unless neutrons[0].nil?
   end
   neutron_api_extensions += ", dvr" if neutron_attr[:use_dvr]
   neutron_api_extensions += ", l3-ha" if neutron_attr[:l3_ha][:use_l3_ha]
-
-  if neutron_attr[:networking_plugin] == "ml2"
-    neutron_ml2_mechanism_drivers = neutron_attr[:ml2_mechanism_drivers]
-  end
 end
 
 neutron_api_extensions += ", dns-integration" if enabled_services.include?("dns")
@@ -619,7 +614,6 @@ template "/etc/tempest/tempest.conf" do
         # network settings
         public_network_id: node[:tempest][:public_network_id],
         neutron_api_extensions: neutron_api_extensions,
-        neutron_ml2_mechanism_drivers: neutron_ml2_mechanism_drivers,
         neutron_lbaasv2_driver: neutron_lbaasv2_driver,
         # object storage settings
         swift_cluster_name: swift_cluster_name,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -145,9 +145,6 @@ floating_network_name = floating
 [network-feature-enabled]
 api_extensions = <%= @neutron_api_extensions %>
 port_security = True
-# Skip TestNetworkBasicOps.test_update_instance_port_admin_state
-# test when neutron uses linuxbridge until SOC-10138 gets fixed
-port_admin_state_change = <%= @neutron_ml2_mechanism_drivers.include?("linuxbridge") ? 'false' : 'true' %>
 
 [object-storage]
 region = <%= @keystone_settings['endpoint_region'] %>


### PR DESCRIPTION
The underlying problem has been fixed. The #2189 workaround can be removed.
