### PR TITLE
Restore undeprecated nova dhcp_domain option (bsc#1171594)

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -153,12 +153,14 @@ if neutron_servers.length > 0
   neutron_server_port = neutron_server[:neutron][:api][:service_port]
   neutron_service_user = neutron_server[:neutron][:service_user]
   neutron_service_password = neutron_server[:neutron][:service_password]
+  neutron_dhcp_domain = neutron_server[:neutron][:dns_domain]
   neutron_ml2_drivers = neutron_server[:neutron][:ml2_type_drivers]
   neutron_has_tunnel = neutron_ml2_drivers.include?("gre") || neutron_ml2_drivers.include?("vxlan")
 else
   neutron_server_host = nil
   neutron_server_port = nil
   neutron_service_user = nil
+  neutron_dhcp_domain = "novalocal"
   neutron_service_password = nil
   neutron_has_tunnel = false
 end
@@ -403,6 +405,7 @@ template node[:nova][:config_file] do
     neutron_insecure: neutron_insecure,
     neutron_service_user: neutron_service_user,
     neutron_service_password: neutron_service_password,
+    neutron_dhcp_domain: neutron_dhcp_domain,
     neutron_has_tunnel: neutron_has_tunnel,
     keystone_settings: keystone_settings,
     profiler_settings: profiler_settings,

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -49,6 +49,7 @@ ssl_ca_file = <%= @ssl_ca_file %>
 <% if @force_config_drive || @libvirt_type.eql?('zvm') %>
 flat_injected = true
 <% end %>
+dhcp_domain = <%= @neutron_dhcp_domain %>
 security_group_api = neutron
 <% if @force_config_drive and !@libvirt_type.eql?('zvm') %>
 config_drive_format = vfat


### PR DESCRIPTION
This option was removed [1] in crowbar because it was deprecated in nova.
But it is required by the metadata service so the deprecated status was removed [2].

[1] https://github.com/crowbar/crowbar-openstack/commit/fff5958b50d29b3c99a0874eebfcec93aeeee840
[2] https://opendev.org/openstack/nova/commit/886b0a5d748ae1deda3a039734f831d7c0cf0476