### PR TITLE
Fix magnum tempest tests (SOC-9298)

### DIFF
--- a/chef/cookbooks/magnum/templates/default/magnum.conf.erb
+++ b/chef/cookbooks/magnum/templates/default/magnum.conf.erb
@@ -27,6 +27,9 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
 [database]
 connection = <%= @sql_connection %>
 
+[drivers]
+verify_ca = false
+
 [glance_client]
 region_name = <%= @keystone_settings['endpoint_region'] %>
 insecure = <%= @keystone_settings['insecure'] %>

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -512,6 +512,15 @@ else
   horizon_protocol = horizon[:horizon][:apache][:ssl] ? "https" : "http"
 end
 
+# Extra roles to assign to the tempest user
+tempest_roles = ["Member"]
+
+dns_server_node = node_search_with_cache("roles:dns-server").first
+dns_server_node_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
+  dns_server_node,
+  "admin"
+).address
+
 template "/etc/tempest/tempest.conf" do
   source "tempest.conf.erb"
   mode 0o640
@@ -526,6 +535,7 @@ template "/etc/tempest/tempest.conf" do
         use_swift: use_swift,
         use_horizon: use_horizon,
         enabled_services: enabled_services,
+        tempest_roles: tempest_roles.join(", "),
         # boto settings
         ec2_protocol: nova[:nova][:ssl][:enabled] ? "https" : "http",
         ec2_host: CrowbarHelper.get_host_for_admin_url(nova, nova[:nova][:ha][:enabled]),
@@ -598,7 +608,8 @@ template "/etc/tempest/tempest.conf" do
         magnum_settings: tempest_magnum_settings,
         # heat (orchestration) settings
         heat_settings: tempest_heat_settings,
-        kibana_version: kibana_version
+        kibana_version: kibana_version,
+        dns_server_node_ip: dns_server_node_ip
       }
     }
   )

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -13,6 +13,7 @@ admin_username = <%= @keystone_settings['admin_user'] %>
 admin_tenant_name = <%= @keystone_settings['default_tenant'] %>
 admin_password = <%= @keystone_settings['admin_password'] %>
 admin_domain_name = Default
+tempest_roles = <%= @tempest_roles %>
 
 [aws]
 ec2_url = <%= @ec2_protocol %>://<%= @ec2_host %>:<%= @ec2_port %>/
@@ -118,6 +119,7 @@ image_id = <%= @magnum_settings['image_id'] %>
 nic_id = floating
 flavor_id = <%= @magnum_settings['flavor_id'] %>
 master_flavor_id = <%= @magnum_settings['master_flavor_id'] %>
+dns_nameserver = <%= @dns_server_node_ip %>
 
 [network]
 region = <%= @keystone_settings['endpoint_region'] %>


### PR DESCRIPTION
- magnum barclamp: set `verify_ca = false`. The magnum barclamp does not
support setting `openstack_ca_file` which leaves magnum unusable when
deploying crowbar using self-signed certificates. Setting `verify_ca =
false` ensures that it will work for any case.

- tempest barclamp: set the DNS nameserver for magnum to the crowbar DNS
server; and add `member` to the list of roles used for tempest.

(cherry picked from commit abae955fdf8f3775e0b4d695fd9e9c803e667d4f)