### PR TITLE
magnum: Add SSL support (SOC-9849)

### DIFF
--- a/chef/cookbooks/magnum/attributes/default.rb
+++ b/chef/cookbooks/magnum/attributes/default.rb
@@ -34,3 +34,8 @@ default[:magnum][:ha][:conductor][:op][:monitor][:interval] = "10s"
 default[:magnum][:ha][:conductor][:agent] = "systemd:openstack-magnum-conductor"
 
 default[:magnum][:cert][:cert_manager_type] = "local"
+
+default[:magnum][:ssl][:certfile] = "/etc/magnum/ssl/certs/signing_cert.pem"
+default[:magnum][:ssl][:keyfile] = "/etc/magnum/ssl/private/signing_key.pem"
+default[:magnum][:ssl][:generate_certs] = false
+default[:magnum][:ssl][:insecure] = false

--- a/chef/cookbooks/magnum/recipes/common.rb
+++ b/chef/cookbooks/magnum/recipes/common.rb
@@ -56,3 +56,14 @@ template node[:magnum][:config_file] do
       CrowbarPacemakerHelper.cluster_nodes(node, "magnum-server"))
   )
 end
+
+# ssl
+if node[:magnum][:api][:protocol] == "https"
+  ssl_setup "setting up ssl for magnum" do
+    generate_certs node[:magnum][:ssl][:generate_certs]
+    certfile node[:magnum][:ssl][:certfile]
+    keyfile node[:magnum][:ssl][:keyfile]
+    group node[:magnum][:group]
+    fqdn node[:fqdn]
+  end
+end

--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -14,6 +14,11 @@ host = <%= node["hostname"] %>
 [api]
 port = <%= @bind_port %>
 host = <%= @bind_host %>
+<% if @ssl_enabled -%>
+enabled_ssl = true
+ssl_cert_file = <%= @ssl_settings[:certfile] %>
+ssl_key_file = <%= @ssl_settings[:keyfile] %>
+<% end -%>
 
 [barbican_client]
 region_name = <%= @keystone_settings['endpoint_region'] %>

--- a/chef/data_bags/crowbar/migrate/magnum/301_add_ssl_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/magnum/301_add_ssl_attributes.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["ssl"] = template_attrs["ssl"] unless attrs.key?("ssl")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs.delete("ssl")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-magnum.json
+++ b/chef/data_bags/crowbar/template-magnum.json
@@ -34,6 +34,12 @@
       },
       "cert": {
         "cert_manager_type": "x509keypair"
+      },
+      "ssl": {
+        "certfile": "/etc/magnum/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/magnum/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false
       }
     }
   },
@@ -41,7 +47,7 @@
     "magnum": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
-      "schema-revision": 300,
+      "schema-revision": 301,
       "element_states": {
         "magnum-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-magnum.schema
+++ b/chef/data_bags/crowbar/template-magnum.schema
@@ -55,6 +55,14 @@
               "mapping": {
                 "cert_manager_type": { "type": "str", "required": true }
               }
+            },
+            "ssl": {
+              "type": "map", "required": true, "mapping": {
+                "certfile": { "type": "str", "required": true },
+                "keyfile": { "type": "str", "required": true },
+                "generate_certs": { "type": "bool", "required": true },
+                "insecure": { "type" : "bool", "required": true }
+              }
             }
           }
         }

--- a/crowbar_framework/app/helpers/barclamp/magnum_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/magnum_helper.rb
@@ -27,5 +27,15 @@ module Barclamp
         selected.to_s
       )
     end
+
+    def api_protocols_for_magnum(selected)
+      options_for_select(
+        [
+          ["HTTP", "http"],
+          ["HTTPS", "https"]
+        ],
+        selected.to_s
+      )
+    end
   end
 end

--- a/crowbar_framework/app/views/barclamp/magnum/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/magnum/_edit_attributes.html.haml
@@ -21,3 +21,18 @@
       %legend
         = t('.logging_header')
       = boolean_field :verbose
+    %fieldset
+      %legend
+        = t('.ssl_header')
+
+      = select_field %w(api protocol),
+        :collection => :api_protocols_for_magnum,
+        'data-sslprefix' => 'ssl',
+        'data-sslcert' => '/etc/magnum/ssl/certs/signing_cert.pem',
+        'data-sslkey' => '/etc/magnum/ssl/private/signing_key.pem'
+
+      #ssl_container
+        = boolean_field %w(ssl generate_certs)
+        = string_field %w(ssl certfile)
+        = string_field %w(ssl keyfile)
+        = boolean_field %w(ssl insecure)

--- a/crowbar_framework/config/locales/magnum/en.yml
+++ b/crowbar_framework/config/locales/magnum/en.yml
@@ -32,6 +32,14 @@ en:
         cert_header: 'Certificate Manager'
         cert:
           cert_manager_type: 'Plugin'
+        ssl_header: 'SSL Support'
+        ssl:
+          generate_certs: 'Generate (self-signed) certificates (implies insecure)'
+          certfile: 'SSL Certificate File'
+          keyfile: 'SSL (Private) Key File'
+          insecure: 'SSL Certificate is insecure (for instance, self-signed)'
+        api:
+          protocol: 'Protocol'
       validation:
         barbican:
           barbican_not_deployed: 'The "barbican-controller" role is not deployed. Please check the Barbican barclamp'


### PR DESCRIPTION
Added options to configure SSL settings in Magnum barclamp.

Taken over from https://github.com/crowbar/crowbar-openstack/pull/1608