### PR TITLE
nova: Populate cinder SES settings early (SOC-11179)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -117,6 +117,9 @@ if cinder_servers.length > 0
   keymgr_fixed_key = cinder_server[:cinder][:keymgr_fixed_key]
 
   if node.roles.include? "nova-compute-kvm"
+    # make sure cinder volumes are filled with settings from SES data bag
+    SesHelper.populate_cinder_volumes_with_ses_settings(cinder_server)
+
     cinder_server[:cinder][:volumes].each do |volume|
       next unless volume["backend_driver"] == "rbd"
       rbd_enabled = true


### PR DESCRIPTION
If nova_compute_kvm recipe is included in the runlist but nothing
populates cinder volumes before that, some values might be missing
in the generated configuration for ephemeral storage.
Added another "populate" call just before preparing the ephemeral
config just to be sure everything is ready for use.