### PR TITLE
nova: Hide setup_shared_instance_storage (SOC-11225)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/nova/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/nova/application.js
@@ -14,28 +14,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-var useSharedStorageSelection = null;
-
-function setup_shared_instance_storage_check() {
-  switch ($('#setup_shared_instance_storage').val()) {
-  case 'true':
-    $('#use_shared_instance_storage_container').hide();
-    if (useSharedStorageSelection === null) {
-      useSharedStorageSelection = $('#use_shared_instance_storage').val();
-    }
-    $('#use_shared_instance_storage').val('true').trigger('change');
-    break;
-  case 'false':
-    if (useSharedStorageSelection !== null) {
-      $('#use_shared_instance_storage').val(useSharedStorageSelection).trigger('change');
-      useSharedStorageSelection = null;
-    }
-    $('#use_shared_instance_storage_container').show();
-    break;
-  }
-}
-
-$(document).ready(function($) {
-  $('#setup_shared_instance_storage').on('change', setup_shared_instance_storage_check).trigger('change');
-});

--- a/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova/_edit_attributes.html.haml
@@ -28,9 +28,7 @@
         = t(".live_migration_header")
 
       = boolean_field :use_migration
-      = boolean_field :setup_shared_instance_storage
-      #use_shared_instance_storage_container
-        = boolean_field :use_shared_instance_storage
+      = boolean_field :use_shared_instance_storage
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -34,7 +34,6 @@ en:
           disk_allocation_ratio: 'Virtual Disk to Physical Disk allocation ratio'
           reserved_host_memory_mb: 'Reserved Memory for Nova Compute hosts (MB)'
         live_migration_header: 'Live Migration Support'
-        setup_shared_instance_storage: 'Set up Shared Storage on nova-controller for Nova instances'
         use_shared_instance_storage: 'Shared Storage for Nova instances has been manually configured'
         use_migration: 'Enable Libvirt Migration'
         kvm_header: 'KVM Options'


### PR DESCRIPTION
This option is meant to be used only with Xen live migration.
Since Xen support has been removed, this option should not be presented
to the users anymore.

docs snippet
![Zrzut ekranu z 2020-04-21 11-02-08](https://user-images.githubusercontent.com/2458112/79847163-9df08800-83bf-11ea-974a-7105d441e958.png)
