### PR TITLE
Fix availability zone script for SOC9

### DIFF
--- a/chef/cookbooks/nova/files/default/crowbar-nova-set-availability-zone
+++ b/chef/cookbooks/nova/files/default/crowbar-nova-set-availability-zone
@@ -76,6 +76,20 @@ parser.add_argument('--endpoint-type',
                     default='internalURL',
                     help='Defaults to internalURL.')
 
+parser.add_argument('--os-project-domain-name',
+                    metavar='<project-domain-name>',
+                    default=os.environ.get('OS_PROJECT_DOMAIN_NAME', None),
+                    help='Defaults to env[OS_PROJECT_DOMAIN_NAME].')
+parser.add_argument('--os_project_domain_name',
+                    help=argparse.SUPPRESS)
+
+parser.add_argument('--os-user-domain-name',
+                    metavar='<user-domain-name>',
+                    default=os.environ.get('OS_USER_DOMAIN_NAME', None),
+                    help='Defaults to env[OS_USER_DOMAIN_NAME].')
+parser.add_argument('--os_user_domain_name',
+                    help=argparse.SUPPRESS)
+
 parser.add_argument('--insecure',
                     default=False,
                     action='store_true',
@@ -92,7 +106,7 @@ parser.add_argument('--debug',
 
 args = parser.parse_args()
 debug = args.debug
-target_host_name = args.host
+host_name = args.host
 target_availability_zone = args.availability_zone
 
 if not args.os_username:
@@ -107,16 +121,24 @@ if not args.os_tenant_name:
 if not args.os_auth_url:
     print >> sys.stderr, 'You must provide an auth url via either --os-auth-url or via env[OS_AUTH_URL]'
     sys.exit(1)
+if not args.os_project_domain_name:
+    print >> sys.stderr, 'You must provide the project domain name via either --os-project-domain-name or via env[OS_PROJECT_DOMAIN_NAME]'
+    sys.exit(1)
+if not args.os_user_domain_name:
+    print >> sys.stderr, 'You must provide the user domain name via either --os-user-domain-name or via env[OS_USER_DOMAIN_NAME]'
+    sys.exit(1)
 
 c = nova_client.Client("2",
                        args.os_username,
                        args.os_password,
-                       args.os_tenant_name,
+                       project_name=args.os_tenant_name,
                        auth_url=args.os_auth_url,
                        region_name=args.os_region_name,
                        endpoint_type=args.endpoint_type,
                        insecure=args.insecure,
-                       http_log_debug=args.debug)
+                       http_log_debug=args.debug,
+                       project_domain_name=args.os_project_domain_name,
+                       user_domain_name=args.os_user_domain_name)
 
 
 def debug_print(s):
@@ -130,29 +152,29 @@ def random_name(basis, length=6):
 
 
 if target_availability_zone:
-    debug_print("Goal: move %s to availability zone \'%s\'" % (target_host_name, target_availability_zone))
+    debug_print("Goal: move %s to availability zone \'%s\'" % (host_name, target_availability_zone))
 else:
-    debug_print("Goal: move %s to default availability zone (or leave in non-Crowbar-owned availability zone)" % target_host_name)
+    debug_print("Goal: move %s to default availability zone (or leave in non-Crowbar-owned availability zone)" % host_name)
 
-# Find host
 try:
-    hosts = c.hosts.list()
+    azs = c.availability_zones.list()
 except Exception as e:
-    print >> sys.stderr, 'Cannot fetch list of nova hosts: %s' % e
+    print >> sys.stderr, 'Cannot fetch list of availability zones: %s' % e
     # Treat this as temp failure as likely its just the API is not up right now
     sys.exit(69)
 
 try:
-    host = [host for host in hosts if host.service == 'compute' and host.host_name == target_host_name][0]
+    host_zone = [az.zoneName for az in azs if az.zoneName != 'internal'
+                 and az.hosts.get(host_name) is not None][0]
 except IndexError:
-    print >> sys.stderr, 'Host %s not known as compute host (yet?)' % target_host_name
+    print >> sys.stderr, 'Host %s not known as compute host (yet?)' % host_name
     sys.exit(68)
 
-if host.zone == target_availability_zone:
-    debug_print("%s is already in availability zone \'%s\'" % (host.host_name, host.zone))
+if host_zone == target_availability_zone:
+    debug_print("%s is already in availability zone \'%s\'" % (host_name, host_zone))
     sys.exit(0)
 
-debug_print("%s is in availability zone \'%s\'..." % (host.host_name, host.zone))
+debug_print("%s is in availability zone \'%s\'..." % (host_name, host_zone))
 
 # Get info about aggregates
 old_aggregate = None
@@ -162,7 +184,7 @@ aggregates = c.aggregates.list()
 for aggregate in aggregates:
     if aggregate.availability_zone == target_availability_zone:
         target_aggregate = aggregate
-    elif aggregate.availability_zone == host.zone:
+    elif aggregate.availability_zone == host_zone:
         old_aggregate = aggregate
 
 
@@ -184,13 +206,13 @@ if target_aggregate is None and target_availability_zone:
 
 # Remove host from old aggregate
 if old_aggregate is None:
-    debug_print("Availability zone \'%s\' does not match any aggregate; possibly default availability zone..." % host.zone)
+    debug_print("Availability zone \'%s\' does not match any aggregate; possibly default availability zone..." % host_zone)
 else:
-    debug_print("Removing %s from availability zone \'%s\'..." % (host.host_name, host.zone))
+    debug_print("Removing %s from availability zone \'%s\'..." % (host_name, host_zone))
     try:
-        old_aggregate = c.aggregates.remove_host(old_aggregate.id, host.host_name)
+        old_aggregate = c.aggregates.remove_host(old_aggregate.id, host_name)
     except Exception as e:
-        print >> sys.stderr, 'Cannot remove %s from availability zone \'%s\': %s' % (host.host_name, host.zone, e)
+        print >> sys.stderr, 'Cannot remove %s from availability zone \'%s\': %s' % (host_name, host_zone, e)
         sys.exit(1)
 
     # remove aggregate if empty and created by crowbar
@@ -205,9 +227,9 @@ else:
 
 # Add host to target aggregate (if we don't want default availability zone)
 if target_availability_zone:
-    debug_print("Adding %s to availability zone \'%s\'..." % (host.host_name, target_availability_zone))
+    debug_print("Adding %s to availability zone \'%s\'..." % (host_name, target_availability_zone))
     try:
-        c.aggregates.add_host(target_aggregate.id, host.host_name)
+        c.aggregates.add_host(target_aggregate.id, host_name)
     except Exception as e:
-        print >> sys.stderr, 'Cannot add %s to availability zone \'%s\': %s' % (host.host_name, target_availability_zone, e)
+        print >> sys.stderr, 'Cannot add %s to availability zone \'%s\': %s' % (host_name, target_availability_zone, e)
         sys.exit(1)

--- a/chef/cookbooks/nova/libraries/availability_zone.rb
+++ b/chef/cookbooks/nova/libraries/availability_zone.rb
@@ -23,13 +23,15 @@ module NovaAvailabilityZone
     auth_url = KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],
                                                     keystone_settings["internal_url_host"],
                                                     keystone_settings["service_port"],
-                                                    "2.0")
+                                                    keystone_settings["api_version"])
     env = {
       "OS_USERNAME" => keystone_settings["admin_user"],
       "OS_PASSWORD" => keystone_settings["admin_password"],
       "OS_TENANT_NAME" => keystone_settings["default_tenant"],
       "OS_AUTH_URL" => auth_url,
-      "OS_REGION_NAME" => keystone_settings["endpoint_region"]
+      "OS_REGION_NAME" => keystone_settings["endpoint_region"],
+      "OS_USER_DOMAIN_NAME" => keystone_settings["default_user_domain"],
+      "OS_PROJECT_DOMAIN_NAME" => keystone_settings["default_user_domain"]
     }
 
     command = ["/usr/bin/crowbar-nova-set-availability-zone"]


### PR DESCRIPTION
This patch changes the script to use the Keystone v3 endpoint as the 2.0
endpoint is not available in SOC9. Also the python-novaclient in SOC9
does not have the os-hosts bindings [1], so use the availability_zones
bindings to find the host's current availability zone instead.

[1] https://github.com/openstack/python-novaclient/commit/1d88717e751e743ca7edd978346b95b6e7b3f235