### PR TITLE
[5.0] trove: fix rabbitmq connection URL (SOC-11286)

### DIFF
--- a/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-openstack/libraries/helpers.rb
@@ -244,7 +244,7 @@ class CrowbarOpenStackHelper
             url = "#{rabbit[:rabbitmq][:trove][:user]}:"
             url << "#{rabbit[:rabbitmq][:trove][:password]}@"
             url << "#{CrowbarRabbitmqHelper.get_listen_address(rabbit)}:#{port}"
-            url << "/#{rabbit[:rabbitmq][:trove][:vhost]}" unless rabbit.equal? rabbits.first
+            url << "/#{rabbit[:rabbitmq][:trove][:vhost]}" if rabbit.equal? rabbits.last
             url.prepend("rabbit://") if rabbit.equal? rabbits.first
 
             url


### PR DESCRIPTION
(backports #2412)

This patch fixes the rabbitmq generated url by ensuring that the vhost
is properly added only at the end of the url.

(cherry picked from commit cd19cab6de21007c82e8bebba48b4591dd6b214d)