### PR TITLE
monasca: fix monasca-server reinstall state check (SOC-11471)

### DIFF
--- a/chef/cookbooks/monasca/recipes/master.rb
+++ b/chef/cookbooks/monasca/recipes/master.rb
@@ -25,7 +25,7 @@ monasca_hosts = MonascaHelper.monasca_hosts(monasca_servers)
 raise "no nodes with monasca-server role found" if monasca_hosts.nil? || monasca_hosts.empty?
 
 # monasca-server nodes are in reinstall state
-unless monasca_node[:state] == "ready"
+if monasca_node[:state] == "reinstall"
   Chef::Log.warn("monasca-installer: monasca-server node is in reinstall state. skipping")
   return
 end


### PR DESCRIPTION
In the course of fixing bsc#1148158, an overzealous check for
the monasca-server node's state was introduced. This check
causes monasca-installer to not run when the monasca-server
node isn't in state `ready`. This commit changes the check to
only trip when the node is in state `reinstall`.

Note: I'm only targeting stable/pike with this because it does not apply to Cloud 9 where we did away with monasca-installer entirely.