### PR TITLE
horizon: Update configuration for Grafana 5.x

### DIFF
--- a/chef/cookbooks/horizon/files/default/default-dashboards-provider.yaml
+++ b/chef/cookbooks/horizon/files/default/default-dashboards-provider.yaml
@@ -1,0 +1,10 @@
+# config file version
+apiVersion: 1
+
+providers:
+ - name: 'default'
+   orgId: 1
+   folder: ''
+   type: file
+   options:
+     path: /var/lib/grafana/dashboards

--- a/chef/cookbooks/horizon/files/default/grafana-monasca.json
+++ b/chef/cookbooks/horizon/files/default/grafana-monasca.json
@@ -25,6 +25,7 @@
       "version": "0.0.6"
     }
   ],
+  "uid": "Monasca_dashboard",
   "annotations": {
     "enable": false,
     "list": []

--- a/chef/cookbooks/horizon/files/default/grafana-openstack.json
+++ b/chef/cookbooks/horizon/files/default/grafana-openstack.json
@@ -25,6 +25,7 @@
       "version": "0.0.6"
     }
   ],
+  "uid": "OpenStack",
   "annotations": {
     "enable": false,
     "list": []

--- a/chef/cookbooks/horizon/recipes/monasca_ui.rb
+++ b/chef/cookbooks/horizon/recipes/monasca_ui.rb
@@ -105,6 +105,14 @@ cookbook_file "/var/lib/grafana/dashboards/openstack.json" do
   notifies :restart, resources(service: "grafana-server")
 end
 
+cookbook_file "/etc/grafana/provisioning/dashboards/default.yaml" do
+  source "default-dashboards-provider.yaml"
+  owner "root"
+  group "grafana"
+  mode "0640"
+  notifies :restart, resources(service: "grafana-server")
+end
+
 # Grafana takes a few seconds from startup until it's actually listening, so
 # we'll need to wait for it:
 execute "grafana listening?" do

--- a/chef/cookbooks/horizon/templates/default/_80_monasca_ui_settings.py.erb
+++ b/chef/cookbooks/horizon/templates/default/_80_monasca_ui_settings.py.erb
@@ -37,8 +37,8 @@ GRAFANA_URL = { '<%= @endpoint_region %>': "/grafana" }
 
 # Grafana button titles/file names (global across all projects):
 GRAFANA_LINKS = [
-        {'title': 'Dashboard', 'path': '/grafana/dashboard/file/openstack.json?orgId=1', 'raw': True},
-        {'title': 'Monasca Health', 'path': '/grafana/dashboard/file/monasca.json?orgId=1', 'raw': True}
+        {'title': 'Dashboard', 'path': '/grafana/d/OpenStack/suse-openstack-cloud-monitoring-openstack?orgId=1', 'raw': True},
+        {'title': 'Monasca Health', 'path': '/grafana/d/Monasca_dashboard/suse-openstack-cloud-monitoring-monasca?orgId=1', 'raw': True}
 ]
 
 SHOW_GRAFANA_HOME = False

--- a/chef/cookbooks/horizon/templates/default/grafana.ini.erb
+++ b/chef/cookbooks/horizon/templates/default/grafana.ini.erb
@@ -22,8 +22,10 @@
 # Directory where grafana will automatically scan and look for plugins
 #
 ;plugins = /var/lib/grafana/plugins
-
 #
+# folder that contains provisioning config files that grafana will apply on startup and while running.
+;provisioning = /etc/grafana/provisioning
+
 #################################### Server ####################################
 [server]
 # Protocol (http or https)
@@ -351,11 +353,6 @@ org_role = Viewer
 ;enabled = false
 ;rabbitmq_url = amqp://localhost/
 ;exchange = grafana_events
-
-;#################################### Dashboard JSON files ##########################
-[dashboards.json]
-enabled = true
-path = /var/lib/grafana/dashboards
 
 #################################### Alerting ############################
 [alerting]


### PR DESCRIPTION
Starting with Grafana 5.x [dashboards.json] configuration section has
been replaced with provisioning mechanism [1]. This requires following
changes in the set-up:

* Set dashboard uids
* Update default dashboard URLs
* Provide default paths.provisioning configuration value

[1] http://docs.grafana.org/administration/provisioning

(cherry picked from commit 8b62625f6eb46fc6e9c5e79f3113e41cf88289ec)

Note: This is required so we can update Grafana in Cloud 8 (SOC-11362).