### PR TITLE
tempest: update blacklisted tempest test cases (SOC-9801,SOC-11174,SOC-11187)

### DIFF
--- a/chef/cookbooks/tempest/templates/default/run_filters/cinder.txt.erb
+++ b/chef/cookbooks/tempest/templates/default/run_filters/cinder.txt.erb
@@ -4,3 +4,6 @@
 
 # BUG: SOC-10874
 -tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern
+
+# BUG: SOC-11187
+-tempest.api.volume.admin.test_volume_type_access.VolumeTypesAccessV2Test

--- a/chef/cookbooks/tempest/templates/default/run_filters/neutron.txt.erb
+++ b/chef/cookbooks/tempest/templates/default/run_filters/neutron.txt.erb
@@ -1,6 +1,3 @@
 +tempest.api.network.*
 +tempest.scenario.test_network.*
 +tempest.scenario.test_security_groups.*
-
-# see issue SOC-11174
--tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_in_tenant_traffic


### PR DESCRIPTION
Update the list of tempest test cases blacklisted in run filters:
 * re-enable tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps
 (fixed by https://review.opendev.org/#/c/570207/)
 * blacklist tempest.api.volume.admin.test_volume_type_access.VolumeTypesAccessV2Test
 (workaround for SOC-11187)
 * TBD (magnum)