### PR TITLE
keystone: fix keystone node lookup (SOC-11333, bsc#1164838)

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -116,7 +116,13 @@ module KeystoneHelper
       return @keystone_node[instance]
     end
 
-    nodes, _, _ = Chef::Search::Query.new.search(:node, "roles:keystone-server AND keystone_config_environment:keystone-config-#{instance}")
+    nodes, = Chef::Search::Query.new.search(
+      :node,
+      "roles:keystone-server" \
+      " AND keystone_config_environment:keystone-config-#{instance}" \
+      " AND NOT state:crowbar_upgrade"
+    )
+
     if nodes.first
       keystone_node = nodes.first
       keystone_node = node if keystone_node.name == node.name


### PR DESCRIPTION
In a cloud where a controller was added after initial
deployment and MAC addresses are out of sequence, the
search_for_keystone() method may return the wrong controller
in the first upgraded controller's crowbar_join phase. This
commit ensures this does not happen by restricting the search for
nodes that are not in state `crowbar_upgrade`.

(cherry picked from commit e12c448d8eca2b5a71990e8dd208c2301ac2b360)

This is the Cloud 8 backport of https://github.com/crowbar/crowbar-openstack/pull/2369 . It's already tested, I used Cloud 8 (with the same commit) for most of my testing anyway.