### PR TITLE
galera: Make sure checks are executed without password (bsc#1136928)

### DIFF
--- a/chef/cookbooks/mysql/recipes/ha_galera.rb
+++ b/chef/cookbooks/mysql/recipes/ha_galera.rb
@@ -229,6 +229,7 @@ pacemaker_primitive service_name do
     "enable_creation" => true,
     "wsrep_cluster_address" => cluster_addresses,
     "check_user" => "monitoring",
+    "check_passwd_use_empty" => 1,
     "socket" => "/var/run/mysql/mysql.sock",
     "datadir" => node[:database][:mysql][:datadir],
     "log" => "/var/log/mysql/mysqld.log"


### PR DESCRIPTION
Monitoring user that is used for clusterchecks is set up without
the password. Galera pacemaker setup needs to be adjusted so it is
using the empty password instead falling back to default ~/.my.cnf.

We have to wait and publish this only after the fix in resource agents is released:
https://github.com/ClusterLabs/resource-agents/pull/1473