### PR TITLE
[5.0] nova: Remove deprecated options (SOC-7852)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -258,7 +258,6 @@ end
 
 ironic_servers = node_search_with_cache("roles:ironic-server") || []
 if ironic_servers.any? && (node["roles"] & ["nova-compute-ironic", "nova-controller"]).any?
-  use_baremetal_filters = true
   track_instance_changes = false
   ironic_node = ironic_servers.first
   ironic_settings = {}
@@ -273,7 +272,6 @@ if ironic_servers.any? && (node["roles"] & ["nova-compute-ironic", "nova-control
   ironic_settings[:service_password] = ironic_node[:ironic][:service_password]
   reserved_host_memory = 0
 else
-  use_baremetal_filters = false
   track_instance_changes = true
   ironic_settings = nil
   reserved_host_memory = node[:nova][:scheduler][:reserved_host_memory_mb]
@@ -420,7 +418,6 @@ template node[:nova][:config_file] do
     has_itxt: has_itxt,
     enabled_filters: node[:nova][:scheduler][:enabled_filters],
     reserved_host_memory: reserved_host_memory,
-    use_baremetal_filters: use_baremetal_filters,
     track_instance_changes: track_instance_changes,
     ironic_settings: ironic_settings,
     ephemeral_rbd_settings: ephemeral_rbd_settings,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -6,9 +6,6 @@ key = <%= @vncproxy_key_file %>
 instance_name_template=zvm%05x
 <% end %>
 my_ip = <%= node[:nova][:my_ip] %>
-<% unless @ironic_settings.nil? %>
-scheduler_host_manager = ironic_host_manager
-<% end %>
 state_path = /var/lib/nova
 enabled_ssl_apis = <%= @ssl_enabled ? "osapi_compute,metadata" : "" %>
 osapi_compute_listen = <%= @bind_host %>
@@ -348,9 +345,6 @@ host_manager = ironic_host_manager
 <% end %>
 
 [filter_scheduler]
-<% if @use_baremetal_filters %>
-use_baremetal_filters = true
-<% end %>
 <% if @has_itxt %>
 available_filters = nova.scheduler.filters.standard_filters
 <% if @enabled_filters.empty? %>


### PR DESCRIPTION
Removed some deprecated options related to ironic/baremetal deployments.

(cherry picked from commit a2d5815368c3891038165bef0794500a3dab2e45)

port of #2407 