### PR TITLE
Disable  magnum.tests.functional.api.v1.test_cluster (SOC-11224)

### DIFF
--- a/chef/cookbooks/tempest/templates/default/run_filters/magnum.txt.erb
+++ b/chef/cookbooks/tempest/templates/default/run_filters/magnum.txt.erb
@@ -2,3 +2,6 @@
 
 # Fails when using 2+ controllers
 -magnum.tests.functional.api.v1.test_magnum_service.MagnumServiceTest.test_magnum_service_list
+# magnum fail work when ssl enabled for other services e.g. heat.
+# see SOC-11224
+-magnum.tests.functional.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters


### PR DESCRIPTION
Magnum test failing when ssl enabled
To unblock SOC7 gating jobs disabling tests till fix provided
Problem appear due to SOC7 missing https://review.opendev.org/#/c/529166
change.Heat failed to validate magnum certificates and cancel stack
creation.