### PR TITLE
[4.0] rabbitmq: Fix crm running check (SOC-11240)

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha_cluster.rb
@@ -157,8 +157,8 @@ name = "rabbitmq-port-blocker"
 clone_name = "cl-#{name}"
 location_name = "l-#{name}-controller"
 node_upgrading = CrowbarPacemakerHelper.being_upgraded?(node)
-clone_running = "crm resource show #{clone_name}"
-primitive_running = "crm resource show #{name}"
+clone_running = "crm resource show #{clone_name} | grep -q \"is running on:\""
+primitive_running = "crm resource show #{name} | grep -q \"is running on:\""
 port = node[:rabbitmq][:port]
 ssl_port = node[:rabbitmq][:ssl][:port]
 


### PR DESCRIPTION
The "running" commands expected different exit codes depending on the
status for checked resources.
Later tests showed that `crm resource show` returns 0 for both: running
and NOT running cases. Non-zero exit code is returned when e.g. the
checked resource doesn't exist.
Parsing the console output of check commands seems to be more reliable.

(cherry picked from commit c59d41707e590a60cb496486c92b18c82725f61d)

port of #2429 