### PR TITLE
Fix tempest configuration when using RBD on nova (SOC-11176)

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -514,6 +514,7 @@ kvm_compute_nodes = search(:node, "roles:nova-compute-kvm") || []
 
 use_resize = kvm_compute_nodes.length > 1
 use_livemigration = nova[:nova][:use_migration] && kvm_compute_nodes.length > 1
+use_rbd_ephemeral = nova[:nova][:use_rbd_ephemeral]
 
 # tempest timeouts for ssh and connection can be different for XEN, a
 # `nil` value will use the tempest default value
@@ -602,6 +603,7 @@ template "/etc/tempest/tempest.conf" do
         use_suspend: use_suspend,
         use_multiattach: use_multiattach,
         use_vnc: use_vnc,
+        use_rbd_ephemeral: use_rbd_ephemeral,
         use_livemigration: use_livemigration,
         use_attach_encrypted_volume: use_attach_encrypted_volume,
         # dashboard settings

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -701,7 +701,8 @@ cb.manifest["templates"].each do |cb_template|
       lazy do
         {
           enabled_services: enabled_services,
-          neutron_lbaasv2_driver: neutron_lbaasv2_driver
+          neutron_lbaasv2_driver: neutron_lbaasv2_driver,
+          use_rbd_ephemeral: use_rbd_ephemeral
         }
       end
     )

--- a/chef/cookbooks/tempest/templates/default/run_filters/nova.txt.erb
+++ b/chef/cookbooks/tempest/templates/default/run_filters/nova.txt.erb
@@ -11,3 +11,14 @@
 -tempest.api.compute.admin.test_migrations.MigrationsAdminTest.test_resize_server_revert_deleted_flavor
 -tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_resize_server_revert_with_volume_attached
 -tempest.api.compute.admin.test_migrations.MigrationsAdminTest.test_revert_cold_migration
+
+<% if @use_rbd_ephemeral -%>
+
+# SOC-9708 black list failing shelve tests
+-tempest.api.compute.servers.test_servers_negative.ServersNegativeTestJSON.test_shelve_shelved_server
+-tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_shelve_unshelve_server
+-tempest.api.compute.volumes.test_attach_volume.AttachVolumeShelveTestJSON.test_attach_volume_shelved_or_offload_server
+-tempest.api.compute.volumes.test_attach_volume.AttachVolumeShelveTestJSON.test_detach_volume_shelved_or_offload_server
+-tempest.scenario.test_shelve_instance.TestShelveInstance.test_shelve_instance
+
+<% end -%>

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -54,7 +54,7 @@ build_timeout = 600
 resize = <%= @use_resize %>
 suspend = <%= @use_suspend %>
 live_migration = <%= @use_livemigration %>
-block_migration_for_live_migration = true
+block_migration_for_live_migration = <%= not @use_rbd_ephemeral %>
 vnc_console = <%= @use_vnc %>
 rescue = <%= @use_rescue %>
 personality = True


### PR DESCRIPTION
This change fixes the tempest configuration and blacklists some tempest shelve tests that are known to fail when RBD is used for storing the Instance's ephemeral disk.