### PR TITLE
[5.0] tempest: disable block migration when using RBD (SOC-11176)

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -482,6 +482,7 @@ xen_compute_nodes = search(:node, "roles:nova-compute-xen") || []
 
 use_resize = kvm_compute_nodes.length > 1
 use_livemigration = nova[:nova][:use_migration] && kvm_compute_nodes.length > 1
+use_rbd_ephemeral = nova[:nova][:use_rbd_ephemeral]
 
 # create a flag to disable some test for xen (lp#1443898)
 xen_only = !xen_compute_nodes.empty? && kvm_compute_nodes.empty?
@@ -575,6 +576,7 @@ template "/etc/tempest/tempest.conf" do
         use_resize: use_resize,
         use_suspend: use_suspend,
         use_vnc: use_vnc,
+        use_rbd_ephemeral: use_rbd_ephemeral,
         use_livemigration: use_livemigration,
         # compute-feature-enabled settings
         use_config_drive: use_config_drive,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -38,7 +38,7 @@ min_compute_nodes = <%= @use_livemigration ? 2 : 1 %>
 resize = <%= @use_resize %>
 suspend = <%= @use_suspend %>
 live_migration = <%= @use_livemigration %>
-block_migration_for_live_migration = true
+block_migration_for_live_migration = <%= not @use_rbd_ephemeral %>
 vnc_console = <%= @use_vnc %>
 rescue = <%= @use_rescue %>
 interface_attach = <%= @use_interface_attach %>


### PR DESCRIPTION
(backports 1/2 of #2377)

When using RBD for VM's ephemeral disks disable block migration for live
migration as it is not supported when using shared storage.

(cherry picked from commit abb9249679345557b1b856f835194282a8952758)