### PR TITLE
monasca: restart Kibana on update (bsc#1044849)

### DIFF
--- a/chef/cookbooks/monasca/recipes/agent.rb
+++ b/chef/cookbooks/monasca/recipes/agent.rb
@@ -46,6 +46,15 @@ if node["roles"].include?("monasca-server")
                    " monasca-agent setup.")
     return
   end
+
+  # bsc#1044849: Kibana takes a few seconds from startup until it's actually
+  # listening, especially after a package upgrade, so we'll need to wait for
+  # it.  Otherwise its unreachability will trip up monasca-setup.
+  execute "kibana listening?" do
+    command "while true; do sleep 5; curl -s #{kibana_url} > /dev/null && break; done"
+    timeout 120
+  end
+
   # Special monasca-reconfigure script for monasca-server: on this machine
   # monasca-reconfigure will configure the agent.
   template "/usr/sbin/monasca-reconfigure" do

--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -230,6 +230,14 @@ keystone_register "give admin user monasca-user role in monasca tenant" do
   action :add_access
 end
 
+# Make sure Kibana gets restarted after the update to Kibana 4.6.6. This is required
+# for this update only, since after that update, the faulty restart logic in
+# the package's %postun section will no longer be causing trouble (bsc#1044849).
+service "kibana" do
+  action [:restart]
+  only_if "rpm -qa | grep -q 'kibana-4\.6\.6' && zypper ps -s | grep -q kibana"
+end
+
 agents_settings = []
 
 agents_settings.push(node[:monasca][:agent][:keystone])


### PR DESCRIPTION
In the course of the Kibana update from 4.6.3 to 4.6.6,
automatic service restart will not work. Hence, Crowbar needs
to ensure Kibana is restarted.