### PR TITLE
monasca: restart Kibana on update (bsc#1044849)

### DIFF
--- a/chef/cookbooks/monasca/recipes/server.rb
+++ b/chef/cookbooks/monasca/recipes/server.rb
@@ -230,6 +230,14 @@ keystone_register "give admin user monasca-user role in monasca tenant" do
   action :add_access
 end
 
+# Make sure Kibana gets restarted after the update to Kibana 4.6.6. This is required
+# for this update only, since after that update, the faulty restart logic in
+# the package's %postun section will no longer be causing trouble (bsc#1044849).
+service "kibana" do
+  action [:restart]
+  only_if "rpm -qa | grep -q 'kibana-4\.6\.6' && zypper ps -s | grep -q kibana"
+end
+
 agents_settings = []
 
 agents_settings.push(node[:monasca][:agent][:keystone])


### PR DESCRIPTION
In the course of the Kibana update from 4.6.3 to 4.6.6,
automatic service restart will not work. Hence, Crowbar needs
to ensure Kibana is restarted.

(cherry picked from commit bb14b5a328880cdc0687cb92104f6cc0c643fa6a)

Note: this is a backport of https://github.com/crowbar/crowbar-openstack/pull/2436 

It omits the Kibana check in the agent recipe since monasca-setup will work without Kibana being live on Cloud 7 and the check would in fact break the recipe.