### PR TITLE
[5.0]  Fix monasca libvirt ping checks (bsc#1107190)

### DIFF
--- a/chef/data_bags/crowbar/template-monasca.json
+++ b/chef/data_bags/crowbar/template-monasca.json
@@ -24,7 +24,7 @@
               "tenant_name"
               ],
             "nova_refresh": 14400,
-            "ping_check": "/bin/ip netns exec NAMESPACE /usr/bin/ping",
+            "ping_check": "sudo /bin/ip netns exec NAMESPACE /usr/bin/ping",
             "vm_cpu_check_enable": true,
             "vm_disks_check_enable": true,
             "vm_extended_disks_check_enable": false,


### PR DESCRIPTION
This patch is one of the pieces needed to fix the monasca
libvirt ping checks. The other patch is an rpm-packaging patch
to correct the sudoers file used by the monasca-agent.

https://review.opendev.org/724689

(cherry picked from commit b0b10d61f248ea5c2dc26ccdf951dee89a2c5623)