### PR TITLE
Fix monasca libvirt ping checks (bsc#1107190)

### DIFF
--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -24,7 +24,7 @@
               "tenant_name"
               ],
             "nova_refresh": 14400,
-            "ping_check": "/bin/ip netns exec NAMESPACE /usr/bin/ping",
+            "ping_check": "sudo /bin/ip netns exec NAMESPACE /usr/bin/ping",
             "vm_cpu_check_enable": true,
             "vm_disks_check_enable": true,
             "vm_extended_disks_check_enable": false,


### PR DESCRIPTION
This patch is one of the pieces needs to fix the monasca
libvirt ping checks. The other patch is an rpm-packaging patch
to correct the sudoers file used by the monasca-agent.