### PR TITLE
[5.0] run keystone_register on cluster founder only when HA (SOC-11248,SOC-11243)

### DIFF
--- a/chef/cookbooks/barbican/recipes/api.rb
+++ b/chef/cookbooks/barbican/recipes/api.rb
@@ -70,6 +70,7 @@ keystone_register "barbican api wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # Create barbican service
@@ -83,6 +84,7 @@ keystone_register "register barbican service" do
   service_type "key-manager"
   service_description "Openstack Barbican - Key and Secret Management Service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register barbican endpoint" do
@@ -98,6 +100,7 @@ keystone_register "register barbican endpoint" do
   endpoint_adminURL "#{barbican_protocol}://#{admin_host}:#{barbican_port}"
   endpoint_internalURL "#{barbican_protocol}://#{admin_host}:#{barbican_port}"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register barbican user" do
@@ -110,6 +113,7 @@ keystone_register "register barbican user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give barbican user access as admin" do
@@ -122,6 +126,7 @@ keystone_register "give barbican user access as admin" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "add key-manager:service-admin role for barbican" do
@@ -132,6 +137,7 @@ keystone_register "add key-manager:service-admin role for barbican" do
   auth register_auth_hash
   role_name "key-manager:service-admin"
   action :add_role
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give barbican user access as key-manager:service-admin" do
@@ -144,6 +150,7 @@ keystone_register "give barbican user access as key-manager:service-admin" do
   project_name keystone_settings["service_tenant"]
   role_name "key-manager:service-admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "add creator role for barbican" do
@@ -154,6 +161,7 @@ keystone_register "add creator role for barbican" do
   auth register_auth_hash
   role_name "creator"
   action :add_role
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give barbican user access as creator" do
@@ -166,6 +174,7 @@ keystone_register "give barbican user access as creator" do
   project_name keystone_settings["service_tenant"]
   role_name "creator"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "add observer role for barbican" do
@@ -176,6 +185,7 @@ keystone_register "add observer role for barbican" do
   auth register_auth_hash
   role_name "observer"
   action :add_role
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give barbican user access as observer" do
@@ -188,6 +198,7 @@ keystone_register "give barbican user access as observer" do
   project_name keystone_settings["service_tenant"]
   role_name "observer"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "add audit role for barbican" do
@@ -198,6 +209,7 @@ keystone_register "add audit role for barbican" do
   auth register_auth_hash
   role_name "audit"
   action :add_role
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give barbican user access as audit" do
@@ -210,6 +222,7 @@ keystone_register "give barbican user access as audit" do
   project_name keystone_settings["service_tenant"]
   role_name "audit"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-barbican_register" if ha_enabled

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -200,6 +200,7 @@ keystone_register "ceilometer wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register ceilometer user" do
@@ -212,6 +213,7 @@ keystone_register "register ceilometer user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give ceilometer user access" do
@@ -224,6 +226,7 @@ keystone_register "give ceilometer user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 swift_middlewares = node[:ceilometer][:elements]["ceilometer-swift-proxy-middleware"] || []
@@ -238,6 +241,7 @@ unless swift_middlewares.empty?
     project_name keystone_settings["service_tenant"]
     role_name "ResellerAdmin"
     action :add_access
+    only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 end
 

--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -56,6 +56,7 @@ keystone_register "cinder api wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register cinder user" do
@@ -68,6 +69,7 @@ keystone_register "register cinder user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give cinder user access" do
@@ -80,6 +82,7 @@ keystone_register "give cinder user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register cinder service" do
@@ -92,6 +95,7 @@ keystone_register "register cinder service" do
   service_type "volume"
   service_description "Openstack Cinder Service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register cinder endpoint" do
@@ -109,6 +113,7 @@ keystone_register "register cinder endpoint" do
   endpoint_internalURL "#{cinder_protocol}://"\
                        "#{my_admin_host}:#{cinder_port}/v1/$(project_id)s"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register cinder service v2" do
@@ -121,6 +126,7 @@ keystone_register "register cinder service v2" do
   service_type "volumev2"
   service_description "Openstack Cinder Service V2"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register cinder endpoint v2" do
@@ -138,6 +144,7 @@ keystone_register "register cinder endpoint v2" do
   endpoint_internalURL "#{cinder_protocol}://"\
                        "#{my_admin_host}:#{cinder_port}/v2/$(project_id)s"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register cinder service v3" do
@@ -150,6 +157,7 @@ keystone_register "register cinder service v3" do
   service_type "volumev3"
   service_description "Openstack Cinder Service V3"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register cinder endpoint v3" do
@@ -167,6 +175,7 @@ keystone_register "register cinder endpoint v3" do
   endpoint_internalURL "#{cinder_protocol}://"\
                        "#{my_admin_host}:#{cinder_port}/v3/$(project_id)s"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-cinder_register"

--- a/chef/cookbooks/designate/recipes/api.rb
+++ b/chef/cookbooks/designate/recipes/api.rb
@@ -53,6 +53,7 @@ keystone_register "designate api wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register designate user" do
@@ -65,6 +66,7 @@ keystone_register "register designate user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give designate user access" do
@@ -77,6 +79,7 @@ keystone_register "give designate user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register designate service" do
@@ -89,6 +92,7 @@ keystone_register "register designate service" do
   service_type "dns"
   service_description "Designate DNS Service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register designate endpoint" do
@@ -103,6 +107,7 @@ keystone_register "register designate endpoint" do
   endpoint_adminURL "#{designate_protocol}://#{my_admin_host}:#{designate_port}/"
   endpoint_internalURL "#{designate_protocol}://#{my_admin_host}:#{designate_port}/"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-designate_register" if ha_enabled

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -157,6 +157,7 @@ keystone_register "register glance service" do
   service_type "image"
   service_description "Openstack Glance Service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register glance endpoint" do
@@ -171,6 +172,7 @@ keystone_register "register glance endpoint" do
   endpoint_adminURL "#{glance_protocol}://#{endpoint_admin_ip}:#{api_port}"
   endpoint_internalURL "#{glance_protocol}://#{endpoint_admin_ip}:#{api_port}"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-glance_register_service" if ha_enabled

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -88,6 +88,7 @@ keystone_register "glance wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register glance user" do
@@ -100,6 +101,7 @@ keystone_register "register glance user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give glance user access" do
@@ -112,6 +114,7 @@ keystone_register "give glance user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-glance_register_user" if ha_enabled

--- a/chef/cookbooks/magnum/recipes/api.rb
+++ b/chef/cookbooks/magnum/recipes/api.rb
@@ -42,6 +42,7 @@ keystone_register "magnum api wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register magnum user" do
@@ -54,6 +55,7 @@ keystone_register "register magnum user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give magnum user access" do
@@ -66,6 +68,7 @@ keystone_register "give magnum user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register magnum service" do
@@ -78,6 +81,7 @@ keystone_register "register magnum service" do
   service_type "container-infra"
   service_description "Container Infrastructure Management Service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register magnum endpoint" do
@@ -95,6 +99,7 @@ keystone_register "register magnum endpoint" do
   endpoint_internalURL "#{magnum_protocol}://"\
                        "#{my_admin_host}:#{magnum_port}/v1"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-magnum_register" if ha_enabled

--- a/chef/cookbooks/manila/recipes/api.rb
+++ b/chef/cookbooks/manila/recipes/api.rb
@@ -48,6 +48,7 @@ keystone_register "manila api wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register manila user" do
@@ -60,6 +61,7 @@ keystone_register "register manila user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give manila user access" do
@@ -72,6 +74,7 @@ keystone_register "give manila user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register manila service" do
@@ -84,6 +87,7 @@ keystone_register "register manila service" do
   service_type "share"
   service_description "Openstack Manila shared filesystem service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register manila endpoint" do
@@ -101,6 +105,7 @@ keystone_register "register manila endpoint" do
   endpoint_internalURL "#{manila_protocol}://"\
                        "#{my_admin_host}:#{manila_port}/v1/$(project_id)s"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # v2 API is new since Liberty
@@ -114,6 +119,7 @@ keystone_register "register manila service v2" do
   service_type "sharev2"
   service_description "Openstack Manila shared filesystem service V2"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register manila endpoint v2" do
@@ -131,6 +137,7 @@ keystone_register "register manila endpoint v2" do
   endpoint_internalURL "#{manila_protocol}://"\
                        "#{my_admin_host}:#{manila_port}/v2/$(project_id)s"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-manila_register"

--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -36,6 +36,7 @@ keystone_register "neutron api wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register neutron user" do
@@ -48,6 +49,7 @@ keystone_register "register neutron user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give neutron user access" do
@@ -60,6 +62,7 @@ keystone_register "give neutron user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register neutron service" do
@@ -72,6 +75,7 @@ keystone_register "register neutron service" do
   service_type "network"
   service_description "Openstack Neutron Service"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register neutron endpoint" do
@@ -86,6 +90,7 @@ keystone_register "register neutron endpoint" do
   endpoint_adminURL "#{neutron_protocol}://#{my_admin_host}:#{api_port}/"
   endpoint_internalURL "#{neutron_protocol}://#{my_admin_host}:#{api_port}/"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-neutron_register" if ha_enabled

--- a/chef/cookbooks/nova/recipes/api.rb
+++ b/chef/cookbooks/nova/recipes/api.rb
@@ -56,6 +56,7 @@ keystone_register "nova api wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register nova user" do
@@ -68,6 +69,7 @@ keystone_register "register nova user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give nova user access" do
@@ -80,6 +82,7 @@ keystone_register "give nova user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register nova service" do
@@ -92,6 +95,7 @@ keystone_register "register nova service" do
   service_type "compute"
   service_description "Openstack Nova Service"
   action :add_service
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register nova_legacy service" do
@@ -104,6 +108,7 @@ keystone_register "register nova_legacy service" do
   service_type "compute_legacy"
   service_description "Openstack Nova Compute Service (Legacy 2.0)"
   action :add_service
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register nova endpoint" do
@@ -121,6 +126,7 @@ keystone_register "register nova endpoint" do
   endpoint_internalURL "#{api_protocol}://"\
                        "#{admin_api_host}:#{api_port}/v2.1/$(project_id)s"
   action :add_endpoint
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register nova_legacy endpoint" do
@@ -138,6 +144,7 @@ keystone_register "register nova_legacy endpoint" do
   endpoint_internalURL "#{api_protocol}://"\
                        "#{admin_api_host}:#{api_port}/v2/$(project_id)s"
   action :add_endpoint
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-nova_register" if api_ha_enabled

--- a/chef/cookbooks/nova/recipes/placement_api.rb
+++ b/chef/cookbooks/nova/recipes/placement_api.rb
@@ -50,6 +50,7 @@ keystone_register "register placement user '#{node["nova"]["placement_service_us
   user_password node["nova"]["placement_service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give placement user '#{node["nova"]["placement_service_user"]}' access" do
@@ -62,6 +63,7 @@ keystone_register "give placement user '#{node["nova"]["placement_service_user"]
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register placement service" do
@@ -74,6 +76,7 @@ keystone_register "register placement service" do
   service_type "placement"
   service_description "Openstack Placement Service"
   action :add_service
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register placement endpoint" do
@@ -88,6 +91,7 @@ keystone_register "register placement endpoint" do
   endpoint_adminURL "#{api_protocol}://#{admin_api_host}:#{api_port}"
   endpoint_internalURL "#{api_protocol}://#{admin_api_host}:#{api_port}"
   action :add_endpoint
+  only_if { !api_ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 if node[:nova][:ha][:enabled]

--- a/chef/cookbooks/sahara/recipes/api.rb
+++ b/chef/cookbooks/sahara/recipes/api.rb
@@ -41,6 +41,7 @@ keystone_register "sahara api wakeup keystone" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   action :wakeup
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register sahara user" do
@@ -53,6 +54,7 @@ keystone_register "register sahara user" do
   user_password keystone_settings["service_password"]
   project_name keystone_settings["service_tenant"]
   action :add_user
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "give sahara user access" do
@@ -65,6 +67,7 @@ keystone_register "give sahara user access" do
   project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register sahara service" do
@@ -77,6 +80,7 @@ keystone_register "register sahara service" do
   service_type "data-processing"
   service_description "Openstack Sahara - Data Processing"
   action :add_service
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 keystone_register "register sahara endpoint" do
@@ -91,6 +95,7 @@ keystone_register "register sahara endpoint" do
   endpoint_adminURL "#{sahara_protocol}://#{my_admin_host}:#{sahara_port}/v1.1/%(tenant_id)s"
   endpoint_internalURL "#{sahara_protocol}://#{my_admin_host}:#{sahara_port}/v1.1/%(tenant_id)s"
   action :add_endpoint
+  only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-sahara_register" if ha_enabled

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -186,6 +186,7 @@ case proxy_config[:auth_method]
        port keystone_settings["admin_port"]
        auth register_auth_hash
        action :wakeup
+       only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
      end
 
      # ResellerAdmin is used by swift (see reseller_admin_role option)
@@ -198,6 +199,7 @@ case proxy_config[:auth_method]
        auth register_auth_hash
        role_name role
        action :add_role
+       only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
      end
 
      keystone_register "register swift user" do
@@ -210,6 +212,7 @@ case proxy_config[:auth_method]
        user_password keystone_settings["service_password"]
        project_name keystone_settings["service_tenant"]
        action :add_user
+       only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
      end
 
      keystone_register "give swift user access" do
@@ -222,6 +225,7 @@ case proxy_config[:auth_method]
        project_name keystone_settings["service_tenant"]
        role_name "admin"
        action :add_access
+       only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
      end
 
      keystone_register "register swift service" do
@@ -234,6 +238,7 @@ case proxy_config[:auth_method]
        service_type "object-store"
        service_description "Openstack Swift Object Store Service"
        action :add_service
+       only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
      end
 
      # register swift-proxy endpoints only if no SES based RadosGW is being
@@ -256,6 +261,7 @@ case proxy_config[:auth_method]
                               "#{node[:swift][:ports][:proxy]}/v1/"\
                               "#{node[:swift][:reseller_prefix]}$(project_id)s"
          action :add_endpoint
+         only_if { !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node) }
        end
      end
 


### PR DESCRIPTION
(backports #2399 and #2400)

There are still plenty of services where keystone_register is called on all controllers with
a subsequent apache restart. From this, there is a risk of the
keystone_register call be executed while apache (and keystone) is
restarting and consequently failing the deployment.

This change make all calls for keystone_register to be made only on
one of the controllers for all services that supports HA.