### PR TITLE
octavia: rework management network implementation (SOC-10904)

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -154,9 +154,13 @@ if neutron[:neutron][:networking_plugin] == "ml2"
 
   external_networks = ["nova_floating"]
   external_networks.concat(neutron[:neutron][:additional_external_networks])
-  # Add octavia to external_networks if octavia network is configured
-  octavia_net = Barclamp::Inventory.get_network_definition(node, "octavia")
-  external_networks << "octavia" if octavia_net
+
+  # Add octavia to external_networks if octavia network is configured and enabled
+  octavia_net = Barclamp::Inventory.get_network_by_type(node, "octavia")
+  # get_network_by_type returns the admin network if the Octavia network isn't yet enabled
+  # on this node (even if the network definition exists).
+  has_octavia_net = !octavia_net.nil? && octavia_net.name != "admin"
+  external_networks << "octavia" if has_octavia_net
 
   case
   when ml2_mech_drivers.include?("zvm")

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -116,6 +116,8 @@ interface_driver = "openvswitch"
 
 ironic_net = Barclamp::Inventory.get_network_definition(node, "ironic")
 
+octavia_net = Barclamp::Inventory.get_network_definition(node, "octavia")
+
 case node[:neutron][:networking_plugin]
 when "ml2"
   # Find out which physical interfaces we need to define in the config (depends
@@ -125,6 +127,9 @@ when "ml2"
 
   # Add ironic to external_networks if ironic network is configured
   external_networks << "ironic" if ironic_net
+
+  # Add octavia to external_networks if octavia network is configured
+  external_networks << "octavia" if octavia_net
 
   external_networks.concat(node[:neutron][:additional_external_networks])
   network_node = NeutronHelper.get_network_node_from_neutron_attributes(node)

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -116,7 +116,10 @@ interface_driver = "openvswitch"
 
 ironic_net = Barclamp::Inventory.get_network_definition(node, "ironic")
 
-octavia_net = Barclamp::Inventory.get_network_definition(node, "octavia")
+octavia_net = Barclamp::Inventory.get_network_by_type(node, "octavia")
+# get_network_by_type returns the admin network if the Octavia network isn't yet enabled
+# on this node (even if the network definition exists).
+has_octavia_net = !octavia_net.nil? && octavia_net.name != "admin"
 
 case node[:neutron][:networking_plugin]
 when "ml2"
@@ -128,8 +131,8 @@ when "ml2"
   # Add ironic to external_networks if ironic network is configured
   external_networks << "ironic" if ironic_net
 
-  # Add octavia to external_networks if octavia network is configured
-  external_networks << "octavia" if octavia_net
+  # Add octavia to external_networks if octavia network is configured and enabled
+  external_networks << "octavia" if has_octavia_net
 
   external_networks.concat(node[:neutron][:additional_external_networks])
   network_node = NeutronHelper.get_network_node_from_neutron_attributes(node)

--- a/chef/cookbooks/octavia/definitions/octavia_conf.rb
+++ b/chef/cookbooks/octavia/definitions/octavia_conf.rb
@@ -33,6 +33,13 @@ define :octavia_conf do
     end
   end
 
+  octavia_net = \
+    if Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "octavia")
+      "octavia"
+    else
+      "admin"
+    end
+
   conf_files = OctaviaHelper.conf_file(params[:name])
   conf_files.each do |conf_file|
     template conf_file do
@@ -54,7 +61,7 @@ define :octavia_conf do
             octavia_nova_flavor_id: node[:octavia][:flavor_id],
             octavia_mgmt_net_id: node[:octavia][:net_id],
             octavia_mgmt_sec_group_id: node[:octavia][:sec_group_id],
-            octavia_healthmanager_hosts: OctaviaHelper.get_healthmanager_nodes(node, net_name),
+            octavia_healthmanager_hosts: OctaviaHelper.get_healthmanager_nodes(node, octavia_net),
             memcached_servers: MemcachedHelper.get_memcached_servers(node,
                 CrowbarPacemakerHelper.cluster_nodes(node, "octavia-api"))
           }

--- a/chef/cookbooks/octavia/definitions/octavia_conf.rb
+++ b/chef/cookbooks/octavia/definitions/octavia_conf.rb
@@ -14,25 +14,6 @@
 #
 
 define :octavia_conf do
-  amphora = node[:octavia][:amphora]
-  net_name = amphora[:manage_net]
-
-  ruby_block "Check for amphora changes" do
-    block do
-      sec_group_id = shell_out("#{params[:cmd]} security group show " \
-                               "#{amphora[:sec_group]} -f value -c id").stdout.chomp
-      flavor_id = shell_out("#{params[:cmd]} flavor show "\
-                            "#{amphora[:flavor]} -f value -c id").stdout.chomp
-      mgmt_net_id = shell_out("#{params[:cmd]} network list " \
-                              "--format value --column ID --column Name " \
-                              "| grep #{net_name} | cut -d ' ' -f 1").stdout.chomp
-
-      sec_group_id.empty? || node.set[:octavia][:sec_group_id] = sec_group_id
-      flavor_id.empty? || node.set[:octavia][:flavor_id] = flavor_id
-      mgmt_net_id.empty? || node.set[:octavia][:net_id] = mgmt_net_id
-    end
-  end
-
   octavia_net = \
     if Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "octavia")
       "octavia"
@@ -58,9 +39,6 @@ define :octavia_conf do
             barbican_endpoint: OctaviaHelper.get_barbican_endpoint(node),
             octavia_keystone_settings: KeystoneHelper.keystone_settings(node, "octavia"),
             rabbit_settings: fetch_rabbitmq_settings,
-            octavia_nova_flavor_id: node[:octavia][:flavor_id],
-            octavia_mgmt_net_id: node[:octavia][:net_id],
-            octavia_mgmt_sec_group_id: node[:octavia][:sec_group_id],
             octavia_healthmanager_hosts: OctaviaHelper.get_healthmanager_nodes(node, octavia_net),
             memcached_servers: MemcachedHelper.get_memcached_servers(node,
                 CrowbarPacemakerHelper.cluster_nodes(node, "octavia-api"))

--- a/chef/cookbooks/octavia/libraries/helpers.rb
+++ b/chef/cookbooks/octavia/libraries/helpers.rb
@@ -84,6 +84,8 @@ module OctaviaHelper
         @cluster_admin_ip = CrowbarPacemakerHelper.cluster_vip(node, "admin")
       end
 
+      octavia_net = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "octavia")
+
       @network_settings ||= {
         api: {
           bind_host: if !ha_enabled && node[:octavia][:api][:bind_open_address]
@@ -104,7 +106,9 @@ module OctaviaHelper
           ha_bind_port: node[:octavia][:api][:port].to_i
         },
         health_manager: {
-          bind_host: if node[:octavia][:health_manager][:bind_open_address]
+          bind_host: if octavia_net
+                       octavia_net.address
+                     elsif node[:octavia][:health_manager][:bind_open_address]
                        "0.0.0.0"
                      else
                        @admin_ip

--- a/chef/cookbooks/octavia/recipes/api.rb
+++ b/chef/cookbooks/octavia/recipes/api.rb
@@ -16,11 +16,7 @@
 include_recipe "apache2"
 include_recipe "apache2::mod_wsgi"
 
-cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
-
-octavia_conf "api" do
-  cmd cmd
-end
+octavia_conf "api"
 
 package "openstack-octavia-api" if ["rhel", "suse"].include? node[:platform_family]
 

--- a/chef/cookbooks/octavia/recipes/health_manager.rb
+++ b/chef/cookbooks/octavia/recipes/health_manager.rb
@@ -13,10 +13,5 @@
 # limitations under the License.
 #
 
-cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
-
-octavia_conf "health-manager" do
-  cmd cmd
-end
-
+octavia_conf "health-manager"
 octavia_service "health-manager"

--- a/chef/cookbooks/octavia/recipes/housekeeping.rb
+++ b/chef/cookbooks/octavia/recipes/housekeeping.rb
@@ -13,10 +13,5 @@
 # limitations under the License.
 #
 
-cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
-
-octavia_conf "housekeeping" do
-  cmd cmd
-end
-
+octavia_conf "housekeeping"
 octavia_service "housekeeping"

--- a/chef/cookbooks/octavia/recipes/worker.rb
+++ b/chef/cookbooks/octavia/recipes/worker.rb
@@ -14,8 +14,22 @@
 
 cmd = OctaviaHelper.get_openstack_command(node, node[:octavia])
 
-octavia_conf "worker" do
-  cmd cmd
+ruby_block "Check for amphora changes" do
+  block do
+    amphora = node[:octavia][:amphora]
+    sec_group_id = shell_out("#{cmd} security group show " \
+                             "#{amphora[:sec_group]} -f value -c id").stdout.chomp
+    flavor_id = shell_out("#{cmd} flavor show "\
+                          "#{amphora[:flavor]} -f value -c id").stdout.chomp
+    mgmt_net_id = shell_out("#{cmd} network list " \
+                            "--format value --column ID --column Name " \
+                            "| grep #{amphora[:manage_net]} | cut -d ' ' -f 1").stdout.chomp
+
+    sec_group_id.empty? || node.set[:octavia][:sec_group_id] = sec_group_id
+    flavor_id.empty? || node.set[:octavia][:flavor_id] = flavor_id
+    mgmt_net_id.empty? || node.set[:octavia][:net_id] = mgmt_net_id
+  end
 end
 
+octavia_conf "worker"
 octavia_service "worker"

--- a/chef/data_bags/crowbar/migrate/octavia/304_remove_cidr.rb
+++ b/chef/data_bags/crowbar/migrate/octavia/304_remove_cidr.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs[:amphora].delete("manage_cidr")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs[:amphora]["manage_cidr"] = template_attrs["manage_cidr"]
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-octavia.json
+++ b/chef/data_bags/crowbar/template-octavia.json
@@ -49,7 +49,6 @@
         "flavor": "m1.lbaas.amphora",
         "sec_group": "lb-mgmt-sec-group",
         "manage_net": "lb-mgmt-net",
-        "manage_cidr": "172.31.0.0/16",
         "image_tag": "amphora",
         "project": "service",
         "enable_anti_affinity": false,

--- a/chef/data_bags/crowbar/template-octavia.schema
+++ b/chef/data_bags/crowbar/template-octavia.schema
@@ -66,7 +66,6 @@
                         "flavor": { "type": "str", "required": true },
                         "sec_group": { "type": "str", "required": true },
                         "manage_net": { "type": "str", "required": true },
-                        "manage_cidr": { "type": "str", "required": true },
                         "image_tag": { "type": "str", "required": true },
                         "project": { "type": "str", "required": true },
                         "enable_anti_affinity": { "type": "bool", "required": true },

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -536,7 +536,7 @@ class NeutronService < OpenstackServiceObject
         net_svc.enable_interface "default", "ironic", nodename
       end
 
-      # Enable octavia interface as preparation for octavia deployment.
+      # Enable octavia interface as preparation for octavia deployment
       unless network_proposal["attributes"]["network"]["networks"]["octavia"].nil?
         net_svc.enable_interface "default", "octavia", nodename
       end

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -536,7 +536,7 @@ class NeutronService < OpenstackServiceObject
         net_svc.enable_interface "default", "ironic", nodename
       end
 
-      # Enable octavia interface as preparation for octavia deployment
+      # Enable octavia interface as preparation for octavia deployment.
       unless network_proposal["attributes"]["network"]["networks"]["octavia"].nil?
         net_svc.enable_interface "default", "octavia", nodename
       end

--- a/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
@@ -19,7 +19,6 @@
         = t(".mgmt_net_header")
 
       = string_field %w(amphora manage_net)
-      = string_field %w(amphora manage_cidr)
 
     %fieldset
       %legend


### PR DESCRIPTION
TL;DR: Crowbar has a more powerful mechanism of setting up additional networks and connecting interfaces to them. We leverage that here to set up a network for Octavia that doesn't require external routing, meaning that customers don't need to configure any external services or additional routes. This is better than the CLM octavia management network implementation, where customers must provide an external router that is able to route between the octavia management network and the OpenStack management network. Furthermore, this implementation achieves a complete isolation of the octavia management network from all other networks, providing better security. Having it entirely managed by Crowbar reduces the risk of a misconfiguration on the customer's part.

Rework the implementation of the Octavia management network as
a neutron provider network based on attributes taken from the
network.json octavia network, if present.
In this respect, the logic used to set up the Octavia management
network closely follows the logic already supported by Crowbar
allowing users to set up additional external networks [1], with
a few notable differences:
 * the `octavia` network is actually an internal neutron provider
 network (i.e. not usable as a source of floating IPs by other
 tenants)
 * the `octavia` network doesn't need a gateway, because controller
 nodes will communicate with amphora VMs directly, without requiring
 NAT
 * the `octavia` network needs to be set up on compute nodes even
 if DVR is not enabled, because amphorae will use it directly
 * we need to model two non-overlapping IP ranges for the octavia
 neutron provider network:
   * host range: used to allocate IP addresses for Octavia controller nodes
   * dhcp range: used to allocate IP addresses for amphora VMs
 Using a single range will eventually lead to situations in which an IP
 address allocated by neutron to an amphora VM is already in use by an
 Octavia controller node.

 * the octavia barclamp automatically creates the Neutron provider network
 and the subnet associated with the octavia network.json network
 * the controller nodes where Octavia is deployed have allocated
 IP addresses from the octavia network's `host` IP range

This rework also removes the `mgmt_cidr` attribute from the Octavia
barclamp, as it is rendered useless by the fact that all required
attributes to create the provider network are provided by the network.json
configuration. Given that controller nodes now have direct access to the
octavia network, the health manager configuration is also updated such that
if the octavia network is available, the service listens on the octavia
network IP locally configured directly instead of the admin network.

The actual creation of the octavia management network is moved
away from the neutron barclamp and into the octavia barclamp, to avoid
situations where the network isn't created because the neutron
`create_default_networks` attribute is explicitly disabled, as
well as to centralize all the logic responsible for creating
octavia prerequisites to the octavia barclamp. This breaks the
circular dependency between Neutron and Octavia (e.g. the name
of the management network is coded as an Octavia barclamp
attribute, which means Neutron would require Octavia to be
deployed to have access to this attribute, while Octavia relies
on this network to be already created by Neutron before its
services can be configured).


[1] https://documentation.suse.com/soc/9/single-html/suse-openstack-cloud-crowbar-deployment/#sec-setup-multi-ext-networks