### PR TITLE
octavia: remove mgmt_net from UI (SOC-10904)

### DIFF
--- a/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/octavia/_edit_attributes.html.haml
@@ -16,12 +16,6 @@
 
     %fieldset
       %legend
-        = t(".mgmt_net_header")
-
-      = string_field %w(amphora manage_net)
-
-    %fieldset
-      %legend
         = t(".amphora_header")
 
       = string_field %w(amphora ssh_access keyname)

--- a/crowbar_framework/config/locales/octavia/en.yml
+++ b/crowbar_framework/config/locales/octavia/en.yml
@@ -32,8 +32,6 @@ en:
           ssh_access:
             enabled: "Allow SSH Access"
             keyname: "SSH Access Keypair Name"
-          manage_net: 'Management Network Name'
-          manage_cidr: 'Management Network CIDR'
         api_header: 'API Settings'
         api:
           protocol: 'Protocol'
@@ -45,7 +43,6 @@ en:
           insecure: 'SSL Certificate is insecure (for instance, self-signed)'
           cert_required: 'Require Client Certificate'
           ca_certs: 'SSL CA Certificates File'
-        mgmt_net_header: 'Octavia Management Network Settings'
       validation:
         certificates_not_empty: 'The certificates paths cannot be empty.'
         passphrase_not_empty: 'Passphrase cannot be empty.'


### PR DESCRIPTION
The recommended way of configuring the Octavia management network
is by providing an `octavia` network in the network barclamp configuration,
while the Octavia barclamp takes care of the rest. This means it makes
no sense to keep the option of naming a different neutron provider network
as a main configuration option in the UI, because it may confuse customers
into thinking they still need to provide this network themselves.

The option will still be accessible through the raw barclamp view, if
necessary.