### PR TITLE
[5.0] Tempest: enable test_volume_boot_pattern test (SOC-10874)

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -681,7 +681,8 @@ cb.manifest["templates"].each do |cb_template|
     variables(
       lazy do
         {
-          enabled_services: enabled_services
+          enabled_services: enabled_services,
+          storage_protocol: storage_protocol
         }
       end
     )

--- a/chef/cookbooks/tempest/templates/default/run_filters/cinder.txt.erb
+++ b/chef/cookbooks/tempest/templates/default/run_filters/cinder.txt.erb
@@ -2,5 +2,7 @@
 +tempest.scenario.test_volume.*
 +tempest.scenario.test_encrypted.*
 
+<% if @storage_protocol == "iSCSI" -%>
 # BUG: SOC-10874
 -tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern
+<% end -%>


### PR DESCRIPTION
This reverts commit db7d6b3f4158874eff1e47e1146374d9c11c65e9.

As CI is now using Ceph for SOC 8, enable the `test_volume_boot_pattern`
tempest test.