### PR TITLE
fix travis CI to handle reverted commits properly (SOC-11180)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       script:
       - pip install gitlint
       - wget https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/jenkins/gitlint.ini
-      - gitlint --commits master..HEAD -C gitlint.ini
+      - gitlint --commits `git rev-parse --abbrev-ref HEAD`..HEAD -C gitlint.ini
     - name: "Syntaxcheck"
       gemfile: Gemfile
       script:


### PR DESCRIPTION
For reverted commits, Travis CI uses
'git clone --depth=50 --branch=<reverted branch> <repo url> <dir>'
instead of 'git clone --depth=50 <repo url> <dir>' when cloning the repo
for testing.

With 'git clone --depth=50 --branch=<reverted branch> <repo url> <dir>',
there's no master branch. Therefore, we should always use the branch name
instead of master branch when invoking gitlint.