### PR TITLE
Disabling failing tempest tests on SOC7

### DIFF
--- a/chef/cookbooks/tempest/templates/default/run_filters/lbaas.txt.erb
+++ b/chef/cookbooks/tempest/templates/default/run_filters/lbaas.txt.erb
@@ -1,1 +1,5 @@
 +neutron_lbaas.*
+
+# see issue SOC-11173 and SOC-11175
+-neutron_lbaas.tests.tempest.v2.scenario.test_shared_pools.TestSharedPools.test_shared_pools
+-neutron_lbaas.tests.tempest.v2.ddt.test_health_monitor_admin_state_up.CreateHealthMonitorAdminStateTest.test_create_health_monitor_with_scenarios

--- a/chef/cookbooks/tempest/templates/default/run_filters/neutron.txt.erb
+++ b/chef/cookbooks/tempest/templates/default/run_filters/neutron.txt.erb
@@ -1,3 +1,6 @@
 +tempest.api.network.*
 +tempest.scenario.test_network.*
 +tempest.scenario.test_security_groups.*
+
+# see issue SOC-11174
+-tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_in_tenant_traffic


### PR DESCRIPTION
Disabling failing tempest tests for SOC7 as they currently blocking
gating and mu jobs to pass. All filtered test has jira created and
planned to be enabled after fix.

neutron_lbaas.tests.tempest.v2.scenario.test_shared_pools.TestSharedPools.test_shared_pools
neutron_lbaas.tests.tempest.v2.ddt.test_health_monitor_admin_state_up.CreateHealthMonitorAdminStateTest.test_create_health_monitor_with_scenarios
tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_in_tenant_traffic