### PR TITLE
tempest: retry openstack commands (SOC-11238)

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -350,6 +350,8 @@ ruby_block "fetch ec2 credentials" do
     node[:tempest][:ec2_access] = ec2_access
     node[:tempest][:ec2_secret] = ec2_secret
   end
+  retries 5
+  retry_delay 10
 end
 
 # FIXME: should avoid search with no environment in query
@@ -437,6 +439,8 @@ ruby_block "get public network id" do
     end
     node[:tempest][:public_network_id] = stdout.strip
   end
+  retries 5
+  retry_delay 10
 end
 
 # FIXME: the command above should be good enough, but radosgw is broken with


### PR DESCRIPTION
On a HA deployment, actions that requires reapplying barclamps for
openstack services (e.g. enabling SSL on keystone) causes the tempest
barclamp to occasionally fail.

It fails because while reapplying the tempest barclamp
(deployed in one of the controllers), on other nodes everything
was done and the post actions are called which triggers the restart
of openstack services, when the openstack commands from the tempest
barclamp are called at the same time as the service is restarting
those commands fails.

This change adds a retry on the ruby blocks executing openstack
commands. So if the command fails it tries again, giving time for the
service to restart.