### PR TITLE
horizon: Add SSL protocol option.

### DIFF
--- a/chef/cookbooks/horizon/attributes/default.rb
+++ b/chef/cookbooks/horizon/attributes/default.rb
@@ -33,6 +33,7 @@ default[:horizon][:policy_file][:network] = "neutron_policy.json"
 default[:horizon][:policy_file][:neutron_fwaas] = "neutron-fwaas-policy.json"
 
 default[:horizon][:apache][:ssl] = false
+default[:horizon][:apache][:ssl_protocol] = "all -SSLv2 -SSLv3"
 default[:horizon][:apache][:ssl_crt_file] = "/etc/apache2/ssl.crt/openstack-dashboard-server.crt"
 default[:horizon][:apache][:ssl_key_file] = "/etc/apache2/ssl.key/openstack-dashboard-server.key"
 default[:horizon][:apache][:generate_certs] = false

--- a/chef/cookbooks/horizon/recipes/server.rb
+++ b/chef/cookbooks/horizon/recipes/server.rb
@@ -564,6 +564,7 @@ template "#{node[:apache][:dir]}/sites-available/openstack-dashboard.conf" do
     user: node[:apache][:user],
     group: node[:apache][:group],
     use_ssl: node[:horizon][:apache][:ssl],
+    ssl_protocol: node[:horizon][:apache][:ssl_protocol],
     ssl_crt_file: node[:horizon][:apache][:ssl_crt_file],
     ssl_key_file: node[:horizon][:apache][:ssl_key_file],
     ssl_crt_chain_file: node[:horizon][:apache][:ssl_crt_chain_file],

--- a/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
+++ b/chef/cookbooks/horizon/templates/suse/openstack-dashboard.conf.erb
@@ -55,7 +55,7 @@ Listen <%= @bind_host %>:<%= @bind_port_ssl %>
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
     SSLCipherSuite DEFAULT_SUSE
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol <%= @ssl_protocol %>
     # Prevent plaintext downgrade for 180 days
     Header always set Strict-Transport-Security "max-age=15552000"
     SSLCertificateFile <%= @ssl_crt_file %>

--- a/chef/data_bags/crowbar/template-horizon.json
+++ b/chef/data_bags/crowbar/template-horizon.json
@@ -36,6 +36,7 @@
       "apache": {
         "ssl": false,
         "generate_certs": false,
+        "ssl_protocol": "all -SSLv2 -SSLv3",
         "ssl_crt_file": "/etc/apache2/ssl.crt/openstack-dashboard-server.crt",
         "ssl_key_file": "/etc/apache2/ssl.key/openstack-dashboard-server.key",
         "ssl_crt_chain_file": ""
@@ -52,7 +53,7 @@
     "horizon": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 302,
+      "schema-revision": 303,
       "element_states": {
         "horizon-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-horizon.schema
+++ b/chef/data_bags/crowbar/template-horizon.schema
@@ -60,6 +60,7 @@
               "mapping": {
                 "ssl": { "type": "bool", "required": true },
                 "generate_certs": { "type": "bool", "required": true },
+                "ssl_protocol": { "type": "str" },
                 "ssl_crt_file": { "type": "str" },
                 "ssl_key_file": { "type": "str" },
                 "ssl_crt_chain_file": { "type": "str" }

--- a/crowbar_framework/app/views/barclamp/horizon/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/horizon/_edit_attributes.html.haml
@@ -27,6 +27,7 @@
 
       #apache_container
         = boolean_field %w(apache generate_certs)
+        = string_field %w(apache ssl_protocol)
         = string_field %w(apache ssl_crt_file)
         = string_field %w(apache ssl_key_file)
         = string_field %w(apache ssl_crt_chain_file)

--- a/crowbar_framework/config/locales/horizon/en.yml
+++ b/crowbar_framework/config/locales/horizon/en.yml
@@ -31,6 +31,7 @@ en:
         apache:
           ssl: 'Protocol'
           generate_certs: 'Generate (self-signed) certificates'
+          ssl_protocol: 'SSL Protocol Version'
           ssl_crt_file: 'SSL Certificate File'
           ssl_key_file: 'SSL (Private) Key File'
           ssl_crt_chain_file: 'SSL Certificate Chain File'


### PR DESCRIPTION
Current setting in cookbook templates exclude only SSLv2 and SSLv3.
`SSLProtocol all -SSLv2 -SSLv3`
but in these days TLSv1.0 protocol is already deprecated, so it will be nice to have any option how to disable this old protocol.
We can add protocol option (this PR) and keep it up to user to select which protocol he wants, disable TLSv1.0 in default settings or both of them.