### PR TITLE
[5.0] Fix availability zone script (bsc#1171661)

### DIFF
--- a/chef/cookbooks/nova/files/default/crowbar-nova-set-availability-zone
+++ b/chef/cookbooks/nova/files/default/crowbar-nova-set-availability-zone
@@ -111,7 +111,7 @@ if not args.os_auth_url:
 c = nova_client.Client("2",
                        args.os_username,
                        args.os_password,
-                       args.os_tenant_name,
+                       project_name=args.os_tenant_name,
                        auth_url=args.os_auth_url,
                        region_name=args.os_region_name,
                        endpoint_type=args.endpoint_type,


### PR DESCRIPTION
This script was failing with an auth error because
the project_name was not being passed correctly.