### PR TITLE
nova: Add option to disable ephemeral on ceph (SOC-5269)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -120,6 +120,7 @@ if cinder_servers.length > 0
     cinder_server[:cinder][:volumes].each do |volume|
       next unless volume["backend_driver"] == "rbd"
       rbd_enabled = true
+      next unless node[:nova][:use_rbd_ephemeral]
       # use first rbd cinder backend for ephemeral storage settings
       ephemeral_rbd_settings = volume[:rbd].clone
       # override pool with nova section from settings

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -236,7 +236,6 @@ rbd_user = <%= @ephemeral_rbd_settings[:user] %>
 rbd_secret_uuid = <%= @ephemeral_rbd_settings[:secret_uuid] %>
 images_rbd_pool = <%= @ephemeral_rbd_settings[:pool] %>
 images_rbd_ceph_conf = <%= @ephemeral_rbd_settings[:config_file] %>
-disk_cachemodes = network=writeback
 hw_disk_discard = unmap
 <% end %>
 

--- a/chef/data_bags/crowbar/migrate/nova/306_add_use_rbd_ephemeral.rb
+++ b/chef/data_bags/crowbar/migrate/nova/306_add_use_rbd_ephemeral.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "use_rbd_ephemeral"
+  attributes[key] = template_attributes[key] unless attributes.key? key
+  return attributes, deployment
+end
+
+def downgrade(template_attributes, template_deployment, attributes, deployment)
+  key = "use_rbd_ephemeral"
+  attributes.delete(key) unless template_attributes.key? key
+  return attributes, deployment
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -16,6 +16,7 @@
       "libvirt_type": "kvm",
       "use_novnc": true,
       "use_serial": false,
+      "use_rbd_ephemeral": false,
       "debug": false,
       "max_header_line": 16384,
       "setup_shared_instance_storage": false,
@@ -181,7 +182,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 305,
+      "schema-revision": 306,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-ironic": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -26,6 +26,7 @@
             "libvirt_type": { "type": "str", "required": true },
             "use_novnc": { "type": "bool", "required": true },
             "use_serial": { "type": "bool", "required": true },
+            "use_rbd_ephemeral": { "type": "bool", "required": true },
             "max_header_line": { "type": "int", "required": true },
             "trusted_flavors": { "type": "bool", "required": true },
             "use_migration": { "type": "bool", "required": true },

--- a/crowbar_framework/app/models/nova_service.rb
+++ b/crowbar_framework/app/models/nova_service.rb
@@ -196,6 +196,9 @@ class NovaService < OpenstackServiceObject
       rm -f $t ${t}.pub
     ]
 
+    # enable SES/Ceph based ephemeral storage for new deployments
+    base["attributes"]["nova"]["use_rbd_ephemeral"] = true
+
     @logger.debug("Nova create_proposal: exiting")
     base
   end

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -101,3 +101,9 @@
 
         = string_field %w(novnc ssl certfile)
         = string_field %w(novnc ssl keyfile)
+
+    %fieldset
+      %legend
+        = t(".storage_header")
+
+      = boolean_field %w(use_rbd_ephemeral)

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -79,6 +79,8 @@ en:
             generate_certs: 'Generate (self-signed) certificates (implies insecure)'
             cert_required: 'Require Client Certificate'
             ca_certs: 'SSL CA Certificates File'
+        storage_header: 'Storage Settings'
+        use_rbd_ephemeral: 'Use Ceph RBD Ephemeral Backend (if available)'
       validation:
         no_shared_storage_cluster: 'Shared storage cannot be automatically setup when a cluster has the nova-controller role. Please consider using the NFS Client barclamp instead.'
         setup_use_shared_storage: 'When automatically setting up shared storage, it must also be used.'


### PR DESCRIPTION
New attribute was added to enable/disable ephemeral storage on CEPH/SES if
needed.

Added UI part:
![Zrzut ekranu z 2020-03-17 23-08-25](https://user-images.githubusercontent.com/2458112/76906540-6fedc480-68a4-11ea-9f46-78543abf043a.png)

bonus: remove redundant config line