### PR TITLE
Disable keepalive in Keystone Apache config (bsc#1179084)

### DIFF
--- a/chef/cookbooks/crowbar-openstack/providers/wsgi.rb
+++ b/chef/cookbooks/crowbar-openstack/providers/wsgi.rb
@@ -67,6 +67,7 @@ action :create do
         ssl_keyfile: current_resource.ssl_keyfile,
         ssl_cacert: current_resource.ssl_cacert,
         timeout: current_resource.timeout,
+        disable_keepalive: current_resource.disable_keepalive,
         openidc_enabled: current_resource.openidc_enabled,
         openidc_provider: current_resource.openidc_provider,
         openidc_response_type: current_resource.openidc_response_type,
@@ -124,6 +125,7 @@ def load_current_resource
   @current_resource.ssl_cacert(@new_resource.ssl_cacert)
 
   @current_resource.timeout(@new_resource.timeout)
+  @current_resource.disable_keepalive(@new_resource.disable_keepalive)
 
   @current_resource.openidc_enabled(@new_resource.openidc_enabled)
   @current_resource.openidc_provider(@new_resource.openidc_provider)

--- a/chef/cookbooks/crowbar-openstack/resources/wsgi.rb
+++ b/chef/cookbooks/crowbar-openstack/resources/wsgi.rb
@@ -21,6 +21,7 @@ attribute :ssl_keyfile, kind_of: String, default: nil
 attribute :ssl_cacert, kind_of: String, default: nil
 
 attribute :timeout, kind_of: Integer, default: nil
+attribute :disable_keepalive, kind_of: [TrueClass, FalseClass], default: false
 
 attribute :openidc_enabled, kind_of: [TrueClass, FalseClass], default: false
 attribute :openidc_provider, kind_of: String, default: nil

--- a/chef/cookbooks/crowbar-openstack/templates/default/vhost-wsgi.conf.erb
+++ b/chef/cookbooks/crowbar-openstack/templates/default/vhost-wsgi.conf.erb
@@ -17,6 +17,10 @@ Listen <%= @bind_host %>:<%= @bind_port %>
     Timeout <%= @timeout %>
 <% end %>
 
+<% if @disable_keepalive %>
+    KeepAlive Off
+<% end %>
+
 <% if @ssl_enable %>
     SSLEngine on
     SSLCertificateFile <%= @ssl_certfile %>

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -199,6 +199,7 @@ elsif node[:keystone][:frontend] == "apache"
     ssl_cacert node[:keystone][:ssl][:ca_certs] unless node[:keystone][:ssl][:insecure]
     # LDAP backend can be slow..
     timeout 600
+    disable_keepalive true
     # auth_openidc configuration
     openidc_enabled openidc_enabled
     openidc_provider openidc_provider
@@ -232,6 +233,7 @@ elsif node[:keystone][:frontend] == "apache"
     ssl_cacert node[:keystone][:ssl][:ca_certs] unless node[:keystone][:ssl][:insecure]
     # LDAP backend can be slow..
     timeout 600
+    disable_keepalive true
     # auth_openidc configuration
     openidc_enabled openidc_enabled
     openidc_provider openidc_provider


### PR DESCRIPTION
Horizon's cache is preventing the garbage collector from removing
objects [1] with connections to Keystone. Keystone is running under
Apache which closes these connections after 15 seconds and they move
to CLOSE_WAIT on the client side. This can lead to the Horizon process
running out of file descriptors.

This patch disables KeepAlive in the Keystone Apache config, so the
server sends "Connection: close" in the HTTP response header and the
client removes the connection immediately.

[1] https://bugs.launchpad.net/horizon/+bug/1793411