### PR TITLE
keystone wakeup: get new session on any error (bsc#1189052)

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -26,6 +26,7 @@ action :wakeup do
     break unless error && count < 50
     sleep 1
     next unless new_resource.reissue_token_on_error
+    Chef::Log.info "Problem finding /v3/services. Retrying with new session."
     KeystoneHelper.reset_session
     session
   end

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -509,7 +509,7 @@ keystone_register "wakeup keystone" do
   auth register_auth_hash
   retries 5
   retry_delay 10
-  reissue_token_on_error update_admin_password
+  reissue_token_on_error true
   action :wakeup
 end
 


### PR DESCRIPTION
Before f0f3e481 the keystone wakeup action would always get a
new token, but now it tries to reuse the session object. The
sessions's token might be expired, and the retry loop only tries
to get a new session if the password changes. This patch chnages
that so it gets a new session on any error.