### PR TITLE
[5.0] neutron: Fix handling of networks with non-ascii names (SOC-11429)

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -121,7 +121,7 @@ package "python-openstackclient"
 
 execute "create_fixed_network" do
   command "#{openstack_cmd} network create --share #{fixed_network_type} fixed"
-  not_if "out=$(#{openstack_cmd} network list); [ $? != 0 ] || echo ${out} | grep -q ' fixed '"
+  not_if "out=$(#{openstack_cmd} network list --name fixed); [ $? != 0 ] || echo ${out} | grep -q ' fixed '"
   retries 5
   retry_delay 10
   action :nothing
@@ -129,7 +129,7 @@ end
 
 execute "create_floating_network" do
   command "#{openstack_cmd} network create --external #{floating_network_type} floating"
-  not_if "out=$(#{openstack_cmd} network list); [ $? != 0 ] || echo ${out} | grep -q ' floating '"
+  not_if "out=$(#{openstack_cmd} network list --name floating); [ $? != 0 ] || echo ${out} | grep -q ' floating '"
   retries 5
   retry_delay 10
   action :nothing
@@ -138,7 +138,7 @@ end
 execute "create_ironic_network" do
   command "#{openstack_cmd} network create --share #{ironic_network_type} ironic"
   only_if { ironic_net }
-  not_if "out=$(#{openstack_cmd} network list); [ $? != 0 ] || echo ${out} | grep -q ' ironic '"
+  not_if "out=$(#{openstack_cmd} network list --name ironic); [ $? != 0 ] || echo ${out} | grep -q ' ironic '"
   retries 5
   retry_delay 10
   action :nothing
@@ -235,7 +235,7 @@ execute "update_dns_domain_for_floating_network" do
 end
 
 execute "Neutron network configuration" do
-  command "#{openstack_cmd} network list &>/dev/null"
+  command "#{openstack_cmd} network list -c ID &>/dev/null"
   retries 5
   retry_delay 10
   action :nothing


### PR DESCRIPTION
Chef uses default LC_ALL=C locale for all internal ShellOut calls.
These fails if command output contains non-ASCII characters.
The problem is bigger but it was really fixed only in Chef 12.
We could patch ShellOut to use different default be it could cause
some unwanted side effects in many places.
In this case the problem is with network names so it's easier to
limit the output to include only expected entries and not print all
names.

(cherry picked from commit 70356d630962b27cfd53eb569bfe10e3f7a562e5)

port of #2433 