### PR TITLE
[5.0] nova: only create nonexistent cell1

### DIFF
--- a/chef/cookbooks/nova/recipes/database.rb
+++ b/chef/cookbooks/nova/recipes/database.rb
@@ -117,7 +117,8 @@ end
 execute "nova-manage create cell1" do
   user node[:nova][:user]
   group node[:nova][:group]
-  command "nova-manage cell_v2 create_cell --name cell1 --verbose"
+  command "nova-manage cell_v2 list_cells | grep -q ' cell1 ' "\
+          "|| nova-manage cell_v2 create_cell --name cell1 --verbose"
   action :run
   only_if do
     !node[:nova][:db_synced] &&


### PR DESCRIPTION
`nova-manage cell_v2 create_cell --name cell1` will fail if
cell1 exists already, so check for its existence before
attempting to create it blindly.

(cherry picked from commit fe218f4eee1e44af4a55923a6ffb491f323869c6)