### PR TITLE
tempest: retry openstack commands (SOC-11238)

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -331,6 +331,8 @@ ruby_block "fetch ec2 credentials" do
     node[:tempest][:ec2_access] = ec2_access
     node[:tempest][:ec2_secret] = ec2_secret
   end
+  retries 5
+  retry_delay 10
 end
 
 # FIXME: should avoid search with no environment in query
@@ -396,6 +398,8 @@ ruby_block "get public network id" do
     raise("Cannot fetch ID of floating network") if public_network_id.empty?
     node[:tempest][:public_network_id] = public_network_id
   end
+  retries 5
+  retry_delay 10
 end
 
 # FIXME: the command above should be good enough, but radosgw is broken with


### PR DESCRIPTION
(backports #2396)

On a HA deployment, actions that requires reapplying barclamps for
openstack services (e.g. enabling SSL on keystone) causes the tempest
barclamp to occasionally fail.

It fails because while reapplying the tempest barclamp
(deployed in one of the controllers), on other nodes everything
was done and the post actions are called which triggers the restart
of openstack services, when the openstack commands from the tempest
barclamp are called at the same time as the service is restarting
those calls fails.

This change adds a retry on the ruby blocks executing openstack
commands. So if the command fails it tries again, giving time for the
service to restart.

(cherry picked from commit 50d3409abba4b5e319e7d3f7626fda47f1ee848d)